### PR TITLE
fix: add ipset resource to wafv2 perms policy

### DIFF
--- a/packages/static-website/src/cloudfront-web-acl.ts
+++ b/packages/static-website/src/cloudfront-web-acl.ts
@@ -156,6 +156,7 @@ export class CloudfrontWebAcl extends Construct {
                 "wafv2:GetWebACL",
               ],
               resources: [
+                `arn:aws:wafv2:us-east-1:${stack.account}:global/ipset/${aclName}-IPSet/*`,
                 `arn:aws:wafv2:us-east-1:${stack.account}:global/webacl/${aclName}/*`,
                 `arn:aws:wafv2:us-east-1:${stack.account}:global/managedruleset/*/*`,
               ],

--- a/packages/static-website/test/__snapshots__/static-website.test.ts.snap
+++ b/packages/static-website/test/__snapshots__/static-website.test.ts.snap
@@ -832,6 +832,22 @@ Object {
                           Object {
                             "Ref": "AWS::AccountId",
                           },
+                          ":global/ipset/",
+                          Object {
+                            "Ref": "AWS::StackName",
+                          },
+                          "-WebsiteAcl-IPSet/*",
+                        ],
+                      ],
+                    },
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "arn:aws:wafv2:us-east-1:",
+                          Object {
+                            "Ref": "AWS::AccountId",
+                          },
                           ":global/webacl/",
                           Object {
                             "Ref": "AWS::StackName",
@@ -1921,6 +1937,18 @@ Object {
                   ],
                   "Effect": "Allow",
                   "Resource": Array [
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "arn:aws:wafv2:us-east-1:",
+                          Object {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":global/ipset/Default-WebsiteAcl-IPSet/*",
+                        ],
+                      ],
+                    },
                     Object {
                       "Fn::Join": Array [
                         "",


### PR DESCRIPTION
`[FAILED] from custom resource. Message returned: User: arn:aws:sts::<redacted>:assumed-role/<redacted> is not authorized to perform: wafv2:CreateWebACL on resource: arn:aws:wafv2:us-east-1:<redacted>:global/ipset/<redacted>/<redacted> because no identity-based policy allows the wafv2:CreateWebACL action `