### PR TITLE
fix(open-api-gateway): fix python sample api integration

### DIFF
--- a/packages/open-api-gateway/src/project/samples/python.ts
+++ b/packages/open-api-gateway/src/project/samples/python.ts
@@ -100,7 +100,7 @@ class SampleApi(Construct):
           default_authorizer=Authorizers.iam(),
           integrations=OperationConfig(
               say_hello=OpenApiIntegration(
-                  integration=Integrations.lambda(Function(self, 'SayHello',
+                  integration=Integrations.lambda_(Function(self, 'SayHello',
                       runtime=Runtime.PYTHON_3_9,
                       code=Code.from_asset(path.join(str(Path(__file__).parent.absolute()), 'handlers')),
                       handler="say_hello_handler_sample.handler",

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
@@ -15794,7 +15794,7 @@ class SampleApi(Construct):
           default_authorizer=Authorizers.iam(),
           integrations=OperationConfig(
               say_hello=OpenApiIntegration(
-                  integration=Integrations.lambda(Function(self, 'SayHello',
+                  integration=Integrations.lambda_(Function(self, 'SayHello',
                       runtime=Runtime.PYTHON_3_9,
                       code=Code.from_asset(path.join(str(Path(__file__).parent.absolute()), 'handlers')),
                       handler=\\"say_hello_handler_sample.handler\\",

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
@@ -14943,7 +14943,7 @@ class SampleApi(Construct):
           default_authorizer=Authorizers.iam(),
           integrations=OperationConfig(
               say_hello=OpenApiIntegration(
-                  integration=Integrations.lambda(Function(self, 'SayHello',
+                  integration=Integrations.lambda_(Function(self, 'SayHello',
                       runtime=Runtime.PYTHON_3_9,
                       code=Code.from_asset(path.join(str(Path(__file__).parent.absolute()), 'handlers')),
                       handler=\\"say_hello_handler_sample.handler\\",

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/with-docs.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/with-docs.test.ts.snap
@@ -10193,7 +10193,7 @@ class SampleApi(Construct):
           default_authorizer=Authorizers.iam(),
           integrations=OperationConfig(
               say_hello=OpenApiIntegration(
-                  integration=Integrations.lambda(Function(self, 'SayHello',
+                  integration=Integrations.lambda_(Function(self, 'SayHello',
                       runtime=Runtime.PYTHON_3_9,
                       code=Code.from_asset(path.join(str(Path(__file__).parent.absolute()), 'handlers')),
                       handler=\\"say_hello_handler_sample.handler\\",

--- a/packages/open-api-gateway/test/project/smithy-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/smithy-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
@@ -9501,7 +9501,7 @@ class SampleApi(Construct):
           default_authorizer=Authorizers.iam(),
           integrations=OperationConfig(
               say_hello=OpenApiIntegration(
-                  integration=Integrations.lambda(Function(self, 'SayHello',
+                  integration=Integrations.lambda_(Function(self, 'SayHello',
                       runtime=Runtime.PYTHON_3_9,
                       code=Code.from_asset(path.join(str(Path(__file__).parent.absolute()), 'handlers')),
                       handler=\\"say_hello_handler_sample.handler\\",


### PR DESCRIPTION
JSII renames the 'lambda' function to 'lambda_' in python since it's a reserved word. Updated sample api construct to reference the correct method.
