### PR TITLE
feat(open-api-gateway): prefer user-specified dependency versions for auto-added dependencies

### DIFF
--- a/packages/open-api-gateway/src/project/open-api-gateway-java-project.ts
+++ b/packages/open-api-gateway/src/project/open-api-gateway-java-project.ts
@@ -109,7 +109,12 @@ export class OpenApiGatewayJavaProject extends JavaProject {
       "org.projectlombok/lombok@^1",
       "com.fasterxml.jackson.core/jackson-databind@^2",
       "io.github.cdklabs/projen@^0",
-    ].forEach((dep) => this.addDependency(dep));
+    ]
+      .filter(
+        (dep) =>
+          !this.deps.tryGetDependency(dep.split("@")[0], DependencyType.RUNTIME)
+      )
+      .forEach((dep) => this.addDependency(dep));
 
     // Remove the projen test dependency since otherwise it takes precedence, causing projen to be unavailable at synth time
     this.deps.removeDependency("io.github.cdklabs/projen", DependencyType.TEST);

--- a/packages/open-api-gateway/src/project/open-api-gateway-python-project.ts
+++ b/packages/open-api-gateway/src/project/open-api-gateway-python-project.ts
@@ -15,7 +15,13 @@
  ******************************************************************************************************************** */
 
 import * as path from "path";
-import { Project, SampleDir, SampleFile, TextFile } from "projen";
+import {
+  DependencyType,
+  Project,
+  SampleDir,
+  SampleFile,
+  TextFile,
+} from "projen";
 import { PythonProject, PythonProjectOptions } from "projen/lib/python";
 import { ClientSettings } from "./codegen/components/client-settings";
 import { DocsProject } from "./codegen/docs-project";
@@ -112,12 +118,9 @@ export class OpenApiGatewayPythonProject extends PythonProject {
     this.apiSrcDir = options.apiSrcDir ?? "api";
 
     // Generated project should have a dependency on this project, in order to run the generation scripts
-    [
-      OPENAPI_GATEWAY_PDK_PACKAGE_NAME,
-      "constructs",
-      "aws-cdk-lib",
-      "cdk-nag",
-    ].forEach((dep) => this.addDependency(dep));
+    [OPENAPI_GATEWAY_PDK_PACKAGE_NAME, "constructs", "aws-cdk-lib", "cdk-nag"]
+      .filter((dep) => !this.deps.tryGetDependency(dep, DependencyType.RUNTIME))
+      .forEach((dep) => this.addDependency(dep));
 
     // Synthesize the openapi spec early since it's used by the generated python client, which is also synth'd early
     const spec = new OpenApiSpecProject({

--- a/packages/open-api-gateway/src/project/open-api-gateway-ts-project.ts
+++ b/packages/open-api-gateway/src/project/open-api-gateway-ts-project.ts
@@ -16,7 +16,13 @@
 
 import * as path from "path";
 import { getLogger } from "log4js";
-import { Project, SampleDir, SampleFile, YamlFile } from "projen";
+import {
+  DependencyType,
+  Project,
+  SampleDir,
+  SampleFile,
+  YamlFile,
+} from "projen";
 import { NodePackageManager } from "projen/lib/javascript";
 import {
   TypeScriptProject,
@@ -138,10 +144,14 @@ export class OpenApiGatewayTsProject extends TypeScriptProject {
 
     // Generated project should have a dependency on this project, in order to run the generation scripts
     this.addDeps(
-      OPENAPI_GATEWAY_PDK_PACKAGE_NAME,
-      "constructs",
-      "aws-cdk-lib",
-      "cdk-nag"
+      ...[
+        OPENAPI_GATEWAY_PDK_PACKAGE_NAME,
+        "constructs",
+        "aws-cdk-lib",
+        "cdk-nag",
+      ].filter(
+        (dep) => !this.deps.tryGetDependency(dep, DependencyType.RUNTIME)
+      )
     );
 
     // Synthesize the openapi spec early since it's used by the generated typescript client, which is also synth'd early

--- a/packages/open-api-gateway/test/project/open-api-gateway-java-project/standalone.test.ts
+++ b/packages/open-api-gateway/test/project/open-api-gateway-java-project/standalone.test.ts
@@ -31,4 +31,31 @@ describe("OpenAPI Gateway Java Standalone Unit Tests", () => {
     });
     expect(synthSnapshot(project)).toMatchSnapshot();
   });
+
+  it("Honours Dependency Versions", () => {
+    const project = new OpenApiGatewayJavaProject({
+      name: "myapi",
+      groupId: "software.aws.test",
+      artifactId: "my-api",
+      version: "1.0.0",
+      clientLanguages: [],
+      deps: [
+        "software.aws.awsprototypingsdk/open-api-gateway@0.10.2",
+        "software.constructs/constructs@10.1.7",
+        "software.amazon.awscdk/aws-cdk-lib@2.39.0",
+      ],
+    });
+
+    expect(
+      project.deps.getDependency(
+        "software.aws.awsprototypingsdk/open-api-gateway"
+      ).version
+    ).toBe("0.10.2");
+    expect(
+      project.deps.getDependency("software.constructs/constructs").version
+    ).toBe("10.1.7");
+    expect(
+      project.deps.getDependency("software.amazon.awscdk/aws-cdk-lib").version
+    ).toBe("2.39.0");
+  });
 });

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/standalone.test.ts
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/standalone.test.ts
@@ -32,4 +32,26 @@ describe("OpenAPI Gateway Python Standalone Unit Tests", () => {
     });
     expect(synthSnapshot(project)).toMatchSnapshot();
   });
+
+  it("Honours Dependency Versions", () => {
+    const project = new OpenApiGatewayPythonProject({
+      moduleName: "my_api",
+      name: "my_api",
+      authorName: "test",
+      authorEmail: "test@example.com",
+      version: "1.0.0",
+      clientLanguages: [],
+      deps: [
+        "aws_prototyping_sdk.open_api_gateway@0.10.2",
+        "constructs@10.1.7",
+        "aws-cdk-lib@2.39.0",
+      ],
+    });
+
+    expect(
+      project.deps.getDependency("aws_prototyping_sdk.open_api_gateway").version
+    ).toBe("0.10.2");
+    expect(project.deps.getDependency("constructs").version).toBe("10.1.7");
+    expect(project.deps.getDependency("aws-cdk-lib").version).toBe("2.39.0");
+  });
 });

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/standalone.test.ts
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/standalone.test.ts
@@ -35,4 +35,24 @@ describe("OpenAPI Gateway Ts Standalone Unit Tests", () => {
     });
     expect(synthSnapshot(project)).toMatchSnapshot();
   });
+
+  it("Honours Dependency Versions", () => {
+    const project = new OpenApiGatewayTsProject({
+      defaultReleaseBranch: "mainline",
+      name: "@test/my-api",
+      clientLanguages: [],
+      deps: [
+        "@aws-prototyping-sdk/open-api-gateway@0.10.2",
+        "constructs@10.1.7",
+        "aws-cdk-lib@2.39.0",
+      ],
+    });
+
+    expect(
+      project.deps.getDependency("@aws-prototyping-sdk/open-api-gateway")
+        .version
+    ).toBe("0.10.2");
+    expect(project.deps.getDependency("constructs").version).toBe("10.1.7");
+    expect(project.deps.getDependency("aws-cdk-lib").version).toBe("2.39.0");
+  });
 });


### PR DESCRIPTION
Where a user has specified a dependency version, we prefer that over the ones we add automatically. This allows for pinning of the `@aws-prototyping-sdk/open-api-gateway` package version, as well as cdk, constructs etc.

Fixes #164