### PR TITLE
fix: broken python builds when rooted under monorepo

### DIFF
--- a/packages/pipeline/samples/typescript/test/__snapshots__/pipeline.test.ts.snap
+++ b/packages/pipeline/samples/typescript/test/__snapshots__/pipeline.test.ts.snap
@@ -645,7 +645,7 @@ Object {
                   "Version": "1",
                 },
                 "Configuration": Object {
-                  "EnvironmentVariables": "[{\\"name\\":\\"_PROJECT_CONFIG_HASH\\",\\"type\\":\\"PLAINTEXT\\",\\"value\\":\\"ae7d64108857c36deaf14a4939d075c70a5527bd396853794b07e116e10f73cb\\"}]",
+                  "EnvironmentVariables": "[{\\"name\\":\\"_PROJECT_CONFIG_HASH\\",\\"type\\":\\"PLAINTEXT\\",\\"value\\":\\"f78b69a9d9345d64a24b7224685b9cdc6b7f7495f0607df3c63d701642d9d118\\"}]",
                   "ProjectName": Object {
                     "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
                   },
@@ -741,7 +741,7 @@ Object {
     \\"install\\": {
       \\"commands\\": [
         \\"npm install -g aws-cdk\\",
-        \\"yarn install --frozen-lockfile\\"
+        \\"yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile\\"
       ]
     },
     \\"build\\": {

--- a/packages/pipeline/src/pdk-pipeline.ts
+++ b/packages/pipeline/src/pdk-pipeline.ts
@@ -144,7 +144,7 @@ export class PDKPipeline extends CodePipeline {
       ),
       installCommands: [
         "npm install -g aws-cdk",
-        "yarn install --frozen-lockfile",
+        "yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile",
       ],
       commands:
         commands && commands.length > 0

--- a/packages/pipeline/test/__snapshots__/pdk-pipeline-ts-project.test.ts.snap
+++ b/packages/pipeline/test/__snapshots__/pdk-pipeline-ts-project.test.ts.snap
@@ -1727,7 +1727,7 @@ Object {
                   \\"Version\\": \\"1\\",
                 },
                 \\"Configuration\\": Object {
-                  \\"EnvironmentVariables\\": \\"[{\\\\\\\\\\"name\\\\\\\\\\":\\\\\\\\\\"_PROJECT_CONFIG_HASH\\\\\\\\\\",\\\\\\\\\\"type\\\\\\\\\\":\\\\\\\\\\"PLAINTEXT\\\\\\\\\\",\\\\\\\\\\"value\\\\\\\\\\":\\\\\\\\\\"ae7d64108857c36deaf14a4939d075c70a5527bd396853794b07e116e10f73cb\\\\\\\\\\"}]\\",
+                  \\"EnvironmentVariables\\": \\"[{\\\\\\\\\\"name\\\\\\\\\\":\\\\\\\\\\"_PROJECT_CONFIG_HASH\\\\\\\\\\",\\\\\\\\\\"type\\\\\\\\\\":\\\\\\\\\\"PLAINTEXT\\\\\\\\\\",\\\\\\\\\\"value\\\\\\\\\\":\\\\\\\\\\"f78b69a9d9345d64a24b7224685b9cdc6b7f7495f0607df3c63d701642d9d118\\\\\\\\\\"}]\\",
                   \\"ProjectName\\": Object {
                     \\"Ref\\": \\"CodePipelineBuildSynthCdkBuildProjectEDF0E7B6\\",
                   },
@@ -1823,7 +1823,7 @@ Object {
     \\\\\\\\\\"install\\\\\\\\\\": {
       \\\\\\\\\\"commands\\\\\\\\\\": [
         \\\\\\\\\\"npm install -g aws-cdk\\\\\\\\\\",
-        \\\\\\\\\\"yarn install --frozen-lockfile\\\\\\\\\\"
+        \\\\\\\\\\"yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile\\\\\\\\\\"
       ]
     },
     \\\\\\\\\\"build\\\\\\\\\\": {
@@ -4349,7 +4349,7 @@ Object {
                   \\"Version\\": \\"1\\",
                 },
                 \\"Configuration\\": Object {
-                  \\"EnvironmentVariables\\": \\"[{\\\\\\\\\\"name\\\\\\\\\\":\\\\\\\\\\"_PROJECT_CONFIG_HASH\\\\\\\\\\",\\\\\\\\\\"type\\\\\\\\\\":\\\\\\\\\\"PLAINTEXT\\\\\\\\\\",\\\\\\\\\\"value\\\\\\\\\\":\\\\\\\\\\"ae7d64108857c36deaf14a4939d075c70a5527bd396853794b07e116e10f73cb\\\\\\\\\\"}]\\",
+                  \\"EnvironmentVariables\\": \\"[{\\\\\\\\\\"name\\\\\\\\\\":\\\\\\\\\\"_PROJECT_CONFIG_HASH\\\\\\\\\\",\\\\\\\\\\"type\\\\\\\\\\":\\\\\\\\\\"PLAINTEXT\\\\\\\\\\",\\\\\\\\\\"value\\\\\\\\\\":\\\\\\\\\\"f78b69a9d9345d64a24b7224685b9cdc6b7f7495f0607df3c63d701642d9d118\\\\\\\\\\"}]\\",
                   \\"ProjectName\\": Object {
                     \\"Ref\\": \\"CodePipelineBuildSynthCdkBuildProjectEDF0E7B6\\",
                   },
@@ -4445,7 +4445,7 @@ Object {
     \\\\\\\\\\"install\\\\\\\\\\": {
       \\\\\\\\\\"commands\\\\\\\\\\": [
         \\\\\\\\\\"npm install -g aws-cdk\\\\\\\\\\",
-        \\\\\\\\\\"yarn install --frozen-lockfile\\\\\\\\\\"
+        \\\\\\\\\\"yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile\\\\\\\\\\"
       ]
     },
     \\\\\\\\\\"build\\\\\\\\\\": {
@@ -6986,7 +6986,7 @@ Object {
                   \\"Version\\": \\"1\\",
                 },
                 \\"Configuration\\": Object {
-                  \\"EnvironmentVariables\\": \\"[{\\\\\\\\\\"name\\\\\\\\\\":\\\\\\\\\\"_PROJECT_CONFIG_HASH\\\\\\\\\\",\\\\\\\\\\"type\\\\\\\\\\":\\\\\\\\\\"PLAINTEXT\\\\\\\\\\",\\\\\\\\\\"value\\\\\\\\\\":\\\\\\\\\\"ae7d64108857c36deaf14a4939d075c70a5527bd396853794b07e116e10f73cb\\\\\\\\\\"}]\\",
+                  \\"EnvironmentVariables\\": \\"[{\\\\\\\\\\"name\\\\\\\\\\":\\\\\\\\\\"_PROJECT_CONFIG_HASH\\\\\\\\\\",\\\\\\\\\\"type\\\\\\\\\\":\\\\\\\\\\"PLAINTEXT\\\\\\\\\\",\\\\\\\\\\"value\\\\\\\\\\":\\\\\\\\\\"f78b69a9d9345d64a24b7224685b9cdc6b7f7495f0607df3c63d701642d9d118\\\\\\\\\\"}]\\",
                   \\"ProjectName\\": Object {
                     \\"Ref\\": \\"CodePipelineBuildSynthCdkBuildProjectEDF0E7B6\\",
                   },
@@ -7082,7 +7082,7 @@ Object {
     \\\\\\\\\\"install\\\\\\\\\\": {
       \\\\\\\\\\"commands\\\\\\\\\\": [
         \\\\\\\\\\"npm install -g aws-cdk\\\\\\\\\\",
-        \\\\\\\\\\"yarn install --frozen-lockfile\\\\\\\\\\"
+        \\\\\\\\\\"yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile\\\\\\\\\\"
       ]
     },
     \\\\\\\\\\"build\\\\\\\\\\": {

--- a/packages/pipeline/test/__snapshots__/pdk-pipeline.test.ts.snap
+++ b/packages/pipeline/test/__snapshots__/pdk-pipeline.test.ts.snap
@@ -314,7 +314,7 @@ Object {
                   "Version": "1",
                 },
                 "Configuration": Object {
-                  "EnvironmentVariables": "[{\\"name\\":\\"_PROJECT_CONFIG_HASH\\",\\"type\\":\\"PLAINTEXT\\",\\"value\\":\\"e32cd2f8a606637f3ed746f0ded2954d606a0aa7d6ade1e57229f913fa5a8973\\"}]",
+                  "EnvironmentVariables": "[{\\"name\\":\\"_PROJECT_CONFIG_HASH\\",\\"type\\":\\"PLAINTEXT\\",\\"value\\":\\"695a7330a2c9bebdb22e3baca36a4c397c9091b9e57d871d29047d7333b61977\\"}]",
                   "ProjectName": Object {
                     "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
                   },
@@ -552,7 +552,7 @@ Object {
     \\"install\\": {
       \\"commands\\": [
         \\"npm install -g aws-cdk\\",
-        \\"yarn install --frozen-lockfile\\"
+        \\"yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile\\"
       ]
     },
     \\"build\\": {


### PR DESCRIPTION
When trying to build a monorepo project with python packages as children, the following error is observed in the pipeline:

```
👾 install | pip install --upgrade pip
Requirement already satisfied: pip in /root/.pyenv/versions/3.9.12/lib/python3.9/site-packages (22.1.2)
Collecting pip
  Downloading pip-22.2.2-py3-none-any.whl (2.0 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.0/2.0 MB 73.1 MB/s eta 0:00:00
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 22.1.2
    Uninstalling pip-22.1.2:
ERROR: Could not install packages due to an OSError: [Errno 2] No such file or directory: '/root/.pyenv/versions/3.9.12/bin/pip'
```

This is due to the fact that as part of the `yarn install`, given these python packages are apart of the workspace the `install` target will be executed. The issue is that the venv is only set up as part of an `npx projen`. To resolve this we optimistically run `yarn install` however in the event of a failure we run `npx projen` and re-try installing dependencies. We need to perform the attempt, otherwise we won't have the dependencies we need to run `npx projen`.