### PR TITLE
fix(open-api-gateway): iam auth in combination with other authorizers

### DIFF
--- a/packages/open-api-gateway/src/construct/spec/api-gateway-auth.ts
+++ b/packages/open-api-gateway/src/construct/spec/api-gateway-auth.ts
@@ -21,10 +21,12 @@ import {
   CognitoAuthorizer,
   CustomAuthorizer,
   CustomAuthorizerType,
+  NoneAuthorizer,
 } from "../authorizers";
 import {
   isCognitoAuthorizer,
   isCustomAuthorizer,
+  isIamAuthorizer,
 } from "../authorizers/predicates";
 import { OpenApiOptions } from "./api-gateway-integrations-types";
 import { functionInvocationUri } from "./utils";
@@ -70,12 +72,19 @@ export interface CustomApiGatewayAuthorizer {
 /**
  * Open API definition for an api gateway security scheme
  */
-export interface ApiGatewaySecurityScheme<AuthorizerType>
+export interface ApiGatewaySecurityScheme
   extends OpenAPIV3.ApiKeySecurityScheme {
   /**
    * The type of api gateway authorizer
    */
   readonly "x-amazon-apigateway-authtype": string;
+}
+
+/**
+ * Open API definition for an api gateway security scheme with authorizer details
+ */
+export interface ApiGatewaySecuritySchemeWithAuthorizer<AuthorizerType>
+  extends ApiGatewaySecurityScheme {
   /**
    * Details about the authorizer
    */
@@ -86,13 +95,18 @@ export interface ApiGatewaySecurityScheme<AuthorizerType>
  * The security scheme for a cognito authorizer
  */
 export type CognitoSecurityScheme =
-  ApiGatewaySecurityScheme<CognitoApiGatewayAuthorizer>;
+  ApiGatewaySecuritySchemeWithAuthorizer<CognitoApiGatewayAuthorizer>;
 
 /**
  * The security scheme for a custom authorizer
  */
 export type CustomSecurityScheme =
-  ApiGatewaySecurityScheme<CustomApiGatewayAuthorizer>;
+  ApiGatewaySecuritySchemeWithAuthorizer<CustomApiGatewayAuthorizer>;
+
+/**
+ * The security scheme for an iam authorizer
+ */
+export type IamSecurityScheme = ApiGatewaySecurityScheme;
 
 // Regex to match against a single header identity source
 const SINGLE_HEADER_IDENTITY_SOURCE_REGEX =
@@ -103,7 +117,11 @@ const SINGLE_HEADER_IDENTITY_SOURCE_REGEX =
  * @param authorizer the authorizer used for the method
  */
 export const applyMethodAuthorizer = (authorizer: Authorizer) => {
-  if (isCustomAuthorizer(authorizer) || isCognitoAuthorizer(authorizer)) {
+  if (
+    isCustomAuthorizer(authorizer) ||
+    isCognitoAuthorizer(authorizer) ||
+    isIamAuthorizer(authorizer)
+  ) {
     return {
       security: [
         {
@@ -114,13 +132,25 @@ export const applyMethodAuthorizer = (authorizer: Authorizer) => {
       ],
     };
   }
-  // IAM and NONE are specified via x-amazon-apigateway-auth
+
+  // NONE is specified via x-amazon-apigateway-auth
   return {
     "x-amazon-apigateway-auth": {
-      type: authorizer.authorizationType,
+      type: (authorizer as NoneAuthorizer).authorizationType,
     },
   };
 };
+
+/**
+ * Create an OpenAPI security scheme definition for an iam authorizer
+ * @see https://docs.amazonaws.cn/en_us/apigateway/latest/developerguide/api-gateway-swagger-extensions-authtype.html
+ */
+const iamSecurityScheme = (): IamSecurityScheme => ({
+  type: "apiKey",
+  name: "Authorization",
+  in: "header",
+  "x-amazon-apigateway-authtype": "awsSigv4",
+});
 
 /**
  * Create an OpenAPI security scheme definition for a cognito authorizer
@@ -198,7 +228,7 @@ export const prepareSecuritySchemes = (
   // All the defined authorizers
   const allAuthorizers = getAllAuthorizers(options);
 
-  // Cognito and custom authorizers must be declared in security schemes
+  // Cognito, IAM and custom authorizers must be declared in security schemes
   return {
     ...Object.fromEntries(
       allAuthorizers
@@ -215,6 +245,11 @@ export const prepareSecuritySchemes = (
           authorizer.authorizerId,
           customSecurityScheme(scope, authorizer as CustomAuthorizer),
         ])
+    ),
+    ...Object.fromEntries(
+      allAuthorizers
+        .filter((authorizer) => isIamAuthorizer(authorizer))
+        .map((authorizer) => [authorizer.authorizerId, iamSecurityScheme()])
     ),
   };
 };

--- a/packages/open-api-gateway/src/construct/spec/api-gateway-auth.ts
+++ b/packages/open-api-gateway/src/construct/spec/api-gateway-auth.ts
@@ -209,14 +209,19 @@ const customSecurityScheme = (
 };
 
 /**
- * Return a list of all authorizers used in the api
+ * Return a list of all unique authorizers used in the api
  */
-export const getAllAuthorizers = (options: OpenApiOptions): Authorizer[] => [
-  ...(options.defaultAuthorizer ? [options.defaultAuthorizer] : []),
-  ...Object.values(options.integrations).flatMap(({ authorizer }) =>
-    authorizer ? [authorizer] : []
-  ),
-];
+export const getAllAuthorizers = (options: OpenApiOptions): Authorizer[] =>
+  Object.values(
+    Object.fromEntries(
+      [
+        ...(options.defaultAuthorizer ? [options.defaultAuthorizer] : []),
+        ...Object.values(options.integrations).flatMap(({ authorizer }) =>
+          authorizer ? [authorizer] : []
+        ),
+      ].map((a) => [a.authorizerId, a])
+    )
+  );
 
 /**
  * Generate the security schemes section of an OpenAPI specification

--- a/packages/open-api-gateway/test/construct/__snapshots__/open-api-gateway-lambda-api.test.ts.snap
+++ b/packages/open-api-gateway/test/construct/__snapshots__/open-api-gateway-lambda-api.test.ts.snap
@@ -1627,7 +1627,14 @@ Object {
       "Properties": Object {
         "Body": Object {
           "components": Object {
-            "securitySchemes": Object {},
+            "securitySchemes": Object {
+              "iam": Object {
+                "in": "header",
+                "name": "Authorization",
+                "type": "apiKey",
+                "x-amazon-apigateway-authtype": "awsSigv4",
+              },
+            },
           },
           "info": Object {
             "title": "Test API",
@@ -1672,9 +1679,11 @@ Object {
                     },
                   },
                 },
-                "x-amazon-apigateway-auth": Object {
-                  "type": "AWS_IAM",
-                },
+                "security": Array [
+                  Object {
+                    "iam": Array [],
+                  },
+                ],
                 "x-amazon-apigateway-integration": Object {
                   "httpMethod": "POST",
                   "passthroughBehavior": "WHEN_NO_MATCH",
@@ -1860,7 +1869,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestDeployment59A5FA035442b7c5e4c0522c571ff6506b1af844": Object {
+    "ApiTestDeployment59A5FA03f4634d9a9ddbdf61b02560e8063aeebc": Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
@@ -1919,7 +1928,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment59A5FA035442b7c5e4c0522c571ff6506b1af844",
+          "Ref": "ApiTestDeployment59A5FA03f4634d9a9ddbdf61b02560e8063aeebc",
         },
         "MethodSettings": Array [
           Object {
@@ -2143,6 +2152,12 @@ Object {
         "Body": Object {
           "components": Object {
             "securitySchemes": Object {
+              "iam": Object {
+                "in": "header",
+                "name": "Authorization",
+                "type": "apiKey",
+                "x-amazon-apigateway-authtype": "awsSigv4",
+              },
               "myCognitoAuthorizer": Object {
                 "in": "header",
                 "name": "Authorization",
@@ -2223,9 +2238,11 @@ Object {
                     "headers": Object {},
                   },
                 },
-                "x-amazon-apigateway-auth": Object {
-                  "type": "AWS_IAM",
-                },
+                "security": Array [
+                  Object {
+                    "iam": Array [],
+                  },
+                ],
                 "x-amazon-apigateway-integration": Object {
                   "httpMethod": "POST",
                   "passthroughBehavior": "WHEN_NO_MATCH",
@@ -2526,7 +2543,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestDeployment59A5FA03b1b82329eaf0910947bf434208258930": Object {
+    "ApiTestDeployment59A5FA03da04ca3e47ec452e3e6af88f0b33bc62": Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
@@ -2585,7 +2602,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment59A5FA03b1b82329eaf0910947bf434208258930",
+          "Ref": "ApiTestDeployment59A5FA03da04ca3e47ec452e3e6af88f0b33bc62",
         },
         "MethodSettings": Array [
           Object {


### PR DESCRIPTION
Use the securitySchemes way of defining iam auth for api methods, since using
x-amazon-apigateway-auth does not work in conjunction with other authorizers defined in security
schemes.
