### PR TITLE
fix(open-api-gateway): ensure api is redeployed when integrations/authorizers change

### DIFF
--- a/packages/open-api-gateway/test/construct/__snapshots__/open-api-gateway-lambda-api.test.ts.snap
+++ b/packages/open-api-gateway/test/construct/__snapshots__/open-api-gateway-lambda-api.test.ts.snap
@@ -133,7 +133,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestDeployment153EC47818fc1857aed5228af77afc4d202e4d2c": Object {
+    "ApiTestDeployment153EC478d13a017befcb0dc3f94217cff6d5b191": Object {
       "DependsOn": Array [
         "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
@@ -198,7 +198,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment153EC47818fc1857aed5228af77afc4d202e4d2c",
+          "Ref": "ApiTestDeployment153EC478d13a017befcb0dc3f94217cff6d5b191",
         },
         "MethodSettings": Array [
           Object {
@@ -243,7 +243,12 @@ Object {
           "Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "Key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json.prepared-spec.json",
+          "Key": Object {
+            "Fn::GetAtt": Array [
+              "ApiTestPrepareSpecCustomResourceC9800EE6",
+              "outputSpecKey",
+            ],
+          },
         },
         "Name": "ApiTest",
       },
@@ -333,7 +338,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9ac23b37433996e2bb87bdce8397e4b3165288bdb6e1c683a217eba8d7a24988.zip",
+          "S3Key": "99474ee220101b761945cc8f536be61b7cec3bba38a62e4a970f6b5e37c835be.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -419,7 +424,7 @@ Object {
           "bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json.prepared-spec.json",
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
         },
         "securitySchemes": Object {},
       },
@@ -773,7 +778,7 @@ Object {
                         Object {
                           "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
                         },
-                        "/ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json.prepared-spec.json",
+                        "/ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared/*",
                       ],
                     ],
                   },
@@ -1021,7 +1026,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestDeployment153EC47818fc1857aed5228af77afc4d202e4d2c": Object {
+    "ApiTestDeployment153EC478febcc09306d18acf1b08e3a812546fab": Object {
       "DependsOn": Array [
         "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
@@ -1086,7 +1091,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment153EC47818fc1857aed5228af77afc4d202e4d2c",
+          "Ref": "ApiTestDeployment153EC478febcc09306d18acf1b08e3a812546fab",
         },
         "MethodSettings": Array [
           Object {
@@ -1131,7 +1136,12 @@ Object {
           "Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "Key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json.prepared-spec.json",
+          "Key": Object {
+            "Fn::GetAtt": Array [
+              "ApiTestPrepareSpecCustomResourceC9800EE6",
+              "outputSpecKey",
+            ],
+          },
         },
         "Name": "ApiTest",
       },
@@ -1221,7 +1231,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9ac23b37433996e2bb87bdce8397e4b3165288bdb6e1c683a217eba8d7a24988.zip",
+          "S3Key": "99474ee220101b761945cc8f536be61b7cec3bba38a62e4a970f6b5e37c835be.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -1310,7 +1320,7 @@ Object {
           "bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json.prepared-spec.json",
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
         },
         "securitySchemes": Object {
           "myCognitoAuthorizer": Object {
@@ -1682,7 +1692,7 @@ Object {
                         Object {
                           "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
                         },
-                        "/ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json.prepared-spec.json",
+                        "/ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared/*",
                       ],
                     ],
                   },
@@ -1941,7 +1951,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestDeployment153EC47818fc1857aed5228af77afc4d202e4d2c": Object {
+    "ApiTestDeployment153EC4789800efc070b577353172b0de80bd43d4": Object {
       "DependsOn": Array [
         "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
@@ -2006,7 +2016,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment153EC47818fc1857aed5228af77afc4d202e4d2c",
+          "Ref": "ApiTestDeployment153EC4789800efc070b577353172b0de80bd43d4",
         },
         "MethodSettings": Array [
           Object {
@@ -2051,7 +2061,12 @@ Object {
           "Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "Key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json.prepared-spec.json",
+          "Key": Object {
+            "Fn::GetAtt": Array [
+              "ApiTestPrepareSpecCustomResourceC9800EE6",
+              "outputSpecKey",
+            ],
+          },
         },
         "Name": "ApiTest",
       },
@@ -2197,7 +2212,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9ac23b37433996e2bb87bdce8397e4b3165288bdb6e1c683a217eba8d7a24988.zip",
+          "S3Key": "99474ee220101b761945cc8f536be61b7cec3bba38a62e4a970f6b5e37c835be.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -2286,7 +2301,7 @@ Object {
           "bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json.prepared-spec.json",
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
         },
         "securitySchemes": Object {
           "myCustomAuthorizer": Object {
@@ -2675,7 +2690,7 @@ Object {
                         Object {
                           "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
                         },
-                        "/ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json.prepared-spec.json",
+                        "/ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared/*",
                       ],
                     ],
                   },
@@ -2953,7 +2968,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestDeployment153EC47818fc1857aed5228af77afc4d202e4d2c": Object {
+    "ApiTestDeployment153EC478f8975d4b863ce920c7cf5cae4ba2bfd2": Object {
       "DependsOn": Array [
         "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
@@ -3018,7 +3033,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment153EC47818fc1857aed5228af77afc4d202e4d2c",
+          "Ref": "ApiTestDeployment153EC478f8975d4b863ce920c7cf5cae4ba2bfd2",
         },
         "MethodSettings": Array [
           Object {
@@ -3063,7 +3078,12 @@ Object {
           "Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "Key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json.prepared-spec.json",
+          "Key": Object {
+            "Fn::GetAtt": Array [
+              "ApiTestPrepareSpecCustomResourceC9800EE6",
+              "outputSpecKey",
+            ],
+          },
         },
         "Name": "ApiTest",
       },
@@ -3153,7 +3173,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9ac23b37433996e2bb87bdce8397e4b3165288bdb6e1c683a217eba8d7a24988.zip",
+          "S3Key": "99474ee220101b761945cc8f536be61b7cec3bba38a62e4a970f6b5e37c835be.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -3265,7 +3285,7 @@ Object {
           "bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json.prepared-spec.json",
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
         },
         "securitySchemes": Object {
           "iam": Object {
@@ -3626,7 +3646,7 @@ Object {
                         Object {
                           "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
                         },
-                        "/ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json.prepared-spec.json",
+                        "/ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared/*",
                       ],
                     ],
                   },
@@ -3854,7 +3874,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestDeployment153EC47871f772b66b8b6ed1a2335ac17ebfa2af": Object {
+    "ApiTestDeployment153EC4783d8e8dd6135859e4fde61dc2c3739831": Object {
       "DependsOn": Array [
         "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
@@ -3919,7 +3939,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment153EC47871f772b66b8b6ed1a2335ac17ebfa2af",
+          "Ref": "ApiTestDeployment153EC4783d8e8dd6135859e4fde61dc2c3739831",
         },
         "MethodSettings": Array [
           Object {
@@ -3964,7 +3984,12 @@ Object {
           "Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "Key": "59c8d7b10656c48be66a3a7cb22540b5dc6f56cfa67229affa21977c6567f30e.json.prepared-spec.json",
+          "Key": Object {
+            "Fn::GetAtt": Array [
+              "ApiTestPrepareSpecCustomResourceC9800EE6",
+              "outputSpecKey",
+            ],
+          },
         },
         "Name": "ApiTest",
       },
@@ -4278,7 +4303,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "9ac23b37433996e2bb87bdce8397e4b3165288bdb6e1c683a217eba8d7a24988.zip",
+          "S3Key": "99474ee220101b761945cc8f536be61b7cec3bba38a62e4a970f6b5e37c835be.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -4469,7 +4494,7 @@ Object {
           "bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "key": "59c8d7b10656c48be66a3a7cb22540b5dc6f56cfa67229affa21977c6567f30e.json.prepared-spec.json",
+          "key": "59c8d7b10656c48be66a3a7cb22540b5dc6f56cfa67229affa21977c6567f30e.json-prepared",
         },
         "securitySchemes": Object {
           "iam": Object {
@@ -4881,7 +4906,7 @@ Object {
                         Object {
                           "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
                         },
-                        "/59c8d7b10656c48be66a3a7cb22540b5dc6f56cfa67229affa21977c6567f30e.json.prepared-spec.json",
+                        "/59c8d7b10656c48be66a3a7cb22540b5dc6f56cfa67229affa21977c6567f30e.json-prepared/*",
                       ],
                     ],
                   },


### PR DESCRIPTION
File name hash was only based on the parsed spec, not the prepared spec. Include parsed spec hash in
filename to ensure cloudformation redeploys the api when either the input spec or the
integrations/authorizers change.

Additionally include a hash in the api deployment's logical id to ensure the api is also redeployed.
