### PR TITLE
fix(open-api-gateway): remove lib dir in precompile to ensure spec always updated

### DIFF
--- a/packages/open-api-gateway/src/project/open-api-gateway-ts-project.ts
+++ b/packages/open-api-gateway/src/project/open-api-gateway-ts-project.ts
@@ -131,6 +131,9 @@ export class OpenApiGatewayTsProject extends TypeScriptProject {
     });
     spec.synth();
 
+    // Delete the lib directory prior to compilation to ensure latest parsed spec json file is copied
+    this.preCompileTask.exec(`rm -rf ${this.libdir}`);
+
     // Parent the generated code with this project's parent for better integration with monorepos
     this.hasParent = !!options.parent;
     const generatedCodeDirRelativeToParent = this.hasParent

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/custom-directories.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/custom-directories.test.ts.snap
@@ -870,6 +870,11 @@ tsconfig.tsbuildinfo
       "pre-compile": Object {
         "description": "Prepare the project for compilation",
         "name": "pre-compile",
+        "steps": Array [
+          Object {
+            "exec": "rm -rf lib",
+          },
+        ],
       },
       "release:mainline": Object {
         "description": "Prepare a release from \\"mainline\\" branch",

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
@@ -1355,6 +1355,11 @@ tsconfig.tsbuildinfo
       "pre-compile": Object {
         "description": "Prepare the project for compilation",
         "name": "pre-compile",
+        "steps": Array [
+          Object {
+            "exec": "rm -rf lib",
+          },
+        ],
       },
       "test": Object {
         "description": "Run tests",
@@ -16684,6 +16689,11 @@ tsconfig.tsbuildinfo
       "pre-compile": Object {
         "description": "Prepare the project for compilation",
         "name": "pre-compile",
+        "steps": Array [
+          Object {
+            "exec": "rm -rf lib",
+          },
+        ],
       },
       "test": Object {
         "description": "Run tests",
@@ -32029,6 +32039,11 @@ tsconfig.tsbuildinfo
       "pre-compile": Object {
         "description": "Prepare the project for compilation",
         "name": "pre-compile",
+        "steps": Array [
+          Object {
+            "exec": "rm -rf lib",
+          },
+        ],
       },
       "test": Object {
         "description": "Run tests",

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
@@ -873,6 +873,11 @@ tsconfig.tsbuildinfo
       "pre-compile": Object {
         "description": "Prepare the project for compilation",
         "name": "pre-compile",
+        "steps": Array [
+          Object {
+            "exec": "rm -rf lib",
+          },
+        ],
       },
       "release:mainline": Object {
         "description": "Prepare a release from \\"mainline\\" branch",
@@ -15675,6 +15680,11 @@ tsconfig.tsbuildinfo
       "pre-compile": Object {
         "description": "Prepare the project for compilation",
         "name": "pre-compile",
+        "steps": Array [
+          Object {
+            "exec": "rm -rf lib",
+          },
+        ],
       },
       "release:mainline": Object {
         "description": "Prepare a release from \\"mainline\\" branch",
@@ -30470,6 +30480,11 @@ tsconfig.tsbuildinfo
       "pre-compile": Object {
         "description": "Prepare the project for compilation",
         "name": "pre-compile",
+        "steps": Array [
+          Object {
+            "exec": "rm -rf lib",
+          },
+        ],
       },
       "release:mainline": Object {
         "description": "Prepare a release from \\"mainline\\" branch",

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/with-docs.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/with-docs.test.ts.snap
@@ -870,6 +870,11 @@ tsconfig.tsbuildinfo
       "pre-compile": Object {
         "description": "Prepare the project for compilation",
         "name": "pre-compile",
+        "steps": Array [
+          Object {
+            "exec": "rm -rf lib",
+          },
+        ],
       },
       "release:mainline": Object {
         "description": "Prepare a release from \\"mainline\\" branch",

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/without-sample-code.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/without-sample-code.test.ts.snap
@@ -870,6 +870,11 @@ tsconfig.tsbuildinfo
       "pre-compile": Object {
         "description": "Prepare the project for compilation",
         "name": "pre-compile",
+        "steps": Array [
+          Object {
+            "exec": "rm -rf lib",
+          },
+        ],
       },
       "release:mainline": Object {
         "description": "Prepare a release from \\"mainline\\" branch",


### PR DESCRIPTION
The parsed spec file was sometimes not being copied as part of build - it seems that
`tsc` doesn't always copy the file over if it's already there. Remove the lib as a
pre-compile step to force a fresh copy.
