### PR TITLE
fix: dyanmically determine dist version

### DIFF
--- a/packages/open-api-gateway/test-integration/utils/publish-to-local-registry.ts
+++ b/packages/open-api-gateway/test-integration/utils/publish-to-local-registry.ts
@@ -16,6 +16,7 @@
 
 import { execSync } from "child_process";
 import * as fs from "fs";
+import path from "path";
 
 /**
  * Registry configuration is specified via env params.
@@ -49,8 +50,13 @@ export const publishToLocalRegistry = (...pdkPackageNames: string[]) => {
     );
   }
 
+  const versionFile = path.join(__dirname, "../../dist/version.txt");
+  const packageVersion = fs.existsSync(versionFile)
+    ? fs.readFileSync(versionFile).toString()
+    : "0.0.0";
+
   pdkPackageNames.forEach((pdkPackageName) => {
-    const packagePath = `../../packages/${pdkPackageName}/dist/js/${pdkPackageName}@0.0.0.jsii.tgz`;
+    const packagePath = `../../packages/${pdkPackageName}/dist/js/${pdkPackageName}@${packageVersion}.jsii.tgz`;
     execSync(`npm publish ${packagePath} --no-workspaces`, {
       env: process.env, // Ensures this is targeting the local registry
       stdio: "inherit",


### PR DESCRIPTION
The `test:integration` target of open-api-gateway assumes a dist version of 0.0.0. This is not always the case as for the `release:mainline` target, a bumped version is calculated.

This PR dynamically determines the version based on the presence of a version.txt file in dist.