### PR TITLE
fix: do not be prescriptive about fixed values for NXMonorepo

### DIFF
--- a/packages/nx-monorepo/src/nx-monorepo.ts
+++ b/packages/nx-monorepo/src/nx-monorepo.ts
@@ -210,14 +210,14 @@ export class NxMonorepoProject extends TypeScriptProject {
   constructor(options: NxMonorepoProjectOptions) {
     super({
       ...options,
-      github: false,
-      jest: false,
-      package: false,
-      prettier: true,
+      github: options.github ?? false,
+      package: options.package ?? false,
+      prettier: options.prettier ?? true,
       projenrcTs: true,
-      release: false,
-      sampleCode: false,
-      defaultReleaseBranch: "mainline",
+      release: options.release ?? false,
+      jest: options.jest ?? false,
+      defaultReleaseBranch: options.defaultReleaseBranch ?? "mainline",
+      sampleCode: false, // root should never have sample code
     });
 
     this.nxConfig = options.nxConfig;


### PR DESCRIPTION
Allow users to provide configurations for github, package, prettier, release, jest and defaultReleaseBranch.

Fixes #154 #155 