### PR TITLE
fix(cloudscape-react-ts-website): fix blank screen on signin due to missing runtime context

### DIFF
--- a/packages/cloudscape-react-ts-website/samples/src/Auth.tsx
+++ b/packages/cloudscape-react-ts-website/samples/src/Auth.tsx
@@ -107,7 +107,7 @@ const Auth: React.FC<any> = ({ children }) => {
       switch (data.payload.event) {
         case 'signIn':
           AmplifyAuth.currentUserInfo()
-            .then(user => setRuntimeContext({ ...runtimeContext, user }))
+            .then(user => setRuntimeContext((prevRuntimeContext: any) => ({ ...prevRuntimeContext, user })))
             .catch(e => console.error(e));
           break;
         case 'signOut':
@@ -115,7 +115,7 @@ const Auth: React.FC<any> = ({ children }) => {
           break;
       }
     });
-  }, [runtimeContext]);
+  }, []);
 
   const AuthWrapper: React.FC<any> = useCallback(({ children: _children }) => runtimeContext.userPoolId ?
     <ThemeProvider theme={theme}>


### PR DESCRIPTION
When first signing in and making use of runtime context, the context gets cleared, I think this is a race condition where the hub's signin callback fires before the useEffect runs to update the callback with the new runtime config. At any rate, using the setter method with the previous value addresses the issue! :)