### PR TITLE
fix(open-api-gateway): response marshalling status code check

### DIFF
--- a/packages/open-api-gateway/scripts/generators/typescript/templates/operationConfig.mustache
+++ b/packages/open-api-gateway/scripts/generators/typescript/templates/operationConfig.mustache
@@ -188,14 +188,13 @@ export const {{nickname}}Handler = <ApiError>(firstHandler: {{operationIdCamelCa
         body,
     }, event, context);
 
-    const marshal = (responseBody: any): string => {
-
-        let response = responseBody;
-        switch(response.statusCode) {
+    const marshal = (statusCode: number, responseBody: any): string => {
+        let marshalledBody = responseBody;
+        switch(statusCode) {
         {{#responses}}
             case {{code}}:
                 {{^isPrimitiveType}}
-                response = JSON.stringify({{dataType}}ToJSON(response));
+                marshalledBody = JSON.stringify({{dataType}}ToJSON(marshalledBody));
                 {{/isPrimitiveType}}
                 break;
         {{/responses}}
@@ -203,12 +202,12 @@ export const {{nickname}}Handler = <ApiError>(firstHandler: {{operationIdCamelCa
                 break;
         }
 
-        return response;
+        return marshalledBody;
     };
 
     return {
         ...response,
-        body: response.body ? marshal(response.body) : '',
+        body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
 {{/operation}}

--- a/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-typescript-client-source-code.test.ts.snap
+++ b/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-typescript-client-source-code.test.ts.snap
@@ -1456,26 +1456,25 @@ export const someTestOperationHandler = <ApiError>(firstHandler: SomeTestOperati
         body,
     }, event, context);
 
-    const marshal = (responseBody: any): string => {
-
-        let response = responseBody;
-        switch(response.statusCode) {
+    const marshal = (statusCode: number, responseBody: any): string => {
+        let marshalledBody = responseBody;
+        switch(statusCode) {
             case 200:
-                response = JSON.stringify(TestResponseToJSON(response));
+                marshalledBody = JSON.stringify(TestResponseToJSON(marshalledBody));
                 break;
             case 400:
-                response = JSON.stringify(ApiErrorToJSON(response));
+                marshalledBody = JSON.stringify(ApiErrorToJSON(marshalledBody));
                 break;
             default:
                 break;
         }
 
-        return response;
+        return marshalledBody;
     };
 
     return {
         ...response,
-        body: response.body ? marshal(response.body) : '',
+        body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
 ",
@@ -3733,22 +3732,21 @@ export const mediaTypesHandler = <ApiError>(firstHandler: MediaTypesHandlerFunct
         body,
     }, event, context);
 
-    const marshal = (responseBody: any): string => {
-
-        let response = responseBody;
-        switch(response.statusCode) {
+    const marshal = (statusCode: number, responseBody: any): string => {
+        let marshalledBody = responseBody;
+        switch(statusCode) {
             case 200:
                 break;
             default:
                 break;
         }
 
-        return response;
+        return marshalledBody;
     };
 
     return {
         ...response,
-        body: response.body ? marshal(response.body) : '',
+        body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
 // Type alias for the request
@@ -3805,26 +3803,25 @@ export const operationOneHandler = <ApiError>(firstHandler: OperationOneHandlerF
         body,
     }, event, context);
 
-    const marshal = (responseBody: any): string => {
-
-        let response = responseBody;
-        switch(response.statusCode) {
+    const marshal = (statusCode: number, responseBody: any): string => {
+        let marshalledBody = responseBody;
+        switch(statusCode) {
             case 200:
-                response = JSON.stringify(TestResponseToJSON(response));
+                marshalledBody = JSON.stringify(TestResponseToJSON(marshalledBody));
                 break;
             case 400:
-                response = JSON.stringify(ApiErrorToJSON(response));
+                marshalledBody = JSON.stringify(ApiErrorToJSON(marshalledBody));
                 break;
             default:
                 break;
         }
 
-        return response;
+        return marshalledBody;
     };
 
     return {
         ...response,
-        body: response.body ? marshal(response.body) : '',
+        body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
 // Type alias for the request
@@ -3876,23 +3873,22 @@ export const withoutOperationIdDeleteHandler = <ApiError>(firstHandler: WithoutO
         body,
     }, event, context);
 
-    const marshal = (responseBody: any): string => {
-
-        let response = responseBody;
-        switch(response.statusCode) {
+    const marshal = (statusCode: number, responseBody: any): string => {
+        let marshalledBody = responseBody;
+        switch(statusCode) {
             case 200:
-                response = JSON.stringify(TestResponseToJSON(response));
+                marshalledBody = JSON.stringify(TestResponseToJSON(marshalledBody));
                 break;
             default:
                 break;
         }
 
-        return response;
+        return marshalledBody;
     };
 
     return {
         ...response,
-        body: response.body ? marshal(response.body) : '',
+        body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
 ",

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
@@ -13893,26 +13893,25 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         body,
     }, event, context);
 
-    const marshal = (responseBody: any): string => {
-
-        let response = responseBody;
-        switch(response.statusCode) {
+    const marshal = (statusCode: number, responseBody: any): string => {
+        let marshalledBody = responseBody;
+        switch(statusCode) {
             case 200:
-                response = JSON.stringify(HelloResponseToJSON(response));
+                marshalledBody = JSON.stringify(HelloResponseToJSON(marshalledBody));
                 break;
             case 400:
-                response = JSON.stringify(ApiErrorToJSON(response));
+                marshalledBody = JSON.stringify(ApiErrorToJSON(marshalledBody));
                 break;
             default:
                 break;
         }
 
-        return response;
+        return marshalledBody;
     };
 
     return {
         ...response,
-        body: response.body ? marshal(response.body) : '',
+        body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
 ",

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
@@ -13031,26 +13031,25 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         body,
     }, event, context);
 
-    const marshal = (responseBody: any): string => {
-
-        let response = responseBody;
-        switch(response.statusCode) {
+    const marshal = (statusCode: number, responseBody: any): string => {
+        let marshalledBody = responseBody;
+        switch(statusCode) {
             case 200:
-                response = JSON.stringify(HelloResponseToJSON(response));
+                marshalledBody = JSON.stringify(HelloResponseToJSON(marshalledBody));
                 break;
             case 400:
-                response = JSON.stringify(ApiErrorToJSON(response));
+                marshalledBody = JSON.stringify(ApiErrorToJSON(marshalledBody));
                 break;
             default:
                 break;
         }
 
-        return response;
+        return marshalledBody;
     };
 
     return {
         ...response,
-        body: response.body ? marshal(response.body) : '',
+        body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
 ",

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/custom-directories.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/custom-directories.test.ts.snap
@@ -2076,26 +2076,25 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         body,
     }, event, context);
 
-    const marshal = (responseBody: any): string => {
-
-        let response = responseBody;
-        switch(response.statusCode) {
+    const marshal = (statusCode: number, responseBody: any): string => {
+        let marshalledBody = responseBody;
+        switch(statusCode) {
             case 200:
-                response = JSON.stringify(HelloResponseToJSON(response));
+                marshalledBody = JSON.stringify(HelloResponseToJSON(marshalledBody));
                 break;
             case 400:
-                response = JSON.stringify(ApiErrorToJSON(response));
+                marshalledBody = JSON.stringify(ApiErrorToJSON(marshalledBody));
                 break;
             default:
                 break;
         }
 
-        return response;
+        return marshalledBody;
     };
 
     return {
         ...response,
-        body: response.body ? marshal(response.body) : '',
+        body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
 ",

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
@@ -14423,26 +14423,25 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         body,
     }, event, context);
 
-    const marshal = (responseBody: any): string => {
-
-        let response = responseBody;
-        switch(response.statusCode) {
+    const marshal = (statusCode: number, responseBody: any): string => {
+        let marshalledBody = responseBody;
+        switch(statusCode) {
             case 200:
-                response = JSON.stringify(HelloResponseToJSON(response));
+                marshalledBody = JSON.stringify(HelloResponseToJSON(marshalledBody));
                 break;
             case 400:
-                response = JSON.stringify(ApiErrorToJSON(response));
+                marshalledBody = JSON.stringify(ApiErrorToJSON(marshalledBody));
                 break;
             default:
                 break;
         }
 
-        return response;
+        return marshalledBody;
     };
 
     return {
         ...response,
-        body: response.body ? marshal(response.body) : '',
+        body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
 ",
@@ -29897,26 +29896,25 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         body,
     }, event, context);
 
-    const marshal = (responseBody: any): string => {
-
-        let response = responseBody;
-        switch(response.statusCode) {
+    const marshal = (statusCode: number, responseBody: any): string => {
+        let marshalledBody = responseBody;
+        switch(statusCode) {
             case 200:
-                response = JSON.stringify(HelloResponseToJSON(response));
+                marshalledBody = JSON.stringify(HelloResponseToJSON(marshalledBody));
                 break;
             case 400:
-                response = JSON.stringify(ApiErrorToJSON(response));
+                marshalledBody = JSON.stringify(ApiErrorToJSON(marshalledBody));
                 break;
             default:
                 break;
         }
 
-        return response;
+        return marshalledBody;
     };
 
     return {
         ...response,
-        body: response.body ? marshal(response.body) : '',
+        body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
 ",
@@ -45375,26 +45373,25 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         body,
     }, event, context);
 
-    const marshal = (responseBody: any): string => {
-
-        let response = responseBody;
-        switch(response.statusCode) {
+    const marshal = (statusCode: number, responseBody: any): string => {
+        let marshalledBody = responseBody;
+        switch(statusCode) {
             case 200:
-                response = JSON.stringify(HelloResponseToJSON(response));
+                marshalledBody = JSON.stringify(HelloResponseToJSON(marshalledBody));
                 break;
             case 400:
-                response = JSON.stringify(ApiErrorToJSON(response));
+                marshalledBody = JSON.stringify(ApiErrorToJSON(marshalledBody));
                 break;
             default:
                 break;
         }
 
-        return response;
+        return marshalledBody;
     };
 
     return {
         ...response,
-        body: response.body ? marshal(response.body) : '',
+        body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
 ",

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
@@ -13880,26 +13880,25 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         body,
     }, event, context);
 
-    const marshal = (responseBody: any): string => {
-
-        let response = responseBody;
-        switch(response.statusCode) {
+    const marshal = (statusCode: number, responseBody: any): string => {
+        let marshalledBody = responseBody;
+        switch(statusCode) {
             case 200:
-                response = JSON.stringify(HelloResponseToJSON(response));
+                marshalledBody = JSON.stringify(HelloResponseToJSON(marshalledBody));
                 break;
             case 400:
-                response = JSON.stringify(ApiErrorToJSON(response));
+                marshalledBody = JSON.stringify(ApiErrorToJSON(marshalledBody));
                 break;
             default:
                 break;
         }
 
-        return response;
+        return marshalledBody;
     };
 
     return {
         ...response,
-        body: response.body ? marshal(response.body) : '',
+        body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
 ",
@@ -28753,26 +28752,25 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         body,
     }, event, context);
 
-    const marshal = (responseBody: any): string => {
-
-        let response = responseBody;
-        switch(response.statusCode) {
+    const marshal = (statusCode: number, responseBody: any): string => {
+        let marshalledBody = responseBody;
+        switch(statusCode) {
             case 200:
-                response = JSON.stringify(HelloResponseToJSON(response));
+                marshalledBody = JSON.stringify(HelloResponseToJSON(marshalledBody));
                 break;
             case 400:
-                response = JSON.stringify(ApiErrorToJSON(response));
+                marshalledBody = JSON.stringify(ApiErrorToJSON(marshalledBody));
                 break;
             default:
                 break;
         }
 
-        return response;
+        return marshalledBody;
     };
 
     return {
         ...response,
-        body: response.body ? marshal(response.body) : '',
+        body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
 ",
@@ -43607,26 +43605,25 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         body,
     }, event, context);
 
-    const marshal = (responseBody: any): string => {
-
-        let response = responseBody;
-        switch(response.statusCode) {
+    const marshal = (statusCode: number, responseBody: any): string => {
+        let marshalledBody = responseBody;
+        switch(statusCode) {
             case 200:
-                response = JSON.stringify(HelloResponseToJSON(response));
+                marshalledBody = JSON.stringify(HelloResponseToJSON(marshalledBody));
                 break;
             case 400:
-                response = JSON.stringify(ApiErrorToJSON(response));
+                marshalledBody = JSON.stringify(ApiErrorToJSON(marshalledBody));
                 break;
             default:
                 break;
         }
 
-        return response;
+        return marshalledBody;
     };
 
     return {
         ...response,
-        body: response.body ? marshal(response.body) : '',
+        body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
 ",

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/with-docs.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/with-docs.test.ts.snap
@@ -5325,26 +5325,25 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         body,
     }, event, context);
 
-    const marshal = (responseBody: any): string => {
-
-        let response = responseBody;
-        switch(response.statusCode) {
+    const marshal = (statusCode: number, responseBody: any): string => {
+        let marshalledBody = responseBody;
+        switch(statusCode) {
             case 200:
-                response = JSON.stringify(HelloResponseToJSON(response));
+                marshalledBody = JSON.stringify(HelloResponseToJSON(marshalledBody));
                 break;
             case 400:
-                response = JSON.stringify(ApiErrorToJSON(response));
+                marshalledBody = JSON.stringify(ApiErrorToJSON(marshalledBody));
                 break;
             default:
                 break;
         }
 
-        return response;
+        return marshalledBody;
     };
 
     return {
         ...response,
-        body: response.body ? marshal(response.body) : '',
+        body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
 ",

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/without-sample-code.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/without-sample-code.test.ts.snap
@@ -2076,26 +2076,25 @@ export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<
         body,
     }, event, context);
 
-    const marshal = (responseBody: any): string => {
-
-        let response = responseBody;
-        switch(response.statusCode) {
+    const marshal = (statusCode: number, responseBody: any): string => {
+        let marshalledBody = responseBody;
+        switch(statusCode) {
             case 200:
-                response = JSON.stringify(HelloResponseToJSON(response));
+                marshalledBody = JSON.stringify(HelloResponseToJSON(marshalledBody));
                 break;
             case 400:
-                response = JSON.stringify(ApiErrorToJSON(response));
+                marshalledBody = JSON.stringify(ApiErrorToJSON(marshalledBody));
                 break;
             default:
                 break;
         }
 
-        return response;
+        return marshalledBody;
     };
 
     return {
         ...response,
-        body: response.body ? marshal(response.body) : '',
+        body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
 ",


### PR DESCRIPTION
This fixes a 502 Bad Gateway error which was introduced in 0.5.3 - when specific response type
marshalling was added we were actually not switching on the status code, so moving the
JSON.stringify in the last commit caused the lambda response to be malformed
