### PR TITLE
fix(nx-monorepo): run python install sequentially in dependency order

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -98,6 +98,14 @@
         }
       ]
     },
+    "install": {
+      "name": "install",
+      "steps": [
+        {
+          "exec": "npx nx run-many --target install-py --projects pipeline-sample-py --parallel=1"
+        }
+      ]
+    },
     "package": {
       "name": "package",
       "description": "Creates the distribution package"

--- a/nx.json
+++ b/nx.json
@@ -61,6 +61,12 @@
         "target": "upgrade",
         "projects": "dependencies"
       }
+    ],
+    "install-py": [
+      {
+        "target": "install-py",
+        "projects": "dependencies"
+      }
     ]
   },
   "affected": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "eject": "npx projen eject",
     "eslint": "npx projen eslint",
     "git-secrets-scan": "npx projen git-secrets-scan",
+    "install": "npx projen install",
     "package": "npx projen package",
     "post-compile": "npx projen post-compile",
     "pre-compile": "npx projen pre-compile",

--- a/packages/nx-monorepo/test/__snapshots__/nx-monorepo.test.ts.snap
+++ b/packages/nx-monorepo/test/__snapshots__/nx-monorepo.test.ts.snap
@@ -1471,6 +1471,14 @@ target
           },
         ],
       },
+      "install": Object {
+        "name": "install",
+        "steps": Array [
+          Object {
+            "exec": "npx nx run-many --target install-py --projects py-subproject --parallel=1",
+          },
+        ],
+      },
       "package": Object {
         "description": "Creates the distribution package",
         "name": "package",
@@ -1816,6 +1824,12 @@ target
           "target": "build",
         },
       ],
+      "install-py": Array [
+        Object {
+          "projects": "dependencies",
+          "target": "install-py",
+        },
+      ],
     },
     "tasksRunnerOptions": Object {
       "default": Object {
@@ -1872,6 +1886,7 @@ target
       "default": "npx projen default",
       "eject": "npx projen eject",
       "eslint": "npx projen eslint",
+      "install": "npx projen install",
       "package": "npx projen package",
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
@@ -2094,6 +2109,9 @@ cython_debug/
       "install": Object {
         "description": "Install and upgrade dependencies",
         "name": "install",
+      },
+      "install-py": Object {
+        "name": "install-py",
         "steps": Array [
           Object {
             "exec": "pip install --upgrade pip",
@@ -2142,6 +2160,7 @@ cython_debug/
       "default": "npx projen default",
       "eject": "npx projen eject",
       "install": "npx projen install",
+      "install-py": "npx projen install-py",
       "package": "npx projen package",
       "post-compile": "npx projen post-compile",
       "pre-compile": "npx projen pre-compile",

--- a/packages/open-api-gateway/src/project/codegen/generated-python-client-project.ts
+++ b/packages/open-api-gateway/src/project/codegen/generated-python-client-project.ts
@@ -14,7 +14,7 @@
  limitations under the License.
  ******************************************************************************************************************** */
 import * as path from "path";
-import { JsonFile } from "projen";
+import { JsonFile, Task, TaskStep } from "projen";
 import { PythonProject, PythonProjectOptions } from "projen/lib/python";
 import { GeneratedPythonClientSourceCode } from "./components/generated-python-client-source-code";
 import { OpenApiGeneratorIgnoreFile } from "./components/open-api-generator-ignore-file";
@@ -57,6 +57,36 @@ export class GeneratedPythonClientProject extends PythonProject {
       ...options,
     });
 
+    // With pip and venv (default), it's useful to install our package into the shared venv to make
+    // it easier for other packages in the monorepo to take dependencies on this package.
+    if ((options.venv ?? true) && (options.pip ?? true)) {
+      this.depsManager.installTask.exec("pip install --editable .");
+    }
+
+    // Package into a directory that can be used as a lambda layer. This is done as part of install since the end user
+    // must control build order in the monorepo via explicit dependencies, and adding here means we can run as part of
+    // initial project synthesis which ensures this is created regardless of whether the user has remembered to
+    // configure build order.
+    if (options.generateLayer) {
+      const relativeLayerDir = path.join(".", this.layerDistDir, "python");
+      this.depsManager.installTask.exec(`rm -rf ${relativeLayerDir}`);
+      this.depsManager.installTask.exec(
+        `pip install . --target ${relativeLayerDir}`
+      );
+    }
+
+    // The NX monorepo will rewrite install tasks to install-py to ensure installs can be run sequentially in dependency
+    // order. This runs as part of monorepo synthesis which is too late for this project since we synthesize early to
+    // ensure the generated client code is available for the install phase of the api project itself. Thus, we rewrite
+    // the install tasks ourselves instead.
+    if (this.parent && "addImplicitDependency" in this.parent) {
+      const installPyTask = this.addTask("install-py");
+      this.depsManager.installTask.steps.forEach((step) =>
+        this.copyStepIntoTask(step, installPyTask)
+      );
+      this.depsManager.installTask.reset();
+    }
+
     // Use a package.json to ensure the client is discoverable by nx
     new JsonFile(this, "package.json", {
       obj: {
@@ -76,24 +106,6 @@ export class GeneratedPythonClientProject extends PythonProject {
       specPath: options.specPath,
       invokeGenerator: options.generateClient,
     });
-
-    // With pip and venv (default), it's useful to install our package into the shared venv to make
-    // it easier for other packages in the monorepo to take dependencies on this package.
-    if ((options.venv ?? true) && (options.pip ?? true)) {
-      this.depsManager.installTask.exec("pip install --editable .");
-    }
-
-    // Package into a directory that can be used as a lambda layer. This is done as part of install since the end user
-    // must control build order in the monorepo via explicit dependencies, and adding here means we can run as part of
-    // initial project synthesis which ensures this is created regardless of whether the user has remembered to
-    // configure build order.
-    if (options.generateLayer) {
-      const relativeLayerDir = path.join(".", this.layerDistDir, "python");
-      this.depsManager.installTask.exec(`rm -rf ${relativeLayerDir}`);
-      this.depsManager.installTask.exec(
-        `pip install . --target ${relativeLayerDir}`
-      );
-    }
   }
 
   /**
@@ -108,5 +120,24 @@ export class GeneratedPythonClientProject extends PythonProject {
     }
     super.synth();
     this.synthed = true;
+  }
+
+  /**
+   * Copies the given step into the given task within this project
+   * @private
+   */
+  private copyStepIntoTask(step: TaskStep, task: Task) {
+    if (step.exec) {
+      task.exec(step.exec, { name: step.name, cwd: step.cwd });
+    } else if (step.say) {
+      task.say(step.say, { name: step.name, cwd: step.cwd });
+    } else if (step.spawn) {
+      const stepToSpawn = this.tasks.tryFind(step.spawn);
+      if (stepToSpawn) {
+        task.spawn(stepToSpawn, { name: step.name, cwd: step.cwd });
+      }
+    } else if (step.builtin) {
+      task.builtin(step.builtin);
+    }
   }
 }

--- a/packages/open-api-gateway/test/project/open-api-gateway-java-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-java-project/__snapshots__/monorepo.test.ts.snap
@@ -499,6 +499,14 @@ target
           },
         ],
       },
+      "install": Object {
+        "name": "install",
+        "steps": Array [
+          Object {
+            "exec": "npx nx run-many --target install-py --projects myapi-python --parallel=1",
+          },
+        ],
+      },
       "package": Object {
         "description": "Creates the distribution package",
         "name": "package",
@@ -844,6 +852,12 @@ target
           "target": "build",
         },
       ],
+      "install-py": Array [
+        Object {
+          "projects": "dependencies",
+          "target": "install-py",
+        },
+      ],
     },
     "tasksRunnerOptions": Object {
       "default": Object {
@@ -900,6 +914,7 @@ target
       "default": "npx projen default",
       "eject": "npx projen eject",
       "eslint": "npx projen eslint",
+      "install": "npx projen install",
       "package": "npx projen package",
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
@@ -8008,6 +8023,9 @@ tox.ini
       "install": Object {
         "description": "Install and upgrade dependencies",
         "name": "install",
+      },
+      "install-py": Object {
+        "name": "install-py",
         "steps": Array [
           Object {
             "exec": "pip install --upgrade pip",
@@ -14022,6 +14040,7 @@ def log_cache_usage(cache_fn):
       "default": "npx projen default",
       "eject": "npx projen eject",
       "install": "npx projen install",
+      "install-py": "npx projen install-py",
       "package": "npx projen package",
       "post-compile": "npx projen post-compile",
       "pre-compile": "npx projen pre-compile",

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
@@ -501,6 +501,14 @@ target
           },
         ],
       },
+      "install": Object {
+        "name": "install",
+        "steps": Array [
+          Object {
+            "exec": "npx nx run-many --target install-py --projects my_api,my-api-python --parallel=1",
+          },
+        ],
+      },
       "package": Object {
         "description": "Creates the distribution package",
         "name": "package",
@@ -846,6 +854,12 @@ target
           "target": "build",
         },
       ],
+      "install-py": Array [
+        Object {
+          "projects": "dependencies",
+          "target": "install-py",
+        },
+      ],
     },
     "tasksRunnerOptions": Object {
       "default": Object {
@@ -902,6 +916,7 @@ target
       "default": "npx projen default",
       "eject": "npx projen eject",
       "eslint": "npx projen eslint",
+      "install": "npx projen install",
       "package": "npx projen package",
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
@@ -1154,6 +1169,9 @@ cython_debug/
       "install": Object {
         "description": "Install and upgrade dependencies",
         "name": "install",
+      },
+      "install-py": Object {
+        "name": "install-py",
         "steps": Array [
           Object {
             "exec": "pip install --upgrade pip",
@@ -7973,6 +7991,9 @@ tox.ini
       "install": Object {
         "description": "Install and upgrade dependencies",
         "name": "install",
+      },
+      "install-py": Object {
+        "name": "install-py",
         "steps": Array [
           Object {
             "exec": "pip install --upgrade pip",
@@ -13993,6 +14014,7 @@ def log_cache_usage(cache_fn):
       "default": "npx projen default",
       "eject": "npx projen eject",
       "install": "npx projen install",
+      "install-py": "npx projen install-py",
       "package": "npx projen package",
       "post-compile": "npx projen post-compile",
       "pre-compile": "npx projen pre-compile",
@@ -15945,6 +15967,7 @@ def get_generated_client_layer_directory():
       "default": "npx projen default",
       "eject": "npx projen eject",
       "install": "npx projen install",
+      "install-py": "npx projen install-py",
       "package": "npx projen package",
       "post-compile": "npx projen post-compile",
       "pre-compile": "npx projen pre-compile",

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
@@ -499,6 +499,14 @@ target
           },
         ],
       },
+      "install": Object {
+        "name": "install",
+        "steps": Array [
+          Object {
+            "exec": "npx nx run-many --target install-py --projects test-my-api-python --parallel=1",
+          },
+        ],
+      },
       "package": Object {
         "description": "Creates the distribution package",
         "name": "package",
@@ -840,6 +848,12 @@ target
           "target": "build",
         },
       ],
+      "install-py": Array [
+        Object {
+          "projects": "dependencies",
+          "target": "install-py",
+        },
+      ],
     },
     "tasksRunnerOptions": Object {
       "default": Object {
@@ -896,6 +910,7 @@ target
       "default": "npx projen default",
       "eject": "npx projen eject",
       "eslint": "npx projen eslint",
+      "install": "npx projen install",
       "package": "npx projen package",
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
@@ -8487,6 +8502,9 @@ tox.ini
       "install": Object {
         "description": "Install and upgrade dependencies",
         "name": "install",
+      },
+      "install-py": Object {
+        "name": "install-py",
         "steps": Array [
           Object {
             "exec": "pip install --upgrade pip",
@@ -8937,6 +8955,7 @@ git push origin master 2>&1 | grep -v 'To https'
       "default": "npx projen default",
       "eject": "npx projen eject",
       "install": "npx projen install",
+      "install-py": "npx projen install-py",
       "package": "npx projen package",
       "post-compile": "npx projen post-compile",
       "pre-compile": "npx projen pre-compile",
@@ -17216,6 +17235,14 @@ target
           },
         ],
       },
+      "install": Object {
+        "name": "install",
+        "steps": Array [
+          Object {
+            "exec": "npx nx run-many --target install-py --projects test-my-api-python --parallel=1",
+          },
+        ],
+      },
       "package": Object {
         "description": "Creates the distribution package",
         "name": "package",
@@ -17557,6 +17584,12 @@ target
           "target": "build",
         },
       ],
+      "install-py": Array [
+        Object {
+          "projects": "dependencies",
+          "target": "install-py",
+        },
+      ],
     },
     "tasksRunnerOptions": Object {
       "default": Object {
@@ -17615,6 +17648,7 @@ target
       "default": "npx projen default",
       "eject": "npx projen eject",
       "eslint": "npx projen eslint",
+      "install": "npx projen install",
       "package": "npx projen package",
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
@@ -25200,6 +25234,9 @@ tox.ini
       "install": Object {
         "description": "Install and upgrade dependencies",
         "name": "install",
+      },
+      "install-py": Object {
+        "name": "install-py",
         "steps": Array [
           Object {
             "exec": "pip install --upgrade pip",
@@ -25650,6 +25687,7 @@ git push origin master 2>&1 | grep -v 'To https'
       "default": "npx projen default",
       "eject": "npx projen eject",
       "install": "npx projen install",
+      "install-py": "npx projen install-py",
       "package": "npx projen package",
       "post-compile": "npx projen post-compile",
       "pre-compile": "npx projen pre-compile",
@@ -33943,6 +33981,14 @@ target
           },
         ],
       },
+      "install": Object {
+        "name": "install",
+        "steps": Array [
+          Object {
+            "exec": "npx nx run-many --target install-py --projects test-my-api-python --parallel=1",
+          },
+        ],
+      },
       "package": Object {
         "description": "Creates the distribution package",
         "name": "package",
@@ -34284,6 +34330,12 @@ target
           "target": "build",
         },
       ],
+      "install-py": Array [
+        Object {
+          "projects": "dependencies",
+          "target": "install-py",
+        },
+      ],
     },
     "tasksRunnerOptions": Object {
       "default": Object {
@@ -34340,6 +34392,7 @@ target
       "default": "npx projen default",
       "eject": "npx projen eject",
       "eslint": "npx projen eslint",
+      "install": "npx projen install",
       "package": "npx projen package",
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
@@ -41931,6 +41984,9 @@ tox.ini
       "install": Object {
         "description": "Install and upgrade dependencies",
         "name": "install",
+      },
+      "install-py": Object {
+        "name": "install-py",
         "steps": Array [
           Object {
             "exec": "pip install --upgrade pip",
@@ -42381,6 +42437,7 @@ git push origin master 2>&1 | grep -v 'To https'
       "default": "npx projen default",
       "eject": "npx projen eject",
       "install": "npx projen install",
+      "install-py": "npx projen install-py",
       "package": "npx projen package",
       "post-compile": "npx projen post-compile",
       "pre-compile": "npx projen pre-compile",

--- a/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
@@ -500,6 +500,14 @@ target
           },
         ],
       },
+      "install": Object {
+        "name": "install",
+        "steps": Array [
+          Object {
+            "exec": "npx nx run-many --target install-py --projects test-my-api-python --parallel=1",
+          },
+        ],
+      },
       "package": Object {
         "description": "Creates the distribution package",
         "name": "package",
@@ -841,6 +849,12 @@ target
           "target": "build",
         },
       ],
+      "install-py": Array [
+        Object {
+          "projects": "dependencies",
+          "target": "install-py",
+        },
+      ],
     },
     "tasksRunnerOptions": Object {
       "default": Object {
@@ -897,6 +911,7 @@ target
       "default": "npx projen default",
       "eject": "npx projen eject",
       "eslint": "npx projen eslint",
+      "install": "npx projen install",
       "package": "npx projen package",
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
@@ -8490,6 +8505,9 @@ tox.ini
       "install": Object {
         "description": "Install and upgrade dependencies",
         "name": "install",
+      },
+      "install-py": Object {
+        "name": "install-py",
         "steps": Array [
           Object {
             "exec": "pip install --upgrade pip",
@@ -8940,6 +8958,7 @@ git push origin master 2>&1 | grep -v 'To https'
       "default": "npx projen default",
       "eject": "npx projen eject",
       "install": "npx projen install",
+      "install-py": "npx projen install-py",
       "package": "npx projen package",
       "post-compile": "npx projen post-compile",
       "pre-compile": "npx projen pre-compile",
@@ -19703,6 +19722,14 @@ target
           },
         ],
       },
+      "install": Object {
+        "name": "install",
+        "steps": Array [
+          Object {
+            "exec": "npx nx run-many --target install-py --projects test-my-api-python --parallel=1",
+          },
+        ],
+      },
       "package": Object {
         "description": "Creates the distribution package",
         "name": "package",
@@ -20044,6 +20071,12 @@ target
           "target": "build",
         },
       ],
+      "install-py": Array [
+        Object {
+          "projects": "dependencies",
+          "target": "install-py",
+        },
+      ],
     },
     "tasksRunnerOptions": Object {
       "default": Object {
@@ -20102,6 +20135,7 @@ target
       "default": "npx projen default",
       "eject": "npx projen eject",
       "eslint": "npx projen eslint",
+      "install": "npx projen install",
       "package": "npx projen package",
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
@@ -27689,6 +27723,9 @@ tox.ini
       "install": Object {
         "description": "Install and upgrade dependencies",
         "name": "install",
+      },
+      "install-py": Object {
+        "name": "install-py",
         "steps": Array [
           Object {
             "exec": "pip install --upgrade pip",
@@ -28139,6 +28176,7 @@ git push origin master 2>&1 | grep -v 'To https'
       "default": "npx projen default",
       "eject": "npx projen eject",
       "install": "npx projen install",
+      "install-py": "npx projen install-py",
       "package": "npx projen package",
       "post-compile": "npx projen post-compile",
       "pre-compile": "npx projen pre-compile",
@@ -38916,6 +38954,14 @@ target
           },
         ],
       },
+      "install": Object {
+        "name": "install",
+        "steps": Array [
+          Object {
+            "exec": "npx nx run-many --target install-py --projects test-my-api-python --parallel=1",
+          },
+        ],
+      },
       "package": Object {
         "description": "Creates the distribution package",
         "name": "package",
@@ -39257,6 +39303,12 @@ target
           "target": "build",
         },
       ],
+      "install-py": Array [
+        Object {
+          "projects": "dependencies",
+          "target": "install-py",
+        },
+      ],
     },
     "tasksRunnerOptions": Object {
       "default": Object {
@@ -39313,6 +39365,7 @@ target
       "default": "npx projen default",
       "eject": "npx projen eject",
       "eslint": "npx projen eslint",
+      "install": "npx projen install",
       "package": "npx projen package",
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
@@ -46906,6 +46959,9 @@ tox.ini
       "install": Object {
         "description": "Install and upgrade dependencies",
         "name": "install",
+      },
+      "install-py": Object {
+        "name": "install-py",
         "steps": Array [
           Object {
             "exec": "pip install --upgrade pip",
@@ -47356,6 +47412,7 @@ git push origin master 2>&1 | grep -v 'To https'
       "default": "npx projen default",
       "eject": "npx projen eject",
       "install": "npx projen install",
+      "install-py": "npx projen install-py",
       "package": "npx projen package",
       "post-compile": "npx projen post-compile",
       "pre-compile": "npx projen pre-compile",

--- a/packages/pipeline/samples/python/.projen/tasks.json
+++ b/packages/pipeline/samples/python/.projen/tasks.json
@@ -77,6 +77,9 @@
       "name": "install",
       "description": "Install and upgrade dependencies"
     },
+    "install-py": {
+      "name": "install-py"
+    },
     "package": {
       "name": "package",
       "description": "Creates the distribution package"

--- a/packages/pipeline/samples/python/package.json
+++ b/packages/pipeline/samples/python/package.json
@@ -23,6 +23,7 @@
   "private": true,
   "__pdk__": true,
   "scripts": {
+    "install-py": "npx projen install-py",
     "install": "npx projen install",
     "clobber": "npx projen clobber",
     "build": "npx projen build",


### PR DESCRIPTION
The monorepo package manager install command (eg `yarn install`) was running all `install` tasks in parallel. This caused filesystem contention when multiple python projects in the monorepo shared the same virtual env.

We address this by moving all python subproject install task steps to an `install-py` task, which we then execute sequentially and in dependency order as part of the monorepo's `install` task. This ensures no contention, and that projects will always have their local dependencies installed into the environment before their own install task is run.

Fixes #171