### PR TITLE
fix(identity): reference web client in identity pool

### DIFF
--- a/packages/identity/src/user-identity.ts
+++ b/packages/identity/src/user-identity.ts
@@ -110,7 +110,12 @@ export class UserIdentity extends Construct {
           ...(props?.identityPoolOptions?.authenticationProviders?.userPools ||
             []),
           ...(!props?.userPool
-            ? [new UserPoolAuthenticationProvider({ userPool: this.userPool })]
+            ? [
+                new UserPoolAuthenticationProvider({
+                  userPool: this.userPool,
+                  userPoolClient: this.userPoolClient!,
+                }),
+              ]
             : []),
         ],
       },

--- a/packages/identity/test/__snapshots__/user-identity.test.ts.snap
+++ b/packages/identity/test/__snapshots__/user-identity.test.ts.snap
@@ -7,7 +7,6 @@ Object {
       "DependsOn": Array [
         "DefaultsNestedUserPool567C619B",
         "DefaultsNestedUserPoolsmsRole9E53925E",
-        "DefaultsNestedUserPoolUserPoolAuthenticationProviderClient51B6337E",
         "DefaultsNestedUserPoolWebClient15C5E297",
       ],
       "Properties": Object {
@@ -15,7 +14,7 @@ Object {
         "CognitoIdentityProviders": Array [
           Object {
             "ClientId": Object {
-              "Ref": "DefaultsNestedUserPoolUserPoolAuthenticationProviderClient51B6337E",
+              "Ref": "DefaultsNestedUserPoolWebClient15C5E297",
             },
             "ProviderName": Object {
               "Fn::Join": Array [
@@ -46,7 +45,6 @@ Object {
       "DependsOn": Array [
         "DefaultsNestedUserPool567C619B",
         "DefaultsNestedUserPoolsmsRole9E53925E",
-        "DefaultsNestedUserPoolUserPoolAuthenticationProviderClient51B6337E",
         "DefaultsNestedUserPoolWebClient15C5E297",
       ],
       "Properties": Object {
@@ -93,7 +91,6 @@ Object {
       "DependsOn": Array [
         "DefaultsNestedUserPool567C619B",
         "DefaultsNestedUserPoolsmsRole9E53925E",
-        "DefaultsNestedUserPoolUserPoolAuthenticationProviderClient51B6337E",
         "DefaultsNestedUserPoolWebClient15C5E297",
       ],
       "Properties": Object {
@@ -121,7 +118,6 @@ Object {
       "DependsOn": Array [
         "DefaultsNestedUserPool567C619B",
         "DefaultsNestedUserPoolsmsRole9E53925E",
-        "DefaultsNestedUserPoolUserPoolAuthenticationProviderClient51B6337E",
         "DefaultsNestedUserPoolWebClient15C5E297",
       ],
       "Properties": Object {
@@ -218,32 +214,6 @@ Object {
       },
       "Type": "AWS::Cognito::UserPool",
       "UpdateReplacePolicy": "Retain",
-    },
-    "DefaultsNestedUserPoolUserPoolAuthenticationProviderClient51B6337E": Object {
-      "Properties": Object {
-        "AllowedOAuthFlows": Array [
-          "implicit",
-          "code",
-        ],
-        "AllowedOAuthFlowsUserPoolClient": true,
-        "AllowedOAuthScopes": Array [
-          "profile",
-          "phone",
-          "email",
-          "openid",
-          "aws.cognito.signin.user.admin",
-        ],
-        "CallbackURLs": Array [
-          "https://example.com",
-        ],
-        "SupportedIdentityProviders": Array [
-          "COGNITO",
-        ],
-        "UserPoolId": Object {
-          "Ref": "DefaultsNestedUserPool567C619B",
-        },
-      },
-      "Type": "AWS::Cognito::UserPoolClient",
     },
     "DefaultsNestedUserPoolWebClient15C5E297": Object {
       "Properties": Object {
@@ -344,7 +314,6 @@ Object {
       "DependsOn": Array [
         "DefaultsUserPool8771AC2E",
         "DefaultsUserPoolsmsRoleE0CA6B10",
-        "DefaultsUserPoolUserPoolAuthenticationProviderClientF50E7234",
         "DefaultsUserPoolWebClient89951652",
       ],
       "Properties": Object {
@@ -391,7 +360,6 @@ Object {
       "DependsOn": Array [
         "DefaultsUserPool8771AC2E",
         "DefaultsUserPoolsmsRoleE0CA6B10",
-        "DefaultsUserPoolUserPoolAuthenticationProviderClientF50E7234",
         "DefaultsUserPoolWebClient89951652",
       ],
       "Properties": Object {
@@ -399,7 +367,7 @@ Object {
         "CognitoIdentityProviders": Array [
           Object {
             "ClientId": Object {
-              "Ref": "DefaultsUserPoolUserPoolAuthenticationProviderClientF50E7234",
+              "Ref": "DefaultsUserPoolWebClient89951652",
             },
             "ProviderName": Object {
               "Fn::Join": Array [
@@ -430,7 +398,6 @@ Object {
       "DependsOn": Array [
         "DefaultsUserPool8771AC2E",
         "DefaultsUserPoolsmsRoleE0CA6B10",
-        "DefaultsUserPoolUserPoolAuthenticationProviderClientF50E7234",
         "DefaultsUserPoolWebClient89951652",
       ],
       "Properties": Object {
@@ -458,7 +425,6 @@ Object {
       "DependsOn": Array [
         "DefaultsUserPool8771AC2E",
         "DefaultsUserPoolsmsRoleE0CA6B10",
-        "DefaultsUserPoolUserPoolAuthenticationProviderClientF50E7234",
         "DefaultsUserPoolWebClient89951652",
       ],
       "Properties": Object {
@@ -555,32 +521,6 @@ Object {
       },
       "Type": "AWS::Cognito::UserPool",
       "UpdateReplacePolicy": "Retain",
-    },
-    "DefaultsUserPoolUserPoolAuthenticationProviderClientF50E7234": Object {
-      "Properties": Object {
-        "AllowedOAuthFlows": Array [
-          "implicit",
-          "code",
-        ],
-        "AllowedOAuthFlowsUserPoolClient": true,
-        "AllowedOAuthScopes": Array [
-          "profile",
-          "phone",
-          "email",
-          "openid",
-          "aws.cognito.signin.user.admin",
-        ],
-        "CallbackURLs": Array [
-          "https://example.com",
-        ],
-        "SupportedIdentityProviders": Array [
-          "COGNITO",
-        ],
-        "UserPoolId": Object {
-          "Ref": "DefaultsUserPool8771AC2E",
-        },
-      },
-      "Type": "AWS::Cognito::UserPoolClient",
     },
     "DefaultsUserPoolWebClient89951652": Object {
       "Properties": Object {


### PR DESCRIPTION
The IdentityPool was creating an extra user pool client because we'd missed passing the one we created.