### PR TITLE
feat: sigv4 middleware, cors by default for sample api

### DIFF
--- a/packages/cloudscape-react-ts-website/samples/.projen/deps.json
+++ b/packages/cloudscape-react-ts-website/samples/.projen/deps.json
@@ -98,6 +98,10 @@
       "type": "runtime"
     },
     {
+      "name": "aws4fetch",
+      "type": "runtime"
+    },
+    {
       "name": "react",
       "type": "runtime"
     },

--- a/packages/cloudscape-react-ts-website/samples/package.json
+++ b/packages/cloudscape-react-ts-website/samples/package.json
@@ -41,6 +41,7 @@
     "@cloudscape-design/components": "^3.0.22",
     "@cloudscape-design/global-styles": "*",
     "aws-amplify": "^4.3.30",
+    "aws4fetch": "^1.0.13",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.3.0",

--- a/packages/cloudscape-react-ts-website/samples/src/Auth.tsx
+++ b/packages/cloudscape-react-ts-website/samples/src/Auth.tsx
@@ -30,8 +30,7 @@ export const RuntimeConfigContext = createContext<any>({});
  * the runtime-config.json must have the following properties configured: [region, userPoolId, userPoolWebClientId, identityPoolId].
  */
 const Auth: React.FC<any> = ({ children }) => {
-  const [runtimeContext, setRuntimeContext] = useState<any>({});
-  const [runtimeContextLoaded, setRuntimeContextLoaded] = useState(false);
+  const [runtimeContext, setRuntimeContext] = useState<any>(undefined);
   const { tokens } = useTheme();
 
   // Customize your login theme
@@ -98,9 +97,11 @@ const Auth: React.FC<any> = ({ children }) => {
           console.warn('runtime-config.json should have region, userPoolId, userPoolWebClientId & identityPoolId.');
         }
       })
-      .catch(() => console.log('No runtime-config.json detected'))
-      .finally(() => setRuntimeContextLoaded(true));
-  }, [setRuntimeContext, setRuntimeContextLoaded]);
+      .catch(() => {
+        console.log('No runtime-config.json detected');
+        setRuntimeContext({});
+      });
+  }, [setRuntimeContext]);
 
   useEffect(() => {
     Hub.listen('auth', (data) => {
@@ -125,10 +126,10 @@ const Auth: React.FC<any> = ({ children }) => {
     </ThemeProvider> :
     <>
       {
-        runtimeContextLoaded ?
+        runtimeContext ?
           _children : <></> // Don't render anything if the context has not finalized
       }
-    </>, [runtimeContext.userPoolId, runtimeContextLoaded, theme]);
+    </>, [runtimeContext, theme]);
 
   return (
     <AuthWrapper>

--- a/packages/cloudscape-react-ts-website/samples/src/api-client-middleware/sigv4-middleware.ts
+++ b/packages/cloudscape-react-ts-website/samples/src/api-client-middleware/sigv4-middleware.ts
@@ -1,0 +1,93 @@
+/*********************************************************************************************************************
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License").
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ ******************************************************************************************************************** */
+
+import { Auth } from 'aws-amplify';
+import { AwsV4Signer } from 'aws4fetch';
+
+type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
+
+interface RequestContext {
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+}
+
+interface ResponseContext {
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
+}
+
+interface FetchParams {
+  url: string;
+  init: RequestInit;
+}
+
+interface Middleware {
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+}
+
+/**
+ * This middleware is useful for the open-api-gateway generated typescript client, if you are using IAM/Sigv4
+ * authentication. This can safely be removed from your website project if not!
+ */
+export const sigv4SignMiddleware = (region: string): Middleware => ({
+  pre: async ({ init, url }) => {
+    // Retrieve the current signed in user credentials
+    const { accessKeyId, secretAccessKey, sessionToken } = await Auth.currentCredentials();
+    // Sign the request
+    const { url: signedUrl, headers, body, method } = await new AwsV4Signer({
+      accessKeyId,
+      secretAccessKey,
+      sessionToken,
+      region,
+      service: 'execute-api',
+      url,
+      body: init.body,
+      headers: init.headers,
+      method: init.method,
+    }).sign();
+    // Return the signed request
+    return {
+      url: signedUrl.toString(),
+      init: {
+        ...init,
+        headers,
+        body,
+        method,
+      },
+    };
+  },
+});
+
+/**
+ * This middleware is useful for the open-api-gateway generated typescript client, for adding the
+ * application/json content-type header to requests.
+ */
+export const addJsonContentTypeHeaderMiddleware: Middleware = {
+  pre: async ({ init, url }) => ({
+    url,
+    init: {
+      ...init,
+      headers: {
+        ...init.headers,
+        'Content-Type': 'application/json',
+      },
+    },
+  }),
+};

--- a/packages/cloudscape-react-ts-website/test/__snapshots__/cloudscape-react-ts-website-project.test.ts.snap
+++ b/packages/cloudscape-react-ts-website/test/__snapshots__/cloudscape-react-ts-website-project.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AwsUiReactTsWebsiteProject Unit Tests Custom Options 1`] = `
+exports[`CloudscapeReactTsWebsiteProject Unit Tests Custom Options 1`] = `
 Object {
   ".eslintrc.json": Object {
     "env": Object {
@@ -637,6 +637,10 @@ tsconfig.tsbuildinfo
         "type": "runtime",
       },
       Object {
+        "name": "aws4fetch",
+        "type": "runtime",
+      },
+      Object {
         "name": "react",
         "type": "runtime",
       },
@@ -813,7 +817,7 @@ tsconfig.tsbuildinfo
             "spawn": "eslint",
           },
           Object {
-            "exec": "react-scripts test --watchAll=false",
+            "exec": "react-scripts test --watchAll=false --passWithNoTests",
           },
         ],
       },
@@ -1152,6 +1156,7 @@ curl https://dxxxxxxxxxx.cloudfront.net/runtime-config.json > public/runtime-con
       "@cloudscape-design/global-styles": "*",
       "aws-amplify": "*",
       "aws-prototoyping-sdk": "*",
+      "aws4fetch": "*",
       "react": "*",
       "react-dom": "*",
       "react-router-dom": "*",
@@ -1417,8 +1422,7 @@ export const RuntimeConfigContext = createContext<any>({});
  * the runtime-config.json must have the following properties configured: [region, userPoolId, userPoolWebClientId, identityPoolId].
  */
 const Auth: React.FC<any> = ({ children }) => {
-  const [runtimeContext, setRuntimeContext] = useState<any>({});
-  const [runtimeContextLoaded, setRuntimeContextLoaded] = useState(false);
+  const [runtimeContext, setRuntimeContext] = useState<any>(undefined);
   const { tokens } = useTheme();
 
   // Customize your login theme
@@ -1485,9 +1489,11 @@ const Auth: React.FC<any> = ({ children }) => {
           console.warn('runtime-config.json should have region, userPoolId, userPoolWebClientId & identityPoolId.');
         }
       })
-      .catch(() => console.log('No runtime-config.json detected'))
-      .finally(() => setRuntimeContextLoaded(true));
-  }, [setRuntimeContext, setRuntimeContextLoaded]);
+      .catch(() => {
+        console.log('No runtime-config.json detected');
+        setRuntimeContext({});
+      });
+  }, [setRuntimeContext]);
 
   useEffect(() => {
     Hub.listen('auth', (data) => {
@@ -1512,10 +1518,10 @@ const Auth: React.FC<any> = ({ children }) => {
     </ThemeProvider> :
     <>
       {
-        runtimeContextLoaded ?
+        runtimeContext ?
           _children : <></> // Don't render anything if the context has not finalized
       }
-    </>, [runtimeContext.userPoolId, runtimeContextLoaded, theme]);
+    </>, [runtimeContext, theme]);
 
   return (
     <AuthWrapper>
@@ -1692,6 +1698,100 @@ const NavHeader: React.FC = () => {
 };
 
 export default NavHeader;",
+  "src/api-client-middleware/sigv4-middleware.ts": "/*********************************************************************************************************************
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the \\"License\\").
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an \\"AS IS\\" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ ******************************************************************************************************************** */
+
+import { Auth } from 'aws-amplify';
+import { AwsV4Signer } from 'aws4fetch';
+
+type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
+
+interface RequestContext {
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+}
+
+interface ResponseContext {
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
+}
+
+interface FetchParams {
+  url: string;
+  init: RequestInit;
+}
+
+interface Middleware {
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+}
+
+/**
+ * This middleware is useful for the open-api-gateway generated typescript client, if you are using IAM/Sigv4
+ * authentication. This can safely be removed from your website project if not!
+ */
+export const sigv4SignMiddleware = (region: string): Middleware => ({
+  pre: async ({ init, url }) => {
+    // Retrieve the current signed in user credentials
+    const { accessKeyId, secretAccessKey, sessionToken } = await Auth.currentCredentials();
+    // Sign the request
+    const { url: signedUrl, headers, body, method } = await new AwsV4Signer({
+      accessKeyId,
+      secretAccessKey,
+      sessionToken,
+      region,
+      service: 'execute-api',
+      url,
+      body: init.body,
+      headers: init.headers,
+      method: init.method,
+    }).sign();
+    // Return the signed request
+    return {
+      url: signedUrl.toString(),
+      init: {
+        ...init,
+        headers,
+        body,
+        method,
+      },
+    };
+  },
+});
+
+/**
+ * This middleware is useful for the open-api-gateway generated typescript client, for adding the
+ * application/json content-type header to requests.
+ */
+export const addJsonContentTypeHeaderMiddleware: Middleware = {
+  pre: async ({ init, url }) => ({
+    url,
+    init: {
+      ...init,
+      headers: {
+        ...init.headers,
+        'Content-Type': 'application/json',
+      },
+    },
+  }),
+};
+",
   "src/config.json": Object {
     "applicationName": "CustomOptions",
   },
@@ -1885,7 +1985,7 @@ import '@testing-library/jest-dom';
 }
 `;
 
-exports[`AwsUiReactTsWebsiteProject Unit Tests Defaults 1`] = `
+exports[`CloudscapeReactTsWebsiteProject Unit Tests Defaults 1`] = `
 Object {
   ".eslintrc.json": Object {
     "env": Object {
@@ -2518,6 +2618,10 @@ tsconfig.tsbuildinfo
         "type": "runtime",
       },
       Object {
+        "name": "aws4fetch",
+        "type": "runtime",
+      },
+      Object {
         "name": "react",
         "type": "runtime",
       },
@@ -2694,7 +2798,7 @@ tsconfig.tsbuildinfo
             "spawn": "eslint",
           },
           Object {
-            "exec": "react-scripts test --watchAll=false",
+            "exec": "react-scripts test --watchAll=false --passWithNoTests",
           },
         ],
       },
@@ -3032,6 +3136,7 @@ curl https://dxxxxxxxxxx.cloudfront.net/runtime-config.json > public/runtime-con
       "@cloudscape-design/components": "*",
       "@cloudscape-design/global-styles": "*",
       "aws-amplify": "*",
+      "aws4fetch": "*",
       "react": "*",
       "react-dom": "*",
       "react-router-dom": "*",
@@ -3297,8 +3402,7 @@ export const RuntimeConfigContext = createContext<any>({});
  * the runtime-config.json must have the following properties configured: [region, userPoolId, userPoolWebClientId, identityPoolId].
  */
 const Auth: React.FC<any> = ({ children }) => {
-  const [runtimeContext, setRuntimeContext] = useState<any>({});
-  const [runtimeContextLoaded, setRuntimeContextLoaded] = useState(false);
+  const [runtimeContext, setRuntimeContext] = useState<any>(undefined);
   const { tokens } = useTheme();
 
   // Customize your login theme
@@ -3365,9 +3469,11 @@ const Auth: React.FC<any> = ({ children }) => {
           console.warn('runtime-config.json should have region, userPoolId, userPoolWebClientId & identityPoolId.');
         }
       })
-      .catch(() => console.log('No runtime-config.json detected'))
-      .finally(() => setRuntimeContextLoaded(true));
-  }, [setRuntimeContext, setRuntimeContextLoaded]);
+      .catch(() => {
+        console.log('No runtime-config.json detected');
+        setRuntimeContext({});
+      });
+  }, [setRuntimeContext]);
 
   useEffect(() => {
     Hub.listen('auth', (data) => {
@@ -3392,10 +3498,10 @@ const Auth: React.FC<any> = ({ children }) => {
     </ThemeProvider> :
     <>
       {
-        runtimeContextLoaded ?
+        runtimeContext ?
           _children : <></> // Don't render anything if the context has not finalized
       }
-    </>, [runtimeContext.userPoolId, runtimeContextLoaded, theme]);
+    </>, [runtimeContext, theme]);
 
   return (
     <AuthWrapper>
@@ -3572,6 +3678,100 @@ const NavHeader: React.FC = () => {
 };
 
 export default NavHeader;",
+  "src/api-client-middleware/sigv4-middleware.ts": "/*********************************************************************************************************************
+ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the \\"License\\").
+ You may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an \\"AS IS\\" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ ******************************************************************************************************************** */
+
+import { Auth } from 'aws-amplify';
+import { AwsV4Signer } from 'aws4fetch';
+
+type FetchAPI = WindowOrWorkerGlobalScope['fetch'];
+
+interface RequestContext {
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+}
+
+interface ResponseContext {
+  fetch: FetchAPI;
+  url: string;
+  init: RequestInit;
+  response: Response;
+}
+
+interface FetchParams {
+  url: string;
+  init: RequestInit;
+}
+
+interface Middleware {
+  pre?(context: RequestContext): Promise<FetchParams | void>;
+  post?(context: ResponseContext): Promise<Response | void>;
+}
+
+/**
+ * This middleware is useful for the open-api-gateway generated typescript client, if you are using IAM/Sigv4
+ * authentication. This can safely be removed from your website project if not!
+ */
+export const sigv4SignMiddleware = (region: string): Middleware => ({
+  pre: async ({ init, url }) => {
+    // Retrieve the current signed in user credentials
+    const { accessKeyId, secretAccessKey, sessionToken } = await Auth.currentCredentials();
+    // Sign the request
+    const { url: signedUrl, headers, body, method } = await new AwsV4Signer({
+      accessKeyId,
+      secretAccessKey,
+      sessionToken,
+      region,
+      service: 'execute-api',
+      url,
+      body: init.body,
+      headers: init.headers,
+      method: init.method,
+    }).sign();
+    // Return the signed request
+    return {
+      url: signedUrl.toString(),
+      init: {
+        ...init,
+        headers,
+        body,
+        method,
+      },
+    };
+  },
+});
+
+/**
+ * This middleware is useful for the open-api-gateway generated typescript client, for adding the
+ * application/json content-type header to requests.
+ */
+export const addJsonContentTypeHeaderMiddleware: Middleware = {
+  pre: async ({ init, url }) => ({
+    url,
+    init: {
+      ...init,
+      headers: {
+        ...init.headers,
+        'Content-Type': 'application/json',
+      },
+    },
+  }),
+};
+",
   "src/config.json": Object {
     "applicationName": "Defaults",
   },

--- a/packages/cloudscape-react-ts-website/test/cloudscape-react-ts-website-project.test.ts
+++ b/packages/cloudscape-react-ts-website/test/cloudscape-react-ts-website-project.test.ts
@@ -17,7 +17,7 @@
 import { synthSnapshot } from "projen/lib/util/synth";
 import { CloudscapeReactTsWebsiteProject } from "../src";
 
-describe("AwsUiReactTsWebsiteProject Unit Tests", () => {
+describe("CloudscapeReactTsWebsiteProject Unit Tests", () => {
   it("Defaults", () => {
     const project = new CloudscapeReactTsWebsiteProject({
       defaultReleaseBranch: "mainline",

--- a/packages/open-api-gateway/src/project/samples/typescript.ts
+++ b/packages/open-api-gateway/src/project/samples/typescript.ts
@@ -89,6 +89,7 @@ export class Api extends OpenApiGatewayLambdaApi {
         // TODO: Consider generating this sample from the parsed spec
         "sample-api.ts": `import { Authorizers } from "${options.openApiGatewayPackageName}";
 import { Construct } from "constructs";
+import { Cors } from "aws-cdk-lib/aws-apigateway";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Api } from "./api";
 
@@ -99,6 +100,10 @@ export class SampleApi extends Api {
   constructor(scope: Construct, id: string) {
     super(scope, id, {
       defaultAuthorizer: Authorizers.iam(),
+      corsOptions: {
+        allowOrigins: Cors.ALL_ORIGINS,
+        allowMethods: Cors.ALL_METHODS,
+      },
       integrations: {
         sayHello: {
           function: new NodejsFunction(scope, "say-hello"),
@@ -117,6 +122,10 @@ export class SampleApi extends Api {
 export const handler = sayHelloHandler(async (input) => {
   return {
     statusCode: 200,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Headers": "*",
+    },
     body: {
       message: \`Hello \${input.requestParameters.name}!\`,
     },

--- a/private/projects/cloudscape-react-ts-website.ts
+++ b/private/projects/cloudscape-react-ts-website.ts
@@ -68,6 +68,7 @@ class CloudscapeReactTsSampleWebsiteProject extends ReactTypeScriptProject {
         "react-router-dom",
         "aws-amplify",
         "@aws-amplify/ui-react",
+        "aws4fetch",
       ],
       gitignore: ["runtime-config.json"],
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5819,6 +5819,11 @@ aws-sdk@^2.1194.0:
     uuid "8.0.0"
     xml2js "0.4.19"
 
+aws4fetch@^1.0.13:
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/aws4fetch/-/aws4fetch-1.0.13.tgz#81f09e3b7c3c52742c55a5d09def641df252f682"
+  integrity sha512-UTlirJkLtGbJurR9PlL4rOZ9HM1G/1/joWItpVwQ0f7j5Alldd7rfCMcy2kd0l2nDZ4LBdd6cFhrMwsEtazCNw==
+
 axe-core@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.2.tgz#dcf7fb6dea866166c3eab33d68208afe4d5f670c"


### PR DESCRIPTION
* add sigv4 sign middleware for easier integration with iam auth open-api-gateway
* enable cors in default generated sample api for smoother first experience
* minor runtime config load fix to avoid blank screen