### PR TITLE
fix(static-website): Route 403 errors to index.html

### DIFF
--- a/packages/static-website/src/static-website.ts
+++ b/packages/static-website/src/static-website.ts
@@ -172,6 +172,11 @@ export class StaticWebsite extends Construct {
             responseHttpStatus: 200,
             responsePagePath: `/${defaultRootObject}`,
           },
+          {
+            httpStatus: 403, // We need to redirect "access denied" to index.html for single page apps
+            responseHttpStatus: 200,
+            responsePagePath: `/${defaultRootObject}`,
+          },
         ],
       }
     );


### PR DESCRIPTION
Fixes #69

This is just a proposal, and I haven't tested it, because I've only used the Python CDK constructs, and I don't have time to set up a development environment. I'm also aware that there may be other resolutions, e.g. changing the configuration to avoid `AccessDenied` errors in the first place.