### PR TITLE
feat(open-api-gateway): stricter type enforcement for error responses…

### DIFF
--- a/packages/open-api-gateway/scripts/generators/python/templates/operationConfig.mustache
+++ b/packages/open-api-gateway/scripts/generators/python/templates/operationConfig.mustache
@@ -1,6 +1,6 @@
 import urllib.parse
 import json
-from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional
+from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional, Literal
 from functools import wraps
 from dataclasses import dataclass
 
@@ -79,14 +79,13 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
 
 
 ResponseBody = TypeVar('ResponseBody')
-ApiError = TypeVar('ApiError')
-
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
-class ApiResponse(Generic[ResponseBody, ApiError]):
-    status_code: int
+class ApiResponse(Generic[StatusCode, ResponseBody]):
+    status_code: StatusCode
     headers: Dict[str, str]
-    body: Union[ResponseBody, ApiError]
+    body: ResponseBody
 
 
 {{#operations}}
@@ -117,11 +116,16 @@ class {{operationIdCamelCase}}RequestArrayParameters(TypedDict):
 # Request body type (default to Any when no body parameters exist)
 {{operationIdCamelCase}}RequestBody = {{^bodyParams.isEmpty}}{{#bodyParams.0}}{{dataType}}{{/bodyParams.0}}{{/bodyParams.isEmpty}}{{#bodyParams.isEmpty}}Any{{/bodyParams.isEmpty}}
 
+{{#responses}}
+{{operationIdCamelCase}}{{code}}OperationResponse = ApiResponse[Literal[{{code}}], {{^simpleType}}{{dataType}}{{/simpleType}}{{#simpleType}}None{{/simpleType}}]
+{{/responses}}
+{{operationIdCamelCase}}OperationResponses = Union[{{#responses}}{{operationIdCamelCase}}{{code}}OperationResponse, {{/responses}}]
+
 # Request type for {{operationId}}
 {{operationIdCamelCase}}Request = ApiRequest[{{operationIdCamelCase}}RequestParameters, {{operationIdCamelCase}}RequestArrayParameters, {{operationIdCamelCase}}RequestBody]
 
 class {{operationIdCamelCase}}HandlerFunction(Protocol):
-    def __call__(self, input: {{operationIdCamelCase}}Request, **kwargs) -> ApiResponse[{{returnType}}, ApiError]:
+    def __call__(self, input: {{operationIdCamelCase}}Request, **kwargs) -> {{operationIdCamelCase}}OperationResponses:
         ...
 
 def {{operationId}}_handler(handler: {{operationIdCamelCase}}HandlerFunction):

--- a/packages/open-api-gateway/scripts/generators/typescript/templates/operationConfig.mustache
+++ b/packages/open-api-gateway/scripts/generators/typescript/templates/operationConfig.mustache
@@ -67,10 +67,10 @@ const parseBody = (body: string, demarshal: (body: string) => any, contentTypes:
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
 
 // Type of the response to be returned by an operation lambda handler
-export interface OperationResponse<T, ApiError> {
-    statusCode: number;
+export interface OperationResponse<StatusCode extends number, Body> {
+    statusCode: StatusCode;
     headers?: { [key: string]: string };
-    body?: T | ApiError;
+    body: Body;
 }
 
 // Input for a lambda handler for an operation
@@ -83,28 +83,28 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
 /**
  * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
  */
-export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response>,
+) => Promise<Response>;
 
 // Type for a lambda handler function to be wrapped
-export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+) => Promise<Response>;
 
-export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
-  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>;
 }
 
 /**
  * Build a chain from the given array of chained lambda handlers
  */
-const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, Response>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> => {
   if (handlers.length === 0) {
     return {
       next: () => {
@@ -122,9 +122,6 @@ const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBod
 
 {{#operations}}
 {{#operation}}
-// Type alias for the request
-type {{operationIdCamelCase}}RequestInput = {{#allParams.0}}{{#prefixParameterInterfaces}}{{classname}}{{/prefixParameterInterfaces}}{{operationIdCamelCase}}Request{{/allParams.0}}{{^allParams.0}}{}{{/allParams.0}};
-
 /**
  * Single-value path/query parameters for {{operationIdCamelCase}}
  */
@@ -156,13 +153,18 @@ export interface {{operationIdCamelCase}}RequestArrayParameters {
  */
 export type {{operationIdCamelCase}}RequestBody = {{#bodyParam}}{{dataType}}{{/bodyParam}}{{^bodyParam}}never{{/bodyParam}};
 
+{{#responses}}
+export type {{operationIdCamelCase}}{{code}}OperationResponse = OperationResponse<{{code}}, {{#dataType}}{{.}}{{/dataType}}{{^dataType}}undefined{{/dataType}}>;
+{{/responses}}
+export type {{operationIdCamelCase}}OperationResponses = {{#responses}}| {{operationIdCamelCase}}{{code}}OperationResponse {{/responses}};
+
 // Type that the handler function provided to the wrapper must conform to
-export type {{operationIdCamelCase}}HandlerFunction<ApiError> = ChainedLambdaHandlerFunction<{{operationIdCamelCase}}RequestParameters, {{operationIdCamelCase}}RequestArrayParameters, {{operationIdCamelCase}}RequestBody, {{returnType}}, ApiError>;
+export type {{operationIdCamelCase}}HandlerFunction = ChainedLambdaHandlerFunction<{{operationIdCamelCase}}RequestParameters, {{operationIdCamelCase}}RequestArrayParameters, {{operationIdCamelCase}}RequestBody, {{operationIdCamelCase}}OperationResponses>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of {{nickname}}
  */
-export const {{nickname}}Handler = <ApiError>(firstHandler: {{operationIdCamelCase}}HandlerFunction<ApiError>, ...remainingHandlers: {{operationIdCamelCase}}HandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const {{nickname}}Handler = (firstHandler: {{operationIdCamelCase}}HandlerFunction, ...remainingHandlers: {{operationIdCamelCase}}HandlerFunction[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),

--- a/packages/open-api-gateway/src/project/samples/python.ts
+++ b/packages/open-api-gateway/src/project/samples/python.ts
@@ -111,12 +111,11 @@ class SampleApi(Construct):
       )
 `,
         // Generate an example lambda handler
-        "handlers/say_hello_handler_sample.py": `from ${options.pythonClientPackageName}.api.default_api_operation_config import say_hello_handler, SayHelloRequest, ApiResponse
-from ${options.pythonClientPackageName}.model.api_error import ApiError
+        "handlers/say_hello_handler_sample.py": `from ${options.pythonClientPackageName}.api.default_api_operation_config import say_hello_handler, SayHelloRequest, ApiResponse, SayHelloOperationResponses
 from ${options.pythonClientPackageName}.model.hello_response import HelloResponse
 
 @say_hello_handler
-def handler(input: SayHelloRequest, **kwargs) -> ApiResponse[HelloResponse, ApiError]:
+def handler(input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:
     """
     An example lambda handler which uses the generated handler wrapper to manage marshalling inputs/outputs
     """

--- a/packages/open-api-gateway/src/project/samples/typescript.ts
+++ b/packages/open-api-gateway/src/project/samples/typescript.ts
@@ -109,12 +109,12 @@ export class SampleApi extends Api {
 }
 `,
         // Generate an example lambda handler
-        "sample-api.say-hello.ts": `import { sayHelloHandler, ApiError } from "${options.typescriptClientPackageName}";
+        "sample-api.say-hello.ts": `import { sayHelloHandler } from "${options.typescriptClientPackageName}";
 
 /**
  * An example lambda handler which uses the generated handler wrapper to manage marshalling inputs/outputs.
  */
-export const handler = sayHelloHandler<ApiError>(async (input) => {
+export const handler = sayHelloHandler(async (input) => {
   return {
     statusCode: 200,
     body: {

--- a/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-java-client-source-code.test.ts.snap
+++ b/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-java-client-source-code.test.ts.snap
@@ -7337,12 +7337,10 @@ public class Example {
     defaultClient.setBasePath(\\"http://localhost\\");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
-    File body = new File(\\"/path/to/file\\"); // File | 
     try {
-      String result = apiInstance.mediaTypes(body);
-      System.out.println(result);
+      apiInstance.empty();
     } catch (ApiException e) {
-      System.err.println(\\"Exception when calling DefaultApi#mediaTypes\\");
+      System.err.println(\\"Exception when calling DefaultApi#empty\\");
       System.err.println(\\"Status code: \\" + e.getCode());
       System.err.println(\\"Reason: \\" + e.getResponseBody());
       System.err.println(\\"Response headers: \\" + e.getResponseHeaders());
@@ -7359,6 +7357,7 @@ All URIs are relative to *http://localhost*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
+*DefaultApi* | [**empty**](docs/DefaultApi.md#empty) | **PUT** /empty-response | 
 *DefaultApi* | [**mediaTypes**](docs/DefaultApi.md#mediaTypes) | **POST** /different-media-type | 
 *DefaultApi* | [**operationOne**](docs/DefaultApi.md#operationOne) | **POST** /path/{pathParam} | 
 *DefaultApi* | [**withoutOperationIdDelete**](docs/DefaultApi.md#withoutOperationIdDelete) | **DELETE** /without-operation-id | 
@@ -7457,6 +7456,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/TestResponse'
           description: Successful response
+      x-accepts: application/json
+  /empty-response:
+    put:
+      operationId: empty
+      responses:
+        \\"204\\":
+          description: No response body!
       x-accepts: application/json
   /different-media-type:
     post:
@@ -7724,10 +7730,66 @@ All URIs are relative to *http://localhost*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
+| [**empty**](DefaultApi.md#empty) | **PUT** /empty-response |  |
 | [**mediaTypes**](DefaultApi.md#mediaTypes) | **POST** /different-media-type |  |
 | [**operationOne**](DefaultApi.md#operationOne) | **POST** /path/{pathParam} |  |
 | [**withoutOperationIdDelete**](DefaultApi.md#withoutOperationIdDelete) | **DELETE** /without-operation-id |  |
 
+
+<a name=\\"empty\\"></a>
+# **empty**
+> empty()
+
+
+
+### Example
+\`\`\`java
+// Import classes:
+import test.test.client.ApiClient;
+import test.test.client.ApiException;
+import test.test.client.Configuration;
+import test.test.client.models.*;
+import test.test.client.api.DefaultApi;
+
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath(\\"http://localhost\\");
+
+    DefaultApi apiInstance = new DefaultApi(defaultClient);
+    try {
+      apiInstance.empty();
+    } catch (ApiException e) {
+      System.err.println(\\"Exception when calling DefaultApi#empty\\");
+      System.err.println(\\"Status code: \\" + e.getCode());
+      System.err.println(\\"Reason: \\" + e.getResponseBody());
+      System.err.println(\\"Response headers: \\" + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
+}
+\`\`\`
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **204** | No response body! |  -  |
 
 <a name=\\"mediaTypes\\"></a>
 # **mediaTypes**
@@ -12000,6 +12062,119 @@ public class DefaultApi {
     }
 
     /**
+     * Build call for empty
+     * @param _callback Callback for upload/download progress
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     * @http.response.details
+     <table summary=\\"Response Details\\" border=\\"1\\">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 204 </td><td> No response body! </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call emptyCall(final ApiCallback _callback) throws ApiException {
+        String basePath = null;
+        // Operation Servers
+        String[] localBasePaths = new String[] {  };
+
+        // Determine Base Path to Use
+        if (localCustomBaseUrl != null){
+            basePath = localCustomBaseUrl;
+        } else if ( localBasePaths.length > 0 ) {
+            basePath = localBasePaths[localHostIndex];
+        } else {
+            basePath = null;
+        }
+
+        Object localVarPostBody = null;
+
+        // create path and map variables
+        String localVarPath = \\"/empty-response\\";
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        final String[] localVarAccepts = {
+            
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put(\\"Accept\\", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+            
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        if (localVarContentType != null) {
+            localVarHeaderParams.put(\\"Content-Type\\", localVarContentType);
+        }
+
+        String[] localVarAuthNames = new String[] {  };
+        return localVarApiClient.buildCall(basePath, localVarPath, \\"PUT\\", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    @SuppressWarnings(\\"rawtypes\\")
+    private okhttp3.Call emptyValidateBeforeCall(final ApiCallback _callback) throws ApiException {
+        
+
+        okhttp3.Call localVarCall = emptyCall(_callback);
+        return localVarCall;
+
+    }
+
+    /**
+     * 
+     * 
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary=\\"Response Details\\" border=\\"1\\">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 204 </td><td> No response body! </td><td>  -  </td></tr>
+     </table>
+     */
+    public void empty() throws ApiException {
+        emptyWithHttpInfo();
+    }
+
+    /**
+     * 
+     * 
+     * @return ApiResponse&lt;Void&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary=\\"Response Details\\" border=\\"1\\">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 204 </td><td> No response body! </td><td>  -  </td></tr>
+     </table>
+     */
+    public ApiResponse<Void> emptyWithHttpInfo() throws ApiException {
+        okhttp3.Call localVarCall = emptyValidateBeforeCall(null);
+        return localVarApiClient.execute(localVarCall);
+    }
+
+    /**
+     *  (asynchronously)
+     * 
+     * @param _callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     * @http.response.details
+     <table summary=\\"Response Details\\" border=\\"1\\">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 204 </td><td> No response body! </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call emptyAsync(final ApiCallback<Void> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = emptyValidateBeforeCall(_callback);
+        localVarApiClient.executeAsync(localVarCall, _callback);
+        return localVarCall;
+    }
+    /**
      * Build call for mediaTypes
      * @param body  (required)
      * @param _callback Callback for upload/download progress
@@ -12439,6 +12614,7 @@ import java.util.Map;
 // Generic type for object \\"keyed\\" by operation names
 @javax.annotation.Generated(value = \\"org.openapitools.codegen.languages.JavaClientCodegen\\")
 public abstract class OperationConfig<T> {
+    public T empty;
     public T mediaTypes;
     public T operationOne;
     public T withoutOperationIdDelete;
@@ -12469,6 +12645,7 @@ public class OperationLookup {
     public static Map<String, Map<String, String>> getOperationLookup() {
         final Map<String, Map<String, String>> config = new HashMap<>();
 
+        config.put(\\"empty\\", new HashMap<String, String>() { { put(\\"path\\", \\"/empty-response\\"); put(\\"method\\", \\"PUT\\"); } });
         config.put(\\"mediaTypes\\", new HashMap<String, String>() { { put(\\"path\\", \\"/different-media-type\\"); put(\\"method\\", \\"POST\\"); } });
         config.put(\\"operationOne\\", new HashMap<String, String>() { { put(\\"path\\", \\"/path/{pathParam}\\"); put(\\"method\\", \\"POST\\"); } });
         config.put(\\"withoutOperationIdDelete\\", new HashMap<String, String>() { { put(\\"path\\", \\"/without-operation-id\\"); put(\\"method\\", \\"DELETE\\"); } });
@@ -13822,6 +13999,15 @@ import java.util.Map;
 public class DefaultApiTest {
 
     private final DefaultApi api = new DefaultApi();
+
+    /**
+     * @throws ApiException if the Api call fails
+     */
+    @Test
+    public void emptyTest() throws ApiException {
+        api.empty();
+        // TODO: test validations
+    }
 
     /**
      * @throws ApiException if the Api call fails

--- a/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-python-client-source-code.test.ts.snap
+++ b/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-python-client-source-code.test.ts.snap
@@ -1038,7 +1038,7 @@ class SomeTestOperation(api_client.Api):
 ",
   "test/api/default_api_operation_config.py": "import urllib.parse
 import json
-from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional
+from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional, Literal
 from functools import wraps
 from dataclasses import dataclass
 
@@ -1109,14 +1109,13 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
 
 
 ResponseBody = TypeVar('ResponseBody')
-ApiError = TypeVar('ApiError')
-
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
-class ApiResponse(Generic[ResponseBody, ApiError]):
-    status_code: int
+class ApiResponse(Generic[StatusCode, ResponseBody]):
+    status_code: StatusCode
     headers: Dict[str, str]
-    body: Union[ResponseBody, ApiError]
+    body: ResponseBody
 
 
 
@@ -1132,11 +1131,15 @@ class SomeTestOperationRequestArrayParameters(TypedDict):
 # Request body type (default to Any when no body parameters exist)
 SomeTestOperationRequestBody = TestRequest
 
+SomeTestOperation200OperationResponse = ApiResponse[Literal[200], TestResponse]
+SomeTestOperation400OperationResponse = ApiResponse[Literal[400], ApiError]
+SomeTestOperationOperationResponses = Union[SomeTestOperation200OperationResponse, SomeTestOperation400OperationResponse, ]
+
 # Request type for some_test_operation
 SomeTestOperationRequest = ApiRequest[SomeTestOperationRequestParameters, SomeTestOperationRequestArrayParameters, SomeTestOperationRequestBody]
 
 class SomeTestOperationHandlerFunction(Protocol):
-    def __call__(self, input: SomeTestOperationRequest, **kwargs) -> ApiResponse[TestResponse, ApiError]:
+    def __call__(self, input: SomeTestOperationRequest, **kwargs) -> SomeTestOperationOperationResponses:
         ...
 
 def some_test_operation_handler(handler: SomeTestOperationHandlerFunction):
@@ -6596,13 +6599,11 @@ configuration = test.Configuration(
 with test.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    body = open('/path/to/file', 'rb') # file_type | 
-
+    
     try:
-        api_response = api_instance.media_types(body)
-        pprint(api_response)
+        api_instance.empty()
     except test.ApiException as e:
-        print(\\"Exception when calling DefaultApi->media_types: %s\\\\n\\" % e)
+        print(\\"Exception when calling DefaultApi->empty: %s\\\\n\\" % e)
 \`\`\`
 
 ## Documentation for API Endpoints
@@ -6611,6 +6612,7 @@ All URIs are relative to *http://localhost*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
+*DefaultApi* | [**empty**](docs/DefaultApi.md#empty) | **PUT** /empty-response | 
 *DefaultApi* | [**media_types**](docs/DefaultApi.md#media_types) | **POST** /different-media-type | 
 *DefaultApi* | [**operation_one**](docs/DefaultApi.md#operation_one) | **POST** /path/{pathParam} | 
 *DefaultApi* | [**without_operation_id_delete**](docs/DefaultApi.md#without_operation_id_delete) | **DELETE** /without-operation-id | 
@@ -6665,9 +6667,64 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**empty**](DefaultApi.md#empty) | **PUT** /empty-response | 
 [**media_types**](DefaultApi.md#media_types) | **POST** /different-media-type | 
 [**operation_one**](DefaultApi.md#operation_one) | **POST** /path/{pathParam} | 
 [**without_operation_id_delete**](DefaultApi.md#without_operation_id_delete) | **DELETE** /without-operation-id | 
+
+# **empty**
+> empty()
+
+
+
+### Example
+
+\`\`\`python
+import test
+from test.api import default_api
+from pprint import pprint
+# Defining the host is optional and defaults to http://localhost
+# See configuration.py for a list of all supported configuration parameters.
+configuration = test.Configuration(
+    host = \\"http://localhost\\"
+)
+
+# Enter a context with an instance of the API client
+with test.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = default_api.DefaultApi(api_client)
+
+    # example, this endpoint has no required or optional parameters
+    try:
+        api_response = api_instance.empty()
+    except test.ApiException as e:
+        print(\\"Exception when calling DefaultApi->empty: %s\\\\n\\" % e)
+\`\`\`
+### Parameters
+This endpoint does not need any parameter.
+
+### Return Types, Responses
+
+Code | Class | Description
+------------- | ------------- | -------------
+n/a | api_client.ApiResponseWithoutDeserialization | When skip_deserialization is True this response is returned
+204 | ApiResponseFor204 | No response body!
+
+#### ApiResponseFor204
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+response | urllib3.HTTPResponse | Raw response |
+body | Unset | body was not defined |
+headers | Unset | headers were not defined |
+
+
+void (empty response body)
+
+### Authorization
+
+No authorization required
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **media_types**
 > str media_types(body)
@@ -7132,12 +7189,14 @@ if __name__ == \\"__main__\\":
 \\"\\"\\"
 
 from test.api_client import ApiClient
+from test.api.default_api_endpoints.empty import Empty
 from test.api.default_api_endpoints.media_types import MediaTypes
 from test.api.default_api_endpoints.operation_one import OperationOne
 from test.api.default_api_endpoints.without_operation_id_delete import WithoutOperationIdDelete
 
 
 class DefaultApi(
+    Empty,
     MediaTypes,
     OperationOne,
     WithoutOperationIdDelete,
@@ -7153,6 +7212,129 @@ class DefaultApi(
   "test/api/default_api_endpoints/__init__.py": "# do not import all endpoints into this module because that uses a lot of memory and stack frames
 # if you need the ability to import all endpoints from this module, import them with
 # from test.api.default_api import DefaultApi
+",
+  "test/api/default_api_endpoints/empty.py": "# coding: utf-8
+
+\\"\\"\\"
+
+
+    Generated by: https://openapi-generator.tech
+\\"\\"\\"
+
+from dataclasses import dataclass
+import re  # noqa: F401
+import sys  # noqa: F401
+import typing
+import urllib3
+import functools  # noqa: F401
+
+from test import api_client, exceptions
+import decimal  # noqa: F401
+from datetime import date, datetime  # noqa: F401
+from frozendict import frozendict  # noqa: F401
+
+from test.schemas import (  # noqa: F401
+    AnyTypeSchema,
+    ComposedSchema,
+    DictSchema,
+    ListSchema,
+    StrSchema,
+    IntSchema,
+    Int32Schema,
+    Int64Schema,
+    Float32Schema,
+    Float64Schema,
+    NumberSchema,
+    UUIDSchema,
+    DateSchema,
+    DateTimeSchema,
+    DecimalSchema,
+    BoolSchema,
+    BinarySchema,
+    NoneSchema,
+    none_type,
+    Configuration,
+    Unset,
+    unset,
+    ComposedBase,
+    ListBase,
+    DictBase,
+    NoneBase,
+    StrBase,
+    IntBase,
+    Int32Base,
+    Int64Base,
+    Float32Base,
+    Float64Base,
+    NumberBase,
+    UUIDBase,
+    DateBase,
+    DateTimeBase,
+    BoolBase,
+    BinaryBase,
+    Schema,
+    _SchemaValidator,
+    _SchemaTypeChecker,
+    _SchemaEnumMaker
+)
+
+_path = '/empty-response'
+_method = 'PUT'
+
+
+@dataclass
+class ApiResponseFor204(api_client.ApiResponse):
+    response: urllib3.HTTPResponse
+    body: Unset = unset
+    headers: Unset = unset
+
+
+_response_for_204 = api_client.OpenApiResponse(
+    response_cls=ApiResponseFor204,
+)
+_status_code_to_response = {
+    '204': _response_for_204,
+}
+
+
+class Empty(api_client.Api):
+
+    def empty(
+        self: api_client.Api,
+        stream: bool = False,
+        timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
+        skip_deserialization: bool = False,
+    ) -> typing.Union[
+        ApiResponseFor204,
+        api_client.ApiResponseWithoutDeserialization
+    ]:
+        \\"\\"\\"
+        :param skip_deserialization: If true then api_response.response will be set but
+            api_response.body and api_response.headers will not be deserialized into schema
+            class instances
+        \\"\\"\\"
+        # TODO add cookie handling
+
+        response = self.api_client.call_api(
+            resource_path=_path,
+            method=_method,
+            stream=stream,
+            timeout=timeout,
+        )
+
+        if skip_deserialization:
+            api_response = api_client.ApiResponseWithoutDeserialization(response=response)
+        else:
+            response_for_status = _status_code_to_response.get(str(response.status))
+            if response_for_status:
+                api_response = response_for_status.deserialize(response, self.api_client.configuration)
+            else:
+                api_response = api_client.ApiResponseWithoutDeserialization(response=response)
+
+        if not 200 <= response.status <= 299:
+            raise exceptions.ApiException(api_response=api_response)
+
+        return api_response
 ",
   "test/api/default_api_endpoints/media_types.py": "# coding: utf-8
 
@@ -7761,7 +7943,7 @@ class WithoutOperationIdDelete(api_client.Api):
 ",
   "test/api/default_api_operation_config.py": "import urllib.parse
 import json
-from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional
+from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional, Literal
 from functools import wraps
 from dataclasses import dataclass
 
@@ -7781,6 +7963,7 @@ T = TypeVar('T')
 # Generic type for object keyed by operation names
 @dataclass
 class OperationConfig(Generic[T]):
+    empty: T
     media_types: T
     operation_one: T
     without_operation_id_delete: T
@@ -7788,6 +7971,10 @@ class OperationConfig(Generic[T]):
 
 # Look up path and http method for a given operation name
 OperationLookup = {
+    \\"empty\\": {
+        \\"path\\": \\"/empty-response\\",
+        \\"method\\": \\"PUT\\",
+    },
     \\"media_types\\": {
         \\"path\\": \\"/different-media-type\\",
         \\"method\\": \\"POST\\",
@@ -7842,15 +8029,64 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
 
 
 ResponseBody = TypeVar('ResponseBody')
-ApiError = TypeVar('ApiError')
-
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
-class ApiResponse(Generic[ResponseBody, ApiError]):
-    status_code: int
+class ApiResponse(Generic[StatusCode, ResponseBody]):
+    status_code: StatusCode
     headers: Dict[str, str]
-    body: Union[ResponseBody, ApiError]
+    body: ResponseBody
 
+
+
+# Request parameters are single value query params or path params
+class EmptyRequestParameters(TypedDict):
+    ...
+
+# Request array parameters are multi-value query params
+class EmptyRequestArrayParameters(TypedDict):
+    ...
+
+# Request body type (default to Any when no body parameters exist)
+EmptyRequestBody = Any
+
+Empty204OperationResponse = ApiResponse[Literal[204], None]
+EmptyOperationResponses = Union[Empty204OperationResponse, ]
+
+# Request type for empty
+EmptyRequest = ApiRequest[EmptyRequestParameters, EmptyRequestArrayParameters, EmptyRequestBody]
+
+class EmptyHandlerFunction(Protocol):
+    def __call__(self, input: EmptyRequest, **kwargs) -> EmptyOperationResponses:
+        ...
+
+def empty_handler(handler: EmptyHandlerFunction):
+    \\"\\"\\"
+    Decorator for an api handler for the empty operation, providing a typed interface for inputs and outputs
+    \\"\\"\\"
+    @wraps(handler)
+    def wrapper(event, context, **kwargs):
+        request_parameters = decode_request_parameters({
+            **(event['pathParameters'] or {}),
+            **(event['queryStringParameters'] or {}),
+        })
+        request_array_parameters = decode_request_parameters({
+            **(event['multiValueQueryStringParameters'] or {}),
+        })
+        body = parse_body(event['body'], [], EmptyRequestBody)
+        response = handler(ApiRequest(
+            request_parameters,
+            request_array_parameters,
+            body,
+            event,
+            context,
+        ), **kwargs)
+        return {
+            'statusCode': response.status_code,
+            'headers': response.headers,
+            'body': json.dumps(response.body) if response.body is not None else '',
+        }
+    return wrapper
 
 
 # Request parameters are single value query params or path params
@@ -7864,11 +8100,14 @@ class MediaTypesRequestArrayParameters(TypedDict):
 # Request body type (default to Any when no body parameters exist)
 MediaTypesRequestBody = file_type
 
+MediaTypes200OperationResponse = ApiResponse[Literal[200], str]
+MediaTypesOperationResponses = Union[MediaTypes200OperationResponse, ]
+
 # Request type for media_types
 MediaTypesRequest = ApiRequest[MediaTypesRequestParameters, MediaTypesRequestArrayParameters, MediaTypesRequestBody]
 
 class MediaTypesHandlerFunction(Protocol):
-    def __call__(self, input: MediaTypesRequest, **kwargs) -> ApiResponse[str, ApiError]:
+    def __call__(self, input: MediaTypesRequest, **kwargs) -> MediaTypesOperationResponses:
         ...
 
 def media_types_handler(handler: MediaTypesHandlerFunction):
@@ -7915,11 +8154,15 @@ class OperationOneRequestArrayParameters(TypedDict):
 # Request body type (default to Any when no body parameters exist)
 OperationOneRequestBody = TestRequest
 
+OperationOne200OperationResponse = ApiResponse[Literal[200], TestResponse]
+OperationOne400OperationResponse = ApiResponse[Literal[400], ApiError]
+OperationOneOperationResponses = Union[OperationOne200OperationResponse, OperationOne400OperationResponse, ]
+
 # Request type for operation_one
 OperationOneRequest = ApiRequest[OperationOneRequestParameters, OperationOneRequestArrayParameters, OperationOneRequestBody]
 
 class OperationOneHandlerFunction(Protocol):
-    def __call__(self, input: OperationOneRequest, **kwargs) -> ApiResponse[TestResponse, ApiError]:
+    def __call__(self, input: OperationOneRequest, **kwargs) -> OperationOneOperationResponses:
         ...
 
 def operation_one_handler(handler: OperationOneHandlerFunction):
@@ -7962,11 +8205,14 @@ class WithoutOperationIdDeleteRequestArrayParameters(TypedDict):
 # Request body type (default to Any when no body parameters exist)
 WithoutOperationIdDeleteRequestBody = Any
 
+WithoutOperationIdDelete200OperationResponse = ApiResponse[Literal[200], TestResponse]
+WithoutOperationIdDeleteOperationResponses = Union[WithoutOperationIdDelete200OperationResponse, ]
+
 # Request type for without_operation_id_delete
 WithoutOperationIdDeleteRequest = ApiRequest[WithoutOperationIdDeleteRequestParameters, WithoutOperationIdDeleteRequestArrayParameters, WithoutOperationIdDeleteRequestBody]
 
 class WithoutOperationIdDeleteHandlerFunction(Protocol):
-    def __call__(self, input: WithoutOperationIdDeleteRequest, **kwargs) -> ApiResponse[TestResponse, ApiError]:
+    def __call__(self, input: WithoutOperationIdDeleteRequest, **kwargs) -> WithoutOperationIdDeleteOperationResponses:
         ...
 
 def without_operation_id_delete_handler(handler: WithoutOperationIdDeleteHandlerFunction):
@@ -12880,6 +13126,12 @@ class TestDefaultApi(unittest.TestCase):
         self.api = DefaultApi()  # noqa: E501
 
     def tearDown(self):
+        pass
+
+    def test_empty(self):
+        \\"\\"\\"Test case for empty
+
+        \\"\\"\\"
         pass
 
     def test_media_types(self):

--- a/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-typescript-client-source-code.test.ts.snap
+++ b/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-typescript-client-source-code.test.ts.snap
@@ -1352,10 +1352,10 @@ const parseBody = (body: string, demarshal: (body: string) => any, contentTypes:
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
 
 // Type of the response to be returned by an operation lambda handler
-export interface OperationResponse<T, ApiError> {
-    statusCode: number;
+export interface OperationResponse<StatusCode extends number, Body> {
+    statusCode: StatusCode;
     headers?: { [key: string]: string };
-    body?: T | ApiError;
+    body: Body;
 }
 
 // Input for a lambda handler for an operation
@@ -1368,28 +1368,28 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
 /**
  * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
  */
-export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response>,
+) => Promise<Response>;
 
 // Type for a lambda handler function to be wrapped
-export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+) => Promise<Response>;
 
-export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
-  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>;
 }
 
 /**
  * Build a chain from the given array of chained lambda handlers
  */
-const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, Response>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> => {
   if (handlers.length === 0) {
     return {
       next: () => {
@@ -1404,9 +1404,6 @@ const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBod
     },
   };
 };
-
-// Type alias for the request
-type SomeTestOperationRequestInput = SomeTestOperationRequest;
 
 /**
  * Single-value path/query parameters for SomeTestOperation
@@ -1426,13 +1423,17 @@ export interface SomeTestOperationRequestArrayParameters {
  */
 export type SomeTestOperationRequestBody = TestRequest;
 
+export type SomeTestOperation200OperationResponse = OperationResponse<200, TestResponse>;
+export type SomeTestOperation400OperationResponse = OperationResponse<400, ApiError>;
+export type SomeTestOperationOperationResponses = | SomeTestOperation200OperationResponse | SomeTestOperation400OperationResponse ;
+
 // Type that the handler function provided to the wrapper must conform to
-export type SomeTestOperationHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SomeTestOperationRequestParameters, SomeTestOperationRequestArrayParameters, SomeTestOperationRequestBody, TestResponse, ApiError>;
+export type SomeTestOperationHandlerFunction = ChainedLambdaHandlerFunction<SomeTestOperationRequestParameters, SomeTestOperationRequestArrayParameters, SomeTestOperationRequestBody, SomeTestOperationOperationResponses>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of someTestOperation
  */
-export const someTestOperationHandler = <ApiError>(firstHandler: SomeTestOperationHandlerFunction<ApiError>, ...remainingHandlers: SomeTestOperationHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const someTestOperationHandler = (firstHandler: SomeTestOperationHandlerFunction, ...remainingHandlers: SomeTestOperationHandlerFunction[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -3444,6 +3445,29 @@ export class DefaultApi extends runtime.BaseAPI {
 
     /**
      */
+    async emptyRaw(initOverrides?: RequestInit | runtime.InitOverideFunction): Promise<runtime.ApiResponse<void>> {
+        const queryParameters: any = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        const response = await this.request({
+            path: \`/empty-response\`,
+            method: 'PUT',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.VoidApiResponse(response);
+    }
+
+    /**
+     */
+    async empty(initOverrides?: RequestInit | runtime.InitOverideFunction): Promise<void> {
+        await this.emptyRaw(initOverrides);
+    }
+
+    /**
+     */
     async mediaTypesRaw(requestParameters: MediaTypesRequest, initOverrides?: RequestInit | runtime.InitOverideFunction): Promise<runtime.ApiResponse<string>> {
         if (requestParameters.body === null || requestParameters.body === undefined) {
             throw new runtime.RequiredError('body','Required parameter requestParameters.body was null or undefined when calling mediaTypes.');
@@ -3572,6 +3596,7 @@ import {
 } from '../../models';
 // Import request parameter interfaces
 import {
+    
     MediaTypesRequest,
     OperationOneRequest,
     
@@ -3579,6 +3604,7 @@ import {
 
 // Generic type for object keyed by operation names
 export interface OperationConfig<T> {
+    empty: T;
     mediaTypes: T;
     operationOne: T;
     withoutOperationIdDelete: T;
@@ -3586,6 +3612,10 @@ export interface OperationConfig<T> {
 
 // Look up path and http method for a given operation name
 export const OperationLookup = {
+    empty: {
+        path: '/empty-response',
+        method: 'PUT',
+    },
     mediaTypes: {
         path: '/different-media-type',
         method: 'POST',
@@ -3629,10 +3659,10 @@ const parseBody = (body: string, demarshal: (body: string) => any, contentTypes:
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
 
 // Type of the response to be returned by an operation lambda handler
-export interface OperationResponse<T, ApiError> {
-    statusCode: number;
+export interface OperationResponse<StatusCode extends number, Body> {
+    statusCode: StatusCode;
     headers?: { [key: string]: string };
-    body?: T | ApiError;
+    body: Body;
 }
 
 // Input for a lambda handler for an operation
@@ -3645,28 +3675,28 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
 /**
  * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
  */
-export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response>,
+) => Promise<Response>;
 
 // Type for a lambda handler function to be wrapped
-export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+) => Promise<Response>;
 
-export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
-  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>;
 }
 
 /**
  * Build a chain from the given array of chained lambda handlers
  */
-const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, Response>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> => {
   if (handlers.length === 0) {
     return {
       next: () => {
@@ -3682,9 +3712,72 @@ const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBod
   };
 };
 
-// Type alias for the request
-type MediaTypesRequestInput = MediaTypesRequest;
+/**
+ * Single-value path/query parameters for Empty
+ */
+export interface EmptyRequestParameters {
+}
 
+/**
+ * Multi-value query parameters for Empty
+ */
+export interface EmptyRequestArrayParameters {
+}
+
+/**
+ * Request body parameter for Empty
+ */
+export type EmptyRequestBody = never;
+
+export type Empty204OperationResponse = OperationResponse<204, undefined>;
+export type EmptyOperationResponses = | Empty204OperationResponse ;
+
+// Type that the handler function provided to the wrapper must conform to
+export type EmptyHandlerFunction = ChainedLambdaHandlerFunction<EmptyRequestParameters, EmptyRequestArrayParameters, EmptyRequestBody, EmptyOperationResponses>;
+
+/**
+ * Lambda handler wrapper to provide typed interface for the implementation of empty
+ */
+export const emptyHandler = (firstHandler: EmptyHandlerFunction, ...remainingHandlers: EmptyHandlerFunction[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+    const requestParameters = decodeRequestParameters({
+        ...(event.pathParameters || {}),
+        ...(event.queryStringParameters || {}),
+    }) as unknown as EmptyRequestParameters;
+
+    const requestArrayParameters = decodeRequestParameters({
+        ...(event.multiValueQueryStringParameters || {}),
+    }) as unknown as EmptyRequestArrayParameters;
+
+    const demarshal = (bodyString: string): any => {
+        let parsed = JSON.parse(bodyString);
+        return parsed;
+    };
+    const body = parseBody(event.body, demarshal, ['application/json']) as EmptyRequestBody;
+
+    const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
+    const response = await chain.next({
+        requestParameters,
+        requestArrayParameters,
+        body,
+    }, event, context);
+
+    const marshal = (statusCode: number, responseBody: any): string => {
+        let marshalledBody = responseBody;
+        switch(statusCode) {
+            case 204:
+                break;
+            default:
+                break;
+        }
+
+        return marshalledBody;
+    };
+
+    return {
+        ...response,
+        body: response.body ? marshal(response.statusCode, response.body) : '',
+    };
+};
 /**
  * Single-value path/query parameters for MediaTypes
  */
@@ -3702,13 +3795,16 @@ export interface MediaTypesRequestArrayParameters {
  */
 export type MediaTypesRequestBody = Blob;
 
+export type MediaTypes200OperationResponse = OperationResponse<200, string>;
+export type MediaTypesOperationResponses = | MediaTypes200OperationResponse ;
+
 // Type that the handler function provided to the wrapper must conform to
-export type MediaTypesHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<MediaTypesRequestParameters, MediaTypesRequestArrayParameters, MediaTypesRequestBody, string, ApiError>;
+export type MediaTypesHandlerFunction = ChainedLambdaHandlerFunction<MediaTypesRequestParameters, MediaTypesRequestArrayParameters, MediaTypesRequestBody, MediaTypesOperationResponses>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of mediaTypes
  */
-export const mediaTypesHandler = <ApiError>(firstHandler: MediaTypesHandlerFunction<ApiError>, ...remainingHandlers: MediaTypesHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const mediaTypesHandler = (firstHandler: MediaTypesHandlerFunction, ...remainingHandlers: MediaTypesHandlerFunction[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -3749,9 +3845,6 @@ export const mediaTypesHandler = <ApiError>(firstHandler: MediaTypesHandlerFunct
         body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
-// Type alias for the request
-type OperationOneRequestInput = OperationOneRequest;
-
 /**
  * Single-value path/query parameters for OperationOne
  */
@@ -3773,13 +3866,17 @@ export interface OperationOneRequestArrayParameters {
  */
 export type OperationOneRequestBody = TestRequest;
 
+export type OperationOne200OperationResponse = OperationResponse<200, TestResponse>;
+export type OperationOne400OperationResponse = OperationResponse<400, ApiError>;
+export type OperationOneOperationResponses = | OperationOne200OperationResponse | OperationOne400OperationResponse ;
+
 // Type that the handler function provided to the wrapper must conform to
-export type OperationOneHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<OperationOneRequestParameters, OperationOneRequestArrayParameters, OperationOneRequestBody, TestResponse, ApiError>;
+export type OperationOneHandlerFunction = ChainedLambdaHandlerFunction<OperationOneRequestParameters, OperationOneRequestArrayParameters, OperationOneRequestBody, OperationOneOperationResponses>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of operationOne
  */
-export const operationOneHandler = <ApiError>(firstHandler: OperationOneHandlerFunction<ApiError>, ...remainingHandlers: OperationOneHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const operationOneHandler = (firstHandler: OperationOneHandlerFunction, ...remainingHandlers: OperationOneHandlerFunction[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -3824,9 +3921,6 @@ export const operationOneHandler = <ApiError>(firstHandler: OperationOneHandlerF
         body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
-// Type alias for the request
-type WithoutOperationIdDeleteRequestInput = {};
-
 /**
  * Single-value path/query parameters for WithoutOperationIdDelete
  */
@@ -3844,13 +3938,16 @@ export interface WithoutOperationIdDeleteRequestArrayParameters {
  */
 export type WithoutOperationIdDeleteRequestBody = never;
 
+export type WithoutOperationIdDelete200OperationResponse = OperationResponse<200, TestResponse>;
+export type WithoutOperationIdDeleteOperationResponses = | WithoutOperationIdDelete200OperationResponse ;
+
 // Type that the handler function provided to the wrapper must conform to
-export type WithoutOperationIdDeleteHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<WithoutOperationIdDeleteRequestParameters, WithoutOperationIdDeleteRequestArrayParameters, WithoutOperationIdDeleteRequestBody, TestResponse, ApiError>;
+export type WithoutOperationIdDeleteHandlerFunction = ChainedLambdaHandlerFunction<WithoutOperationIdDeleteRequestParameters, WithoutOperationIdDeleteRequestArrayParameters, WithoutOperationIdDeleteRequestBody, WithoutOperationIdDeleteOperationResponses>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of withoutOperationIdDelete
  */
-export const withoutOperationIdDeleteHandler = <ApiError>(firstHandler: WithoutOperationIdDeleteHandlerFunction<ApiError>, ...remainingHandlers: WithoutOperationIdDeleteHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const withoutOperationIdDeleteHandler = (firstHandler: WithoutOperationIdDeleteHandlerFunction, ...remainingHandlers: WithoutOperationIdDeleteHandlerFunction[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),

--- a/packages/open-api-gateway/test/project/codegen/components/docs/__snapshots__/generated-html2-docs.test.ts.snap
+++ b/packages/open-api-gateway/test/project/codegen/components/docs/__snapshots__/generated-html2-docs.test.ts.snap
@@ -4286,6 +4286,9 @@ ul.nav-tabs {
             <li class=\\"nav-fixed nav-header active\\" data-group=\\"_\\"><a href=\\"#api-_\\">API Summary</a></li>
 
                   <li class=\\"nav-header\\" data-group=\\"Default\\"><a href=\\"#api-Default\\">API Methods - Default</a></li>
+                    <li data-group=\\"Default\\" data-name=\\"empty\\" class=\\"\\">
+                      <a href=\\"#api-Default-empty\\">empty</a>
+                    </li>
                     <li data-group=\\"Default\\" data-name=\\"mediaTypes\\" class=\\"\\">
                       <a href=\\"#api-Default-mediaTypes\\">mediaTypes</a>
                     </li>
@@ -4318,6 +4321,250 @@ ul.nav-tabs {
         <div id=\\"sections\\">
                 <section id=\\"api-Default\\">
                   <h1>Default</h1>
+                    <div id=\\"api-Default-empty\\">
+                      <article id=\\"api-Default-empty-0\\" data-group=\\"User\\" data-name=\\"empty\\" data-version=\\"0\\">
+                        <div class=\\"pull-left\\">
+                          <h1>empty</h1>
+                          <p></p>
+                        </div>
+                        <div class=\\"pull-right\\"></div>
+                        <div class=\\"clearfix\\"></div>
+                        <p></p>
+                        <p class=\\"marked\\"></p>
+                        <p></p>
+                        <br />
+                        <pre class=\\"prettyprint language-html prettyprinted\\" data-type=\\"put\\"><code><span class=\\"pln\\">/empty-response</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class=\\"nav nav-tabs nav-tabs-examples\\">
+                          <li class=\\"active\\"><a href=\\"#examples-Default-empty-0-curl\\">Curl</a></li>
+                          <li class=\\"\\"><a href=\\"#examples-Default-empty-0-java\\">Java</a></li>
+                          <li class=\\"\\"><a href=\\"#examples-Default-empty-0-android\\">Android</a></li>
+                          <!--<li class=\\"\\"><a href=\\"#examples-Default-empty-0-groovy\\">Groovy</a></li>-->
+                          <li class=\\"\\"><a href=\\"#examples-Default-empty-0-objc\\">Obj-C</a></li>
+                          <li class=\\"\\"><a href=\\"#examples-Default-empty-0-javascript\\">JavaScript</a></li>
+                          <!--<li class=\\"\\"><a href=\\"#examples-Default-empty-0-angular\\">Angular</a></li>-->
+                          <li class=\\"\\"><a href=\\"#examples-Default-empty-0-csharp\\">C#</a></li>
+                          <li class=\\"\\"><a href=\\"#examples-Default-empty-0-php\\">PHP</a></li>
+                          <li class=\\"\\"><a href=\\"#examples-Default-empty-0-perl\\">Perl</a></li>
+                          <li class=\\"\\"><a href=\\"#examples-Default-empty-0-python\\">Python</a></li>
+                          <li class=\\"\\"><a href=\\"#examples-Default-empty-0-rust\\">Rust</a></li>
+                        </ul>
+
+                        <div class=\\"tab-content\\">
+                          <div class=\\"tab-pane active\\" id=\\"examples-Default-empty-0-curl\\">
+                            <pre class=\\"prettyprint\\"><code class=\\"language-bsh\\">curl -X PUT \\\\
+ \\"http://localhost/empty-response\\"
+</code></pre>
+                          </div>
+                          <div class=\\"tab-pane\\" id=\\"examples-Default-empty-0-java\\">
+                            <pre class=\\"prettyprint\\"><code class=\\"language-java\\">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+
+        try {
+            apiInstance.empty();
+        } catch (ApiException e) {
+            System.err.println(\\"Exception when calling DefaultApi#empty\\");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class=\\"tab-pane\\" id=\\"examples-Default-empty-0-android\\">
+                            <pre class=\\"prettyprint\\"><code class=\\"language-java\\">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+
+        try {
+            apiInstance.empty();
+        } catch (ApiException e) {
+            System.err.println(\\"Exception when calling DefaultApi#empty\\");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class=\\"tab-pane\\" id=\\"examples-Default-empty-0-groovy\\">
+  <pre class=\\"prettyprint language-json prettyprinted\\" data-type=\\"json\\"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class=\\"tab-pane\\" id=\\"examples-Default-empty-0-objc\\">
+                              <pre class=\\"prettyprint\\"><code class=\\"language-cpp\\">
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+
+[apiInstance emptyWithCompletionHandler: 
+              ^(NSError* error) {
+    if (error) {
+        NSLog(@\\"Error: %@\\", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class=\\"tab-pane\\" id=\\"examples-Default-empty-0-javascript\\">
+                              <pre class=\\"prettyprint\\"><code class=\\"language-js\\">var ExampleApi = require('example_api');
+
+// Create an instance of the API class
+var api = new ExampleApi.DefaultApi()
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully.');
+  }
+};
+api.empty(callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class=\\"tab-pane\\" id=\\"examples-Default-empty-0-angular\\">
+              <pre class=\\"prettyprint language-json prettyprinted\\" data-type=\\"json\\"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class=\\"tab-pane\\" id=\\"examples-Default-empty-0-csharp\\">
+                              <pre class=\\"prettyprint\\"><code class=\\"language-cs\\">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class emptyExample
+    {
+        public void main()
+        {
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+
+            try {
+                apiInstance.empty();
+            } catch (Exception e) {
+                Debug.Print(\\"Exception when calling DefaultApi.empty: \\" + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class=\\"tab-pane\\" id=\\"examples-Default-empty-0-php\\">
+                              <pre class=\\"prettyprint\\"><code class=\\"language-php\\"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\\\\Client\\\\Api\\\\DefaultApi();
+
+try {
+    $api_instance->empty();
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->empty: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class=\\"tab-pane\\" id=\\"examples-Default-empty-0-perl\\">
+                              <pre class=\\"prettyprint\\"><code class=\\"language-perl\\">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+
+eval {
+    $api_instance->empty();
+};
+if ($@) {
+    warn \\"Exception when calling DefaultApi->empty: $@\\\\n\\";
+}</code></pre>
+                            </div>
+
+                            <div class=\\"tab-pane\\" id=\\"examples-Default-empty-0-python\\">
+                              <pre class=\\"prettyprint\\"><code class=\\"language-python\\">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+
+try:
+    api_instance.empty()
+except ApiException as e:
+    print(\\"Exception when calling DefaultApi->empty: %s\\\\n\\" % e)</code></pre>
+                            </div>
+
+                            <div class=\\"tab-pane\\" id=\\"examples-Default-empty-0-rust\\">
+                              <pre class=\\"prettyprint\\"><code class=\\"language-rust\\">extern crate DefaultApi;
+
+pub fn main() {
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.empty(&context).wait();
+
+    println!(\\"{:?}\\", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+
+
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id=\\"examples-Default-empty-title-204\\"></h3>
+                            <p id=\\"examples-Default-empty-description-204\\" class=\\"marked\\"></p>
+                            <script>
+                              var responseDefault204_description = \`No response body!\`;
+                              var responseDefault204_description_break = responseDefault204_description.indexOf('\\\\n');
+                              if (responseDefault204_description_break == -1) {
+                                $(\\"#examples-Default-empty-title-204\\").text(\\"Status: 204 - \\" + responseDefault204_description);
+                              } else {
+                                $(\\"#examples-Default-empty-title-204\\").text(\\"Status: 204 - \\" + responseDefault204_description.substring(0, responseDefault204_description_break));
+                                $(\\"#examples-Default-empty-description-204\\").html(responseDefault204_description.substring(responseDefault204_description_break));
+                              }
+                            </script>
+
+
+                            <ul id=\\"responses-detail-Default-empty-204\\" class=\\"nav nav-tabs nav-tabs-examples\\" >
+
+
+                            </ul>
+
+
+                            <div class=\\"tab-content\\" id=\\"responses-Default-empty-204-wrapper\\" style='margin-bottom: 10px;'>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
                     <div id=\\"api-Default-mediaTypes\\">
                       <article id=\\"api-Default-mediaTypes-0\\" data-group=\\"User\\" data-name=\\"mediaTypes\\" data-version=\\"0\\">
                         <div class=\\"pull-left\\">

--- a/packages/open-api-gateway/test/project/codegen/components/docs/__snapshots__/generated-markdown-docs.test.ts.snap
+++ b/packages/open-api-gateway/test/project/codegen/components/docs/__snapshots__/generated-markdown-docs.test.ts.snap
@@ -346,10 +346,33 @@ All URIs are relative to *http://localhost*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
+| [**empty**](DefaultApi.md#empty) | **PUT** /empty-response |  |
 | [**mediaTypes**](DefaultApi.md#mediaTypes) | **POST** /different-media-type |  |
 | [**operationOne**](DefaultApi.md#operationOne) | **POST** /path/{pathParam} |  |
 | [**withoutOperationIdDelete**](DefaultApi.md#withoutOperationIdDelete) | **DELETE** /without-operation-id |  |
 
+
+<a name=\\"empty\\"></a>
+# **empty**
+> empty()
+
+
+
+### Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+null (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: Not defined
 
 <a name=\\"mediaTypes\\"></a>
 # **mediaTypes**
@@ -478,7 +501,8 @@ All URIs are relative to *http://localhost*
 
 | Class | Method | HTTP request | Description |
 |------------ | ------------- | ------------- | -------------|
-| *DefaultApi* | [**mediaTypes**](Apis/DefaultApi.md#mediatypes) | **POST** /different-media-type |  |
+| *DefaultApi* | [**empty**](Apis/DefaultApi.md#empty) | **PUT** /empty-response |  |
+*DefaultApi* | [**mediaTypes**](Apis/DefaultApi.md#mediatypes) | **POST** /different-media-type |  |
 *DefaultApi* | [**operationOne**](Apis/DefaultApi.md#operationone) | **POST** /path/{pathParam} |  |
 *DefaultApi* | [**withoutOperationIdDelete**](Apis/DefaultApi.md#withoutoperationiddelete) | **DELETE** /without-operation-id |  |
 

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
@@ -8032,7 +8032,7 @@ class SayHello(api_client.Api):
 ",
   "packages/my_api/generated/python/my_api_python/api/default_api_operation_config.py": "import urllib.parse
 import json
-from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional
+from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional, Literal
 from functools import wraps
 from dataclasses import dataclass
 
@@ -8102,14 +8102,13 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
 
 
 ResponseBody = TypeVar('ResponseBody')
-ApiError = TypeVar('ApiError')
-
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
-class ApiResponse(Generic[ResponseBody, ApiError]):
-    status_code: int
+class ApiResponse(Generic[StatusCode, ResponseBody]):
+    status_code: StatusCode
     headers: Dict[str, str]
-    body: Union[ResponseBody, ApiError]
+    body: ResponseBody
 
 
 
@@ -8125,11 +8124,15 @@ class SayHelloRequestArrayParameters(TypedDict):
 # Request body type (default to Any when no body parameters exist)
 SayHelloRequestBody = Any
 
+SayHello200OperationResponse = ApiResponse[Literal[200], HelloResponse]
+SayHello400OperationResponse = ApiResponse[Literal[400], ApiError]
+SayHelloOperationResponses = Union[SayHello200OperationResponse, SayHello400OperationResponse, ]
+
 # Request type for say_hello
 SayHelloRequest = ApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
 
 class SayHelloHandlerFunction(Protocol):
-    def __call__(self, input: SayHelloRequest, **kwargs) -> ApiResponse[HelloResponse, ApiError]:
+    def __call__(self, input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:
         ...
 
 def say_hello_handler(handler: SayHelloHandlerFunction):
@@ -13790,10 +13793,10 @@ const parseBody = (body: string, demarshal: (body: string) => any, contentTypes:
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
 
 // Type of the response to be returned by an operation lambda handler
-export interface OperationResponse<T, ApiError> {
-    statusCode: number;
+export interface OperationResponse<StatusCode extends number, Body> {
+    statusCode: StatusCode;
     headers?: { [key: string]: string };
-    body?: T | ApiError;
+    body: Body;
 }
 
 // Input for a lambda handler for an operation
@@ -13806,28 +13809,28 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
 /**
  * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
  */
-export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response>,
+) => Promise<Response>;
 
 // Type for a lambda handler function to be wrapped
-export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+) => Promise<Response>;
 
-export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
-  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>;
 }
 
 /**
  * Build a chain from the given array of chained lambda handlers
  */
-const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, Response>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> => {
   if (handlers.length === 0) {
     return {
       next: () => {
@@ -13842,9 +13845,6 @@ const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBod
     },
   };
 };
-
-// Type alias for the request
-type SayHelloRequestInput = SayHelloRequest;
 
 /**
  * Single-value path/query parameters for SayHello
@@ -13864,13 +13864,17 @@ export interface SayHelloRequestArrayParameters {
  */
 export type SayHelloRequestBody = never;
 
+export type SayHello200OperationResponse = OperationResponse<200, HelloResponse>;
+export type SayHello400OperationResponse = OperationResponse<400, ApiError>;
+export type SayHelloOperationResponses = | SayHello200OperationResponse | SayHello400OperationResponse ;
+
 // Type that the handler function provided to the wrapper must conform to
-export type SayHelloHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
+export type SayHelloHandlerFunction = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, SayHelloOperationResponses>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of sayHello
  */
-export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<ApiError>, ...remainingHandlers: SayHelloHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const sayHelloHandler = (firstHandler: SayHelloHandlerFunction, ...remainingHandlers: SayHelloHandlerFunction[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -14521,12 +14525,11 @@ class Api(OpenApiGatewayLambdaApi):
             operation_lookup=OperationLookup,
         )
 ",
-  "packages/my_api/my_api/api/handlers/say_hello_handler_sample.py": "from my_api_python.api.default_api_operation_config import say_hello_handler, SayHelloRequest, ApiResponse
-from my_api_python.model.api_error import ApiError
+  "packages/my_api/my_api/api/handlers/say_hello_handler_sample.py": "from my_api_python.api.default_api_operation_config import say_hello_handler, SayHelloRequest, ApiResponse, SayHelloOperationResponses
 from my_api_python.model.hello_response import HelloResponse
 
 @say_hello_handler
-def handler(input: SayHelloRequest, **kwargs) -> ApiResponse[HelloResponse, ApiError]:
+def handler(input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:
     \\"\\"\\"
     An example lambda handler which uses the generated handler wrapper to manage marshalling inputs/outputs
     \\"\\"\\"

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
@@ -7165,7 +7165,7 @@ class SayHello(api_client.Api):
 ",
   "generated/python/my_api_python/api/default_api_operation_config.py": "import urllib.parse
 import json
-from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional
+from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional, Literal
 from functools import wraps
 from dataclasses import dataclass
 
@@ -7235,14 +7235,13 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
 
 
 ResponseBody = TypeVar('ResponseBody')
-ApiError = TypeVar('ApiError')
-
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
-class ApiResponse(Generic[ResponseBody, ApiError]):
-    status_code: int
+class ApiResponse(Generic[StatusCode, ResponseBody]):
+    status_code: StatusCode
     headers: Dict[str, str]
-    body: Union[ResponseBody, ApiError]
+    body: ResponseBody
 
 
 
@@ -7258,11 +7257,15 @@ class SayHelloRequestArrayParameters(TypedDict):
 # Request body type (default to Any when no body parameters exist)
 SayHelloRequestBody = Any
 
+SayHello200OperationResponse = ApiResponse[Literal[200], HelloResponse]
+SayHello400OperationResponse = ApiResponse[Literal[400], ApiError]
+SayHelloOperationResponses = Union[SayHello200OperationResponse, SayHello400OperationResponse, ]
+
 # Request type for say_hello
 SayHelloRequest = ApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
 
 class SayHelloHandlerFunction(Protocol):
-    def __call__(self, input: SayHelloRequest, **kwargs) -> ApiResponse[HelloResponse, ApiError]:
+    def __call__(self, input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:
         ...
 
 def say_hello_handler(handler: SayHelloHandlerFunction):
@@ -12928,10 +12931,10 @@ const parseBody = (body: string, demarshal: (body: string) => any, contentTypes:
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
 
 // Type of the response to be returned by an operation lambda handler
-export interface OperationResponse<T, ApiError> {
-    statusCode: number;
+export interface OperationResponse<StatusCode extends number, Body> {
+    statusCode: StatusCode;
     headers?: { [key: string]: string };
-    body?: T | ApiError;
+    body: Body;
 }
 
 // Input for a lambda handler for an operation
@@ -12944,28 +12947,28 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
 /**
  * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
  */
-export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response>,
+) => Promise<Response>;
 
 // Type for a lambda handler function to be wrapped
-export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+) => Promise<Response>;
 
-export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
-  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>;
 }
 
 /**
  * Build a chain from the given array of chained lambda handlers
  */
-const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, Response>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> => {
   if (handlers.length === 0) {
     return {
       next: () => {
@@ -12980,9 +12983,6 @@ const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBod
     },
   };
 };
-
-// Type alias for the request
-type SayHelloRequestInput = SayHelloRequest;
 
 /**
  * Single-value path/query parameters for SayHello
@@ -13002,13 +13002,17 @@ export interface SayHelloRequestArrayParameters {
  */
 export type SayHelloRequestBody = never;
 
+export type SayHello200OperationResponse = OperationResponse<200, HelloResponse>;
+export type SayHello400OperationResponse = OperationResponse<400, ApiError>;
+export type SayHelloOperationResponses = | SayHello200OperationResponse | SayHello400OperationResponse ;
+
 // Type that the handler function provided to the wrapper must conform to
-export type SayHelloHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
+export type SayHelloHandlerFunction = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, SayHelloOperationResponses>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of sayHello
  */
-export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<ApiError>, ...remainingHandlers: SayHelloHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const sayHelloHandler = (firstHandler: SayHelloHandlerFunction, ...remainingHandlers: SayHelloHandlerFunction[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -13659,12 +13663,11 @@ class Api(OpenApiGatewayLambdaApi):
             operation_lookup=OperationLookup,
         )
 ",
-  "my_api/api/handlers/say_hello_handler_sample.py": "from my_api_python.api.default_api_operation_config import say_hello_handler, SayHelloRequest, ApiResponse
-from my_api_python.model.api_error import ApiError
+  "my_api/api/handlers/say_hello_handler_sample.py": "from my_api_python.api.default_api_operation_config import say_hello_handler, SayHelloRequest, ApiResponse, SayHelloOperationResponses
 from my_api_python.model.hello_response import HelloResponse
 
 @say_hello_handler
-def handler(input: SayHelloRequest, **kwargs) -> ApiResponse[HelloResponse, ApiError]:
+def handler(input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:
     \\"\\"\\"
     An example lambda handler which uses the generated handler wrapper to manage marshalling inputs/outputs
     \\"\\"\\"

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/with-docs.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/with-docs.test.ts.snap
@@ -4475,7 +4475,7 @@ class SayHello(api_client.Api):
 ",
   "generated/python/my_api_python/api/default_api_operation_config.py": "import urllib.parse
 import json
-from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional
+from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional, Literal
 from functools import wraps
 from dataclasses import dataclass
 
@@ -4545,14 +4545,13 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
 
 
 ResponseBody = TypeVar('ResponseBody')
-ApiError = TypeVar('ApiError')
-
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
-class ApiResponse(Generic[ResponseBody, ApiError]):
-    status_code: int
+class ApiResponse(Generic[StatusCode, ResponseBody]):
+    status_code: StatusCode
     headers: Dict[str, str]
-    body: Union[ResponseBody, ApiError]
+    body: ResponseBody
 
 
 
@@ -4568,11 +4567,15 @@ class SayHelloRequestArrayParameters(TypedDict):
 # Request body type (default to Any when no body parameters exist)
 SayHelloRequestBody = Any
 
+SayHello200OperationResponse = ApiResponse[Literal[200], HelloResponse]
+SayHello400OperationResponse = ApiResponse[Literal[400], ApiError]
+SayHelloOperationResponses = Union[SayHello200OperationResponse, SayHello400OperationResponse, ]
+
 # Request type for say_hello
 SayHelloRequest = ApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
 
 class SayHelloHandlerFunction(Protocol):
-    def __call__(self, input: SayHelloRequest, **kwargs) -> ApiResponse[HelloResponse, ApiError]:
+    def __call__(self, input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:
         ...
 
 def say_hello_handler(handler: SayHelloHandlerFunction):
@@ -9507,12 +9510,11 @@ class Api(OpenApiGatewayLambdaApi):
             operation_lookup=OperationLookup,
         )
 ",
-  "my_api/api/handlers/say_hello_handler_sample.py": "from my_api_python.api.default_api_operation_config import say_hello_handler, SayHelloRequest, ApiResponse
-from my_api_python.model.api_error import ApiError
+  "my_api/api/handlers/say_hello_handler_sample.py": "from my_api_python.api.default_api_operation_config import say_hello_handler, SayHelloRequest, ApiResponse, SayHelloOperationResponses
 from my_api_python.model.hello_response import HelloResponse
 
 @say_hello_handler
-def handler(input: SayHelloRequest, **kwargs) -> ApiResponse[HelloResponse, ApiError]:
+def handler(input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:
     \\"\\"\\"
     An example lambda handler which uses the generated handler wrapper to manage marshalling inputs/outputs
     \\"\\"\\"

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/custom-directories.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/custom-directories.test.ts.snap
@@ -1973,10 +1973,10 @@ const parseBody = (body: string, demarshal: (body: string) => any, contentTypes:
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
 
 // Type of the response to be returned by an operation lambda handler
-export interface OperationResponse<T, ApiError> {
-    statusCode: number;
+export interface OperationResponse<StatusCode extends number, Body> {
+    statusCode: StatusCode;
     headers?: { [key: string]: string };
-    body?: T | ApiError;
+    body: Body;
 }
 
 // Input for a lambda handler for an operation
@@ -1989,28 +1989,28 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
 /**
  * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
  */
-export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response>,
+) => Promise<Response>;
 
 // Type for a lambda handler function to be wrapped
-export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+) => Promise<Response>;
 
-export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
-  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>;
 }
 
 /**
  * Build a chain from the given array of chained lambda handlers
  */
-const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, Response>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> => {
   if (handlers.length === 0) {
     return {
       next: () => {
@@ -2025,9 +2025,6 @@ const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBod
     },
   };
 };
-
-// Type alias for the request
-type SayHelloRequestInput = SayHelloRequest;
 
 /**
  * Single-value path/query parameters for SayHello
@@ -2047,13 +2044,17 @@ export interface SayHelloRequestArrayParameters {
  */
 export type SayHelloRequestBody = never;
 
+export type SayHello200OperationResponse = OperationResponse<200, HelloResponse>;
+export type SayHello400OperationResponse = OperationResponse<400, ApiError>;
+export type SayHelloOperationResponses = | SayHello200OperationResponse | SayHello400OperationResponse ;
+
 // Type that the handler function provided to the wrapper must conform to
-export type SayHelloHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
+export type SayHelloHandlerFunction = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, SayHelloOperationResponses>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of sayHello
  */
-export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<ApiError>, ...remainingHandlers: SayHelloHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const sayHelloHandler = (firstHandler: SayHelloHandlerFunction, ...remainingHandlers: SayHelloHandlerFunction[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
@@ -8728,7 +8728,7 @@ class SayHello(api_client.Api):
 ",
   "packages/api/generated/python/test_my_api_python/api/default_api_operation_config.py": "import urllib.parse
 import json
-from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional
+from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional, Literal
 from functools import wraps
 from dataclasses import dataclass
 
@@ -8798,14 +8798,13 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
 
 
 ResponseBody = TypeVar('ResponseBody')
-ApiError = TypeVar('ApiError')
-
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
-class ApiResponse(Generic[ResponseBody, ApiError]):
-    status_code: int
+class ApiResponse(Generic[StatusCode, ResponseBody]):
+    status_code: StatusCode
     headers: Dict[str, str]
-    body: Union[ResponseBody, ApiError]
+    body: ResponseBody
 
 
 
@@ -8821,11 +8820,15 @@ class SayHelloRequestArrayParameters(TypedDict):
 # Request body type (default to Any when no body parameters exist)
 SayHelloRequestBody = Any
 
+SayHello200OperationResponse = ApiResponse[Literal[200], HelloResponse]
+SayHello400OperationResponse = ApiResponse[Literal[400], ApiError]
+SayHelloOperationResponses = Union[SayHello200OperationResponse, SayHello400OperationResponse, ]
+
 # Request type for say_hello
 SayHelloRequest = ApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
 
 class SayHelloHandlerFunction(Protocol):
-    def __call__(self, input: SayHelloRequest, **kwargs) -> ApiResponse[HelloResponse, ApiError]:
+    def __call__(self, input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:
         ...
 
 def say_hello_handler(handler: SayHelloHandlerFunction):
@@ -14320,10 +14323,10 @@ const parseBody = (body: string, demarshal: (body: string) => any, contentTypes:
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
 
 // Type of the response to be returned by an operation lambda handler
-export interface OperationResponse<T, ApiError> {
-    statusCode: number;
+export interface OperationResponse<StatusCode extends number, Body> {
+    statusCode: StatusCode;
     headers?: { [key: string]: string };
-    body?: T | ApiError;
+    body: Body;
 }
 
 // Input for a lambda handler for an operation
@@ -14336,28 +14339,28 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
 /**
  * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
  */
-export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response>,
+) => Promise<Response>;
 
 // Type for a lambda handler function to be wrapped
-export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+) => Promise<Response>;
 
-export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
-  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>;
 }
 
 /**
  * Build a chain from the given array of chained lambda handlers
  */
-const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, Response>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> => {
   if (handlers.length === 0) {
     return {
       next: () => {
@@ -14372,9 +14375,6 @@ const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBod
     },
   };
 };
-
-// Type alias for the request
-type SayHelloRequestInput = SayHelloRequest;
 
 /**
  * Single-value path/query parameters for SayHello
@@ -14394,13 +14394,17 @@ export interface SayHelloRequestArrayParameters {
  */
 export type SayHelloRequestBody = never;
 
+export type SayHello200OperationResponse = OperationResponse<200, HelloResponse>;
+export type SayHello400OperationResponse = OperationResponse<400, ApiError>;
+export type SayHelloOperationResponses = | SayHello200OperationResponse | SayHello400OperationResponse ;
+
 // Type that the handler function provided to the wrapper must conform to
-export type SayHelloHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
+export type SayHelloHandlerFunction = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, SayHelloOperationResponses>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of sayHello
  */
-export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<ApiError>, ...remainingHandlers: SayHelloHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const sayHelloHandler = (firstHandler: SayHelloHandlerFunction, ...remainingHandlers: SayHelloHandlerFunction[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -15144,12 +15148,12 @@ export class Api extends OpenApiGatewayLambdaApi {
 ",
   "packages/api/src/api/index.ts": "export * from './api';
 export * from './sample-api';",
-  "packages/api/src/api/sample-api.say-hello.ts": "import { sayHelloHandler, ApiError } from \\"@test/my-api-typescript\\";
+  "packages/api/src/api/sample-api.say-hello.ts": "import { sayHelloHandler } from \\"@test/my-api-typescript\\";
 
 /**
  * An example lambda handler which uses the generated handler wrapper to manage marshalling inputs/outputs.
  */
-export const handler = sayHelloHandler<ApiError>(async (input) => {
+export const handler = sayHelloHandler(async (input) => {
   return {
     statusCode: 200,
     body: {
@@ -24196,7 +24200,7 @@ class SayHello(api_client.Api):
 ",
   "packages/api/generated/python/test_my_api_python/api/default_api_operation_config.py": "import urllib.parse
 import json
-from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional
+from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional, Literal
 from functools import wraps
 from dataclasses import dataclass
 
@@ -24266,14 +24270,13 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
 
 
 ResponseBody = TypeVar('ResponseBody')
-ApiError = TypeVar('ApiError')
-
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
-class ApiResponse(Generic[ResponseBody, ApiError]):
-    status_code: int
+class ApiResponse(Generic[StatusCode, ResponseBody]):
+    status_code: StatusCode
     headers: Dict[str, str]
-    body: Union[ResponseBody, ApiError]
+    body: ResponseBody
 
 
 
@@ -24289,11 +24292,15 @@ class SayHelloRequestArrayParameters(TypedDict):
 # Request body type (default to Any when no body parameters exist)
 SayHelloRequestBody = Any
 
+SayHello200OperationResponse = ApiResponse[Literal[200], HelloResponse]
+SayHello400OperationResponse = ApiResponse[Literal[400], ApiError]
+SayHelloOperationResponses = Union[SayHello200OperationResponse, SayHello400OperationResponse, ]
+
 # Request type for say_hello
 SayHelloRequest = ApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
 
 class SayHelloHandlerFunction(Protocol):
-    def __call__(self, input: SayHelloRequest, **kwargs) -> ApiResponse[HelloResponse, ApiError]:
+    def __call__(self, input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:
         ...
 
 def say_hello_handler(handler: SayHelloHandlerFunction):
@@ -29794,10 +29801,10 @@ const parseBody = (body: string, demarshal: (body: string) => any, contentTypes:
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
 
 // Type of the response to be returned by an operation lambda handler
-export interface OperationResponse<T, ApiError> {
-    statusCode: number;
+export interface OperationResponse<StatusCode extends number, Body> {
+    statusCode: StatusCode;
     headers?: { [key: string]: string };
-    body?: T | ApiError;
+    body: Body;
 }
 
 // Input for a lambda handler for an operation
@@ -29810,28 +29817,28 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
 /**
  * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
  */
-export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response>,
+) => Promise<Response>;
 
 // Type for a lambda handler function to be wrapped
-export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+) => Promise<Response>;
 
-export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
-  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>;
 }
 
 /**
  * Build a chain from the given array of chained lambda handlers
  */
-const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, Response>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> => {
   if (handlers.length === 0) {
     return {
       next: () => {
@@ -29846,9 +29853,6 @@ const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBod
     },
   };
 };
-
-// Type alias for the request
-type SayHelloRequestInput = SayHelloRequest;
 
 /**
  * Single-value path/query parameters for SayHello
@@ -29868,13 +29872,17 @@ export interface SayHelloRequestArrayParameters {
  */
 export type SayHelloRequestBody = never;
 
+export type SayHello200OperationResponse = OperationResponse<200, HelloResponse>;
+export type SayHello400OperationResponse = OperationResponse<400, ApiError>;
+export type SayHelloOperationResponses = | SayHello200OperationResponse | SayHello400OperationResponse ;
+
 // Type that the handler function provided to the wrapper must conform to
-export type SayHelloHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
+export type SayHelloHandlerFunction = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, SayHelloOperationResponses>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of sayHello
  */
-export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<ApiError>, ...remainingHandlers: SayHelloHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const sayHelloHandler = (firstHandler: SayHelloHandlerFunction, ...remainingHandlers: SayHelloHandlerFunction[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -30618,12 +30626,12 @@ export class Api extends OpenApiGatewayLambdaApi {
 ",
   "packages/api/src/api/index.ts": "export * from './api';
 export * from './sample-api';",
-  "packages/api/src/api/sample-api.say-hello.ts": "import { sayHelloHandler, ApiError } from \\"@test/my-api-typescript\\";
+  "packages/api/src/api/sample-api.say-hello.ts": "import { sayHelloHandler } from \\"@test/my-api-typescript\\";
 
 /**
  * An example lambda handler which uses the generated handler wrapper to manage marshalling inputs/outputs.
  */
-export const handler = sayHelloHandler<ApiError>(async (input) => {
+export const handler = sayHelloHandler(async (input) => {
   return {
     statusCode: 200,
     body: {
@@ -39680,7 +39688,7 @@ class SayHello(api_client.Api):
 ",
   "packages/api/generated/python/test_my_api_python/api/default_api_operation_config.py": "import urllib.parse
 import json
-from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional
+from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional, Literal
 from functools import wraps
 from dataclasses import dataclass
 
@@ -39750,14 +39758,13 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
 
 
 ResponseBody = TypeVar('ResponseBody')
-ApiError = TypeVar('ApiError')
-
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
-class ApiResponse(Generic[ResponseBody, ApiError]):
-    status_code: int
+class ApiResponse(Generic[StatusCode, ResponseBody]):
+    status_code: StatusCode
     headers: Dict[str, str]
-    body: Union[ResponseBody, ApiError]
+    body: ResponseBody
 
 
 
@@ -39773,11 +39780,15 @@ class SayHelloRequestArrayParameters(TypedDict):
 # Request body type (default to Any when no body parameters exist)
 SayHelloRequestBody = Any
 
+SayHello200OperationResponse = ApiResponse[Literal[200], HelloResponse]
+SayHello400OperationResponse = ApiResponse[Literal[400], ApiError]
+SayHelloOperationResponses = Union[SayHello200OperationResponse, SayHello400OperationResponse, ]
+
 # Request type for say_hello
 SayHelloRequest = ApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
 
 class SayHelloHandlerFunction(Protocol):
-    def __call__(self, input: SayHelloRequest, **kwargs) -> ApiResponse[HelloResponse, ApiError]:
+    def __call__(self, input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:
         ...
 
 def say_hello_handler(handler: SayHelloHandlerFunction):
@@ -45272,10 +45283,10 @@ const parseBody = (body: string, demarshal: (body: string) => any, contentTypes:
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
 
 // Type of the response to be returned by an operation lambda handler
-export interface OperationResponse<T, ApiError> {
-    statusCode: number;
+export interface OperationResponse<StatusCode extends number, Body> {
+    statusCode: StatusCode;
     headers?: { [key: string]: string };
-    body?: T | ApiError;
+    body: Body;
 }
 
 // Input for a lambda handler for an operation
@@ -45288,28 +45299,28 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
 /**
  * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
  */
-export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response>,
+) => Promise<Response>;
 
 // Type for a lambda handler function to be wrapped
-export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+) => Promise<Response>;
 
-export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
-  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>;
 }
 
 /**
  * Build a chain from the given array of chained lambda handlers
  */
-const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, Response>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> => {
   if (handlers.length === 0) {
     return {
       next: () => {
@@ -45324,9 +45335,6 @@ const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBod
     },
   };
 };
-
-// Type alias for the request
-type SayHelloRequestInput = SayHelloRequest;
 
 /**
  * Single-value path/query parameters for SayHello
@@ -45346,13 +45354,17 @@ export interface SayHelloRequestArrayParameters {
  */
 export type SayHelloRequestBody = never;
 
+export type SayHello200OperationResponse = OperationResponse<200, HelloResponse>;
+export type SayHello400OperationResponse = OperationResponse<400, ApiError>;
+export type SayHelloOperationResponses = | SayHello200OperationResponse | SayHello400OperationResponse ;
+
 // Type that the handler function provided to the wrapper must conform to
-export type SayHelloHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
+export type SayHelloHandlerFunction = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, SayHelloOperationResponses>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of sayHello
  */
-export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<ApiError>, ...remainingHandlers: SayHelloHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const sayHelloHandler = (firstHandler: SayHelloHandlerFunction, ...remainingHandlers: SayHelloHandlerFunction[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -46096,12 +46108,12 @@ export class Api extends OpenApiGatewayLambdaApi {
 ",
   "packages/api/src/api/index.ts": "export * from './api';
 export * from './sample-api';",
-  "packages/api/src/api/sample-api.say-hello.ts": "import { sayHelloHandler, ApiError } from \\"@test/my-api-typescript\\";
+  "packages/api/src/api/sample-api.say-hello.ts": "import { sayHelloHandler } from \\"@test/my-api-typescript\\";
 
 /**
  * An example lambda handler which uses the generated handler wrapper to manage marshalling inputs/outputs.
  */
-export const handler = sayHelloHandler<ApiError>(async (input) => {
+export const handler = sayHelloHandler(async (input) => {
   return {
     statusCode: 200,
     body: {

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
@@ -8185,7 +8185,7 @@ class SayHello(api_client.Api):
 ",
   "generated/python/test_my_api_python/api/default_api_operation_config.py": "import urllib.parse
 import json
-from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional
+from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional, Literal
 from functools import wraps
 from dataclasses import dataclass
 
@@ -8255,14 +8255,13 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
 
 
 ResponseBody = TypeVar('ResponseBody')
-ApiError = TypeVar('ApiError')
-
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
-class ApiResponse(Generic[ResponseBody, ApiError]):
-    status_code: int
+class ApiResponse(Generic[StatusCode, ResponseBody]):
+    status_code: StatusCode
     headers: Dict[str, str]
-    body: Union[ResponseBody, ApiError]
+    body: ResponseBody
 
 
 
@@ -8278,11 +8277,15 @@ class SayHelloRequestArrayParameters(TypedDict):
 # Request body type (default to Any when no body parameters exist)
 SayHelloRequestBody = Any
 
+SayHello200OperationResponse = ApiResponse[Literal[200], HelloResponse]
+SayHello400OperationResponse = ApiResponse[Literal[400], ApiError]
+SayHelloOperationResponses = Union[SayHello200OperationResponse, SayHello400OperationResponse, ]
+
 # Request type for say_hello
 SayHelloRequest = ApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
 
 class SayHelloHandlerFunction(Protocol):
-    def __call__(self, input: SayHelloRequest, **kwargs) -> ApiResponse[HelloResponse, ApiError]:
+    def __call__(self, input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:
         ...
 
 def say_hello_handler(handler: SayHelloHandlerFunction):
@@ -13777,10 +13780,10 @@ const parseBody = (body: string, demarshal: (body: string) => any, contentTypes:
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
 
 // Type of the response to be returned by an operation lambda handler
-export interface OperationResponse<T, ApiError> {
-    statusCode: number;
+export interface OperationResponse<StatusCode extends number, Body> {
+    statusCode: StatusCode;
     headers?: { [key: string]: string };
-    body?: T | ApiError;
+    body: Body;
 }
 
 // Input for a lambda handler for an operation
@@ -13793,28 +13796,28 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
 /**
  * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
  */
-export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response>,
+) => Promise<Response>;
 
 // Type for a lambda handler function to be wrapped
-export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+) => Promise<Response>;
 
-export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
-  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>;
 }
 
 /**
  * Build a chain from the given array of chained lambda handlers
  */
-const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, Response>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> => {
   if (handlers.length === 0) {
     return {
       next: () => {
@@ -13829,9 +13832,6 @@ const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBod
     },
   };
 };
-
-// Type alias for the request
-type SayHelloRequestInput = SayHelloRequest;
 
 /**
  * Single-value path/query parameters for SayHello
@@ -13851,13 +13851,17 @@ export interface SayHelloRequestArrayParameters {
  */
 export type SayHelloRequestBody = never;
 
+export type SayHello200OperationResponse = OperationResponse<200, HelloResponse>;
+export type SayHello400OperationResponse = OperationResponse<400, ApiError>;
+export type SayHelloOperationResponses = | SayHello200OperationResponse | SayHello400OperationResponse ;
+
 // Type that the handler function provided to the wrapper must conform to
-export type SayHelloHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
+export type SayHelloHandlerFunction = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, SayHelloOperationResponses>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of sayHello
  */
-export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<ApiError>, ...remainingHandlers: SayHelloHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const sayHelloHandler = (firstHandler: SayHelloHandlerFunction, ...remainingHandlers: SayHelloHandlerFunction[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -14600,12 +14604,12 @@ export class Api extends OpenApiGatewayLambdaApi {
 ",
   "src/api/index.ts": "export * from './api';
 export * from './sample-api';",
-  "src/api/sample-api.say-hello.ts": "import { sayHelloHandler, ApiError } from \\"@test/my-api-typescript\\";
+  "src/api/sample-api.say-hello.ts": "import { sayHelloHandler } from \\"@test/my-api-typescript\\";
 
 /**
  * An example lambda handler which uses the generated handler wrapper to manage marshalling inputs/outputs.
  */
-export const handler = sayHelloHandler<ApiError>(async (input) => {
+export const handler = sayHelloHandler(async (input) => {
   return {
     statusCode: 200,
     body: {
@@ -23052,7 +23056,7 @@ class SayHello(api_client.Api):
 ",
   "generated/python/test_my_api_python/api/default_api_operation_config.py": "import urllib.parse
 import json
-from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional
+from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional, Literal
 from functools import wraps
 from dataclasses import dataclass
 
@@ -23122,14 +23126,13 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
 
 
 ResponseBody = TypeVar('ResponseBody')
-ApiError = TypeVar('ApiError')
-
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
-class ApiResponse(Generic[ResponseBody, ApiError]):
-    status_code: int
+class ApiResponse(Generic[StatusCode, ResponseBody]):
+    status_code: StatusCode
     headers: Dict[str, str]
-    body: Union[ResponseBody, ApiError]
+    body: ResponseBody
 
 
 
@@ -23145,11 +23148,15 @@ class SayHelloRequestArrayParameters(TypedDict):
 # Request body type (default to Any when no body parameters exist)
 SayHelloRequestBody = Any
 
+SayHello200OperationResponse = ApiResponse[Literal[200], HelloResponse]
+SayHello400OperationResponse = ApiResponse[Literal[400], ApiError]
+SayHelloOperationResponses = Union[SayHello200OperationResponse, SayHello400OperationResponse, ]
+
 # Request type for say_hello
 SayHelloRequest = ApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
 
 class SayHelloHandlerFunction(Protocol):
-    def __call__(self, input: SayHelloRequest, **kwargs) -> ApiResponse[HelloResponse, ApiError]:
+    def __call__(self, input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:
         ...
 
 def say_hello_handler(handler: SayHelloHandlerFunction):
@@ -28650,10 +28657,10 @@ const parseBody = (body: string, demarshal: (body: string) => any, contentTypes:
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
 
 // Type of the response to be returned by an operation lambda handler
-export interface OperationResponse<T, ApiError> {
-    statusCode: number;
+export interface OperationResponse<StatusCode extends number, Body> {
+    statusCode: StatusCode;
     headers?: { [key: string]: string };
-    body?: T | ApiError;
+    body: Body;
 }
 
 // Input for a lambda handler for an operation
@@ -28666,28 +28673,28 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
 /**
  * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
  */
-export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response>,
+) => Promise<Response>;
 
 // Type for a lambda handler function to be wrapped
-export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+) => Promise<Response>;
 
-export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
-  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>;
 }
 
 /**
  * Build a chain from the given array of chained lambda handlers
  */
-const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, Response>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> => {
   if (handlers.length === 0) {
     return {
       next: () => {
@@ -28702,9 +28709,6 @@ const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBod
     },
   };
 };
-
-// Type alias for the request
-type SayHelloRequestInput = SayHelloRequest;
 
 /**
  * Single-value path/query parameters for SayHello
@@ -28724,13 +28728,17 @@ export interface SayHelloRequestArrayParameters {
  */
 export type SayHelloRequestBody = never;
 
+export type SayHello200OperationResponse = OperationResponse<200, HelloResponse>;
+export type SayHello400OperationResponse = OperationResponse<400, ApiError>;
+export type SayHelloOperationResponses = | SayHello200OperationResponse | SayHello400OperationResponse ;
+
 // Type that the handler function provided to the wrapper must conform to
-export type SayHelloHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
+export type SayHelloHandlerFunction = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, SayHelloOperationResponses>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of sayHello
  */
-export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<ApiError>, ...remainingHandlers: SayHelloHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const sayHelloHandler = (firstHandler: SayHelloHandlerFunction, ...remainingHandlers: SayHelloHandlerFunction[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -29473,12 +29481,12 @@ export class Api extends OpenApiGatewayLambdaApi {
 ",
   "src/api/index.ts": "export * from './api';
 export * from './sample-api';",
-  "src/api/sample-api.say-hello.ts": "import { sayHelloHandler, ApiError } from \\"@test/my-api-typescript\\";
+  "src/api/sample-api.say-hello.ts": "import { sayHelloHandler } from \\"@test/my-api-typescript\\";
 
 /**
  * An example lambda handler which uses the generated handler wrapper to manage marshalling inputs/outputs.
  */
-export const handler = sayHelloHandler<ApiError>(async (input) => {
+export const handler = sayHelloHandler(async (input) => {
   return {
     statusCode: 200,
     body: {
@@ -37912,7 +37920,7 @@ class SayHello(api_client.Api):
 ",
   "generated/python/test_my_api_python/api/default_api_operation_config.py": "import urllib.parse
 import json
-from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional
+from typing import Callable, Any, Dict, List, NamedTuple, TypeVar, Generic, Union, TypedDict, Protocol, Optional, Literal
 from functools import wraps
 from dataclasses import dataclass
 
@@ -37982,14 +37990,13 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
 
 
 ResponseBody = TypeVar('ResponseBody')
-ApiError = TypeVar('ApiError')
-
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
-class ApiResponse(Generic[ResponseBody, ApiError]):
-    status_code: int
+class ApiResponse(Generic[StatusCode, ResponseBody]):
+    status_code: StatusCode
     headers: Dict[str, str]
-    body: Union[ResponseBody, ApiError]
+    body: ResponseBody
 
 
 
@@ -38005,11 +38012,15 @@ class SayHelloRequestArrayParameters(TypedDict):
 # Request body type (default to Any when no body parameters exist)
 SayHelloRequestBody = Any
 
+SayHello200OperationResponse = ApiResponse[Literal[200], HelloResponse]
+SayHello400OperationResponse = ApiResponse[Literal[400], ApiError]
+SayHelloOperationResponses = Union[SayHello200OperationResponse, SayHello400OperationResponse, ]
+
 # Request type for say_hello
 SayHelloRequest = ApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
 
 class SayHelloHandlerFunction(Protocol):
-    def __call__(self, input: SayHelloRequest, **kwargs) -> ApiResponse[HelloResponse, ApiError]:
+    def __call__(self, input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:
         ...
 
 def say_hello_handler(handler: SayHelloHandlerFunction):
@@ -43504,10 +43515,10 @@ const parseBody = (body: string, demarshal: (body: string) => any, contentTypes:
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
 
 // Type of the response to be returned by an operation lambda handler
-export interface OperationResponse<T, ApiError> {
-    statusCode: number;
+export interface OperationResponse<StatusCode extends number, Body> {
+    statusCode: StatusCode;
     headers?: { [key: string]: string };
-    body?: T | ApiError;
+    body: Body;
 }
 
 // Input for a lambda handler for an operation
@@ -43520,28 +43531,28 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
 /**
  * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
  */
-export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response>,
+) => Promise<Response>;
 
 // Type for a lambda handler function to be wrapped
-export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+) => Promise<Response>;
 
-export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
-  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>;
 }
 
 /**
  * Build a chain from the given array of chained lambda handlers
  */
-const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, Response>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> => {
   if (handlers.length === 0) {
     return {
       next: () => {
@@ -43556,9 +43567,6 @@ const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBod
     },
   };
 };
-
-// Type alias for the request
-type SayHelloRequestInput = SayHelloRequest;
 
 /**
  * Single-value path/query parameters for SayHello
@@ -43578,13 +43586,17 @@ export interface SayHelloRequestArrayParameters {
  */
 export type SayHelloRequestBody = never;
 
+export type SayHello200OperationResponse = OperationResponse<200, HelloResponse>;
+export type SayHello400OperationResponse = OperationResponse<400, ApiError>;
+export type SayHelloOperationResponses = | SayHello200OperationResponse | SayHello400OperationResponse ;
+
 // Type that the handler function provided to the wrapper must conform to
-export type SayHelloHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
+export type SayHelloHandlerFunction = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, SayHelloOperationResponses>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of sayHello
  */
-export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<ApiError>, ...remainingHandlers: SayHelloHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const sayHelloHandler = (firstHandler: SayHelloHandlerFunction, ...remainingHandlers: SayHelloHandlerFunction[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -44327,12 +44339,12 @@ export class Api extends OpenApiGatewayLambdaApi {
 ",
   "src/api/index.ts": "export * from './api';
 export * from './sample-api';",
-  "src/api/sample-api.say-hello.ts": "import { sayHelloHandler, ApiError } from \\"@test/my-api-typescript\\";
+  "src/api/sample-api.say-hello.ts": "import { sayHelloHandler } from \\"@test/my-api-typescript\\";
 
 /**
  * An example lambda handler which uses the generated handler wrapper to manage marshalling inputs/outputs.
  */
-export const handler = sayHelloHandler<ApiError>(async (input) => {
+export const handler = sayHelloHandler(async (input) => {
   return {
     statusCode: 200,
     body: {

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/with-docs.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/with-docs.test.ts.snap
@@ -5222,10 +5222,10 @@ const parseBody = (body: string, demarshal: (body: string) => any, contentTypes:
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
 
 // Type of the response to be returned by an operation lambda handler
-export interface OperationResponse<T, ApiError> {
-    statusCode: number;
+export interface OperationResponse<StatusCode extends number, Body> {
+    statusCode: StatusCode;
     headers?: { [key: string]: string };
-    body?: T | ApiError;
+    body: Body;
 }
 
 // Input for a lambda handler for an operation
@@ -5238,28 +5238,28 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
 /**
  * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
  */
-export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response>,
+) => Promise<Response>;
 
 // Type for a lambda handler function to be wrapped
-export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+) => Promise<Response>;
 
-export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
-  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>;
 }
 
 /**
  * Build a chain from the given array of chained lambda handlers
  */
-const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, Response>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> => {
   if (handlers.length === 0) {
     return {
       next: () => {
@@ -5274,9 +5274,6 @@ const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBod
     },
   };
 };
-
-// Type alias for the request
-type SayHelloRequestInput = SayHelloRequest;
 
 /**
  * Single-value path/query parameters for SayHello
@@ -5296,13 +5293,17 @@ export interface SayHelloRequestArrayParameters {
  */
 export type SayHelloRequestBody = never;
 
+export type SayHello200OperationResponse = OperationResponse<200, HelloResponse>;
+export type SayHello400OperationResponse = OperationResponse<400, ApiError>;
+export type SayHelloOperationResponses = | SayHello200OperationResponse | SayHello400OperationResponse ;
+
 // Type that the handler function provided to the wrapper must conform to
-export type SayHelloHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
+export type SayHelloHandlerFunction = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, SayHelloOperationResponses>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of sayHello
  */
-export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<ApiError>, ...remainingHandlers: SayHelloHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const sayHelloHandler = (firstHandler: SayHelloHandlerFunction, ...remainingHandlers: SayHelloHandlerFunction[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -6045,12 +6046,12 @@ export class Api extends OpenApiGatewayLambdaApi {
 ",
   "src/api/index.ts": "export * from './api';
 export * from './sample-api';",
-  "src/api/sample-api.say-hello.ts": "import { sayHelloHandler, ApiError } from \\"@test/my-api-typescript\\";
+  "src/api/sample-api.say-hello.ts": "import { sayHelloHandler } from \\"@test/my-api-typescript\\";
 
 /**
  * An example lambda handler which uses the generated handler wrapper to manage marshalling inputs/outputs.
  */
-export const handler = sayHelloHandler<ApiError>(async (input) => {
+export const handler = sayHelloHandler(async (input) => {
   return {
     statusCode: 200,
     body: {

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/without-sample-code.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/without-sample-code.test.ts.snap
@@ -1973,10 +1973,10 @@ const parseBody = (body: string, demarshal: (body: string) => any, contentTypes:
 type ApiGatewayLambdaHandler = (event: any, context: any) => Promise<any>;
 
 // Type of the response to be returned by an operation lambda handler
-export interface OperationResponse<T, ApiError> {
-    statusCode: number;
+export interface OperationResponse<StatusCode extends number, Body> {
+    statusCode: StatusCode;
     headers?: { [key: string]: string };
-    body?: T | ApiError;
+    body: Body;
 }
 
 // Input for a lambda handler for an operation
@@ -1989,28 +1989,28 @@ export type LambdaRequestParameters<RequestParameters, RequestArrayParameters, R
 /**
  * A lambda handler function which is part of a chain. It may invoke the remainder of the chain via the given chain input
  */
-export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+  chain: LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response>,
+) => Promise<Response>;
 
 // Type for a lambda handler function to be wrapped
-export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> = (
+export type LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response> = (
   input: LambdaRequestParameters<RequestParameters, RequestArrayParameters, RequestBody>,
   event: any,
   context: any,
-) => Promise<OperationResponse<RequestOutput, ApiError>>;
+) => Promise<Response>;
 
-export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> {
-  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>;
+export interface LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> {
+  next: LambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>;
 }
 
 /**
  * Build a chain from the given array of chained lambda handlers
  */
-const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, RequestOutput, ApiError> => {
+const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBody, Response>(...handlers: ChainedLambdaHandlerFunction<RequestParameters, RequestArrayParameters, RequestBody, Response>[]): LambdaHandlerChain<RequestParameters, RequestArrayParameters, RequestBody, Response> => {
   if (handlers.length === 0) {
     return {
       next: () => {
@@ -2025,9 +2025,6 @@ const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBod
     },
   };
 };
-
-// Type alias for the request
-type SayHelloRequestInput = SayHelloRequest;
 
 /**
  * Single-value path/query parameters for SayHello
@@ -2047,13 +2044,17 @@ export interface SayHelloRequestArrayParameters {
  */
 export type SayHelloRequestBody = never;
 
+export type SayHello200OperationResponse = OperationResponse<200, HelloResponse>;
+export type SayHello400OperationResponse = OperationResponse<400, ApiError>;
+export type SayHelloOperationResponses = | SayHello200OperationResponse | SayHello400OperationResponse ;
+
 // Type that the handler function provided to the wrapper must conform to
-export type SayHelloHandlerFunction<ApiError> = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, HelloResponse, ApiError>;
+export type SayHelloHandlerFunction = ChainedLambdaHandlerFunction<SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody, SayHelloOperationResponses>;
 
 /**
  * Lambda handler wrapper to provide typed interface for the implementation of sayHello
  */
-export const sayHelloHandler = <ApiError>(firstHandler: SayHelloHandlerFunction<ApiError>, ...remainingHandlers: SayHelloHandlerFunction<ApiError>[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+export const sayHelloHandler = (firstHandler: SayHelloHandlerFunction, ...remainingHandlers: SayHelloHandlerFunction[]): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),

--- a/packages/open-api-gateway/test/project/spec/components/__snapshots__/parsed-spec.test.ts.snap
+++ b/packages/open-api-gateway/test/project/spec/components/__snapshots__/parsed-spec.test.ts.snap
@@ -358,6 +358,16 @@ node_modules/
           },
         },
       },
+      "/empty-response": Object {
+        "put": Object {
+          "operationId": "empty",
+          "responses": Object {
+            "204": Object {
+              "description": "No response body!",
+            },
+          },
+        },
+      },
       "/path/{pathParam}": Object {
         "post": Object {
           "operationId": "operationOne",

--- a/packages/open-api-gateway/test/resources/specs/single.yaml
+++ b/packages/open-api-gateway/test/resources/specs/single.yaml
@@ -57,6 +57,12 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/TestResponse'
+  /empty-response:
+    put:
+      operationId: empty
+      responses:
+        204:
+          description: No response body!
   /different-media-type:
     post:
       operationId: mediaTypes


### PR DESCRIPTION
… in ts/python lambda handlers

Rather than allowing any error type to be returned by a lambda handler wrapper via a generic
parameter, we enforce that the response body returned corresponds to the correct type for the status
code of the response.

This will ensure that lambdas better conform to the api spec since it forces error types to be explicitly specified in the spec where they can occur.

BREAKING CHANGE: lambda handler wrappers no longer accept a type parameter for errors. lambda
handlers must return the matching response body for the status code defined in the specification.
