### PR TITLE
fix: revert #69 as this can expose application specific details

### DIFF
--- a/packages/static-website/src/static-website.ts
+++ b/packages/static-website/src/static-website.ts
@@ -197,11 +197,6 @@ export class StaticWebsite extends Construct {
             responseHttpStatus: 200,
             responsePagePath: `/${defaultRootObject}`,
           },
-          {
-            httpStatus: 403, // We need to redirect "access denied" to index.html for single page apps
-            responseHttpStatus: 200,
-            responsePagePath: `/${defaultRootObject}`,
-          },
         ],
         ...distributionProps,
       }

--- a/packages/static-website/test/__snapshots__/static-website.test.ts.snap
+++ b/packages/static-website/test/__snapshots__/static-website.test.ts.snap
@@ -273,11 +273,6 @@ Object {
               "ResponseCode": 200,
               "ResponsePagePath": "/index.html",
             },
-            Object {
-              "ErrorCode": 403,
-              "ResponseCode": 200,
-              "ResponsePagePath": "/index.html",
-            },
           ],
           "DefaultCacheBehavior": Object {
             "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
@@ -1393,11 +1388,6 @@ Object {
           "CustomErrorResponses": Array [
             Object {
               "ErrorCode": 404,
-              "ResponseCode": 200,
-              "ResponsePagePath": "/index.html",
-            },
-            Object {
-              "ErrorCode": 403,
               "ResponseCode": 200,
               "ResponsePagePath": "/index.html",
             },


### PR DESCRIPTION
BREAKING CHANGE: Removing default error page for 403 as it can lead to the accidental leakage of information from the index.html page which otherwise would be blocked by WAF.

Fixes #69 