### PR TITLE
fix: Change default encryption to S3MANAGED for static website

### DIFF
--- a/packages/static-website/test/__snapshots__/static-website.test.ts.snap
+++ b/packages/static-website/test/__snapshots__/static-website.test.ts.snap
@@ -154,22 +154,6 @@ Object {
             },
             Object {
               "Action": Array [
-                "kms:Decrypt",
-                "kms:DescribeKey",
-                "kms:Encrypt",
-                "kms:ReEncrypt*",
-                "kms:GenerateDataKey*",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "DefaultsWebsiteBucketKeyAD72391B",
-                  "Arn",
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
                 "cloudfront:GetInvalidation",
                 "cloudfront:CreateInvalidation",
               ],
@@ -529,13 +513,7 @@ Object {
           "ServerSideEncryptionConfiguration": Array [
             Object {
               "ServerSideEncryptionByDefault": Object {
-                "KMSMasterKeyID": Object {
-                  "Fn::GetAtt": Array [
-                    "DefaultsWebsiteBucketKeyAD72391B",
-                    "Arn",
-                  ],
-                },
-                "SSEAlgorithm": "aws:kms",
+                "SSEAlgorithm": "AES256",
               },
             },
           ],
@@ -578,48 +556,6 @@ Object {
       },
       "Type": "Custom::S3AutoDeleteObjects",
       "UpdateReplacePolicy": "Delete",
-    },
-    "DefaultsWebsiteBucketKeyAD72391B": Object {
-      "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "Description": "Created by Default/Defaults/WebsiteBucket",
-        "KeyPolicy": Object {
-          "Statement": Array [
-            Object {
-              "Action": "kms:*",
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":iam::",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":root",
-                    ],
-                  ],
-                },
-              },
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "Tags": Array [
-          Object {
-            "Key": "aws-cdk:cr-owned:fb67e0d5",
-            "Value": "true",
-          },
-        ],
-      },
-      "Type": "AWS::KMS::Key",
-      "UpdateReplacePolicy": "Retain",
     },
     "DefaultsWebsiteBucketPolicy594E6643": Object {
       "Properties": Object {


### PR DESCRIPTION
Fixes #45 

It does appear OAI does not support KMS encryption without a Lambda@Edge signer.

Change default encryption to S3_MANAGED as using KMS would only be mandatory for regulated customers. If they require KMS, the current StaticWebsite API allows them to associate a Lamda@Edge function to the Cloudfront default behaviour and they have the option of either passing in their own S3 bucket with KMS encryption or using the newly added KMS encryption type.