### PR TITLE
fix: corrects dependencies in sample projects

### DIFF
--- a/packages/pipeline/samples/typescript/src/pipeline-stack.ts
+++ b/packages/pipeline/samples/typescript/src/pipeline-stack.ts
@@ -13,8 +13,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  ******************************************************************************************************************** */
+import { PDKPipeline } from '@aws-prototyping-sdk/pipeline';
 import { Stack, StackProps } from 'aws-cdk-lib';
-import { PDKPipeline } from 'aws-prototyping-sdk/pipeline';
 import { Construct } from 'constructs';
 
 export class PipelineStack extends Stack {

--- a/packages/pipeline/samples/typescript/src/pipeline.ts
+++ b/packages/pipeline/samples/typescript/src/pipeline.ts
@@ -14,7 +14,7 @@
  limitations under the License.
  ******************************************************************************************************************** */
 
-import { PDKNag } from 'aws-prototyping-sdk/pdk-nag';
+import { PDKNag } from '@aws-prototyping-sdk/pdk-nag';
 import { ApplicationStage } from './application-stage';
 import { PipelineStack } from './pipeline-stack';
 


### PR DESCRIPTION
The pipeline Typescript samples refer to projen dependencies
(incorrectly) as just `aws-prototyping-sdk` prefixed, which doesn't
match the project declaration of the corresponding packages.

These have been corrected to reflect the right package name
declarations:

- `@aws-prototyping-sdk/pdk-nag`
- `@aws-prototyping-sdk/pipeline`
