### PR TITLE
fix: Enable aws api gateway test console to invoke lambdas

### DIFF
--- a/packages/open-api-gateway/src/construct/integrations/integrations.ts
+++ b/packages/open-api-gateway/src/construct/integrations/integrations.ts
@@ -271,11 +271,12 @@ export class LambdaIntegration extends Integration {
       sourceArn: Stack.of(scope).formatArn({
         service: "execute-api",
         resource: api.restApiId,
-        // Scope permissions to the stage, method and path of the operation.
+        // Scope permissions to any stage and a specific method and path of the operation.
         // Path parameters (eg {param} are replaced with wildcards)
-        resourceName: `${
-          api.deploymentStage.stageName
-        }/${method.toUpperCase()}${path.replace(/{[^\}]*\}/g, "*")}`,
+        resourceName: `*/${method.toUpperCase()}${path.replace(
+          /{[^\}]*\}/g,
+          "*"
+        )}`,
       }),
     });
   }

--- a/packages/open-api-gateway/test/construct/__snapshots__/open-api-gateway-rest-api.test.ts.snap
+++ b/packages/open-api-gateway/test/construct/__snapshots__/open-api-gateway-rest-api.test.ts.snap
@@ -414,11 +414,7 @@ Object {
               Object {
                 "Ref": "ApiTestEE73F324",
               },
-              "/",
-              Object {
-                "Ref": "ApiTestDeploymentStageprod660267A6",
-              },
-              "/GET/test",
+              "/*/GET/test",
             ],
           ],
         },
@@ -1410,11 +1406,7 @@ Object {
               Object {
                 "Ref": "ApiTestEE73F324",
               },
-              "/",
-              Object {
-                "Ref": "ApiTestDeploymentStageprod660267A6",
-              },
-              "/GET/test",
+              "/*/GET/test",
             ],
           ],
         },
@@ -2423,11 +2415,7 @@ Object {
               Object {
                 "Ref": "ApiTestEE73F324",
               },
-              "/",
-              Object {
-                "Ref": "ApiTestDeploymentStageprod660267A6",
-              },
-              "/GET/test",
+              "/*/GET/test",
             ],
           ],
         },
@@ -3524,11 +3512,7 @@ Object {
               Object {
                 "Ref": "ApiTestEE73F324",
               },
-              "/",
-              Object {
-                "Ref": "ApiTestDeploymentStageprod660267A6",
-              },
-              "/GET/test",
+              "/*/GET/test",
             ],
           ],
         },
@@ -4623,11 +4607,7 @@ Object {
               Object {
                 "Ref": "ApiTestEE73F324",
               },
-              "/",
-              Object {
-                "Ref": "ApiTestDeploymentStageprod660267A6",
-              },
-              "/GET/test",
+              "/*/GET/test",
             ],
           ],
         },
@@ -5616,11 +5596,7 @@ Object {
               Object {
                 "Ref": "ApiTestEE73F324",
               },
-              "/",
-              Object {
-                "Ref": "ApiTestDeploymentStageprod660267A6",
-              },
-              "/GET/test",
+              "/*/GET/test",
             ],
           ],
         },
@@ -6642,11 +6618,7 @@ Object {
               Object {
                 "Ref": "ApiTestEE73F324",
               },
-              "/",
-              Object {
-                "Ref": "ApiTestDeploymentStageprod660267A6",
-              },
-              "/DELETE/test",
+              "/*/DELETE/test",
             ],
           ],
         },
@@ -6702,11 +6674,7 @@ Object {
               Object {
                 "Ref": "ApiTestEE73F324",
               },
-              "/",
-              Object {
-                "Ref": "ApiTestDeploymentStageprod660267A6",
-              },
-              "/GET/test",
+              "/*/GET/test",
             ],
           ],
         },
@@ -6818,11 +6786,7 @@ Object {
               Object {
                 "Ref": "ApiTestEE73F324",
               },
-              "/",
-              Object {
-                "Ref": "ApiTestDeploymentStageprod660267A6",
-              },
-              "/POST/test",
+              "/*/POST/test",
             ],
           ],
         },
@@ -6878,11 +6842,7 @@ Object {
               Object {
                 "Ref": "ApiTestEE73F324",
               },
-              "/",
-              Object {
-                "Ref": "ApiTestDeploymentStageprod660267A6",
-              },
-              "/PUT/test",
+              "/*/PUT/test",
             ],
           ],
         },
@@ -8130,11 +8090,7 @@ Object {
               Object {
                 "Ref": "ApiTestEE73F324",
               },
-              "/",
-              Object {
-                "Ref": "ApiTestDeploymentStageprod660267A6",
-              },
-              "/GET/test/*/fixed/*/*",
+              "/*/GET/test/*/fixed/*/*",
             ],
           ],
         },
@@ -9179,11 +9135,7 @@ Object {
               Object {
                 "Ref": "ApiTestEE73F324",
               },
-              "/",
-              Object {
-                "Ref": "ApiTestDeploymentStageprod660267A6",
-              },
-              "/GET/test",
+              "/*/GET/test",
             ],
           ],
         },
@@ -10065,11 +10017,7 @@ Object {
               Object {
                 "Ref": "ApiTestEE73F324",
               },
-              "/",
-              Object {
-                "Ref": "ApiTestDeploymentStageprod660267A6",
-              },
-              "/GET/test",
+              "/*/GET/test",
             ],
           ],
         },


### PR DESCRIPTION
Fixes #178

I propose using a "*" as stage name, I do not see any immediate security threats and I believe the general intent of lambda integrations is for them to be enabled for every stage available on the api gateway.
This follows the pattern of the resource policy which is auto-generated from the aws console when adding a new lambda integration to a method