### PR TITLE
fix: ensure aspects run for Pipeline stages

### DIFF
--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -70,7 +70,7 @@
     "projen": "^0.58.29"
   },
   "dependencies": {
-    "@aws-prototyping-sdk/pdk-nag": "^0.3.9"
+    "@aws-prototyping-sdk/pdk-nag": "^0.3.11"
   },
   "keywords": [
     "aws",

--- a/packages/open-api-gateway/package.json
+++ b/packages/open-api-gateway/package.json
@@ -69,7 +69,7 @@
     "projen": "^0.58.29"
   },
   "dependencies": {
-    "@aws-prototyping-sdk/pdk-nag": "^0.3.9",
+    "@aws-prototyping-sdk/pdk-nag": "^0.3.11",
     "fs-extra": "^10.1.0",
     "openapi-types": "^12.0.0"
   },

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -68,7 +68,7 @@
     "projen": "^0.58.29"
   },
   "dependencies": {
-    "@aws-prototyping-sdk/pdk-nag": "^0.3.9"
+    "@aws-prototyping-sdk/pdk-nag": "^0.3.11"
   },
   "keywords": [
     "aws",

--- a/packages/pipeline/src/pdk-pipeline.ts
+++ b/packages/pipeline/src/pdk-pipeline.ts
@@ -15,7 +15,7 @@
  ******************************************************************************************************************** */
 
 import { PDKNag } from "@aws-prototyping-sdk/pdk-nag";
-import { CfnOutput, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { Aspects, CfnOutput, RemovalPolicy, Stack, Stage } from "aws-cdk-lib";
 import { Repository } from "aws-cdk-lib/aws-codecommit";
 import { Pipeline } from "aws-cdk-lib/aws-codepipeline";
 import {
@@ -24,11 +24,13 @@ import {
   BucketEncryption,
 } from "aws-cdk-lib/aws-s3";
 import {
+  AddStageOpts,
   CodePipeline,
   CodePipelineProps,
   CodePipelineSource,
   ShellStep,
   ShellStepProps,
+  StageDeployment,
 } from "aws-cdk-lib/pipelines";
 import { NagSuppressions } from "cdk-nag";
 import { Construct } from "constructs";
@@ -173,6 +175,17 @@ export class PDKPipeline extends CodePipeline {
       exportName: "CodeRepositoryGRCUrl",
       value: this.codeRepository.repositoryCloneUrlGrc,
     });
+  }
+
+  /**
+   * @inheritDoc
+   */
+  addStage(stage: Stage, options?: AddStageOpts): StageDeployment {
+    // Add any root Aspects to the stage level as currently this doesn't happen automatically
+    Aspects.of(stage.node.root).all.forEach((aspect) =>
+      Aspects.of(stage).add(aspect)
+    );
+    return super.addStage(stage, options);
   }
 
   buildPipeline() {

--- a/packages/pipeline/test/__snapshots__/pdk-pipeline.test.ts.snap
+++ b/packages/pipeline/test/__snapshots__/pdk-pipeline.test.ts.snap
@@ -1272,7 +1272,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-Stage/StageAppStack7618C9EF.assets.json\\\\\\" --verbose publish \\\\\\"ceacd5038123a988476c038703763f6784171a66b69d3ae26e5afc1240045a30:current_account-current_region\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-Stage/StageAppStack7618C9EF.assets.json\\\\\\" --verbose publish \\\\\\"53626188d0da022a93cea7ec04407154b29bc9b793007c8c712eae7e3e337161:current_account-current_region\\\\\\"\\"
       ]
     }
   }

--- a/packages/pipeline/test/pdk-pipeline.test.ts
+++ b/packages/pipeline/test/pdk-pipeline.test.ts
@@ -18,6 +18,7 @@ import * as path from "path";
 import { PDKNag } from "@aws-prototyping-sdk/pdk-nag";
 import { Stack, Stage } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
+import { Bucket } from "aws-cdk-lib/aws-s3";
 import { Asset } from "aws-cdk-lib/aws-s3-assets";
 import { PDKPipeline } from "../src";
 
@@ -48,5 +49,35 @@ describe("PDK Pipeline Unit Tests", () => {
     pipeline.buildPipeline();
 
     expect(Template.fromStack(stack)).toMatchSnapshot();
+  });
+
+  it("StageNagRuns", () => {
+    const app = PDKNag.app({ failOnError: false });
+    const stack = new Stack(app);
+
+    const pipeline = new PDKPipeline(stack, "StageNagRuns", {
+      primarySynthDirectory: "cdk.out",
+      repositoryName: "StageNagRuns",
+      synth: {},
+      sonarCodeScannerConfig: {
+        sonarqubeAuthorizedGroup: "dev",
+        sonarqubeDefaultProfileOrGateName: "dev",
+        sonarqubeEndpoint: "https://sonar.dev",
+        sonarqubeProjectName: "Default",
+      },
+    });
+
+    const stage = new Stage(app, "Stage");
+    const appStack = new Stack(stage, "AppStack");
+    new Bucket(appStack, "Non-Compliant");
+
+    pipeline.addStage(stage);
+    pipeline.buildPipeline();
+
+    app.synth();
+
+    expect(app.nagResults()[0].resource).toEqual(
+      "Stage/AppStack/Non-Compliant/Resource"
+    );
   });
 });

--- a/packages/static-website/package.json
+++ b/packages/static-website/package.json
@@ -69,7 +69,7 @@
     "projen": "^0.58.29"
   },
   "dependencies": {
-    "@aws-prototyping-sdk/pdk-nag": "^0.3.9"
+    "@aws-prototyping-sdk/pdk-nag": "^0.3.11"
   },
   "keywords": [
     "aws",

--- a/yarn.lock
+++ b/yarn.lock
@@ -353,10 +353,10 @@
     "@aws-sdk/util-utf8-browser" "^3.0.0"
     tslib "^1.11.1"
 
-"@aws-prototyping-sdk/pdk-nag@^0.3.9":
-  version "0.3.9"
-  resolved "https://registry.yarnpkg.com/@aws-prototyping-sdk/pdk-nag/-/pdk-nag-0.3.9.tgz#2284fb2e26b4a2062b53f73c9e727572eea1e3c6"
-  integrity sha512-aJir0Rs0DnoUbxEuYWQcwWInXDqdIJiQx0B63c6ca0SHpnukImHAjaRt/4S0aH0Aj7NvF3OvntbBMYf2YPEn7g==
+"@aws-prototyping-sdk/pdk-nag@^0.3.11":
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/@aws-prototyping-sdk/pdk-nag/-/pdk-nag-0.3.11.tgz#224ba23623397d7a8f9e1c64f0e8421a87848be6"
+  integrity sha512-MyKQHOvYTWAMC4Vm2N8gTW1eGLyy6jWuh4rsxpCmXGt4ZnUezxnhDsc/8xui3aMT/+F7zZsybyt++TVUfvzdxQ==
 
 "@aws-sdk/abort-controller@3.47.2":
   version "3.47.2"


### PR DESCRIPTION
This PR fixes the below CDK issues by propagating all Aspects applied at the root level (App) to stages when they are added to the pipeline.

https://github.com/aws/aws-cdk/issues/20468
https://github.com/aws/aws-cdk/issues/17805