### PR TITLE
fix(open-api-gateway): ensure cors options request does not inherit default authorizer

### DIFF
--- a/packages/open-api-gateway/src/construct/prepare-spec-event-handler/prepare-spec.ts
+++ b/packages/open-api-gateway/src/construct/prepare-spec-event-handler/prepare-spec.ts
@@ -91,6 +91,14 @@ export interface PrepareApiSpecOptions {
   readonly defaultAuthorizerReference?: SerialisedAuthorizerReference;
 }
 
+// Add to methods to ensure no auth is added
+const NO_AUTH_SPEC_SNIPPET = {
+  security: [],
+  "x-amazon-apigateway-auth": {
+    type: "NONE",
+  },
+};
+
 /**
  * Create the OpenAPI definition with api gateway extensions for the given authorizer
  * @param methodAuthorizer the authorizer used for the method
@@ -100,12 +108,7 @@ const applyMethodAuthorizer = (
 ) => {
   if (methodAuthorizer) {
     if (methodAuthorizer.authorizerId === DefaultAuthorizerIds.NONE) {
-      return {
-        security: [],
-        "x-amazon-apigateway-auth": {
-          type: "NONE",
-        },
-      };
+      return NO_AUTH_SPEC_SNIPPET;
     } else {
       return {
         security: [
@@ -245,6 +248,8 @@ const generateCorsOptionsMethod = (
           },
         },
       },
+      // No auth for CORS options requests
+      ...NO_AUTH_SPEC_SNIPPET,
     },
   };
 };

--- a/packages/open-api-gateway/test/construct/__snapshots__/open-api-gateway-lambda-api.test.ts.snap
+++ b/packages/open-api-gateway/test/construct/__snapshots__/open-api-gateway-lambda-api.test.ts.snap
@@ -449,7 +449,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "78dcda1fbae7280b213f9e62e9ea758237ede8cfaa75b6e85cc3c334371f0a51.zip",
+          "S3Key": "31d09dbe5679ff0c189d29d7c87ec2217d5b13d30c709f7d6698761ead00d8ff.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -1436,7 +1436,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "78dcda1fbae7280b213f9e62e9ea758237ede8cfaa75b6e85cc3c334371f0a51.zip",
+          "S3Key": "31d09dbe5679ff0c189d29d7c87ec2217d5b13d30c709f7d6698761ead00d8ff.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -2440,7 +2440,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "78dcda1fbae7280b213f9e62e9ea758237ede8cfaa75b6e85cc3c334371f0a51.zip",
+          "S3Key": "31d09dbe5679ff0c189d29d7c87ec2217d5b13d30c709f7d6698761ead00d8ff.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -3532,7 +3532,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "78dcda1fbae7280b213f9e62e9ea758237ede8cfaa75b6e85cc3c334371f0a51.zip",
+          "S3Key": "31d09dbe5679ff0c189d29d7c87ec2217d5b13d30c709f7d6698761ead00d8ff.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -4622,7 +4622,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "78dcda1fbae7280b213f9e62e9ea758237ede8cfaa75b6e85cc3c334371f0a51.zip",
+          "S3Key": "31d09dbe5679ff0c189d29d7c87ec2217d5b13d30c709f7d6698761ead00d8ff.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -5401,7 +5401,7 @@ Object {
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC478daad7971086a0656f59f38f98e90f459": Object {
+    "ApiTestDeployment153EC4781fd0330a24a90a9d5cce712b647e79f0": Object {
       "DependsOn": Array [
         "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
@@ -5466,7 +5466,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment153EC478daad7971086a0656f59f38f98e90f459",
+          "Ref": "ApiTestDeployment153EC4781fd0330a24a90a9d5cce712b647e79f0",
         },
         "MethodSettings": Array [
           Object {
@@ -5606,7 +5606,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "78dcda1fbae7280b213f9e62e9ea758237ede8cfaa75b6e85cc3c334371f0a51.zip",
+          "S3Key": "31d09dbe5679ff0c189d29d7c87ec2217d5b13d30c709f7d6698761ead00d8ff.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -6847,7 +6847,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "78dcda1fbae7280b213f9e62e9ea758237ede8cfaa75b6e85cc3c334371f0a51.zip",
+          "S3Key": "31d09dbe5679ff0c189d29d7c87ec2217d5b13d30c709f7d6698761ead00d8ff.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -8131,7 +8131,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "78dcda1fbae7280b213f9e62e9ea758237ede8cfaa75b6e85cc3c334371f0a51.zip",
+          "S3Key": "31d09dbe5679ff0c189d29d7c87ec2217d5b13d30c709f7d6698761ead00d8ff.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -9008,7 +9008,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "78dcda1fbae7280b213f9e62e9ea758237ede8cfaa75b6e85cc3c334371f0a51.zip",
+          "S3Key": "31d09dbe5679ff0c189d29d7c87ec2217d5b13d30c709f7d6698761ead00d8ff.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",


### PR DESCRIPTION
CORS options methods were inheriting the default authorizer unintentionally since I changed how the default authorizer was defined in the processed api spec. This ensures no authorizer is used for the CORS options methods since browsers don't send authentication headers in preflight requests. Note that users can define their own OPTIONS methods or omit CORS options to not have this behaviour.
