### PR TITLE
fix: fix bundling to support inter-dependencies

### DIFF
--- a/packages/aws-prototyping-sdk/.npmignore
+++ b/packages/aws-prototyping-sdk/.npmignore
@@ -22,3 +22,7 @@ tsconfig.tsbuildinfo
 /dist/version.txt
 !LICENSE_THIRD_PARTY
 /scripts/
+**/*.ts
+!**/*.d.ts
+!**/samples/**/*.ts
+!samples


### PR DESCRIPTION
This PR aims to solve the inter-dependency issue by accomplishing the following:

- Dynamically write peer, runtime and bundled deps into the `aws-prototyping-sdk` manifest.
- Rewrite imports to use relative paths instead of the `@aws-prototyping-sdk` scope.

Fixes #58 