### PR TITLE
fix: improve security posture of OpenAPI construct

### DIFF
--- a/packages/open-api-gateway/.projen/deps.json
+++ b/packages/open-api-gateway/.projen/deps.json
@@ -6,6 +6,11 @@
       "type": "build"
     },
     {
+      "name": "@aws-prototyping-sdk/pdk-nag",
+      "version": "0.0.0",
+      "type": "build"
+    },
+    {
       "name": "@types/jest",
       "version": "^27",
       "type": "build"
@@ -27,6 +32,10 @@
     },
     {
       "name": "aws-cdk-lib",
+      "type": "build"
+    },
+    {
+      "name": "cdk-nag",
       "type": "build"
     },
     {
@@ -123,6 +132,10 @@
     },
     {
       "name": "aws-cdk-lib",
+      "type": "peer"
+    },
+    {
+      "name": "cdk-nag",
       "type": "peer"
     },
     {

--- a/packages/open-api-gateway/package.json
+++ b/packages/open-api-gateway/package.json
@@ -35,11 +35,13 @@
   },
   "devDependencies": {
     "@aws-prototyping-sdk/nx-monorepo": "0.0.0",
+    "@aws-prototyping-sdk/pdk-nag": "0.0.0",
     "@types/jest": "^27",
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
     "aws-cdk-lib": "^2.29.1",
+    "cdk-nag": "2.15.10",
     "constructs": "^10.1.42",
     "eslint": "^8",
     "eslint-config-prettier": "^8.5.0",
@@ -63,6 +65,7 @@
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.29.1",
+    "cdk-nag": "^2.15.10",
     "constructs": "^10.1.42",
     "projen": "^0.58.21"
   },

--- a/packages/open-api-gateway/src/construct/open-api-gateway-lambda-api.ts
+++ b/packages/open-api-gateway/src/construct/open-api-gateway-lambda-api.ts
@@ -62,7 +62,6 @@ export class OpenApiGatewayLambdaApi extends SpecRestApi {
       apiDefinition: ApiDefinition.fromInline(
         prepareApiSpec(scope, spec, props)
       ),
-      cloudWatchRole: false,
       deployOptions: {
         accessLogDestination: new LogGroupLogDestination(
           new LogGroup(scope, `AccessLogs`)
@@ -86,6 +85,21 @@ export class OpenApiGatewayLambdaApi extends SpecRestApi {
         }),
       });
     });
+
+    NagSuppressions.addResourceSuppressions(
+      this,
+      [
+        {
+          id: "AwsSolutions-IAM4",
+          reason:
+            "Cloudwatch Role requires access to create/read groups at the root level.",
+          appliesTo: [
+            "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+          ],
+        },
+      ],
+      true
+    );
 
     NagSuppressions.addResourceSuppressions(
       this,

--- a/packages/open-api-gateway/test/construct/__snapshots__/open-api-gateway-lambda-api.test.ts.snap
+++ b/packages/open-api-gateway/test/construct/__snapshots__/open-api-gateway-lambda-api.test.ts.snap
@@ -51,6 +51,13 @@ Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
@@ -143,10 +150,96 @@ Object {
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
-    "ApiTestDeployment59A5FA035e4d0429daf818a8f1f242387168d181": Object {
+    "ApiTestAccount2AC853EB": Object {
+      "DependsOn": Array [
+        "ApiTest0B514494",
+      ],
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "ApiTestCloudWatchRole49F4F360",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+    },
+    "ApiTestCloudWatchRole49F4F360": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiTestDeployment59A5FA033b69bb37ea13c87d7b1c564e1d5f5687": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
             Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
@@ -167,6 +260,13 @@ Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
@@ -184,7 +284,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment59A5FA035e4d0429daf818a8f1f242387168d181",
+          "Ref": "ApiTestDeployment59A5FA033b69bb37ea13c87d7b1c564e1d5f5687",
         },
         "MethodSettings": Array [
           Object {
@@ -205,6 +305,13 @@ Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
             Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
@@ -400,6 +507,13 @@ Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
@@ -512,10 +626,96 @@ Object {
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
-    "ApiTestDeployment59A5FA03cbbb66398383b93bd8d3d8b71f417300": Object {
+    "ApiTestAccount2AC853EB": Object {
+      "DependsOn": Array [
+        "ApiTest0B514494",
+      ],
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "ApiTestCloudWatchRole49F4F360",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+    },
+    "ApiTestCloudWatchRole49F4F360": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiTestDeployment59A5FA03f652d8ddd2cdc27f2f5d74c2aa2f90c5": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
             Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
@@ -536,6 +736,13 @@ Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
@@ -553,7 +760,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment59A5FA03cbbb66398383b93bd8d3d8b71f417300",
+          "Ref": "ApiTestDeployment59A5FA03f652d8ddd2cdc27f2f5d74c2aa2f90c5",
         },
         "MethodSettings": Array [
           Object {
@@ -574,6 +781,13 @@ Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
             Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
@@ -780,6 +994,13 @@ Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
@@ -909,10 +1130,96 @@ Object {
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
-    "ApiTestDeployment59A5FA038b545fcb89075e1733a017f76f730033": Object {
+    "ApiTestAccount2AC853EB": Object {
+      "DependsOn": Array [
+        "ApiTest0B514494",
+      ],
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "ApiTestCloudWatchRole49F4F360",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+    },
+    "ApiTestCloudWatchRole49F4F360": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiTestDeployment59A5FA034e5e8ba2e7580ec9b380fd96608926e3": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
             Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
@@ -933,6 +1240,13 @@ Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
@@ -950,7 +1264,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment59A5FA038b545fcb89075e1733a017f76f730033",
+          "Ref": "ApiTestDeployment59A5FA034e5e8ba2e7580ec9b380fd96608926e3",
         },
         "MethodSettings": Array [
           Object {
@@ -971,6 +1285,13 @@ Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
             Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
@@ -1018,6 +1339,13 @@ Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
             Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
@@ -1243,6 +1571,13 @@ Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
@@ -1402,10 +1737,96 @@ Object {
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
-    "ApiTestDeployment59A5FA03575dd9289b43f637d78ff5bb0a2d1e0a": Object {
+    "ApiTestAccount2AC853EB": Object {
+      "DependsOn": Array [
+        "ApiTest0B514494",
+      ],
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "ApiTestCloudWatchRole49F4F360",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+    },
+    "ApiTestCloudWatchRole49F4F360": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiTestDeployment59A5FA035c70b9cd1bc0a164afe24eca0e86792e": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
             Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
@@ -1426,6 +1847,13 @@ Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
@@ -1443,7 +1871,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment59A5FA03575dd9289b43f637d78ff5bb0a2d1e0a",
+          "Ref": "ApiTestDeployment59A5FA035c70b9cd1bc0a164afe24eca0e86792e",
         },
         "MethodSettings": Array [
           Object {
@@ -1464,6 +1892,13 @@ Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
             Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
@@ -1638,6 +2073,13 @@ Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
             Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
@@ -1949,10 +2391,96 @@ Object {
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
-    "ApiTestDeployment59A5FA0398c4a71b3e221b42acf36e22c1cac09b": Object {
+    "ApiTestAccount2AC853EB": Object {
+      "DependsOn": Array [
+        "ApiTest0B514494",
+      ],
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "ApiTestCloudWatchRole49F4F360",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+    },
+    "ApiTestCloudWatchRole49F4F360": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiTestDeployment59A5FA030aa2f590eb77bd1ed42b0881f1119f31": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
             Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
@@ -1973,6 +2501,13 @@ Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
@@ -1990,7 +2525,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment59A5FA0398c4a71b3e221b42acf36e22c1cac09b",
+          "Ref": "ApiTestDeployment59A5FA030aa2f590eb77bd1ed42b0881f1119f31",
         },
         "MethodSettings": Array [
           Object {
@@ -2011,6 +2546,13 @@ Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
             Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
@@ -2059,6 +2601,13 @@ Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
@@ -2105,6 +2654,13 @@ Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
             Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
@@ -2153,6 +2709,13 @@ Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
@@ -2199,6 +2762,13 @@ Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
             Object {
               "id": "AwsSolutions-APIG2",
               "reason": "This construct implements fine grained validation via OpenApi.",

--- a/packages/open-api-gateway/test/construct/__snapshots__/open-api-gateway-lambda-api.test.ts.snap
+++ b/packages/open-api-gateway/test/construct/__snapshots__/open-api-gateway-lambda-api.test.ts.snap
@@ -38,7 +38,25 @@ Object {
     },
   },
   "Resources": Object {
+    "AccessLogs8B620ECA": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "RetentionInDays": 731,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
     "ApiTest0B514494": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Body": Object {
           "components": Object {
@@ -125,52 +143,17 @@ Object {
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
-    "ApiTestAccount2AC853EB": Object {
-      "DependsOn": Array [
-        "ApiTest0B514494",
-      ],
-      "Properties": Object {
-        "CloudWatchRoleArn": Object {
-          "Fn::GetAtt": Array [
-            "ApiTestCloudWatchRole49F4F360",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::ApiGateway::Account",
-    },
-    "ApiTestCloudWatchRole49F4F360": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
+    "ApiTestDeployment59A5FA035e4d0429daf818a8f1f242387168d181": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
             Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "apigateway.amazonaws.com",
-              },
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
-          "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
-              ],
-            ],
-          },
-        ],
       },
-      "Type": "AWS::IAM::Role",
-    },
-    "ApiTestDeployment59A5FA03f7f5915dc2cd4b0c7d95c3a8ddc265c6": Object {
       "Properties": Object {
         "Description": "Automatically created by the RestApi construct",
         "RestApiId": Object {
@@ -180,10 +163,37 @@ Object {
       "Type": "AWS::ApiGateway::Deployment",
     },
     "ApiTestDeploymentStageprod77F35FA8": Object {
-      "Properties": Object {
-        "DeploymentId": Object {
-          "Ref": "ApiTestDeployment59A5FA03f7f5915dc2cd4b0c7d95c3a8ddc265c6",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
         },
+      },
+      "Properties": Object {
+        "AccessLogSetting": Object {
+          "DestinationArn": Object {
+            "Fn::GetAtt": Array [
+              "AccessLogs8B620ECA",
+              "Arn",
+            ],
+          },
+          "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
+        },
+        "DeploymentId": Object {
+          "Ref": "ApiTestDeployment59A5FA035e4d0429daf818a8f1f242387168d181",
+        },
+        "MethodSettings": Array [
+          Object {
+            "DataTraceEnabled": false,
+            "HttpMethod": "*",
+            "LoggingLevel": "INFO",
+            "ResourcePath": "/*",
+          },
+        ],
         "RestApiId": Object {
           "Ref": "ApiTest0B514494",
         },
@@ -192,6 +202,16 @@ Object {
       "Type": "AWS::ApiGateway::Stage",
     },
     "ApiTestLambdaPermissiontestOperationECAC1A2D": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -232,6 +252,16 @@ Object {
       "DependsOn": Array [
         "LambdaServiceRoleA8ED4D3B",
       ],
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM4",
+              "reason": "This is a test construct.",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Code": Object {
           "ZipFile": "code",
@@ -248,6 +278,16 @@ Object {
       "Type": "AWS::Lambda::Function",
     },
     "LambdaServiceRoleA8ED4D3B": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM4",
+              "reason": "This is a test construct.",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -347,7 +387,25 @@ Object {
     },
   },
   "Resources": Object {
+    "AccessLogs8B620ECA": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "RetentionInDays": 731,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
     "ApiTest0B514494": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Body": Object {
           "components": Object {
@@ -454,52 +512,17 @@ Object {
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
-    "ApiTestAccount2AC853EB": Object {
-      "DependsOn": Array [
-        "ApiTest0B514494",
-      ],
-      "Properties": Object {
-        "CloudWatchRoleArn": Object {
-          "Fn::GetAtt": Array [
-            "ApiTestCloudWatchRole49F4F360",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::ApiGateway::Account",
-    },
-    "ApiTestCloudWatchRole49F4F360": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
+    "ApiTestDeployment59A5FA03cbbb66398383b93bd8d3d8b71f417300": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
             Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "apigateway.amazonaws.com",
-              },
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
-          "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
-              ],
-            ],
-          },
-        ],
       },
-      "Type": "AWS::IAM::Role",
-    },
-    "ApiTestDeployment59A5FA03ac95339e646863af27b3305d012ba89a": Object {
       "Properties": Object {
         "Description": "Automatically created by the RestApi construct",
         "RestApiId": Object {
@@ -509,10 +532,37 @@ Object {
       "Type": "AWS::ApiGateway::Deployment",
     },
     "ApiTestDeploymentStageprod77F35FA8": Object {
-      "Properties": Object {
-        "DeploymentId": Object {
-          "Ref": "ApiTestDeployment59A5FA03ac95339e646863af27b3305d012ba89a",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
         },
+      },
+      "Properties": Object {
+        "AccessLogSetting": Object {
+          "DestinationArn": Object {
+            "Fn::GetAtt": Array [
+              "AccessLogs8B620ECA",
+              "Arn",
+            ],
+          },
+          "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
+        },
+        "DeploymentId": Object {
+          "Ref": "ApiTestDeployment59A5FA03cbbb66398383b93bd8d3d8b71f417300",
+        },
+        "MethodSettings": Array [
+          Object {
+            "DataTraceEnabled": false,
+            "HttpMethod": "*",
+            "LoggingLevel": "INFO",
+            "ResourcePath": "/*",
+          },
+        ],
         "RestApiId": Object {
           "Ref": "ApiTest0B514494",
         },
@@ -521,6 +571,16 @@ Object {
       "Type": "AWS::ApiGateway::Stage",
     },
     "ApiTestLambdaPermissiontestOperationECAC1A2D": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -707,7 +767,25 @@ Object {
     },
   },
   "Resources": Object {
+    "AccessLogs8B620ECA": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "RetentionInDays": 731,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
     "ApiTest0B514494": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Body": Object {
           "components": Object {
@@ -831,52 +909,17 @@ Object {
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
-    "ApiTestAccount2AC853EB": Object {
-      "DependsOn": Array [
-        "ApiTest0B514494",
-      ],
-      "Properties": Object {
-        "CloudWatchRoleArn": Object {
-          "Fn::GetAtt": Array [
-            "ApiTestCloudWatchRole49F4F360",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::ApiGateway::Account",
-    },
-    "ApiTestCloudWatchRole49F4F360": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
+    "ApiTestDeployment59A5FA038b545fcb89075e1733a017f76f730033": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
             Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "apigateway.amazonaws.com",
-              },
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
-          "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
-              ],
-            ],
-          },
-        ],
       },
-      "Type": "AWS::IAM::Role",
-    },
-    "ApiTestDeployment59A5FA03ded27202b212780ef7c4b9eb4b08b1e6": Object {
       "Properties": Object {
         "Description": "Automatically created by the RestApi construct",
         "RestApiId": Object {
@@ -886,10 +929,37 @@ Object {
       "Type": "AWS::ApiGateway::Deployment",
     },
     "ApiTestDeploymentStageprod77F35FA8": Object {
-      "Properties": Object {
-        "DeploymentId": Object {
-          "Ref": "ApiTestDeployment59A5FA03ded27202b212780ef7c4b9eb4b08b1e6",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
         },
+      },
+      "Properties": Object {
+        "AccessLogSetting": Object {
+          "DestinationArn": Object {
+            "Fn::GetAtt": Array [
+              "AccessLogs8B620ECA",
+              "Arn",
+            ],
+          },
+          "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
+        },
+        "DeploymentId": Object {
+          "Ref": "ApiTestDeployment59A5FA038b545fcb89075e1733a017f76f730033",
+        },
+        "MethodSettings": Array [
+          Object {
+            "DataTraceEnabled": false,
+            "HttpMethod": "*",
+            "LoggingLevel": "INFO",
+            "ResourcePath": "/*",
+          },
+        ],
         "RestApiId": Object {
           "Ref": "ApiTest0B514494",
         },
@@ -898,6 +968,16 @@ Object {
       "Type": "AWS::ApiGateway::Stage",
     },
     "ApiTestLambdaPermissionmyCustomAuthorizer2D3D850D": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -935,6 +1015,16 @@ Object {
       "Type": "AWS::Lambda::Permission",
     },
     "ApiTestLambdaPermissiontestOperationECAC1A2D": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -1140,7 +1230,25 @@ Object {
     },
   },
   "Resources": Object {
+    "AccessLogs8B620ECA": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "RetentionInDays": 731,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
     "ApiTest0B514494": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Body": Object {
           "components": Object {
@@ -1294,52 +1402,17 @@ Object {
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
-    "ApiTestAccount2AC853EB": Object {
-      "DependsOn": Array [
-        "ApiTest0B514494",
-      ],
-      "Properties": Object {
-        "CloudWatchRoleArn": Object {
-          "Fn::GetAtt": Array [
-            "ApiTestCloudWatchRole49F4F360",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::ApiGateway::Account",
-    },
-    "ApiTestCloudWatchRole49F4F360": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
+    "ApiTestDeployment59A5FA03575dd9289b43f637d78ff5bb0a2d1e0a": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
             Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "apigateway.amazonaws.com",
-              },
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
-          "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
-              ],
-            ],
-          },
-        ],
       },
-      "Type": "AWS::IAM::Role",
-    },
-    "ApiTestDeployment59A5FA034a40be2fb188aa60e2044804988f4bb3": Object {
       "Properties": Object {
         "Description": "Automatically created by the RestApi construct",
         "RestApiId": Object {
@@ -1349,10 +1422,37 @@ Object {
       "Type": "AWS::ApiGateway::Deployment",
     },
     "ApiTestDeploymentStageprod77F35FA8": Object {
-      "Properties": Object {
-        "DeploymentId": Object {
-          "Ref": "ApiTestDeployment59A5FA034a40be2fb188aa60e2044804988f4bb3",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
         },
+      },
+      "Properties": Object {
+        "AccessLogSetting": Object {
+          "DestinationArn": Object {
+            "Fn::GetAtt": Array [
+              "AccessLogs8B620ECA",
+              "Arn",
+            ],
+          },
+          "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
+        },
+        "DeploymentId": Object {
+          "Ref": "ApiTestDeployment59A5FA03575dd9289b43f637d78ff5bb0a2d1e0a",
+        },
+        "MethodSettings": Array [
+          Object {
+            "DataTraceEnabled": false,
+            "HttpMethod": "*",
+            "LoggingLevel": "INFO",
+            "ResourcePath": "/*",
+          },
+        ],
         "RestApiId": Object {
           "Ref": "ApiTest0B514494",
         },
@@ -1361,6 +1461,16 @@ Object {
       "Type": "AWS::ApiGateway::Stage",
     },
     "ApiTestLambdaPermissiontestOperationECAC1A2D": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -1516,7 +1626,25 @@ Object {
     },
   },
   "Resources": Object {
+    "AccessLogs8B620ECA": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "RetentionInDays": 731,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
     "ApiTest0B514494": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Body": Object {
           "components": Object {
@@ -1821,52 +1949,17 @@ Object {
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
-    "ApiTestAccount2AC853EB": Object {
-      "DependsOn": Array [
-        "ApiTest0B514494",
-      ],
-      "Properties": Object {
-        "CloudWatchRoleArn": Object {
-          "Fn::GetAtt": Array [
-            "ApiTestCloudWatchRole49F4F360",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::ApiGateway::Account",
-    },
-    "ApiTestCloudWatchRole49F4F360": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
+    "ApiTestDeployment59A5FA0398c4a71b3e221b42acf36e22c1cac09b": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
             Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "apigateway.amazonaws.com",
-              },
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
-          "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
-              ],
-            ],
-          },
-        ],
       },
-      "Type": "AWS::IAM::Role",
-    },
-    "ApiTestDeployment59A5FA03090657f00483089fb1f90799c5e8ca8c": Object {
       "Properties": Object {
         "Description": "Automatically created by the RestApi construct",
         "RestApiId": Object {
@@ -1876,10 +1969,37 @@ Object {
       "Type": "AWS::ApiGateway::Deployment",
     },
     "ApiTestDeploymentStageprod77F35FA8": Object {
-      "Properties": Object {
-        "DeploymentId": Object {
-          "Ref": "ApiTestDeployment59A5FA03090657f00483089fb1f90799c5e8ca8c",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
         },
+      },
+      "Properties": Object {
+        "AccessLogSetting": Object {
+          "DestinationArn": Object {
+            "Fn::GetAtt": Array [
+              "AccessLogs8B620ECA",
+              "Arn",
+            ],
+          },
+          "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
+        },
+        "DeploymentId": Object {
+          "Ref": "ApiTestDeployment59A5FA0398c4a71b3e221b42acf36e22c1cac09b",
+        },
+        "MethodSettings": Array [
+          Object {
+            "DataTraceEnabled": false,
+            "HttpMethod": "*",
+            "LoggingLevel": "INFO",
+            "ResourcePath": "/*",
+          },
+        ],
         "RestApiId": Object {
           "Ref": "ApiTest0B514494",
         },
@@ -1888,6 +2008,16 @@ Object {
       "Type": "AWS::ApiGateway::Stage",
     },
     "ApiTestLambdaPermissiondeleteOperationCF8B1751": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -1925,6 +2055,16 @@ Object {
       "Type": "AWS::Lambda::Permission",
     },
     "ApiTestLambdaPermissiongetOperationE32C7896": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -1962,6 +2102,16 @@ Object {
       "Type": "AWS::Lambda::Permission",
     },
     "ApiTestLambdaPermissionmyCustomAuthorizer2D3D850D": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -1999,6 +2149,16 @@ Object {
       "Type": "AWS::Lambda::Permission",
     },
     "ApiTestLambdaPermissionpostOperation5287C28F": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
@@ -2036,6 +2196,16 @@ Object {
       "Type": "AWS::Lambda::Permission",
     },
     "ApiTestLambdaPermissionputOperation80355FB2": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {

--- a/private/projects/open-api-gateway-project.ts
+++ b/private/projects/open-api-gateway-project.ts
@@ -36,10 +36,12 @@ export class OpenApiGatewayProject extends PDKProject {
         "projen",
         "aws-cdk-lib",
         "constructs",
+        "cdk-nag",
+        "@aws-prototyping-sdk/pdk-nag@0.0.0",
       ],
       deps: ["fs-extra"],
       bundledDeps: ["openapi-types", "fs-extra"],
-      peerDeps: ["projen", "aws-cdk-lib", "constructs"],
+      peerDeps: ["projen", "aws-cdk-lib", "constructs", "cdk-nag"],
       stability: Stability.EXPERIMENTAL,
       eslintOptions: {
         dirs: ["src", "scripts"],


### PR DESCRIPTION
- Enable access logging.
- Suppress validations as OpenAPI is already this.
- Disable cloudwatch role.