### PR TITLE
feat(open-api-gateway): add python interceptor support

### DIFF
--- a/packages/open-api-gateway/scripts/generators/python/templates/operationConfig.mustache
+++ b/packages/open-api-gateway/scripts/generators/python/templates/operationConfig.mustache
@@ -68,7 +68,8 @@ def parse_body(body, content_types, model):
 RequestParameters = TypeVar('RequestParameters')
 RequestArrayParameters = TypeVar('RequestArrayParameters')
 RequestBody = TypeVar('RequestBody')
-
+ResponseBody = TypeVar('ResponseBody')
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
 class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]):
@@ -77,10 +78,13 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
     body: RequestBody
     event: Any
     context: Any
+    interceptor_context: Dict[str, Any]
 
+@dataclass
+class ChainedApiRequest(ApiRequest[RequestParameters, RequestArrayParameters, RequestBody],
+    Generic[RequestParameters, RequestArrayParameters, RequestBody]):
 
-ResponseBody = TypeVar('ResponseBody')
-StatusCode = TypeVar('StatusCode')
+    chain: 'HandlerChain'
 
 @dataclass
 class ApiResponse(Generic[StatusCode, ResponseBody]):
@@ -88,6 +92,31 @@ class ApiResponse(Generic[StatusCode, ResponseBody]):
     headers: Dict[str, str]
     body: ResponseBody
 
+class HandlerChain(Generic[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+    def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+        raise Exception("Not implemented!")
+
+def _build_handler_chain(_interceptors, handler) -> HandlerChain:
+    if len(_interceptors) == 0:
+        class BaseHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return handler(request)
+        return BaseHandlerChain()
+    else:
+        interceptor = _interceptors.pop(0)
+
+        class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return interceptor(ChainedApiRequest(
+                    request_parameters = request.request_parameters,
+                    request_array_parameters = request.request_array_parameters,
+                    body = request.body,
+                    event = request.event,
+                    context = request.context,
+                    interceptor_context = request.interceptor_context,
+                    chain = _build_handler_chain(_interceptors, handler),
+                ))
+        return RemainingHandlerChain()
 
 {{#operations}}
 {{#operation}}
@@ -124,38 +153,54 @@ class {{operationIdCamelCase}}RequestArrayParameters(TypedDict):
 
 # Request type for {{operationId}}
 {{operationIdCamelCase}}Request = ApiRequest[{{operationIdCamelCase}}RequestParameters, {{operationIdCamelCase}}RequestArrayParameters, {{operationIdCamelCase}}RequestBody]
+{{operationIdCamelCase}}ChainedRequest = ChainedApiRequest[{{operationIdCamelCase}}RequestParameters, {{operationIdCamelCase}}RequestArrayParameters, {{operationIdCamelCase}}RequestBody]
 
 class {{operationIdCamelCase}}HandlerFunction(Protocol):
     def __call__(self, input: {{operationIdCamelCase}}Request, **kwargs) -> {{operationIdCamelCase}}OperationResponses:
         ...
 
-def {{operationId}}_handler(handler: {{operationIdCamelCase}}HandlerFunction):
+{{operationIdCamelCase}}Interceptor = Callable[[{{operationIdCamelCase}}ChainedRequest], {{operationIdCamelCase}}OperationResponses]
+
+def {{operationId}}_handler(_handler: {{operationIdCamelCase}}HandlerFunction = None, interceptors: List[{{operationIdCamelCase}}Interceptor] = []):
     """
     Decorator for an api handler for the {{operationId}} operation, providing a typed interface for inputs and outputs
     """
-    @wraps(handler)
-    def wrapper(event, context, **kwargs):
-        request_parameters = decode_request_parameters({
-            **(event['pathParameters'] or {}),
-            **(event['queryStringParameters'] or {}),
-        })
-        request_array_parameters = decode_request_parameters({
-            **(event['multiValueQueryStringParameters'] or {}),
-        })
-        body = parse_body(event['body'], [{{^consumes}}'application/json'{{/consumes}}{{#consumes}}{{#mediaType}}'{{{.}}}',{{/mediaType}}{{/consumes}}], {{operationIdCamelCase}}RequestBody)
-        response = handler(ApiRequest(
-            request_parameters,
-            request_array_parameters,
-            body,
-            event,
-            context,
-        ), **kwargs)
-        return {
-            'statusCode': response.status_code,
-            'headers': response.headers,
-            'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
-        }
-    return wrapper
+    def _handler_wrapper(handler: {{operationIdCamelCase}}HandlerFunction):
+        @wraps(handler)
+        def wrapper(event, context, **kwargs):
+            request_parameters = decode_request_parameters({
+                **(event['pathParameters'] or {}),
+                **(event['queryStringParameters'] or {}),
+            })
+            request_array_parameters = decode_request_parameters({
+                **(event['multiValueQueryStringParameters'] or {}),
+            })
+            body = parse_body(event['body'], [{{^consumes}}'application/json'{{/consumes}}{{#consumes}}{{#mediaType}}'{{{.}}}',{{/mediaType}}{{/consumes}}], {{operationIdCamelCase}}RequestBody)
 
+            interceptor_context = {}
+
+            chain = _build_handler_chain(interceptors, handler)
+            response = chain.next(ApiRequest(
+                request_parameters,
+                request_array_parameters,
+                body,
+                event,
+                context,
+                interceptor_context,
+            ), **kwargs)
+            return {
+                'statusCode': response.status_code,
+                'headers': response.headers,
+                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+            }
+        return wrapper
+
+    # Support use as a decorator with no arguments, or with interceptor arguments
+    if callable(_handler):
+        return _handler_wrapper(_handler)
+    elif _handler is None:
+        return _handler_wrapper
+    else:
+        raise Exception("Positional arguments are not supported by {{operationId}}_handler.")
 {{/operation}}
 {{/operations}}

--- a/packages/open-api-gateway/src/project/codegen/generated-python-client-project.ts
+++ b/packages/open-api-gateway/src/project/codegen/generated-python-client-project.ts
@@ -72,10 +72,12 @@ export class GeneratedPythonClientProject extends PythonProject {
     // Package into a directory that can be used as a lambda layer. This is done as part of install since the end user
     // must control build order in the monorepo via explicit dependencies, and adding here means we can run as part of
     // initial project synthesis which ensures this is created regardless of whether the user has remembered to
-    // configure build order
+    // configure build order.
     if (options.generateLayer) {
+      const relativeLayerDir = path.join(".", this.layerDistDir, "python");
+      this.depsManager.installTask.exec(`rm -rf ${relativeLayerDir}`);
       this.depsManager.installTask.exec(
-        `pip install . --target ${path.join(".", this.layerDistDir, "python")}`
+        `pip install . --target ${relativeLayerDir}`
       );
     }
   }

--- a/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-python-client-source-code.test.ts.snap
+++ b/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-python-client-source-code.test.ts.snap
@@ -1098,7 +1098,8 @@ def parse_body(body, content_types, model):
 RequestParameters = TypeVar('RequestParameters')
 RequestArrayParameters = TypeVar('RequestArrayParameters')
 RequestBody = TypeVar('RequestBody')
-
+ResponseBody = TypeVar('ResponseBody')
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
 class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]):
@@ -1107,10 +1108,13 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
     body: RequestBody
     event: Any
     context: Any
+    interceptor_context: Dict[str, Any]
 
+@dataclass
+class ChainedApiRequest(ApiRequest[RequestParameters, RequestArrayParameters, RequestBody],
+    Generic[RequestParameters, RequestArrayParameters, RequestBody]):
 
-ResponseBody = TypeVar('ResponseBody')
-StatusCode = TypeVar('StatusCode')
+    chain: 'HandlerChain'
 
 @dataclass
 class ApiResponse(Generic[StatusCode, ResponseBody]):
@@ -1118,6 +1122,31 @@ class ApiResponse(Generic[StatusCode, ResponseBody]):
     headers: Dict[str, str]
     body: ResponseBody
 
+class HandlerChain(Generic[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+    def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+        raise Exception(\\"Not implemented!\\")
+
+def _build_handler_chain(_interceptors, handler) -> HandlerChain:
+    if len(_interceptors) == 0:
+        class BaseHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return handler(request)
+        return BaseHandlerChain()
+    else:
+        interceptor = _interceptors.pop(0)
+
+        class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return interceptor(ChainedApiRequest(
+                    request_parameters = request.request_parameters,
+                    request_array_parameters = request.request_array_parameters,
+                    body = request.body,
+                    event = request.event,
+                    context = request.context,
+                    interceptor_context = request.interceptor_context,
+                    chain = _build_handler_chain(_interceptors, handler),
+                ))
+        return RemainingHandlerChain()
 
 
 # Request parameters are single value query params or path params
@@ -1138,39 +1167,55 @@ SomeTestOperationOperationResponses = Union[SomeTestOperation200OperationRespons
 
 # Request type for some_test_operation
 SomeTestOperationRequest = ApiRequest[SomeTestOperationRequestParameters, SomeTestOperationRequestArrayParameters, SomeTestOperationRequestBody]
+SomeTestOperationChainedRequest = ChainedApiRequest[SomeTestOperationRequestParameters, SomeTestOperationRequestArrayParameters, SomeTestOperationRequestBody]
 
 class SomeTestOperationHandlerFunction(Protocol):
     def __call__(self, input: SomeTestOperationRequest, **kwargs) -> SomeTestOperationOperationResponses:
         ...
 
-def some_test_operation_handler(handler: SomeTestOperationHandlerFunction):
+SomeTestOperationInterceptor = Callable[[SomeTestOperationChainedRequest], SomeTestOperationOperationResponses]
+
+def some_test_operation_handler(_handler: SomeTestOperationHandlerFunction = None, interceptors: List[SomeTestOperationInterceptor] = []):
     \\"\\"\\"
     Decorator for an api handler for the some_test_operation operation, providing a typed interface for inputs and outputs
     \\"\\"\\"
-    @wraps(handler)
-    def wrapper(event, context, **kwargs):
-        request_parameters = decode_request_parameters({
-            **(event['pathParameters'] or {}),
-            **(event['queryStringParameters'] or {}),
-        })
-        request_array_parameters = decode_request_parameters({
-            **(event['multiValueQueryStringParameters'] or {}),
-        })
-        body = parse_body(event['body'], ['application/json',], SomeTestOperationRequestBody)
-        response = handler(ApiRequest(
-            request_parameters,
-            request_array_parameters,
-            body,
-            event,
-            context,
-        ), **kwargs)
-        return {
-            'statusCode': response.status_code,
-            'headers': response.headers,
-            'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
-        }
-    return wrapper
+    def _handler_wrapper(handler: SomeTestOperationHandlerFunction):
+        @wraps(handler)
+        def wrapper(event, context, **kwargs):
+            request_parameters = decode_request_parameters({
+                **(event['pathParameters'] or {}),
+                **(event['queryStringParameters'] or {}),
+            })
+            request_array_parameters = decode_request_parameters({
+                **(event['multiValueQueryStringParameters'] or {}),
+            })
+            body = parse_body(event['body'], ['application/json',], SomeTestOperationRequestBody)
 
+            interceptor_context = {}
+
+            chain = _build_handler_chain(interceptors, handler)
+            response = chain.next(ApiRequest(
+                request_parameters,
+                request_array_parameters,
+                body,
+                event,
+                context,
+                interceptor_context,
+            ), **kwargs)
+            return {
+                'statusCode': response.status_code,
+                'headers': response.headers,
+                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+            }
+        return wrapper
+
+    # Support use as a decorator with no arguments, or with interceptor arguments
+    if callable(_handler):
+        return _handler_wrapper(_handler)
+    elif _handler is None:
+        return _handler_wrapper
+    else:
+        raise Exception(\\"Positional arguments are not supported by some_test_operation_handler.\\")
 ",
   "test/api_client.py": "# coding: utf-8
 \\"\\"\\"
@@ -8060,7 +8105,8 @@ def parse_body(body, content_types, model):
 RequestParameters = TypeVar('RequestParameters')
 RequestArrayParameters = TypeVar('RequestArrayParameters')
 RequestBody = TypeVar('RequestBody')
-
+ResponseBody = TypeVar('ResponseBody')
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
 class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]):
@@ -8069,10 +8115,13 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
     body: RequestBody
     event: Any
     context: Any
+    interceptor_context: Dict[str, Any]
 
+@dataclass
+class ChainedApiRequest(ApiRequest[RequestParameters, RequestArrayParameters, RequestBody],
+    Generic[RequestParameters, RequestArrayParameters, RequestBody]):
 
-ResponseBody = TypeVar('ResponseBody')
-StatusCode = TypeVar('StatusCode')
+    chain: 'HandlerChain'
 
 @dataclass
 class ApiResponse(Generic[StatusCode, ResponseBody]):
@@ -8080,6 +8129,31 @@ class ApiResponse(Generic[StatusCode, ResponseBody]):
     headers: Dict[str, str]
     body: ResponseBody
 
+class HandlerChain(Generic[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+    def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+        raise Exception(\\"Not implemented!\\")
+
+def _build_handler_chain(_interceptors, handler) -> HandlerChain:
+    if len(_interceptors) == 0:
+        class BaseHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return handler(request)
+        return BaseHandlerChain()
+    else:
+        interceptor = _interceptors.pop(0)
+
+        class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return interceptor(ChainedApiRequest(
+                    request_parameters = request.request_parameters,
+                    request_array_parameters = request.request_array_parameters,
+                    body = request.body,
+                    event = request.event,
+                    context = request.context,
+                    interceptor_context = request.interceptor_context,
+                    chain = _build_handler_chain(_interceptors, handler),
+                ))
+        return RemainingHandlerChain()
 
 
 # Request parameters are single value query params or path params
@@ -8098,39 +8172,55 @@ EmptyOperationResponses = Union[Empty204OperationResponse, ]
 
 # Request type for empty
 EmptyRequest = ApiRequest[EmptyRequestParameters, EmptyRequestArrayParameters, EmptyRequestBody]
+EmptyChainedRequest = ChainedApiRequest[EmptyRequestParameters, EmptyRequestArrayParameters, EmptyRequestBody]
 
 class EmptyHandlerFunction(Protocol):
     def __call__(self, input: EmptyRequest, **kwargs) -> EmptyOperationResponses:
         ...
 
-def empty_handler(handler: EmptyHandlerFunction):
+EmptyInterceptor = Callable[[EmptyChainedRequest], EmptyOperationResponses]
+
+def empty_handler(_handler: EmptyHandlerFunction = None, interceptors: List[EmptyInterceptor] = []):
     \\"\\"\\"
     Decorator for an api handler for the empty operation, providing a typed interface for inputs and outputs
     \\"\\"\\"
-    @wraps(handler)
-    def wrapper(event, context, **kwargs):
-        request_parameters = decode_request_parameters({
-            **(event['pathParameters'] or {}),
-            **(event['queryStringParameters'] or {}),
-        })
-        request_array_parameters = decode_request_parameters({
-            **(event['multiValueQueryStringParameters'] or {}),
-        })
-        body = parse_body(event['body'], [], EmptyRequestBody)
-        response = handler(ApiRequest(
-            request_parameters,
-            request_array_parameters,
-            body,
-            event,
-            context,
-        ), **kwargs)
-        return {
-            'statusCode': response.status_code,
-            'headers': response.headers,
-            'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
-        }
-    return wrapper
+    def _handler_wrapper(handler: EmptyHandlerFunction):
+        @wraps(handler)
+        def wrapper(event, context, **kwargs):
+            request_parameters = decode_request_parameters({
+                **(event['pathParameters'] or {}),
+                **(event['queryStringParameters'] or {}),
+            })
+            request_array_parameters = decode_request_parameters({
+                **(event['multiValueQueryStringParameters'] or {}),
+            })
+            body = parse_body(event['body'], [], EmptyRequestBody)
 
+            interceptor_context = {}
+
+            chain = _build_handler_chain(interceptors, handler)
+            response = chain.next(ApiRequest(
+                request_parameters,
+                request_array_parameters,
+                body,
+                event,
+                context,
+                interceptor_context,
+            ), **kwargs)
+            return {
+                'statusCode': response.status_code,
+                'headers': response.headers,
+                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+            }
+        return wrapper
+
+    # Support use as a decorator with no arguments, or with interceptor arguments
+    if callable(_handler):
+        return _handler_wrapper(_handler)
+    elif _handler is None:
+        return _handler_wrapper
+    else:
+        raise Exception(\\"Positional arguments are not supported by empty_handler.\\")
 
 # Request parameters are single value query params or path params
 class MediaTypesRequestParameters(TypedDict):
@@ -8148,39 +8238,55 @@ MediaTypesOperationResponses = Union[MediaTypes200OperationResponse, ]
 
 # Request type for media_types
 MediaTypesRequest = ApiRequest[MediaTypesRequestParameters, MediaTypesRequestArrayParameters, MediaTypesRequestBody]
+MediaTypesChainedRequest = ChainedApiRequest[MediaTypesRequestParameters, MediaTypesRequestArrayParameters, MediaTypesRequestBody]
 
 class MediaTypesHandlerFunction(Protocol):
     def __call__(self, input: MediaTypesRequest, **kwargs) -> MediaTypesOperationResponses:
         ...
 
-def media_types_handler(handler: MediaTypesHandlerFunction):
+MediaTypesInterceptor = Callable[[MediaTypesChainedRequest], MediaTypesOperationResponses]
+
+def media_types_handler(_handler: MediaTypesHandlerFunction = None, interceptors: List[MediaTypesInterceptor] = []):
     \\"\\"\\"
     Decorator for an api handler for the media_types operation, providing a typed interface for inputs and outputs
     \\"\\"\\"
-    @wraps(handler)
-    def wrapper(event, context, **kwargs):
-        request_parameters = decode_request_parameters({
-            **(event['pathParameters'] or {}),
-            **(event['queryStringParameters'] or {}),
-        })
-        request_array_parameters = decode_request_parameters({
-            **(event['multiValueQueryStringParameters'] or {}),
-        })
-        body = parse_body(event['body'], ['application/pdf',], MediaTypesRequestBody)
-        response = handler(ApiRequest(
-            request_parameters,
-            request_array_parameters,
-            body,
-            event,
-            context,
-        ), **kwargs)
-        return {
-            'statusCode': response.status_code,
-            'headers': response.headers,
-            'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
-        }
-    return wrapper
+    def _handler_wrapper(handler: MediaTypesHandlerFunction):
+        @wraps(handler)
+        def wrapper(event, context, **kwargs):
+            request_parameters = decode_request_parameters({
+                **(event['pathParameters'] or {}),
+                **(event['queryStringParameters'] or {}),
+            })
+            request_array_parameters = decode_request_parameters({
+                **(event['multiValueQueryStringParameters'] or {}),
+            })
+            body = parse_body(event['body'], ['application/pdf',], MediaTypesRequestBody)
 
+            interceptor_context = {}
+
+            chain = _build_handler_chain(interceptors, handler)
+            response = chain.next(ApiRequest(
+                request_parameters,
+                request_array_parameters,
+                body,
+                event,
+                context,
+                interceptor_context,
+            ), **kwargs)
+            return {
+                'statusCode': response.status_code,
+                'headers': response.headers,
+                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+            }
+        return wrapper
+
+    # Support use as a decorator with no arguments, or with interceptor arguments
+    if callable(_handler):
+        return _handler_wrapper(_handler)
+    elif _handler is None:
+        return _handler_wrapper
+    else:
+        raise Exception(\\"Positional arguments are not supported by media_types_handler.\\")
 
 # Request parameters are single value query params or path params
 class OperationOneRequestParameters(TypedDict):
@@ -8204,39 +8310,55 @@ OperationOneOperationResponses = Union[OperationOne200OperationResponse, Operati
 
 # Request type for operation_one
 OperationOneRequest = ApiRequest[OperationOneRequestParameters, OperationOneRequestArrayParameters, OperationOneRequestBody]
+OperationOneChainedRequest = ChainedApiRequest[OperationOneRequestParameters, OperationOneRequestArrayParameters, OperationOneRequestBody]
 
 class OperationOneHandlerFunction(Protocol):
     def __call__(self, input: OperationOneRequest, **kwargs) -> OperationOneOperationResponses:
         ...
 
-def operation_one_handler(handler: OperationOneHandlerFunction):
+OperationOneInterceptor = Callable[[OperationOneChainedRequest], OperationOneOperationResponses]
+
+def operation_one_handler(_handler: OperationOneHandlerFunction = None, interceptors: List[OperationOneInterceptor] = []):
     \\"\\"\\"
     Decorator for an api handler for the operation_one operation, providing a typed interface for inputs and outputs
     \\"\\"\\"
-    @wraps(handler)
-    def wrapper(event, context, **kwargs):
-        request_parameters = decode_request_parameters({
-            **(event['pathParameters'] or {}),
-            **(event['queryStringParameters'] or {}),
-        })
-        request_array_parameters = decode_request_parameters({
-            **(event['multiValueQueryStringParameters'] or {}),
-        })
-        body = parse_body(event['body'], ['application/json',], OperationOneRequestBody)
-        response = handler(ApiRequest(
-            request_parameters,
-            request_array_parameters,
-            body,
-            event,
-            context,
-        ), **kwargs)
-        return {
-            'statusCode': response.status_code,
-            'headers': response.headers,
-            'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
-        }
-    return wrapper
+    def _handler_wrapper(handler: OperationOneHandlerFunction):
+        @wraps(handler)
+        def wrapper(event, context, **kwargs):
+            request_parameters = decode_request_parameters({
+                **(event['pathParameters'] or {}),
+                **(event['queryStringParameters'] or {}),
+            })
+            request_array_parameters = decode_request_parameters({
+                **(event['multiValueQueryStringParameters'] or {}),
+            })
+            body = parse_body(event['body'], ['application/json',], OperationOneRequestBody)
 
+            interceptor_context = {}
+
+            chain = _build_handler_chain(interceptors, handler)
+            response = chain.next(ApiRequest(
+                request_parameters,
+                request_array_parameters,
+                body,
+                event,
+                context,
+                interceptor_context,
+            ), **kwargs)
+            return {
+                'statusCode': response.status_code,
+                'headers': response.headers,
+                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+            }
+        return wrapper
+
+    # Support use as a decorator with no arguments, or with interceptor arguments
+    if callable(_handler):
+        return _handler_wrapper(_handler)
+    elif _handler is None:
+        return _handler_wrapper
+    else:
+        raise Exception(\\"Positional arguments are not supported by operation_one_handler.\\")
 
 # Request parameters are single value query params or path params
 class WithoutOperationIdDeleteRequestParameters(TypedDict):
@@ -8254,39 +8376,55 @@ WithoutOperationIdDeleteOperationResponses = Union[WithoutOperationIdDelete200Op
 
 # Request type for without_operation_id_delete
 WithoutOperationIdDeleteRequest = ApiRequest[WithoutOperationIdDeleteRequestParameters, WithoutOperationIdDeleteRequestArrayParameters, WithoutOperationIdDeleteRequestBody]
+WithoutOperationIdDeleteChainedRequest = ChainedApiRequest[WithoutOperationIdDeleteRequestParameters, WithoutOperationIdDeleteRequestArrayParameters, WithoutOperationIdDeleteRequestBody]
 
 class WithoutOperationIdDeleteHandlerFunction(Protocol):
     def __call__(self, input: WithoutOperationIdDeleteRequest, **kwargs) -> WithoutOperationIdDeleteOperationResponses:
         ...
 
-def without_operation_id_delete_handler(handler: WithoutOperationIdDeleteHandlerFunction):
+WithoutOperationIdDeleteInterceptor = Callable[[WithoutOperationIdDeleteChainedRequest], WithoutOperationIdDeleteOperationResponses]
+
+def without_operation_id_delete_handler(_handler: WithoutOperationIdDeleteHandlerFunction = None, interceptors: List[WithoutOperationIdDeleteInterceptor] = []):
     \\"\\"\\"
     Decorator for an api handler for the without_operation_id_delete operation, providing a typed interface for inputs and outputs
     \\"\\"\\"
-    @wraps(handler)
-    def wrapper(event, context, **kwargs):
-        request_parameters = decode_request_parameters({
-            **(event['pathParameters'] or {}),
-            **(event['queryStringParameters'] or {}),
-        })
-        request_array_parameters = decode_request_parameters({
-            **(event['multiValueQueryStringParameters'] or {}),
-        })
-        body = parse_body(event['body'], [], WithoutOperationIdDeleteRequestBody)
-        response = handler(ApiRequest(
-            request_parameters,
-            request_array_parameters,
-            body,
-            event,
-            context,
-        ), **kwargs)
-        return {
-            'statusCode': response.status_code,
-            'headers': response.headers,
-            'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
-        }
-    return wrapper
+    def _handler_wrapper(handler: WithoutOperationIdDeleteHandlerFunction):
+        @wraps(handler)
+        def wrapper(event, context, **kwargs):
+            request_parameters = decode_request_parameters({
+                **(event['pathParameters'] or {}),
+                **(event['queryStringParameters'] or {}),
+            })
+            request_array_parameters = decode_request_parameters({
+                **(event['multiValueQueryStringParameters'] or {}),
+            })
+            body = parse_body(event['body'], [], WithoutOperationIdDeleteRequestBody)
 
+            interceptor_context = {}
+
+            chain = _build_handler_chain(interceptors, handler)
+            response = chain.next(ApiRequest(
+                request_parameters,
+                request_array_parameters,
+                body,
+                event,
+                context,
+                interceptor_context,
+            ), **kwargs)
+            return {
+                'statusCode': response.status_code,
+                'headers': response.headers,
+                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+            }
+        return wrapper
+
+    # Support use as a decorator with no arguments, or with interceptor arguments
+    if callable(_handler):
+        return _handler_wrapper(_handler)
+    elif _handler is None:
+        return _handler_wrapper
+    else:
+        raise Exception(\\"Positional arguments are not supported by without_operation_id_delete_handler.\\")
 ",
   "test/api_client.py": "# coding: utf-8
 \\"\\"\\"

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
@@ -7965,6 +7965,9 @@ tox.ini
             "exec": "pip install --editable .",
           },
           Object {
+            "exec": "rm -rf dist/layer/python",
+          },
+          Object {
             "exec": "pip install . --target dist/layer/python",
           },
         ],
@@ -8638,7 +8641,8 @@ def parse_body(body, content_types, model):
 RequestParameters = TypeVar('RequestParameters')
 RequestArrayParameters = TypeVar('RequestArrayParameters')
 RequestBody = TypeVar('RequestBody')
-
+ResponseBody = TypeVar('ResponseBody')
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
 class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]):
@@ -8647,10 +8651,13 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
     body: RequestBody
     event: Any
     context: Any
+    interceptor_context: Dict[str, Any]
 
+@dataclass
+class ChainedApiRequest(ApiRequest[RequestParameters, RequestArrayParameters, RequestBody],
+    Generic[RequestParameters, RequestArrayParameters, RequestBody]):
 
-ResponseBody = TypeVar('ResponseBody')
-StatusCode = TypeVar('StatusCode')
+    chain: 'HandlerChain'
 
 @dataclass
 class ApiResponse(Generic[StatusCode, ResponseBody]):
@@ -8658,6 +8665,31 @@ class ApiResponse(Generic[StatusCode, ResponseBody]):
     headers: Dict[str, str]
     body: ResponseBody
 
+class HandlerChain(Generic[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+    def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+        raise Exception(\\"Not implemented!\\")
+
+def _build_handler_chain(_interceptors, handler) -> HandlerChain:
+    if len(_interceptors) == 0:
+        class BaseHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return handler(request)
+        return BaseHandlerChain()
+    else:
+        interceptor = _interceptors.pop(0)
+
+        class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return interceptor(ChainedApiRequest(
+                    request_parameters = request.request_parameters,
+                    request_array_parameters = request.request_array_parameters,
+                    body = request.body,
+                    event = request.event,
+                    context = request.context,
+                    interceptor_context = request.interceptor_context,
+                    chain = _build_handler_chain(_interceptors, handler),
+                ))
+        return RemainingHandlerChain()
 
 
 # Request parameters are single value query params or path params
@@ -8678,39 +8710,55 @@ SayHelloOperationResponses = Union[SayHello200OperationResponse, SayHello400Oper
 
 # Request type for say_hello
 SayHelloRequest = ApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
+SayHelloChainedRequest = ChainedApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
 
 class SayHelloHandlerFunction(Protocol):
     def __call__(self, input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:
         ...
 
-def say_hello_handler(handler: SayHelloHandlerFunction):
+SayHelloInterceptor = Callable[[SayHelloChainedRequest], SayHelloOperationResponses]
+
+def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: List[SayHelloInterceptor] = []):
     \\"\\"\\"
     Decorator for an api handler for the say_hello operation, providing a typed interface for inputs and outputs
     \\"\\"\\"
-    @wraps(handler)
-    def wrapper(event, context, **kwargs):
-        request_parameters = decode_request_parameters({
-            **(event['pathParameters'] or {}),
-            **(event['queryStringParameters'] or {}),
-        })
-        request_array_parameters = decode_request_parameters({
-            **(event['multiValueQueryStringParameters'] or {}),
-        })
-        body = parse_body(event['body'], [], SayHelloRequestBody)
-        response = handler(ApiRequest(
-            request_parameters,
-            request_array_parameters,
-            body,
-            event,
-            context,
-        ), **kwargs)
-        return {
-            'statusCode': response.status_code,
-            'headers': response.headers,
-            'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
-        }
-    return wrapper
+    def _handler_wrapper(handler: SayHelloHandlerFunction):
+        @wraps(handler)
+        def wrapper(event, context, **kwargs):
+            request_parameters = decode_request_parameters({
+                **(event['pathParameters'] or {}),
+                **(event['queryStringParameters'] or {}),
+            })
+            request_array_parameters = decode_request_parameters({
+                **(event['multiValueQueryStringParameters'] or {}),
+            })
+            body = parse_body(event['body'], [], SayHelloRequestBody)
 
+            interceptor_context = {}
+
+            chain = _build_handler_chain(interceptors, handler)
+            response = chain.next(ApiRequest(
+                request_parameters,
+                request_array_parameters,
+                body,
+                event,
+                context,
+                interceptor_context,
+            ), **kwargs)
+            return {
+                'statusCode': response.status_code,
+                'headers': response.headers,
+                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+            }
+        return wrapper
+
+    # Support use as a decorator with no arguments, or with interceptor arguments
+    if callable(_handler):
+        return _handler_wrapper(_handler)
+    elif _handler is None:
+        return _handler_wrapper
+    else:
+        raise Exception(\\"Positional arguments are not supported by say_hello_handler.\\")
 ",
   "packages/my_api/generated/python/my_api_python/api_client.py": "# coding: utf-8
 \\"\\"\\"

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
@@ -7097,6 +7097,9 @@ tox.ini
             "exec": "pip install --editable .",
           },
           Object {
+            "exec": "rm -rf dist/layer/python",
+          },
+          Object {
             "exec": "pip install . --target dist/layer/python",
           },
         ],
@@ -7770,7 +7773,8 @@ def parse_body(body, content_types, model):
 RequestParameters = TypeVar('RequestParameters')
 RequestArrayParameters = TypeVar('RequestArrayParameters')
 RequestBody = TypeVar('RequestBody')
-
+ResponseBody = TypeVar('ResponseBody')
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
 class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]):
@@ -7779,10 +7783,13 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
     body: RequestBody
     event: Any
     context: Any
+    interceptor_context: Dict[str, Any]
 
+@dataclass
+class ChainedApiRequest(ApiRequest[RequestParameters, RequestArrayParameters, RequestBody],
+    Generic[RequestParameters, RequestArrayParameters, RequestBody]):
 
-ResponseBody = TypeVar('ResponseBody')
-StatusCode = TypeVar('StatusCode')
+    chain: 'HandlerChain'
 
 @dataclass
 class ApiResponse(Generic[StatusCode, ResponseBody]):
@@ -7790,6 +7797,31 @@ class ApiResponse(Generic[StatusCode, ResponseBody]):
     headers: Dict[str, str]
     body: ResponseBody
 
+class HandlerChain(Generic[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+    def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+        raise Exception(\\"Not implemented!\\")
+
+def _build_handler_chain(_interceptors, handler) -> HandlerChain:
+    if len(_interceptors) == 0:
+        class BaseHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return handler(request)
+        return BaseHandlerChain()
+    else:
+        interceptor = _interceptors.pop(0)
+
+        class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return interceptor(ChainedApiRequest(
+                    request_parameters = request.request_parameters,
+                    request_array_parameters = request.request_array_parameters,
+                    body = request.body,
+                    event = request.event,
+                    context = request.context,
+                    interceptor_context = request.interceptor_context,
+                    chain = _build_handler_chain(_interceptors, handler),
+                ))
+        return RemainingHandlerChain()
 
 
 # Request parameters are single value query params or path params
@@ -7810,39 +7842,55 @@ SayHelloOperationResponses = Union[SayHello200OperationResponse, SayHello400Oper
 
 # Request type for say_hello
 SayHelloRequest = ApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
+SayHelloChainedRequest = ChainedApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
 
 class SayHelloHandlerFunction(Protocol):
     def __call__(self, input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:
         ...
 
-def say_hello_handler(handler: SayHelloHandlerFunction):
+SayHelloInterceptor = Callable[[SayHelloChainedRequest], SayHelloOperationResponses]
+
+def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: List[SayHelloInterceptor] = []):
     \\"\\"\\"
     Decorator for an api handler for the say_hello operation, providing a typed interface for inputs and outputs
     \\"\\"\\"
-    @wraps(handler)
-    def wrapper(event, context, **kwargs):
-        request_parameters = decode_request_parameters({
-            **(event['pathParameters'] or {}),
-            **(event['queryStringParameters'] or {}),
-        })
-        request_array_parameters = decode_request_parameters({
-            **(event['multiValueQueryStringParameters'] or {}),
-        })
-        body = parse_body(event['body'], [], SayHelloRequestBody)
-        response = handler(ApiRequest(
-            request_parameters,
-            request_array_parameters,
-            body,
-            event,
-            context,
-        ), **kwargs)
-        return {
-            'statusCode': response.status_code,
-            'headers': response.headers,
-            'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
-        }
-    return wrapper
+    def _handler_wrapper(handler: SayHelloHandlerFunction):
+        @wraps(handler)
+        def wrapper(event, context, **kwargs):
+            request_parameters = decode_request_parameters({
+                **(event['pathParameters'] or {}),
+                **(event['queryStringParameters'] or {}),
+            })
+            request_array_parameters = decode_request_parameters({
+                **(event['multiValueQueryStringParameters'] or {}),
+            })
+            body = parse_body(event['body'], [], SayHelloRequestBody)
 
+            interceptor_context = {}
+
+            chain = _build_handler_chain(interceptors, handler)
+            response = chain.next(ApiRequest(
+                request_parameters,
+                request_array_parameters,
+                body,
+                event,
+                context,
+                interceptor_context,
+            ), **kwargs)
+            return {
+                'statusCode': response.status_code,
+                'headers': response.headers,
+                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+            }
+        return wrapper
+
+    # Support use as a decorator with no arguments, or with interceptor arguments
+    if callable(_handler):
+        return _handler_wrapper(_handler)
+    elif _handler is None:
+        return _handler_wrapper
+    else:
+        raise Exception(\\"Positional arguments are not supported by say_hello_handler.\\")
 ",
   "generated/python/my_api_python/api_client.py": "# coding: utf-8
 \\"\\"\\"

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/with-docs.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/with-docs.test.ts.snap
@@ -3872,6 +3872,9 @@ tox.ini
             "exec": "pip install --editable .",
           },
           Object {
+            "exec": "rm -rf dist/layer/python",
+          },
+          Object {
             "exec": "pip install . --target dist/layer/python",
           },
         ],
@@ -4545,7 +4548,8 @@ def parse_body(body, content_types, model):
 RequestParameters = TypeVar('RequestParameters')
 RequestArrayParameters = TypeVar('RequestArrayParameters')
 RequestBody = TypeVar('RequestBody')
-
+ResponseBody = TypeVar('ResponseBody')
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
 class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]):
@@ -4554,10 +4558,13 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
     body: RequestBody
     event: Any
     context: Any
+    interceptor_context: Dict[str, Any]
 
+@dataclass
+class ChainedApiRequest(ApiRequest[RequestParameters, RequestArrayParameters, RequestBody],
+    Generic[RequestParameters, RequestArrayParameters, RequestBody]):
 
-ResponseBody = TypeVar('ResponseBody')
-StatusCode = TypeVar('StatusCode')
+    chain: 'HandlerChain'
 
 @dataclass
 class ApiResponse(Generic[StatusCode, ResponseBody]):
@@ -4565,6 +4572,31 @@ class ApiResponse(Generic[StatusCode, ResponseBody]):
     headers: Dict[str, str]
     body: ResponseBody
 
+class HandlerChain(Generic[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+    def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+        raise Exception(\\"Not implemented!\\")
+
+def _build_handler_chain(_interceptors, handler) -> HandlerChain:
+    if len(_interceptors) == 0:
+        class BaseHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return handler(request)
+        return BaseHandlerChain()
+    else:
+        interceptor = _interceptors.pop(0)
+
+        class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return interceptor(ChainedApiRequest(
+                    request_parameters = request.request_parameters,
+                    request_array_parameters = request.request_array_parameters,
+                    body = request.body,
+                    event = request.event,
+                    context = request.context,
+                    interceptor_context = request.interceptor_context,
+                    chain = _build_handler_chain(_interceptors, handler),
+                ))
+        return RemainingHandlerChain()
 
 
 # Request parameters are single value query params or path params
@@ -4585,39 +4617,55 @@ SayHelloOperationResponses = Union[SayHello200OperationResponse, SayHello400Oper
 
 # Request type for say_hello
 SayHelloRequest = ApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
+SayHelloChainedRequest = ChainedApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
 
 class SayHelloHandlerFunction(Protocol):
     def __call__(self, input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:
         ...
 
-def say_hello_handler(handler: SayHelloHandlerFunction):
+SayHelloInterceptor = Callable[[SayHelloChainedRequest], SayHelloOperationResponses]
+
+def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: List[SayHelloInterceptor] = []):
     \\"\\"\\"
     Decorator for an api handler for the say_hello operation, providing a typed interface for inputs and outputs
     \\"\\"\\"
-    @wraps(handler)
-    def wrapper(event, context, **kwargs):
-        request_parameters = decode_request_parameters({
-            **(event['pathParameters'] or {}),
-            **(event['queryStringParameters'] or {}),
-        })
-        request_array_parameters = decode_request_parameters({
-            **(event['multiValueQueryStringParameters'] or {}),
-        })
-        body = parse_body(event['body'], [], SayHelloRequestBody)
-        response = handler(ApiRequest(
-            request_parameters,
-            request_array_parameters,
-            body,
-            event,
-            context,
-        ), **kwargs)
-        return {
-            'statusCode': response.status_code,
-            'headers': response.headers,
-            'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
-        }
-    return wrapper
+    def _handler_wrapper(handler: SayHelloHandlerFunction):
+        @wraps(handler)
+        def wrapper(event, context, **kwargs):
+            request_parameters = decode_request_parameters({
+                **(event['pathParameters'] or {}),
+                **(event['queryStringParameters'] or {}),
+            })
+            request_array_parameters = decode_request_parameters({
+                **(event['multiValueQueryStringParameters'] or {}),
+            })
+            body = parse_body(event['body'], [], SayHelloRequestBody)
 
+            interceptor_context = {}
+
+            chain = _build_handler_chain(interceptors, handler)
+            response = chain.next(ApiRequest(
+                request_parameters,
+                request_array_parameters,
+                body,
+                event,
+                context,
+                interceptor_context,
+            ), **kwargs)
+            return {
+                'statusCode': response.status_code,
+                'headers': response.headers,
+                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+            }
+        return wrapper
+
+    # Support use as a decorator with no arguments, or with interceptor arguments
+    if callable(_handler):
+        return _handler_wrapper(_handler)
+    elif _handler is None:
+        return _handler_wrapper
+    else:
+        raise Exception(\\"Positional arguments are not supported by say_hello_handler.\\")
 ",
   "generated/python/my_api_python/api_client.py": "# coding: utf-8
 \\"\\"\\"

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
@@ -9334,7 +9334,8 @@ def parse_body(body, content_types, model):
 RequestParameters = TypeVar('RequestParameters')
 RequestArrayParameters = TypeVar('RequestArrayParameters')
 RequestBody = TypeVar('RequestBody')
-
+ResponseBody = TypeVar('ResponseBody')
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
 class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]):
@@ -9343,10 +9344,13 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
     body: RequestBody
     event: Any
     context: Any
+    interceptor_context: Dict[str, Any]
 
+@dataclass
+class ChainedApiRequest(ApiRequest[RequestParameters, RequestArrayParameters, RequestBody],
+    Generic[RequestParameters, RequestArrayParameters, RequestBody]):
 
-ResponseBody = TypeVar('ResponseBody')
-StatusCode = TypeVar('StatusCode')
+    chain: 'HandlerChain'
 
 @dataclass
 class ApiResponse(Generic[StatusCode, ResponseBody]):
@@ -9354,6 +9358,31 @@ class ApiResponse(Generic[StatusCode, ResponseBody]):
     headers: Dict[str, str]
     body: ResponseBody
 
+class HandlerChain(Generic[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+    def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+        raise Exception(\\"Not implemented!\\")
+
+def _build_handler_chain(_interceptors, handler) -> HandlerChain:
+    if len(_interceptors) == 0:
+        class BaseHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return handler(request)
+        return BaseHandlerChain()
+    else:
+        interceptor = _interceptors.pop(0)
+
+        class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return interceptor(ChainedApiRequest(
+                    request_parameters = request.request_parameters,
+                    request_array_parameters = request.request_array_parameters,
+                    body = request.body,
+                    event = request.event,
+                    context = request.context,
+                    interceptor_context = request.interceptor_context,
+                    chain = _build_handler_chain(_interceptors, handler),
+                ))
+        return RemainingHandlerChain()
 
 
 # Request parameters are single value query params or path params
@@ -9374,39 +9403,55 @@ SayHelloOperationResponses = Union[SayHello200OperationResponse, SayHello400Oper
 
 # Request type for say_hello
 SayHelloRequest = ApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
+SayHelloChainedRequest = ChainedApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
 
 class SayHelloHandlerFunction(Protocol):
     def __call__(self, input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:
         ...
 
-def say_hello_handler(handler: SayHelloHandlerFunction):
+SayHelloInterceptor = Callable[[SayHelloChainedRequest], SayHelloOperationResponses]
+
+def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: List[SayHelloInterceptor] = []):
     \\"\\"\\"
     Decorator for an api handler for the say_hello operation, providing a typed interface for inputs and outputs
     \\"\\"\\"
-    @wraps(handler)
-    def wrapper(event, context, **kwargs):
-        request_parameters = decode_request_parameters({
-            **(event['pathParameters'] or {}),
-            **(event['queryStringParameters'] or {}),
-        })
-        request_array_parameters = decode_request_parameters({
-            **(event['multiValueQueryStringParameters'] or {}),
-        })
-        body = parse_body(event['body'], [], SayHelloRequestBody)
-        response = handler(ApiRequest(
-            request_parameters,
-            request_array_parameters,
-            body,
-            event,
-            context,
-        ), **kwargs)
-        return {
-            'statusCode': response.status_code,
-            'headers': response.headers,
-            'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
-        }
-    return wrapper
+    def _handler_wrapper(handler: SayHelloHandlerFunction):
+        @wraps(handler)
+        def wrapper(event, context, **kwargs):
+            request_parameters = decode_request_parameters({
+                **(event['pathParameters'] or {}),
+                **(event['queryStringParameters'] or {}),
+            })
+            request_array_parameters = decode_request_parameters({
+                **(event['multiValueQueryStringParameters'] or {}),
+            })
+            body = parse_body(event['body'], [], SayHelloRequestBody)
 
+            interceptor_context = {}
+
+            chain = _build_handler_chain(interceptors, handler)
+            response = chain.next(ApiRequest(
+                request_parameters,
+                request_array_parameters,
+                body,
+                event,
+                context,
+                interceptor_context,
+            ), **kwargs)
+            return {
+                'statusCode': response.status_code,
+                'headers': response.headers,
+                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+            }
+        return wrapper
+
+    # Support use as a decorator with no arguments, or with interceptor arguments
+    if callable(_handler):
+        return _handler_wrapper(_handler)
+    elif _handler is None:
+        return _handler_wrapper
+    else:
+        raise Exception(\\"Positional arguments are not supported by say_hello_handler.\\")
 ",
   "packages/api/generated/python/test_my_api_python/api_client.py": "# coding: utf-8
 \\"\\"\\"
@@ -25363,7 +25408,8 @@ def parse_body(body, content_types, model):
 RequestParameters = TypeVar('RequestParameters')
 RequestArrayParameters = TypeVar('RequestArrayParameters')
 RequestBody = TypeVar('RequestBody')
-
+ResponseBody = TypeVar('ResponseBody')
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
 class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]):
@@ -25372,10 +25418,13 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
     body: RequestBody
     event: Any
     context: Any
+    interceptor_context: Dict[str, Any]
 
+@dataclass
+class ChainedApiRequest(ApiRequest[RequestParameters, RequestArrayParameters, RequestBody],
+    Generic[RequestParameters, RequestArrayParameters, RequestBody]):
 
-ResponseBody = TypeVar('ResponseBody')
-StatusCode = TypeVar('StatusCode')
+    chain: 'HandlerChain'
 
 @dataclass
 class ApiResponse(Generic[StatusCode, ResponseBody]):
@@ -25383,6 +25432,31 @@ class ApiResponse(Generic[StatusCode, ResponseBody]):
     headers: Dict[str, str]
     body: ResponseBody
 
+class HandlerChain(Generic[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+    def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+        raise Exception(\\"Not implemented!\\")
+
+def _build_handler_chain(_interceptors, handler) -> HandlerChain:
+    if len(_interceptors) == 0:
+        class BaseHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return handler(request)
+        return BaseHandlerChain()
+    else:
+        interceptor = _interceptors.pop(0)
+
+        class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return interceptor(ChainedApiRequest(
+                    request_parameters = request.request_parameters,
+                    request_array_parameters = request.request_array_parameters,
+                    body = request.body,
+                    event = request.event,
+                    context = request.context,
+                    interceptor_context = request.interceptor_context,
+                    chain = _build_handler_chain(_interceptors, handler),
+                ))
+        return RemainingHandlerChain()
 
 
 # Request parameters are single value query params or path params
@@ -25403,39 +25477,55 @@ SayHelloOperationResponses = Union[SayHello200OperationResponse, SayHello400Oper
 
 # Request type for say_hello
 SayHelloRequest = ApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
+SayHelloChainedRequest = ChainedApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
 
 class SayHelloHandlerFunction(Protocol):
     def __call__(self, input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:
         ...
 
-def say_hello_handler(handler: SayHelloHandlerFunction):
+SayHelloInterceptor = Callable[[SayHelloChainedRequest], SayHelloOperationResponses]
+
+def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: List[SayHelloInterceptor] = []):
     \\"\\"\\"
     Decorator for an api handler for the say_hello operation, providing a typed interface for inputs and outputs
     \\"\\"\\"
-    @wraps(handler)
-    def wrapper(event, context, **kwargs):
-        request_parameters = decode_request_parameters({
-            **(event['pathParameters'] or {}),
-            **(event['queryStringParameters'] or {}),
-        })
-        request_array_parameters = decode_request_parameters({
-            **(event['multiValueQueryStringParameters'] or {}),
-        })
-        body = parse_body(event['body'], [], SayHelloRequestBody)
-        response = handler(ApiRequest(
-            request_parameters,
-            request_array_parameters,
-            body,
-            event,
-            context,
-        ), **kwargs)
-        return {
-            'statusCode': response.status_code,
-            'headers': response.headers,
-            'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
-        }
-    return wrapper
+    def _handler_wrapper(handler: SayHelloHandlerFunction):
+        @wraps(handler)
+        def wrapper(event, context, **kwargs):
+            request_parameters = decode_request_parameters({
+                **(event['pathParameters'] or {}),
+                **(event['queryStringParameters'] or {}),
+            })
+            request_array_parameters = decode_request_parameters({
+                **(event['multiValueQueryStringParameters'] or {}),
+            })
+            body = parse_body(event['body'], [], SayHelloRequestBody)
 
+            interceptor_context = {}
+
+            chain = _build_handler_chain(interceptors, handler)
+            response = chain.next(ApiRequest(
+                request_parameters,
+                request_array_parameters,
+                body,
+                event,
+                context,
+                interceptor_context,
+            ), **kwargs)
+            return {
+                'statusCode': response.status_code,
+                'headers': response.headers,
+                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+            }
+        return wrapper
+
+    # Support use as a decorator with no arguments, or with interceptor arguments
+    if callable(_handler):
+        return _handler_wrapper(_handler)
+    elif _handler is None:
+        return _handler_wrapper
+    else:
+        raise Exception(\\"Positional arguments are not supported by say_hello_handler.\\")
 ",
   "packages/api/generated/python/test_my_api_python/api_client.py": "# coding: utf-8
 \\"\\"\\"
@@ -41408,7 +41498,8 @@ def parse_body(body, content_types, model):
 RequestParameters = TypeVar('RequestParameters')
 RequestArrayParameters = TypeVar('RequestArrayParameters')
 RequestBody = TypeVar('RequestBody')
-
+ResponseBody = TypeVar('ResponseBody')
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
 class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]):
@@ -41417,10 +41508,13 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
     body: RequestBody
     event: Any
     context: Any
+    interceptor_context: Dict[str, Any]
 
+@dataclass
+class ChainedApiRequest(ApiRequest[RequestParameters, RequestArrayParameters, RequestBody],
+    Generic[RequestParameters, RequestArrayParameters, RequestBody]):
 
-ResponseBody = TypeVar('ResponseBody')
-StatusCode = TypeVar('StatusCode')
+    chain: 'HandlerChain'
 
 @dataclass
 class ApiResponse(Generic[StatusCode, ResponseBody]):
@@ -41428,6 +41522,31 @@ class ApiResponse(Generic[StatusCode, ResponseBody]):
     headers: Dict[str, str]
     body: ResponseBody
 
+class HandlerChain(Generic[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+    def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+        raise Exception(\\"Not implemented!\\")
+
+def _build_handler_chain(_interceptors, handler) -> HandlerChain:
+    if len(_interceptors) == 0:
+        class BaseHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return handler(request)
+        return BaseHandlerChain()
+    else:
+        interceptor = _interceptors.pop(0)
+
+        class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return interceptor(ChainedApiRequest(
+                    request_parameters = request.request_parameters,
+                    request_array_parameters = request.request_array_parameters,
+                    body = request.body,
+                    event = request.event,
+                    context = request.context,
+                    interceptor_context = request.interceptor_context,
+                    chain = _build_handler_chain(_interceptors, handler),
+                ))
+        return RemainingHandlerChain()
 
 
 # Request parameters are single value query params or path params
@@ -41448,39 +41567,55 @@ SayHelloOperationResponses = Union[SayHello200OperationResponse, SayHello400Oper
 
 # Request type for say_hello
 SayHelloRequest = ApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
+SayHelloChainedRequest = ChainedApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
 
 class SayHelloHandlerFunction(Protocol):
     def __call__(self, input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:
         ...
 
-def say_hello_handler(handler: SayHelloHandlerFunction):
+SayHelloInterceptor = Callable[[SayHelloChainedRequest], SayHelloOperationResponses]
+
+def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: List[SayHelloInterceptor] = []):
     \\"\\"\\"
     Decorator for an api handler for the say_hello operation, providing a typed interface for inputs and outputs
     \\"\\"\\"
-    @wraps(handler)
-    def wrapper(event, context, **kwargs):
-        request_parameters = decode_request_parameters({
-            **(event['pathParameters'] or {}),
-            **(event['queryStringParameters'] or {}),
-        })
-        request_array_parameters = decode_request_parameters({
-            **(event['multiValueQueryStringParameters'] or {}),
-        })
-        body = parse_body(event['body'], [], SayHelloRequestBody)
-        response = handler(ApiRequest(
-            request_parameters,
-            request_array_parameters,
-            body,
-            event,
-            context,
-        ), **kwargs)
-        return {
-            'statusCode': response.status_code,
-            'headers': response.headers,
-            'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
-        }
-    return wrapper
+    def _handler_wrapper(handler: SayHelloHandlerFunction):
+        @wraps(handler)
+        def wrapper(event, context, **kwargs):
+            request_parameters = decode_request_parameters({
+                **(event['pathParameters'] or {}),
+                **(event['queryStringParameters'] or {}),
+            })
+            request_array_parameters = decode_request_parameters({
+                **(event['multiValueQueryStringParameters'] or {}),
+            })
+            body = parse_body(event['body'], [], SayHelloRequestBody)
 
+            interceptor_context = {}
+
+            chain = _build_handler_chain(interceptors, handler)
+            response = chain.next(ApiRequest(
+                request_parameters,
+                request_array_parameters,
+                body,
+                event,
+                context,
+                interceptor_context,
+            ), **kwargs)
+            return {
+                'statusCode': response.status_code,
+                'headers': response.headers,
+                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+            }
+        return wrapper
+
+    # Support use as a decorator with no arguments, or with interceptor arguments
+    if callable(_handler):
+        return _handler_wrapper(_handler)
+    elif _handler is None:
+        return _handler_wrapper
+    else:
+        raise Exception(\\"Positional arguments are not supported by say_hello_handler.\\")
 ",
   "packages/api/generated/python/test_my_api_python/api_client.py": "# coding: utf-8
 \\"\\"\\"

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
@@ -8790,7 +8790,8 @@ def parse_body(body, content_types, model):
 RequestParameters = TypeVar('RequestParameters')
 RequestArrayParameters = TypeVar('RequestArrayParameters')
 RequestBody = TypeVar('RequestBody')
-
+ResponseBody = TypeVar('ResponseBody')
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
 class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]):
@@ -8799,10 +8800,13 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
     body: RequestBody
     event: Any
     context: Any
+    interceptor_context: Dict[str, Any]
 
+@dataclass
+class ChainedApiRequest(ApiRequest[RequestParameters, RequestArrayParameters, RequestBody],
+    Generic[RequestParameters, RequestArrayParameters, RequestBody]):
 
-ResponseBody = TypeVar('ResponseBody')
-StatusCode = TypeVar('StatusCode')
+    chain: 'HandlerChain'
 
 @dataclass
 class ApiResponse(Generic[StatusCode, ResponseBody]):
@@ -8810,6 +8814,31 @@ class ApiResponse(Generic[StatusCode, ResponseBody]):
     headers: Dict[str, str]
     body: ResponseBody
 
+class HandlerChain(Generic[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+    def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+        raise Exception(\\"Not implemented!\\")
+
+def _build_handler_chain(_interceptors, handler) -> HandlerChain:
+    if len(_interceptors) == 0:
+        class BaseHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return handler(request)
+        return BaseHandlerChain()
+    else:
+        interceptor = _interceptors.pop(0)
+
+        class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return interceptor(ChainedApiRequest(
+                    request_parameters = request.request_parameters,
+                    request_array_parameters = request.request_array_parameters,
+                    body = request.body,
+                    event = request.event,
+                    context = request.context,
+                    interceptor_context = request.interceptor_context,
+                    chain = _build_handler_chain(_interceptors, handler),
+                ))
+        return RemainingHandlerChain()
 
 
 # Request parameters are single value query params or path params
@@ -8830,39 +8859,55 @@ SayHelloOperationResponses = Union[SayHello200OperationResponse, SayHello400Oper
 
 # Request type for say_hello
 SayHelloRequest = ApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
+SayHelloChainedRequest = ChainedApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
 
 class SayHelloHandlerFunction(Protocol):
     def __call__(self, input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:
         ...
 
-def say_hello_handler(handler: SayHelloHandlerFunction):
+SayHelloInterceptor = Callable[[SayHelloChainedRequest], SayHelloOperationResponses]
+
+def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: List[SayHelloInterceptor] = []):
     \\"\\"\\"
     Decorator for an api handler for the say_hello operation, providing a typed interface for inputs and outputs
     \\"\\"\\"
-    @wraps(handler)
-    def wrapper(event, context, **kwargs):
-        request_parameters = decode_request_parameters({
-            **(event['pathParameters'] or {}),
-            **(event['queryStringParameters'] or {}),
-        })
-        request_array_parameters = decode_request_parameters({
-            **(event['multiValueQueryStringParameters'] or {}),
-        })
-        body = parse_body(event['body'], [], SayHelloRequestBody)
-        response = handler(ApiRequest(
-            request_parameters,
-            request_array_parameters,
-            body,
-            event,
-            context,
-        ), **kwargs)
-        return {
-            'statusCode': response.status_code,
-            'headers': response.headers,
-            'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
-        }
-    return wrapper
+    def _handler_wrapper(handler: SayHelloHandlerFunction):
+        @wraps(handler)
+        def wrapper(event, context, **kwargs):
+            request_parameters = decode_request_parameters({
+                **(event['pathParameters'] or {}),
+                **(event['queryStringParameters'] or {}),
+            })
+            request_array_parameters = decode_request_parameters({
+                **(event['multiValueQueryStringParameters'] or {}),
+            })
+            body = parse_body(event['body'], [], SayHelloRequestBody)
 
+            interceptor_context = {}
+
+            chain = _build_handler_chain(interceptors, handler)
+            response = chain.next(ApiRequest(
+                request_parameters,
+                request_array_parameters,
+                body,
+                event,
+                context,
+                interceptor_context,
+            ), **kwargs)
+            return {
+                'statusCode': response.status_code,
+                'headers': response.headers,
+                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+            }
+        return wrapper
+
+    # Support use as a decorator with no arguments, or with interceptor arguments
+    if callable(_handler):
+        return _handler_wrapper(_handler)
+    elif _handler is None:
+        return _handler_wrapper
+    else:
+        raise Exception(\\"Positional arguments are not supported by say_hello_handler.\\")
 ",
   "generated/python/test_my_api_python/api_client.py": "# coding: utf-8
 \\"\\"\\"
@@ -24217,7 +24262,8 @@ def parse_body(body, content_types, model):
 RequestParameters = TypeVar('RequestParameters')
 RequestArrayParameters = TypeVar('RequestArrayParameters')
 RequestBody = TypeVar('RequestBody')
-
+ResponseBody = TypeVar('ResponseBody')
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
 class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]):
@@ -24226,10 +24272,13 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
     body: RequestBody
     event: Any
     context: Any
+    interceptor_context: Dict[str, Any]
 
+@dataclass
+class ChainedApiRequest(ApiRequest[RequestParameters, RequestArrayParameters, RequestBody],
+    Generic[RequestParameters, RequestArrayParameters, RequestBody]):
 
-ResponseBody = TypeVar('ResponseBody')
-StatusCode = TypeVar('StatusCode')
+    chain: 'HandlerChain'
 
 @dataclass
 class ApiResponse(Generic[StatusCode, ResponseBody]):
@@ -24237,6 +24286,31 @@ class ApiResponse(Generic[StatusCode, ResponseBody]):
     headers: Dict[str, str]
     body: ResponseBody
 
+class HandlerChain(Generic[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+    def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+        raise Exception(\\"Not implemented!\\")
+
+def _build_handler_chain(_interceptors, handler) -> HandlerChain:
+    if len(_interceptors) == 0:
+        class BaseHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return handler(request)
+        return BaseHandlerChain()
+    else:
+        interceptor = _interceptors.pop(0)
+
+        class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return interceptor(ChainedApiRequest(
+                    request_parameters = request.request_parameters,
+                    request_array_parameters = request.request_array_parameters,
+                    body = request.body,
+                    event = request.event,
+                    context = request.context,
+                    interceptor_context = request.interceptor_context,
+                    chain = _build_handler_chain(_interceptors, handler),
+                ))
+        return RemainingHandlerChain()
 
 
 # Request parameters are single value query params or path params
@@ -24257,39 +24331,55 @@ SayHelloOperationResponses = Union[SayHello200OperationResponse, SayHello400Oper
 
 # Request type for say_hello
 SayHelloRequest = ApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
+SayHelloChainedRequest = ChainedApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
 
 class SayHelloHandlerFunction(Protocol):
     def __call__(self, input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:
         ...
 
-def say_hello_handler(handler: SayHelloHandlerFunction):
+SayHelloInterceptor = Callable[[SayHelloChainedRequest], SayHelloOperationResponses]
+
+def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: List[SayHelloInterceptor] = []):
     \\"\\"\\"
     Decorator for an api handler for the say_hello operation, providing a typed interface for inputs and outputs
     \\"\\"\\"
-    @wraps(handler)
-    def wrapper(event, context, **kwargs):
-        request_parameters = decode_request_parameters({
-            **(event['pathParameters'] or {}),
-            **(event['queryStringParameters'] or {}),
-        })
-        request_array_parameters = decode_request_parameters({
-            **(event['multiValueQueryStringParameters'] or {}),
-        })
-        body = parse_body(event['body'], [], SayHelloRequestBody)
-        response = handler(ApiRequest(
-            request_parameters,
-            request_array_parameters,
-            body,
-            event,
-            context,
-        ), **kwargs)
-        return {
-            'statusCode': response.status_code,
-            'headers': response.headers,
-            'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
-        }
-    return wrapper
+    def _handler_wrapper(handler: SayHelloHandlerFunction):
+        @wraps(handler)
+        def wrapper(event, context, **kwargs):
+            request_parameters = decode_request_parameters({
+                **(event['pathParameters'] or {}),
+                **(event['queryStringParameters'] or {}),
+            })
+            request_array_parameters = decode_request_parameters({
+                **(event['multiValueQueryStringParameters'] or {}),
+            })
+            body = parse_body(event['body'], [], SayHelloRequestBody)
 
+            interceptor_context = {}
+
+            chain = _build_handler_chain(interceptors, handler)
+            response = chain.next(ApiRequest(
+                request_parameters,
+                request_array_parameters,
+                body,
+                event,
+                context,
+                interceptor_context,
+            ), **kwargs)
+            return {
+                'statusCode': response.status_code,
+                'headers': response.headers,
+                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+            }
+        return wrapper
+
+    # Support use as a decorator with no arguments, or with interceptor arguments
+    if callable(_handler):
+        return _handler_wrapper(_handler)
+    elif _handler is None:
+        return _handler_wrapper
+    else:
+        raise Exception(\\"Positional arguments are not supported by say_hello_handler.\\")
 ",
   "generated/python/test_my_api_python/api_client.py": "# coding: utf-8
 \\"\\"\\"
@@ -39637,7 +39727,8 @@ def parse_body(body, content_types, model):
 RequestParameters = TypeVar('RequestParameters')
 RequestArrayParameters = TypeVar('RequestArrayParameters')
 RequestBody = TypeVar('RequestBody')
-
+ResponseBody = TypeVar('ResponseBody')
+StatusCode = TypeVar('StatusCode')
 
 @dataclass
 class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]):
@@ -39646,10 +39737,13 @@ class ApiRequest(Generic[RequestParameters, RequestArrayParameters, RequestBody]
     body: RequestBody
     event: Any
     context: Any
+    interceptor_context: Dict[str, Any]
 
+@dataclass
+class ChainedApiRequest(ApiRequest[RequestParameters, RequestArrayParameters, RequestBody],
+    Generic[RequestParameters, RequestArrayParameters, RequestBody]):
 
-ResponseBody = TypeVar('ResponseBody')
-StatusCode = TypeVar('StatusCode')
+    chain: 'HandlerChain'
 
 @dataclass
 class ApiResponse(Generic[StatusCode, ResponseBody]):
@@ -39657,6 +39751,31 @@ class ApiResponse(Generic[StatusCode, ResponseBody]):
     headers: Dict[str, str]
     body: ResponseBody
 
+class HandlerChain(Generic[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+    def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+        raise Exception(\\"Not implemented!\\")
+
+def _build_handler_chain(_interceptors, handler) -> HandlerChain:
+    if len(_interceptors) == 0:
+        class BaseHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return handler(request)
+        return BaseHandlerChain()
+    else:
+        interceptor = _interceptors.pop(0)
+
+        class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
+            def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
+                return interceptor(ChainedApiRequest(
+                    request_parameters = request.request_parameters,
+                    request_array_parameters = request.request_array_parameters,
+                    body = request.body,
+                    event = request.event,
+                    context = request.context,
+                    interceptor_context = request.interceptor_context,
+                    chain = _build_handler_chain(_interceptors, handler),
+                ))
+        return RemainingHandlerChain()
 
 
 # Request parameters are single value query params or path params
@@ -39677,39 +39796,55 @@ SayHelloOperationResponses = Union[SayHello200OperationResponse, SayHello400Oper
 
 # Request type for say_hello
 SayHelloRequest = ApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
+SayHelloChainedRequest = ChainedApiRequest[SayHelloRequestParameters, SayHelloRequestArrayParameters, SayHelloRequestBody]
 
 class SayHelloHandlerFunction(Protocol):
     def __call__(self, input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:
         ...
 
-def say_hello_handler(handler: SayHelloHandlerFunction):
+SayHelloInterceptor = Callable[[SayHelloChainedRequest], SayHelloOperationResponses]
+
+def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: List[SayHelloInterceptor] = []):
     \\"\\"\\"
     Decorator for an api handler for the say_hello operation, providing a typed interface for inputs and outputs
     \\"\\"\\"
-    @wraps(handler)
-    def wrapper(event, context, **kwargs):
-        request_parameters = decode_request_parameters({
-            **(event['pathParameters'] or {}),
-            **(event['queryStringParameters'] or {}),
-        })
-        request_array_parameters = decode_request_parameters({
-            **(event['multiValueQueryStringParameters'] or {}),
-        })
-        body = parse_body(event['body'], [], SayHelloRequestBody)
-        response = handler(ApiRequest(
-            request_parameters,
-            request_array_parameters,
-            body,
-            event,
-            context,
-        ), **kwargs)
-        return {
-            'statusCode': response.status_code,
-            'headers': response.headers,
-            'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
-        }
-    return wrapper
+    def _handler_wrapper(handler: SayHelloHandlerFunction):
+        @wraps(handler)
+        def wrapper(event, context, **kwargs):
+            request_parameters = decode_request_parameters({
+                **(event['pathParameters'] or {}),
+                **(event['queryStringParameters'] or {}),
+            })
+            request_array_parameters = decode_request_parameters({
+                **(event['multiValueQueryStringParameters'] or {}),
+            })
+            body = parse_body(event['body'], [], SayHelloRequestBody)
 
+            interceptor_context = {}
+
+            chain = _build_handler_chain(interceptors, handler)
+            response = chain.next(ApiRequest(
+                request_parameters,
+                request_array_parameters,
+                body,
+                event,
+                context,
+                interceptor_context,
+            ), **kwargs)
+            return {
+                'statusCode': response.status_code,
+                'headers': response.headers,
+                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+            }
+        return wrapper
+
+    # Support use as a decorator with no arguments, or with interceptor arguments
+    if callable(_handler):
+        return _handler_wrapper(_handler)
+    elif _handler is None:
+        return _handler_wrapper
+    else:
+        raise Exception(\\"Positional arguments are not supported by say_hello_handler.\\")
 ",
   "generated/python/test_my_api_python/api_client.py": "# coding: utf-8
 \\"\\"\\"


### PR DESCRIPTION
Add ability to define interceptors in python for parity with ts and java.

Also remove ensure the layer is always recreated when running `npx projen`, as `pip` doesn't seem to do a clean install into the directory if it exists.