### PR TITLE
fix(docs): fail docs build when errors are thrown

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Install dependencies
         run: yarn install --check-files
+      - name: Synth Project
+        run: npx projen
       - name: Start NX CI Run
         run: npx nx-cloud start-ci-run    
       - name: Build
@@ -32,57 +34,8 @@ jobs:
       - name: Stop NX Agents
         if: always()
         run: npx nx-cloud stop-all-agents
-      - id: self_mutation
-        name: Find mutations
-        run: |-
-          git add .
-          git diff --staged --patch --exit-code > .repo.patch || echo "::set-output name=self_mutation_happened::true"
-      - if: steps.self_mutation.outputs.self_mutation_happened
-        name: Upload patch
-        uses: actions/upload-artifact@v2
-        with:
-          name: .repo.patch
-          path: .repo.patch
-      - name: Fail build on mutation
-        if: steps.self_mutation.outputs.self_mutation_happened
-        run: |-
-          echo "::error::Files were changed during build (see build log). If this was triggered from a fork, you will need to update your branch."
-          cat .repo.patch
-          exit 1
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2.1.1
-        with:
-          name: build-artifact
-          path: packages/aws-prototyping-sdk/dist
-  self-mutation:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    if: always() && needs.build.outputs.self_mutation_happened && !(github.event.pull_request.head.repo.full_name != github.repository)
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Download patch
-        uses: actions/download-artifact@v2
-        with:
-          name: .repo.patch
-          path: ${{ runner.temp }}
-      - name: Apply patch
-        run: '[ -s ${{ runner.temp }}/.repo.patch ] && git apply ${{ runner.temp }}/.repo.patch || echo "Empty patch. Skipping."'
-      - name: Set git identity
-        run: |-
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-      - name: Push changes
-        run: |2-
-            git add .
-            git commit -s -m "chore: self mutation"
-            git push origin HEAD:${{ github.event.pull_request.head.ref }}
+      - name: Check for mutations
+        run: git diff --ignore-space-at-eol --exit-code
   agents:
     runs-on: ubuntu-latest
     name: Agent 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,8 @@ jobs:
           git config user.email "github-actions@github.com"
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
+      - name: Synth Project
+        run: npx projen
       - name: Start NX CI Run
         run: npx nx-cloud start-ci-run    
       - name: Build

--- a/packages/static-website/.projen/deps.json
+++ b/packages/static-website/.projen/deps.json
@@ -1,11 +1,6 @@
 {
   "dependencies": [
     {
-      "name": "@aws-prototyping-sdk/identity",
-      "version": "0.0.0",
-      "type": "build"
-    },
-    {
       "name": "@types/jest",
       "type": "build"
     },

--- a/packages/static-website/.projen/tasks.json
+++ b/packages/static-website/.projen/tasks.json
@@ -263,19 +263,19 @@
           "exec": "yarn upgrade npm-check-updates"
         },
         {
-          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='@aws-prototyping-sdk/identity'"
+          "exec": "npm-check-updates --dep dev --upgrade --target=minor"
         },
         {
-          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='@aws-prototyping-sdk/identity'"
+          "exec": "npm-check-updates --dep optional --upgrade --target=minor"
         },
         {
-          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='@aws-prototyping-sdk/identity'"
+          "exec": "npm-check-updates --dep peer --upgrade --target=minor"
         },
         {
-          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='@aws-prototyping-sdk/identity'"
+          "exec": "npm-check-updates --dep prod --upgrade --target=minor"
         },
         {
-          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='@aws-prototyping-sdk/identity'"
+          "exec": "npm-check-updates --dep bundle --upgrade --target=minor"
         },
         {
           "exec": "yarn install --check-files"

--- a/packages/static-website/package.json
+++ b/packages/static-website/package.json
@@ -36,7 +36,6 @@
     "organization": false
   },
   "devDependencies": {
-    "@aws-prototyping-sdk/identity": "0.0.0",
     "@types/jest": "^28.1.1",
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",

--- a/public/docs/scripts/build-docs
+++ b/public/docs/scripts/build-docs
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 rm -rf build dist
 ./scripts/generate-markdown
 cd build/docs

--- a/public/docs/scripts/generate-markdown.js
+++ b/public/docs/scripts/generate-markdown.js
@@ -62,14 +62,15 @@ async function main() {
       .map((language) => `  - ${language.name}`)
       .join('\n')}`);
 
-  SUPPORTED_LANGUAGES.map((l) => l.name).forEach((language) => {
+  const languages = SUPPORTED_LANGUAGES.map((l) => l.name);
+  for (const language of languages) {
     fs.mkdirSync(`${cwd}/build/docs/content/${language}`, { recursive: true });
 
     const pkgs = fs.readdirSync(RELATIVE_PKG_ROOT)
       .filter(p => "aws-prototyping-sdk" !== p)
       .filter(p => fs.existsSync(`${RELATIVE_PKG_ROOT}/${p}/.jsii`));
 
-    pkgs.map(async (pkg) => {
+    for (const pkg of pkgs) {
         const pkgJsii = JSON.parse(fs.readFileSync(`${RELATIVE_PKG_ROOT}/${pkg}/.jsii`).toString());
         const stability = pkgJsii.docs.stability;
 
@@ -85,7 +86,7 @@ async function main() {
             .find(([, v]) => v.symbolId.split('/')[0] === pkg)[0]
             .split('aws-prototyping-sdk.')[1];
           markdown = await backOff.backOff(async () =>
-            docs.toMarkdown({
+            await docs.toMarkdown({
               language: docgen.Language.fromString(language),
               submodule,
               readme: true,
@@ -94,7 +95,7 @@ async function main() {
         } else {
           const docs = await docgen.Documentation.forProject(`${RELATIVE_PKG_ROOT}/${pkg}`);
           markdown = await backOff.backOff(async () =>
-            docs.toMarkdown({
+            await docs.toMarkdown({
               language: docgen.Language.fromString(language),
               allSubmodules: true,
               readme: true,
@@ -107,7 +108,7 @@ async function main() {
           `${cwd}/build/docs/content/${language}/${pkg}/index.md`,
           includeBanner(getArtifact(language, pkgJsii), markdown.render(), stability),
         );
-      });
+      }
 
       fs.writeFileSync(
         `${cwd}/build/docs/content/${language}/.pages.yml`,
@@ -129,12 +130,12 @@ async function main() {
           .join('\n')}`,
       );
 
-  });
+  }
 }
 
 exports.main = main;
 
-(async () => main())().catch((e) => {
+(async () => await main())().catch((e) => {
   console.error(e);
   process.exit(1);
 });


### PR DESCRIPTION
This PR fails the build when any failures are detected in the markdown generator.

Additional fixes:
  - Perform synth on build/release workflows to ensure no mutable changes.
  - Cleanup old references to identity (this won't happen anymore with above fix).

Fixes #57