### PR TITLE
feat(open-api-gateway): support for chained request/response interceptors in typescript

### DIFF
--- a/packages/open-api-gateway/README.md
+++ b/packages/open-api-gateway/README.md
@@ -1,6 +1,6 @@
 ## OpenAPI Gateway
 
-Define your APIs using [OpenAPI v3](https://swagger.io/specification/), and leverage the power of generated clients, automatic input validation, and type safe client and server code!
+Define your APIs using [OpenAPI v3](https://swagger.io/specification/), and leverage the power of generated clients and documentation, automatic input validation, and type safe client and server code!
 
 This package vends a projen project type which allows you to define an API using [OpenAPI v3](https://swagger.io/specification/), and a construct which manages deploying this API in API Gateway, given a lambda integration for every operation.
 
@@ -19,7 +19,7 @@ For usage in a monorepo:
 Create the project in your .projenrc:
 
 ```ts
-import {ClientLanguage, OpenApiGatewayTsProject} from "@aws-prototyping-sdk/open-api-gateway";
+import { ClientLanguage, DocumentationFormat, OpenApiGatewayTsProject } from "@aws-prototyping-sdk/open-api-gateway";
 
 new OpenApiGatewayTsProject({
   parent: myNxMonorepo,
@@ -27,6 +27,7 @@ new OpenApiGatewayTsProject({
   name: "my-api",
   outdir: "packages/api",
   clientLanguages: [ClientLanguage.TYPESCRIPT, ClientLanguage.PYTHON, ClientLanguage.JAVA],
+  documentationFormats: [DocumentationFormat.HTML2, DocumentationFormat.PLANTUML, DocumentationFormat.MARKDOWN],
 });
 ```
 
@@ -48,6 +49,10 @@ In the output directory (`outdir`), you'll find a few files to get you started.
     |_ typescript/ - A generated typescript API client, including generated lambda handler wrappers
     |_ python/ - A generated python API client.
     |_ java/ - A generated java API client.
+    |_ documentation/
+        |_ html2/ - Generated html documentation
+        |_ markdown/ - Generated markdown documentation
+        |_ plantuml/ - Generated plant uml documentation
 ```
 
 If you would prefer to not generate the sample code, you can pass `sampleCode: false` to `OpenApiGatewayTsProject`.
@@ -431,6 +436,66 @@ def handler(input: SayHelloRequest, **kwargs) -> ApiResponse[HelloResponse, ApiE
         body=HelloResponse(message="Hello {}!".format(input.request_parameters["name"])),
         headers={}
     )
+```
+
+### Interceptors
+
+The lambda handler wrappers allow you to pass in a _chain_ of handler functions to handle the request. This allows you to implement middleware / interceptors for handling requests. Each handler function may choose whether or not to continue the handler chain by invoking `chain.next(input, event, context)`. Note that the last handler in the chain (ie the actual request handler which transforms the input to the output) should not call `chain.next`.
+
+#### Typescript
+
+In typescript, interceptors are passed as separate arguments to the generated handler wrapper, in the order in which they should be executed.
+
+```ts
+import { sayHelloHandler, ApiError } from "my-api-typescript-client";
+
+// Interceptor to wrap invocations in a try/catch, returning a 500 error for any unhandled exceptions.
+const tryCatchInterceptor = async (input, event, context, chain) => {
+  try {
+    return await chain.next(input, event, context);
+  } catch (e) {
+    return { statusCode: 500, body: { errorMessage: e.message }};
+  }
+};
+
+// tryCatchInterceptor is passed first, so it runs first and calls the second argument function (the request handler) via chain.next
+export const handler = sayHelloHandler<ApiError>(tryCatchInterceptor, async (input) => {
+  return {
+    statusCode: 200,
+    body: {
+      message: `Hello ${input.requestParameters.name}!`,
+    },
+  };
+});
+```
+
+Another example interceptor might be to record request time metrics. The example below includes the full generic type signature for an interceptor:
+
+```ts
+import {
+  LambdaRequestParameters,
+  LambdaHandlerChain,
+  OperationResponse,
+} from 'my-api-typescript-client';
+
+const timingInterceptor = async <
+  RequestParameters,
+  RequestArrayParameters,
+  RequestBody,
+  RequestOutput,
+  TError
+>(
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, TError>,
+): Promise<OperationResponse<RequestOutput, TError>> => {
+  const start = Date.now();
+  const response = await chain.next(input, event, context);
+  const end = Date.now();
+  console.log(`Took ${end - start}ms`);
+  return response;
+};
 ```
 
 ### Other Details

--- a/packages/open-api-gateway/README.md
+++ b/packages/open-api-gateway/README.md
@@ -447,10 +447,27 @@ The lambda handler wrappers allow you to pass in a _chain_ of handler functions 
 In typescript, interceptors are passed as separate arguments to the generated handler wrapper, in the order in which they should be executed.
 
 ```ts
-import { sayHelloHandler, ApiError } from "my-api-typescript-client";
+import {
+  sayHelloHandler,
+  ApiError,
+  LambdaRequestParameters,
+  LambdaHandlerChain,
+  OperationResponse
+} from "my-api-typescript-client";
 
 // Interceptor to wrap invocations in a try/catch, returning a 500 error for any unhandled exceptions.
-const tryCatchInterceptor = async (input, event, context, chain) => {
+const tryCatchInterceptor = async <
+  RequestParameters,
+  RequestArrayParameters,
+  RequestBody,
+  RequestOutput,
+  TError
+>(
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, TError>,
+): Promise<OperationResponse<RequestOutput, TError>> => {
   try {
     return await chain.next(input, event, context);
   } catch (e) {

--- a/packages/open-api-gateway/scripts/generators/typescript/templates/operationConfig.mustache
+++ b/packages/open-api-gateway/scripts/generators/typescript/templates/operationConfig.mustache
@@ -3,10 +3,8 @@
 import {
     {{#imports}}
     {{className}},
-    {{^withoutRuntimeChecks}}
     {{className}}FromJSON,
     {{className}}ToJSON,
-    {{/withoutRuntimeChecks}}
     {{/imports}}
 } from '../../models';
 {{/imports.0}}
@@ -63,7 +61,7 @@ const decodeRequestParameters = (parameters: ApiGatewayRequestParameters): ApiGa
 /**
  * Parse the body if the content type is json, otherwise leave as a raw string
  */
-const parseBody = (body: string, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? JSON.parse(body || '{}') : body;
+const parseBody = (body: string, demarshal: (body: string) => any, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? demarshal(body || '{}') : body;
 
 // Api gateway lambda handler type
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
@@ -174,7 +172,14 @@ export const {{nickname}}Handler = <ApiError>(firstHandler: {{operationIdCamelCa
         ...(event.multiValueQueryStringParameters || {}),
     }) as unknown as {{operationIdCamelCase}}RequestArrayParameters;
 
-    const body = parseBody(event.body, [{{^consumes}}'application/json'{{/consumes}}{{#consumes}}{{#mediaType}}'{{{.}}}',{{/mediaType}}{{/consumes}}]) as {{operationIdCamelCase}}RequestBody;
+    const demarshal = (bodyString: string): any => {
+        let parsed = JSON.parse(bodyString);
+        {{#bodyParam}}
+        parsed = {{dataType}}FromJSON(parsed);
+        {{/bodyParam}}
+        return parsed;
+    };
+    const body = parseBody(event.body, demarshal, [{{^consumes}}'application/json'{{/consumes}}{{#consumes}}{{#mediaType}}'{{{.}}}',{{/mediaType}}{{/consumes}}]) as {{operationIdCamelCase}}RequestBody;
 
     const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
     const response = await chain.next({
@@ -183,9 +188,24 @@ export const {{nickname}}Handler = <ApiError>(firstHandler: {{operationIdCamelCa
         body,
     }, event, context);
 
+    const marshal = (responseBody: any): string => {
+        let response = responseBody;
+        switch(response.statusCode) {
+        {{#responses}}
+            case {{code}}:
+                response = {{dataType}}ToJSON(response);
+                break;
+        {{/responses}}
+            default:
+                break;
+        }
+
+        return JSON.stringify(response);
+    };
+
     return {
         ...response,
-        body: response.body ? JSON.stringify(response.body) : '',
+        body: response.body ? marshal(response.body) : '',
     };
 };
 {{/operation}}

--- a/packages/open-api-gateway/scripts/generators/typescript/templates/operationConfig.mustache
+++ b/packages/open-api-gateway/scripts/generators/typescript/templates/operationConfig.mustache
@@ -82,12 +82,45 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
     body: RequestBody,
 };
 
+/**
+ * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
+ */
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
+) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
 // Type for a lambda handler function to be wrapped
 export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
-    input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
-    event: any,
-    context: any,
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
 ) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+}
+
+/**
+ * Build a chain from the given array of chained lambda handlers
+ */
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+  if (handlers.length === 0) {
+    return {
+      next: () => {
+        throw new Error("No more handlers remain in the chain! The last handler should not call next.");
+      }
+    };
+  }
+  const [currentHandler, ...remainingHandlers] = handlers;
+  return {
+    next: (input, event, context) => {
+      return currentHandler(input, event, context, buildHandlerChain(...remainingHandlers));
+    },
+  };
+};
 
 {{#operations}}
 {{#operation}}
@@ -126,12 +159,12 @@ export interface {{operationIdCamelCase}}RequestArrayParameters {
 export type {{operationIdCamelCase}}RequestBody = {{#bodyParam}}{{dataType}}{{/bodyParam}}{{^bodyParam}}never{{/bodyParam}};
 
 // Type that the handler function provided to the wrapper must conform to
-type {{operationIdCamelCase}}HandlerFunction<ApiError> = LambdaHandlerFunction<{{operationIdCamelCase}}RequestParameters, {{operationIdCamelCase}}RequestArrayParameters, {{operationIdCamelCase}}RequestBody, {{returnType}}, ApiError>;
+export type {{operationIdCamelCase}}HandlerFunction<ApiError> = ChainedLambdaHandlerFunction<{{operationIdCamelCase}}RequestParameters, {{operationIdCamelCase}}RequestArrayParameters, {{operationIdCamelCase}}RequestBody, {{returnType}}, ApiError>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of {{nickname}}
  */
-export const {{nickname}}Handler = <ApiError>(handler: {{operationIdCamelCase}}HandlerFunction<ApiError>): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const {{nickname}}Handler = <ApiError>(firstHandler: {{operationIdCamelCase}}HandlerFunction<ApiError>, ...remainingHandlers: {{operationIdCamelCase}}HandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -143,7 +176,8 @@ export const {{nickname}}Handler = <ApiError>(handler: {{operationIdCamelCase}}H
 
     const body = parseBody(event.body, [{{^consumes}}'application/json'{{/consumes}}{{#consumes}}{{#mediaType}}'{{{.}}}',{{/mediaType}}{{/consumes}}]) as {{operationIdCamelCase}}RequestBody;
 
-    const response = await handler({
+    const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
+    const response = await chain.next({
         requestParameters,
         requestArrayParameters,
         body,

--- a/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-typescript-client-source-code.test.ts.snap
+++ b/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-typescript-client-source-code.test.ts.snap
@@ -1346,7 +1346,7 @@ const decodeRequestParameters = (parameters: ApiGatewayRequestParameters): ApiGa
 /**
  * Parse the body if the content type is json, otherwise leave as a raw string
  */
-const parseBody = (body: string, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? JSON.parse(body || '{}') : body;
+const parseBody = (body: string, demarshal: (body: string) => any, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? demarshal(body || '{}') : body;
 
 // Api gateway lambda handler type
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
@@ -1442,7 +1442,12 @@ export const someTestOperationHandler = <ApiError>(firstHandler: SomeTestOperati
         ...(event.multiValueQueryStringParameters || {}),
     }) as unknown as SomeTestOperationRequestArrayParameters;
 
-    const body = parseBody(event.body, ['application/json',]) as SomeTestOperationRequestBody;
+    const demarshal = (bodyString: string): any => {
+        let parsed = JSON.parse(bodyString);
+        parsed = TestRequestFromJSON(parsed);
+        return parsed;
+    };
+    const body = parseBody(event.body, demarshal, ['application/json',]) as SomeTestOperationRequestBody;
 
     const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
     const response = await chain.next({
@@ -1451,9 +1456,25 @@ export const someTestOperationHandler = <ApiError>(firstHandler: SomeTestOperati
         body,
     }, event, context);
 
+    const marshal = (responseBody: any): string => {
+        let response = responseBody;
+        switch(response.statusCode) {
+            case 200:
+                response = TestResponseToJSON(response);
+                break;
+            case 400:
+                response = ApiErrorToJSON(response);
+                break;
+            default:
+                break;
+        }
+
+        return JSON.stringify(response);
+    };
+
     return {
         ...response,
-        body: response.body ? JSON.stringify(response.body) : '',
+        body: response.body ? marshal(response.body) : '',
     };
 };
 ",
@@ -3561,7 +3582,7 @@ const decodeRequestParameters = (parameters: ApiGatewayRequestParameters): ApiGa
 /**
  * Parse the body if the content type is json, otherwise leave as a raw string
  */
-const parseBody = (body: string, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? JSON.parse(body || '{}') : body;
+const parseBody = (body: string, demarshal: (body: string) => any, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? demarshal(body || '{}') : body;
 
 // Api gateway lambda handler type
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
@@ -3660,7 +3681,12 @@ export const operationOneHandler = <ApiError>(firstHandler: OperationOneHandlerF
         ...(event.multiValueQueryStringParameters || {}),
     }) as unknown as OperationOneRequestArrayParameters;
 
-    const body = parseBody(event.body, ['application/json',]) as OperationOneRequestBody;
+    const demarshal = (bodyString: string): any => {
+        let parsed = JSON.parse(bodyString);
+        parsed = TestRequestFromJSON(parsed);
+        return parsed;
+    };
+    const body = parseBody(event.body, demarshal, ['application/json',]) as OperationOneRequestBody;
 
     const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
     const response = await chain.next({
@@ -3669,9 +3695,25 @@ export const operationOneHandler = <ApiError>(firstHandler: OperationOneHandlerF
         body,
     }, event, context);
 
+    const marshal = (responseBody: any): string => {
+        let response = responseBody;
+        switch(response.statusCode) {
+            case 200:
+                response = TestResponseToJSON(response);
+                break;
+            case 400:
+                response = ApiErrorToJSON(response);
+                break;
+            default:
+                break;
+        }
+
+        return JSON.stringify(response);
+    };
+
     return {
         ...response,
-        body: response.body ? JSON.stringify(response.body) : '',
+        body: response.body ? marshal(response.body) : '',
     };
 };
 // Type alias for the request
@@ -3710,7 +3752,11 @@ export const withoutOperationIdDeleteHandler = <ApiError>(firstHandler: WithoutO
         ...(event.multiValueQueryStringParameters || {}),
     }) as unknown as WithoutOperationIdDeleteRequestArrayParameters;
 
-    const body = parseBody(event.body, ['application/json']) as WithoutOperationIdDeleteRequestBody;
+    const demarshal = (bodyString: string): any => {
+        let parsed = JSON.parse(bodyString);
+        return parsed;
+    };
+    const body = parseBody(event.body, demarshal, ['application/json']) as WithoutOperationIdDeleteRequestBody;
 
     const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
     const response = await chain.next({
@@ -3719,9 +3765,22 @@ export const withoutOperationIdDeleteHandler = <ApiError>(firstHandler: WithoutO
         body,
     }, event, context);
 
+    const marshal = (responseBody: any): string => {
+        let response = responseBody;
+        switch(response.statusCode) {
+            case 200:
+                response = TestResponseToJSON(response);
+                break;
+            default:
+                break;
+        }
+
+        return JSON.stringify(response);
+    };
+
     return {
         ...response,
-        body: response.body ? JSON.stringify(response.body) : '',
+        body: response.body ? marshal(response.body) : '',
     };
 };
 ",

--- a/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-typescript-client-source-code.test.ts.snap
+++ b/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-typescript-client-source-code.test.ts.snap
@@ -1365,12 +1365,45 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
     body: RequestBody,
 };
 
+/**
+ * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
+ */
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
+) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
 // Type for a lambda handler function to be wrapped
 export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
-    input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
-    event: any,
-    context: any,
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
 ) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+}
+
+/**
+ * Build a chain from the given array of chained lambda handlers
+ */
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+  if (handlers.length === 0) {
+    return {
+      next: () => {
+        throw new Error(\\"No more handlers remain in the chain! The last handler should not call next.\\");
+      }
+    };
+  }
+  const [currentHandler, ...remainingHandlers] = handlers;
+  return {
+    next: (input, event, context) => {
+      return currentHandler(input, event, context, buildHandlerChain(...remainingHandlers));
+    },
+  };
+};
 
 // Type alias for the request
 type SomeTestOperationRequestInput = SomeTestOperationRequest;
@@ -1394,12 +1427,12 @@ export interface SomeTestOperationRequestArrayParameters {
 export type SomeTestOperationRequestBody = TestRequest;
 
 // Type that the handler function provided to the wrapper must conform to
-type SomeTestOperationHandlerFunction<ApiError> = LambdaHandlerFunction<SomeTestOperationRequestParameters, SomeTestOperationRequestArrayParameters, SomeTestOperationRequestBody, TestResponse, ApiError>;
+export type SomeTestOperationHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SomeTestOperationRequestParameters, SomeTestOperationRequestArrayParameters, SomeTestOperationRequestBody, TestResponse, ApiError>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of someTestOperation
  */
-export const someTestOperationHandler = <ApiError>(handler: SomeTestOperationHandlerFunction<ApiError>): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const someTestOperationHandler = <ApiError>(firstHandler: SomeTestOperationHandlerFunction<ApiError>, ...remainingHandlers: SomeTestOperationHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -1411,7 +1444,8 @@ export const someTestOperationHandler = <ApiError>(handler: SomeTestOperationHan
 
     const body = parseBody(event.body, ['application/json',]) as SomeTestOperationRequestBody;
 
-    const response = await handler({
+    const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
+    const response = await chain.next({
         requestParameters,
         requestArrayParameters,
         body,
@@ -3546,12 +3580,45 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
     body: RequestBody,
 };
 
+/**
+ * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
+ */
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
+) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
 // Type for a lambda handler function to be wrapped
 export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
-    input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
-    event: any,
-    context: any,
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
 ) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+}
+
+/**
+ * Build a chain from the given array of chained lambda handlers
+ */
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+  if (handlers.length === 0) {
+    return {
+      next: () => {
+        throw new Error(\\"No more handlers remain in the chain! The last handler should not call next.\\");
+      }
+    };
+  }
+  const [currentHandler, ...remainingHandlers] = handlers;
+  return {
+    next: (input, event, context) => {
+      return currentHandler(input, event, context, buildHandlerChain(...remainingHandlers));
+    },
+  };
+};
 
 // Type alias for the request
 type OperationOneRequestInput = OperationOneRequest;
@@ -3578,12 +3645,12 @@ export interface OperationOneRequestArrayParameters {
 export type OperationOneRequestBody = TestRequest;
 
 // Type that the handler function provided to the wrapper must conform to
-type OperationOneHandlerFunction<ApiError> = LambdaHandlerFunction<OperationOneRequestParameters, OperationOneRequestArrayParameters, OperationOneRequestBody, TestResponse, ApiError>;
+export type OperationOneHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<OperationOneRequestParameters, OperationOneRequestArrayParameters, OperationOneRequestBody, TestResponse, ApiError>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of operationOne
  */
-export const operationOneHandler = <ApiError>(handler: OperationOneHandlerFunction<ApiError>): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const operationOneHandler = <ApiError>(firstHandler: OperationOneHandlerFunction<ApiError>, ...remainingHandlers: OperationOneHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -3595,7 +3662,8 @@ export const operationOneHandler = <ApiError>(handler: OperationOneHandlerFuncti
 
     const body = parseBody(event.body, ['application/json',]) as OperationOneRequestBody;
 
-    const response = await handler({
+    const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
+    const response = await chain.next({
         requestParameters,
         requestArrayParameters,
         body,
@@ -3627,12 +3695,12 @@ export interface WithoutOperationIdDeleteRequestArrayParameters {
 export type WithoutOperationIdDeleteRequestBody = never;
 
 // Type that the handler function provided to the wrapper must conform to
-type WithoutOperationIdDeleteHandlerFunction<ApiError> = LambdaHandlerFunction<WithoutOperationIdDeleteRequestParameters, WithoutOperationIdDeleteRequestArrayParameters, WithoutOperationIdDeleteRequestBody, TestResponse, ApiError>;
+export type WithoutOperationIdDeleteHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<WithoutOperationIdDeleteRequestParameters, WithoutOperationIdDeleteRequestArrayParameters, WithoutOperationIdDeleteRequestBody, TestResponse, ApiError>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of withoutOperationIdDelete
  */
-export const withoutOperationIdDeleteHandler = <ApiError>(handler: WithoutOperationIdDeleteHandlerFunction<ApiError>): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const withoutOperationIdDeleteHandler = <ApiError>(firstHandler: WithoutOperationIdDeleteHandlerFunction<ApiError>, ...remainingHandlers: WithoutOperationIdDeleteHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -3644,7 +3712,8 @@ export const withoutOperationIdDeleteHandler = <ApiError>(handler: WithoutOperat
 
     const body = parseBody(event.body, ['application/json']) as WithoutOperationIdDeleteRequestBody;
 
-    const response = await handler({
+    const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
+    const response = await chain.next({
         requestParameters,
         requestArrayParameters,
         body,

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
@@ -13784,7 +13784,7 @@ const decodeRequestParameters = (parameters: ApiGatewayRequestParameters): ApiGa
 /**
  * Parse the body if the content type is json, otherwise leave as a raw string
  */
-const parseBody = (body: string, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? JSON.parse(body || '{}') : body;
+const parseBody = (body: string, demarshal: (body: string) => any, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? demarshal(body || '{}') : body;
 
 // Api gateway lambda handler type
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
@@ -13880,7 +13880,11 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         ...(event.multiValueQueryStringParameters || {}),
     }) as unknown as SayHelloRequestArrayParameters;
 
-    const body = parseBody(event.body, ['application/json']) as SayHelloRequestBody;
+    const demarshal = (bodyString: string): any => {
+        let parsed = JSON.parse(bodyString);
+        return parsed;
+    };
+    const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 
     const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
     const response = await chain.next({
@@ -13889,9 +13893,25 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         body,
     }, event, context);
 
+    const marshal = (responseBody: any): string => {
+        let response = responseBody;
+        switch(response.statusCode) {
+            case 200:
+                response = HelloResponseToJSON(response);
+                break;
+            case 400:
+                response = ApiErrorToJSON(response);
+                break;
+            default:
+                break;
+        }
+
+        return JSON.stringify(response);
+    };
+
     return {
         ...response,
-        body: response.body ? JSON.stringify(response.body) : '',
+        body: response.body ? marshal(response.body) : '',
     };
 };
 ",

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
@@ -13803,12 +13803,45 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
     body: RequestBody,
 };
 
+/**
+ * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
+ */
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
+) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
 // Type for a lambda handler function to be wrapped
 export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
-    input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
-    event: any,
-    context: any,
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
 ) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+}
+
+/**
+ * Build a chain from the given array of chained lambda handlers
+ */
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+  if (handlers.length === 0) {
+    return {
+      next: () => {
+        throw new Error(\\"No more handlers remain in the chain! The last handler should not call next.\\");
+      }
+    };
+  }
+  const [currentHandler, ...remainingHandlers] = handlers;
+  return {
+    next: (input, event, context) => {
+      return currentHandler(input, event, context, buildHandlerChain(...remainingHandlers));
+    },
+  };
+};
 
 // Type alias for the request
 type SayHelloRequestInput = SayHelloRequest;
@@ -13832,12 +13865,12 @@ export interface SayHelloRequestArrayParameters {
 export type SayHelloRequestBody = never;
 
 // Type that the handler function provided to the wrapper must conform to
-type SayHelloHandlerFunction<ApiError> = LambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
+export type SayHelloHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of sayHello
  */
-export const sayHelloHandler = <ApiError>(handler: SayHelloHandlerFunction<ApiError>): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<ApiError>, ...remainingHandlers: SayHelloHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -13849,7 +13882,8 @@ export const sayHelloHandler = <ApiError>(handler: SayHelloHandlerFunction<ApiEr
 
     const body = parseBody(event.body, ['application/json']) as SayHelloRequestBody;
 
-    const response = await handler({
+    const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
+    const response = await chain.next({
         requestParameters,
         requestArrayParameters,
         body,

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
@@ -12922,7 +12922,7 @@ const decodeRequestParameters = (parameters: ApiGatewayRequestParameters): ApiGa
 /**
  * Parse the body if the content type is json, otherwise leave as a raw string
  */
-const parseBody = (body: string, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? JSON.parse(body || '{}') : body;
+const parseBody = (body: string, demarshal: (body: string) => any, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? demarshal(body || '{}') : body;
 
 // Api gateway lambda handler type
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
@@ -13018,7 +13018,11 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         ...(event.multiValueQueryStringParameters || {}),
     }) as unknown as SayHelloRequestArrayParameters;
 
-    const body = parseBody(event.body, ['application/json']) as SayHelloRequestBody;
+    const demarshal = (bodyString: string): any => {
+        let parsed = JSON.parse(bodyString);
+        return parsed;
+    };
+    const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 
     const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
     const response = await chain.next({
@@ -13027,9 +13031,25 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         body,
     }, event, context);
 
+    const marshal = (responseBody: any): string => {
+        let response = responseBody;
+        switch(response.statusCode) {
+            case 200:
+                response = HelloResponseToJSON(response);
+                break;
+            case 400:
+                response = ApiErrorToJSON(response);
+                break;
+            default:
+                break;
+        }
+
+        return JSON.stringify(response);
+    };
+
     return {
         ...response,
-        body: response.body ? JSON.stringify(response.body) : '',
+        body: response.body ? marshal(response.body) : '',
     };
 };
 ",

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
@@ -12941,12 +12941,45 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
     body: RequestBody,
 };
 
+/**
+ * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
+ */
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
+) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
 // Type for a lambda handler function to be wrapped
 export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
-    input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
-    event: any,
-    context: any,
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
 ) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+}
+
+/**
+ * Build a chain from the given array of chained lambda handlers
+ */
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+  if (handlers.length === 0) {
+    return {
+      next: () => {
+        throw new Error(\\"No more handlers remain in the chain! The last handler should not call next.\\");
+      }
+    };
+  }
+  const [currentHandler, ...remainingHandlers] = handlers;
+  return {
+    next: (input, event, context) => {
+      return currentHandler(input, event, context, buildHandlerChain(...remainingHandlers));
+    },
+  };
+};
 
 // Type alias for the request
 type SayHelloRequestInput = SayHelloRequest;
@@ -12970,12 +13003,12 @@ export interface SayHelloRequestArrayParameters {
 export type SayHelloRequestBody = never;
 
 // Type that the handler function provided to the wrapper must conform to
-type SayHelloHandlerFunction<ApiError> = LambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
+export type SayHelloHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of sayHello
  */
-export const sayHelloHandler = <ApiError>(handler: SayHelloHandlerFunction<ApiError>): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<ApiError>, ...remainingHandlers: SayHelloHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -12987,7 +13020,8 @@ export const sayHelloHandler = <ApiError>(handler: SayHelloHandlerFunction<ApiEr
 
     const body = parseBody(event.body, ['application/json']) as SayHelloRequestBody;
 
-    const response = await handler({
+    const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
+    const response = await chain.next({
         requestParameters,
         requestArrayParameters,
         body,

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/custom-directories.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/custom-directories.test.ts.snap
@@ -1967,7 +1967,7 @@ const decodeRequestParameters = (parameters: ApiGatewayRequestParameters): ApiGa
 /**
  * Parse the body if the content type is json, otherwise leave as a raw string
  */
-const parseBody = (body: string, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? JSON.parse(body || '{}') : body;
+const parseBody = (body: string, demarshal: (body: string) => any, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? demarshal(body || '{}') : body;
 
 // Api gateway lambda handler type
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
@@ -2063,7 +2063,11 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         ...(event.multiValueQueryStringParameters || {}),
     }) as unknown as SayHelloRequestArrayParameters;
 
-    const body = parseBody(event.body, ['application/json']) as SayHelloRequestBody;
+    const demarshal = (bodyString: string): any => {
+        let parsed = JSON.parse(bodyString);
+        return parsed;
+    };
+    const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 
     const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
     const response = await chain.next({
@@ -2072,9 +2076,25 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         body,
     }, event, context);
 
+    const marshal = (responseBody: any): string => {
+        let response = responseBody;
+        switch(response.statusCode) {
+            case 200:
+                response = HelloResponseToJSON(response);
+                break;
+            case 400:
+                response = ApiErrorToJSON(response);
+                break;
+            default:
+                break;
+        }
+
+        return JSON.stringify(response);
+    };
+
     return {
         ...response,
-        body: response.body ? JSON.stringify(response.body) : '',
+        body: response.body ? marshal(response.body) : '',
     };
 };
 ",

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/custom-directories.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/custom-directories.test.ts.snap
@@ -1986,12 +1986,45 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
     body: RequestBody,
 };
 
+/**
+ * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
+ */
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
+) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
 // Type for a lambda handler function to be wrapped
 export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
-    input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
-    event: any,
-    context: any,
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
 ) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+}
+
+/**
+ * Build a chain from the given array of chained lambda handlers
+ */
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+  if (handlers.length === 0) {
+    return {
+      next: () => {
+        throw new Error(\\"No more handlers remain in the chain! The last handler should not call next.\\");
+      }
+    };
+  }
+  const [currentHandler, ...remainingHandlers] = handlers;
+  return {
+    next: (input, event, context) => {
+      return currentHandler(input, event, context, buildHandlerChain(...remainingHandlers));
+    },
+  };
+};
 
 // Type alias for the request
 type SayHelloRequestInput = SayHelloRequest;
@@ -2015,12 +2048,12 @@ export interface SayHelloRequestArrayParameters {
 export type SayHelloRequestBody = never;
 
 // Type that the handler function provided to the wrapper must conform to
-type SayHelloHandlerFunction<ApiError> = LambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
+export type SayHelloHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of sayHello
  */
-export const sayHelloHandler = <ApiError>(handler: SayHelloHandlerFunction<ApiError>): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<ApiError>, ...remainingHandlers: SayHelloHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -2032,7 +2065,8 @@ export const sayHelloHandler = <ApiError>(handler: SayHelloHandlerFunction<ApiEr
 
     const body = parseBody(event.body, ['application/json']) as SayHelloRequestBody;
 
-    const response = await handler({
+    const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
+    const response = await chain.next({
         requestParameters,
         requestArrayParameters,
         body,

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
@@ -14314,7 +14314,7 @@ const decodeRequestParameters = (parameters: ApiGatewayRequestParameters): ApiGa
 /**
  * Parse the body if the content type is json, otherwise leave as a raw string
  */
-const parseBody = (body: string, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? JSON.parse(body || '{}') : body;
+const parseBody = (body: string, demarshal: (body: string) => any, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? demarshal(body || '{}') : body;
 
 // Api gateway lambda handler type
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
@@ -14410,7 +14410,11 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         ...(event.multiValueQueryStringParameters || {}),
     }) as unknown as SayHelloRequestArrayParameters;
 
-    const body = parseBody(event.body, ['application/json']) as SayHelloRequestBody;
+    const demarshal = (bodyString: string): any => {
+        let parsed = JSON.parse(bodyString);
+        return parsed;
+    };
+    const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 
     const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
     const response = await chain.next({
@@ -14419,9 +14423,25 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         body,
     }, event, context);
 
+    const marshal = (responseBody: any): string => {
+        let response = responseBody;
+        switch(response.statusCode) {
+            case 200:
+                response = HelloResponseToJSON(response);
+                break;
+            case 400:
+                response = ApiErrorToJSON(response);
+                break;
+            default:
+                break;
+        }
+
+        return JSON.stringify(response);
+    };
+
     return {
         ...response,
-        body: response.body ? JSON.stringify(response.body) : '',
+        body: response.body ? marshal(response.body) : '',
     };
 };
 ",
@@ -29767,7 +29787,7 @@ const decodeRequestParameters = (parameters: ApiGatewayRequestParameters): ApiGa
 /**
  * Parse the body if the content type is json, otherwise leave as a raw string
  */
-const parseBody = (body: string, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? JSON.parse(body || '{}') : body;
+const parseBody = (body: string, demarshal: (body: string) => any, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? demarshal(body || '{}') : body;
 
 // Api gateway lambda handler type
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
@@ -29863,7 +29883,11 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         ...(event.multiValueQueryStringParameters || {}),
     }) as unknown as SayHelloRequestArrayParameters;
 
-    const body = parseBody(event.body, ['application/json']) as SayHelloRequestBody;
+    const demarshal = (bodyString: string): any => {
+        let parsed = JSON.parse(bodyString);
+        return parsed;
+    };
+    const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 
     const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
     const response = await chain.next({
@@ -29872,9 +29896,25 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         body,
     }, event, context);
 
+    const marshal = (responseBody: any): string => {
+        let response = responseBody;
+        switch(response.statusCode) {
+            case 200:
+                response = HelloResponseToJSON(response);
+                break;
+            case 400:
+                response = ApiErrorToJSON(response);
+                break;
+            default:
+                break;
+        }
+
+        return JSON.stringify(response);
+    };
+
     return {
         ...response,
-        body: response.body ? JSON.stringify(response.body) : '',
+        body: response.body ? marshal(response.body) : '',
     };
 };
 ",
@@ -45224,7 +45264,7 @@ const decodeRequestParameters = (parameters: ApiGatewayRequestParameters): ApiGa
 /**
  * Parse the body if the content type is json, otherwise leave as a raw string
  */
-const parseBody = (body: string, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? JSON.parse(body || '{}') : body;
+const parseBody = (body: string, demarshal: (body: string) => any, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? demarshal(body || '{}') : body;
 
 // Api gateway lambda handler type
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
@@ -45320,7 +45360,11 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         ...(event.multiValueQueryStringParameters || {}),
     }) as unknown as SayHelloRequestArrayParameters;
 
-    const body = parseBody(event.body, ['application/json']) as SayHelloRequestBody;
+    const demarshal = (bodyString: string): any => {
+        let parsed = JSON.parse(bodyString);
+        return parsed;
+    };
+    const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 
     const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
     const response = await chain.next({
@@ -45329,9 +45373,25 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         body,
     }, event, context);
 
+    const marshal = (responseBody: any): string => {
+        let response = responseBody;
+        switch(response.statusCode) {
+            case 200:
+                response = HelloResponseToJSON(response);
+                break;
+            case 400:
+                response = ApiErrorToJSON(response);
+                break;
+            default:
+                break;
+        }
+
+        return JSON.stringify(response);
+    };
+
     return {
         ...response,
-        body: response.body ? JSON.stringify(response.body) : '',
+        body: response.body ? marshal(response.body) : '',
     };
 };
 ",

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
@@ -14333,12 +14333,45 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
     body: RequestBody,
 };
 
+/**
+ * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
+ */
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
+) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
 // Type for a lambda handler function to be wrapped
 export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
-    input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
-    event: any,
-    context: any,
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
 ) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+}
+
+/**
+ * Build a chain from the given array of chained lambda handlers
+ */
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+  if (handlers.length === 0) {
+    return {
+      next: () => {
+        throw new Error(\\"No more handlers remain in the chain! The last handler should not call next.\\");
+      }
+    };
+  }
+  const [currentHandler, ...remainingHandlers] = handlers;
+  return {
+    next: (input, event, context) => {
+      return currentHandler(input, event, context, buildHandlerChain(...remainingHandlers));
+    },
+  };
+};
 
 // Type alias for the request
 type SayHelloRequestInput = SayHelloRequest;
@@ -14362,12 +14395,12 @@ export interface SayHelloRequestArrayParameters {
 export type SayHelloRequestBody = never;
 
 // Type that the handler function provided to the wrapper must conform to
-type SayHelloHandlerFunction<ApiError> = LambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
+export type SayHelloHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of sayHello
  */
-export const sayHelloHandler = <ApiError>(handler: SayHelloHandlerFunction<ApiError>): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<ApiError>, ...remainingHandlers: SayHelloHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -14379,7 +14412,8 @@ export const sayHelloHandler = <ApiError>(handler: SayHelloHandlerFunction<ApiEr
 
     const body = parseBody(event.body, ['application/json']) as SayHelloRequestBody;
 
-    const response = await handler({
+    const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
+    const response = await chain.next({
         requestParameters,
         requestArrayParameters,
         body,
@@ -29752,12 +29786,45 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
     body: RequestBody,
 };
 
+/**
+ * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
+ */
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
+) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
 // Type for a lambda handler function to be wrapped
 export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
-    input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
-    event: any,
-    context: any,
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
 ) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+}
+
+/**
+ * Build a chain from the given array of chained lambda handlers
+ */
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+  if (handlers.length === 0) {
+    return {
+      next: () => {
+        throw new Error(\\"No more handlers remain in the chain! The last handler should not call next.\\");
+      }
+    };
+  }
+  const [currentHandler, ...remainingHandlers] = handlers;
+  return {
+    next: (input, event, context) => {
+      return currentHandler(input, event, context, buildHandlerChain(...remainingHandlers));
+    },
+  };
+};
 
 // Type alias for the request
 type SayHelloRequestInput = SayHelloRequest;
@@ -29781,12 +29848,12 @@ export interface SayHelloRequestArrayParameters {
 export type SayHelloRequestBody = never;
 
 // Type that the handler function provided to the wrapper must conform to
-type SayHelloHandlerFunction<ApiError> = LambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
+export type SayHelloHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of sayHello
  */
-export const sayHelloHandler = <ApiError>(handler: SayHelloHandlerFunction<ApiError>): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<ApiError>, ...remainingHandlers: SayHelloHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -29798,7 +29865,8 @@ export const sayHelloHandler = <ApiError>(handler: SayHelloHandlerFunction<ApiEr
 
     const body = parseBody(event.body, ['application/json']) as SayHelloRequestBody;
 
-    const response = await handler({
+    const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
+    const response = await chain.next({
         requestParameters,
         requestArrayParameters,
         body,
@@ -45175,12 +45243,45 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
     body: RequestBody,
 };
 
+/**
+ * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
+ */
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
+) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
 // Type for a lambda handler function to be wrapped
 export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
-    input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
-    event: any,
-    context: any,
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
 ) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+}
+
+/**
+ * Build a chain from the given array of chained lambda handlers
+ */
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+  if (handlers.length === 0) {
+    return {
+      next: () => {
+        throw new Error(\\"No more handlers remain in the chain! The last handler should not call next.\\");
+      }
+    };
+  }
+  const [currentHandler, ...remainingHandlers] = handlers;
+  return {
+    next: (input, event, context) => {
+      return currentHandler(input, event, context, buildHandlerChain(...remainingHandlers));
+    },
+  };
+};
 
 // Type alias for the request
 type SayHelloRequestInput = SayHelloRequest;
@@ -45204,12 +45305,12 @@ export interface SayHelloRequestArrayParameters {
 export type SayHelloRequestBody = never;
 
 // Type that the handler function provided to the wrapper must conform to
-type SayHelloHandlerFunction<ApiError> = LambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
+export type SayHelloHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of sayHello
  */
-export const sayHelloHandler = <ApiError>(handler: SayHelloHandlerFunction<ApiError>): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<ApiError>, ...remainingHandlers: SayHelloHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -45221,7 +45322,8 @@ export const sayHelloHandler = <ApiError>(handler: SayHelloHandlerFunction<ApiEr
 
     const body = parseBody(event.body, ['application/json']) as SayHelloRequestBody;
 
-    const response = await handler({
+    const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
+    const response = await chain.next({
         requestParameters,
         requestArrayParameters,
         body,

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
@@ -13771,7 +13771,7 @@ const decodeRequestParameters = (parameters: ApiGatewayRequestParameters): ApiGa
 /**
  * Parse the body if the content type is json, otherwise leave as a raw string
  */
-const parseBody = (body: string, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? JSON.parse(body || '{}') : body;
+const parseBody = (body: string, demarshal: (body: string) => any, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? demarshal(body || '{}') : body;
 
 // Api gateway lambda handler type
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
@@ -13867,7 +13867,11 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         ...(event.multiValueQueryStringParameters || {}),
     }) as unknown as SayHelloRequestArrayParameters;
 
-    const body = parseBody(event.body, ['application/json']) as SayHelloRequestBody;
+    const demarshal = (bodyString: string): any => {
+        let parsed = JSON.parse(bodyString);
+        return parsed;
+    };
+    const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 
     const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
     const response = await chain.next({
@@ -13876,9 +13880,25 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         body,
     }, event, context);
 
+    const marshal = (responseBody: any): string => {
+        let response = responseBody;
+        switch(response.statusCode) {
+            case 200:
+                response = HelloResponseToJSON(response);
+                break;
+            case 400:
+                response = ApiErrorToJSON(response);
+                break;
+            default:
+                break;
+        }
+
+        return JSON.stringify(response);
+    };
+
     return {
         ...response,
-        body: response.body ? JSON.stringify(response.body) : '',
+        body: response.body ? marshal(response.body) : '',
     };
 };
 ",
@@ -28623,7 +28643,7 @@ const decodeRequestParameters = (parameters: ApiGatewayRequestParameters): ApiGa
 /**
  * Parse the body if the content type is json, otherwise leave as a raw string
  */
-const parseBody = (body: string, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? JSON.parse(body || '{}') : body;
+const parseBody = (body: string, demarshal: (body: string) => any, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? demarshal(body || '{}') : body;
 
 // Api gateway lambda handler type
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
@@ -28719,7 +28739,11 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         ...(event.multiValueQueryStringParameters || {}),
     }) as unknown as SayHelloRequestArrayParameters;
 
-    const body = parseBody(event.body, ['application/json']) as SayHelloRequestBody;
+    const demarshal = (bodyString: string): any => {
+        let parsed = JSON.parse(bodyString);
+        return parsed;
+    };
+    const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 
     const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
     const response = await chain.next({
@@ -28728,9 +28752,25 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         body,
     }, event, context);
 
+    const marshal = (responseBody: any): string => {
+        let response = responseBody;
+        switch(response.statusCode) {
+            case 200:
+                response = HelloResponseToJSON(response);
+                break;
+            case 400:
+                response = ApiErrorToJSON(response);
+                break;
+            default:
+                break;
+        }
+
+        return JSON.stringify(response);
+    };
+
     return {
         ...response,
-        body: response.body ? JSON.stringify(response.body) : '',
+        body: response.body ? marshal(response.body) : '',
     };
 };
 ",
@@ -43456,7 +43496,7 @@ const decodeRequestParameters = (parameters: ApiGatewayRequestParameters): ApiGa
 /**
  * Parse the body if the content type is json, otherwise leave as a raw string
  */
-const parseBody = (body: string, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? JSON.parse(body || '{}') : body;
+const parseBody = (body: string, demarshal: (body: string) => any, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? demarshal(body || '{}') : body;
 
 // Api gateway lambda handler type
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
@@ -43552,7 +43592,11 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         ...(event.multiValueQueryStringParameters || {}),
     }) as unknown as SayHelloRequestArrayParameters;
 
-    const body = parseBody(event.body, ['application/json']) as SayHelloRequestBody;
+    const demarshal = (bodyString: string): any => {
+        let parsed = JSON.parse(bodyString);
+        return parsed;
+    };
+    const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 
     const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
     const response = await chain.next({
@@ -43561,9 +43605,25 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         body,
     }, event, context);
 
+    const marshal = (responseBody: any): string => {
+        let response = responseBody;
+        switch(response.statusCode) {
+            case 200:
+                response = HelloResponseToJSON(response);
+                break;
+            case 400:
+                response = ApiErrorToJSON(response);
+                break;
+            default:
+                break;
+        }
+
+        return JSON.stringify(response);
+    };
+
     return {
         ...response,
-        body: response.body ? JSON.stringify(response.body) : '',
+        body: response.body ? marshal(response.body) : '',
     };
 };
 ",

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
@@ -13790,12 +13790,45 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
     body: RequestBody,
 };
 
+/**
+ * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
+ */
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
+) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
 // Type for a lambda handler function to be wrapped
 export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
-    input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
-    event: any,
-    context: any,
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
 ) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+}
+
+/**
+ * Build a chain from the given array of chained lambda handlers
+ */
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+  if (handlers.length === 0) {
+    return {
+      next: () => {
+        throw new Error(\\"No more handlers remain in the chain! The last handler should not call next.\\");
+      }
+    };
+  }
+  const [currentHandler, ...remainingHandlers] = handlers;
+  return {
+    next: (input, event, context) => {
+      return currentHandler(input, event, context, buildHandlerChain(...remainingHandlers));
+    },
+  };
+};
 
 // Type alias for the request
 type SayHelloRequestInput = SayHelloRequest;
@@ -13819,12 +13852,12 @@ export interface SayHelloRequestArrayParameters {
 export type SayHelloRequestBody = never;
 
 // Type that the handler function provided to the wrapper must conform to
-type SayHelloHandlerFunction<ApiError> = LambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
+export type SayHelloHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of sayHello
  */
-export const sayHelloHandler = <ApiError>(handler: SayHelloHandlerFunction<ApiError>): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<ApiError>, ...remainingHandlers: SayHelloHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -13836,7 +13869,8 @@ export const sayHelloHandler = <ApiError>(handler: SayHelloHandlerFunction<ApiEr
 
     const body = parseBody(event.body, ['application/json']) as SayHelloRequestBody;
 
-    const response = await handler({
+    const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
+    const response = await chain.next({
         requestParameters,
         requestArrayParameters,
         body,
@@ -28608,12 +28642,45 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
     body: RequestBody,
 };
 
+/**
+ * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
+ */
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
+) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
 // Type for a lambda handler function to be wrapped
 export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
-    input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
-    event: any,
-    context: any,
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
 ) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+}
+
+/**
+ * Build a chain from the given array of chained lambda handlers
+ */
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+  if (handlers.length === 0) {
+    return {
+      next: () => {
+        throw new Error(\\"No more handlers remain in the chain! The last handler should not call next.\\");
+      }
+    };
+  }
+  const [currentHandler, ...remainingHandlers] = handlers;
+  return {
+    next: (input, event, context) => {
+      return currentHandler(input, event, context, buildHandlerChain(...remainingHandlers));
+    },
+  };
+};
 
 // Type alias for the request
 type SayHelloRequestInput = SayHelloRequest;
@@ -28637,12 +28704,12 @@ export interface SayHelloRequestArrayParameters {
 export type SayHelloRequestBody = never;
 
 // Type that the handler function provided to the wrapper must conform to
-type SayHelloHandlerFunction<ApiError> = LambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
+export type SayHelloHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of sayHello
  */
-export const sayHelloHandler = <ApiError>(handler: SayHelloHandlerFunction<ApiError>): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<ApiError>, ...remainingHandlers: SayHelloHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -28654,7 +28721,8 @@ export const sayHelloHandler = <ApiError>(handler: SayHelloHandlerFunction<ApiEr
 
     const body = parseBody(event.body, ['application/json']) as SayHelloRequestBody;
 
-    const response = await handler({
+    const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
+    const response = await chain.next({
         requestParameters,
         requestArrayParameters,
         body,
@@ -43407,12 +43475,45 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
     body: RequestBody,
 };
 
+/**
+ * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
+ */
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
+) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
 // Type for a lambda handler function to be wrapped
 export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
-    input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
-    event: any,
-    context: any,
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
 ) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+}
+
+/**
+ * Build a chain from the given array of chained lambda handlers
+ */
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+  if (handlers.length === 0) {
+    return {
+      next: () => {
+        throw new Error(\\"No more handlers remain in the chain! The last handler should not call next.\\");
+      }
+    };
+  }
+  const [currentHandler, ...remainingHandlers] = handlers;
+  return {
+    next: (input, event, context) => {
+      return currentHandler(input, event, context, buildHandlerChain(...remainingHandlers));
+    },
+  };
+};
 
 // Type alias for the request
 type SayHelloRequestInput = SayHelloRequest;
@@ -43436,12 +43537,12 @@ export interface SayHelloRequestArrayParameters {
 export type SayHelloRequestBody = never;
 
 // Type that the handler function provided to the wrapper must conform to
-type SayHelloHandlerFunction<ApiError> = LambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
+export type SayHelloHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of sayHello
  */
-export const sayHelloHandler = <ApiError>(handler: SayHelloHandlerFunction<ApiError>): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<ApiError>, ...remainingHandlers: SayHelloHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -43453,7 +43554,8 @@ export const sayHelloHandler = <ApiError>(handler: SayHelloHandlerFunction<ApiEr
 
     const body = parseBody(event.body, ['application/json']) as SayHelloRequestBody;
 
-    const response = await handler({
+    const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
+    const response = await chain.next({
         requestParameters,
         requestArrayParameters,
         body,

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/with-docs.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/with-docs.test.ts.snap
@@ -5216,7 +5216,7 @@ const decodeRequestParameters = (parameters: ApiGatewayRequestParameters): ApiGa
 /**
  * Parse the body if the content type is json, otherwise leave as a raw string
  */
-const parseBody = (body: string, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? JSON.parse(body || '{}') : body;
+const parseBody = (body: string, demarshal: (body: string) => any, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? demarshal(body || '{}') : body;
 
 // Api gateway lambda handler type
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
@@ -5312,7 +5312,11 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         ...(event.multiValueQueryStringParameters || {}),
     }) as unknown as SayHelloRequestArrayParameters;
 
-    const body = parseBody(event.body, ['application/json']) as SayHelloRequestBody;
+    const demarshal = (bodyString: string): any => {
+        let parsed = JSON.parse(bodyString);
+        return parsed;
+    };
+    const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 
     const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
     const response = await chain.next({
@@ -5321,9 +5325,25 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         body,
     }, event, context);
 
+    const marshal = (responseBody: any): string => {
+        let response = responseBody;
+        switch(response.statusCode) {
+            case 200:
+                response = HelloResponseToJSON(response);
+                break;
+            case 400:
+                response = ApiErrorToJSON(response);
+                break;
+            default:
+                break;
+        }
+
+        return JSON.stringify(response);
+    };
+
     return {
         ...response,
-        body: response.body ? JSON.stringify(response.body) : '',
+        body: response.body ? marshal(response.body) : '',
     };
 };
 ",

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/with-docs.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/with-docs.test.ts.snap
@@ -5235,12 +5235,45 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
     body: RequestBody,
 };
 
+/**
+ * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
+ */
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
+) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
 // Type for a lambda handler function to be wrapped
 export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
-    input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
-    event: any,
-    context: any,
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
 ) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+}
+
+/**
+ * Build a chain from the given array of chained lambda handlers
+ */
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+  if (handlers.length === 0) {
+    return {
+      next: () => {
+        throw new Error(\\"No more handlers remain in the chain! The last handler should not call next.\\");
+      }
+    };
+  }
+  const [currentHandler, ...remainingHandlers] = handlers;
+  return {
+    next: (input, event, context) => {
+      return currentHandler(input, event, context, buildHandlerChain(...remainingHandlers));
+    },
+  };
+};
 
 // Type alias for the request
 type SayHelloRequestInput = SayHelloRequest;
@@ -5264,12 +5297,12 @@ export interface SayHelloRequestArrayParameters {
 export type SayHelloRequestBody = never;
 
 // Type that the handler function provided to the wrapper must conform to
-type SayHelloHandlerFunction<ApiError> = LambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
+export type SayHelloHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of sayHello
  */
-export const sayHelloHandler = <ApiError>(handler: SayHelloHandlerFunction<ApiError>): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<ApiError>, ...remainingHandlers: SayHelloHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -5281,7 +5314,8 @@ export const sayHelloHandler = <ApiError>(handler: SayHelloHandlerFunction<ApiEr
 
     const body = parseBody(event.body, ['application/json']) as SayHelloRequestBody;
 
-    const response = await handler({
+    const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
+    const response = await chain.next({
         requestParameters,
         requestArrayParameters,
         body,

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/without-sample-code.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/without-sample-code.test.ts.snap
@@ -1967,7 +1967,7 @@ const decodeRequestParameters = (parameters: ApiGatewayRequestParameters): ApiGa
 /**
  * Parse the body if the content type is json, otherwise leave as a raw string
  */
-const parseBody = (body: string, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? JSON.parse(body || '{}') : body;
+const parseBody = (body: string, demarshal: (body: string) => any, contentTypes: string[]): any => contentTypes.filter((contentType) => contentType !== 'application/json').length === 0 ? demarshal(body || '{}') : body;
 
 // Api gateway lambda handler type
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
@@ -2063,7 +2063,11 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         ...(event.multiValueQueryStringParameters || {}),
     }) as unknown as SayHelloRequestArrayParameters;
 
-    const body = parseBody(event.body, ['application/json']) as SayHelloRequestBody;
+    const demarshal = (bodyString: string): any => {
+        let parsed = JSON.parse(bodyString);
+        return parsed;
+    };
+    const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 
     const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
     const response = await chain.next({
@@ -2072,9 +2076,25 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         body,
     }, event, context);
 
+    const marshal = (responseBody: any): string => {
+        let response = responseBody;
+        switch(response.statusCode) {
+            case 200:
+                response = HelloResponseToJSON(response);
+                break;
+            case 400:
+                response = ApiErrorToJSON(response);
+                break;
+            default:
+                break;
+        }
+
+        return JSON.stringify(response);
+    };
+
     return {
         ...response,
-        body: response.body ? JSON.stringify(response.body) : '',
+        body: response.body ? marshal(response.body) : '',
     };
 };
 ",

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/without-sample-code.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/without-sample-code.test.ts.snap
@@ -1986,12 +1986,45 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
     body: RequestBody,
 };
 
+/**
+ * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
+ */
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
+) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
 // Type for a lambda handler function to be wrapped
 export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
-    input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
-    event: any,
-    context: any,
+  input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
+  event: any,
+  context: any,
 ) => Promise<OperationResponse<RequestOutput, ApiError>>;
+
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+}
+
+/**
+ * Build a chain from the given array of chained lambda handlers
+ */
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+  if (handlers.length === 0) {
+    return {
+      next: () => {
+        throw new Error(\\"No more handlers remain in the chain! The last handler should not call next.\\");
+      }
+    };
+  }
+  const [currentHandler, ...remainingHandlers] = handlers;
+  return {
+    next: (input, event, context) => {
+      return currentHandler(input, event, context, buildHandlerChain(...remainingHandlers));
+    },
+  };
+};
 
 // Type alias for the request
 type SayHelloRequestInput = SayHelloRequest;
@@ -2015,12 +2048,12 @@ export interface SayHelloRequestArrayParameters {
 export type SayHelloRequestBody = never;
 
 // Type that the handler function provided to the wrapper must conform to
-type SayHelloHandlerFunction<ApiError> = LambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
+export type SayHelloHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of sayHello
  */
-export const sayHelloHandler = <ApiError>(handler: SayHelloHandlerFunction<ApiError>): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<ApiError>, ...remainingHandlers: SayHelloHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -2032,7 +2065,8 @@ export const sayHelloHandler = <ApiError>(handler: SayHelloHandlerFunction<ApiEr
 
     const body = parseBody(event.body, ['application/json']) as SayHelloRequestBody;
 
-    const response = await handler({
+    const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
+    const response = await chain.next({
         requestParameters,
         requestArrayParameters,
         body,


### PR DESCRIPTION
Each generated handler wrapper now allows request interceptors to be passed as varargs. Interceptors are just functions which have the same interface as handler methods, but can delegate to the remainder of the chain to handle the request.