### PR TITLE
fix(open-api-gateway): throw error for unsupported http methods instead of silently omitting

### DIFF
--- a/packages/open-api-gateway/src/construct/prepare-spec-event-handler/prepare-spec.ts
+++ b/packages/open-api-gateway/src/construct/prepare-spec-event-handler/prepare-spec.ts
@@ -259,6 +259,20 @@ const preparePathSpec = (
   options: PrepareApiSpecOptions,
   getOperationName: (methodAndPath: MethodAndPath) => string
 ): OpenAPIV3.PathItemObject => {
+  const supportedHttpMethods = new Set<string>(Object.values(HttpMethods));
+  const unsupportedMethodsInSpec = Object.keys(pathItem).filter(
+    (method) => !supportedHttpMethods.has(method)
+  );
+  if (unsupportedMethodsInSpec.length > 0) {
+    throw new Error(
+      `Path ${path} contains unsupported method${
+        unsupportedMethodsInSpec.length > 1 ? "s" : ""
+      } ${unsupportedMethodsInSpec.join(
+        ", "
+      )}. Supported methods are ${Object.values(HttpMethods).join(", ")}.`
+    );
+  }
+
   return {
     ...pathItem,
     ...Object.fromEntries(

--- a/packages/open-api-gateway/test/construct/__snapshots__/open-api-gateway-rest-api.test.ts.snap
+++ b/packages/open-api-gateway/test/construct/__snapshots__/open-api-gateway-rest-api.test.ts.snap
@@ -449,7 +449,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4442dcdc262d32a369242bea6269c04a00b79d1a3d24a56a52041bdb87d5dbdf.zip",
+          "S3Key": "7e0b646807e5ff55e634d8c598d0622db410e8a408794f469d70fe488dfd2381.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -1441,7 +1441,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4442dcdc262d32a369242bea6269c04a00b79d1a3d24a56a52041bdb87d5dbdf.zip",
+          "S3Key": "7e0b646807e5ff55e634d8c598d0622db410e8a408794f469d70fe488dfd2381.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -2450,7 +2450,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4442dcdc262d32a369242bea6269c04a00b79d1a3d24a56a52041bdb87d5dbdf.zip",
+          "S3Key": "7e0b646807e5ff55e634d8c598d0622db410e8a408794f469d70fe488dfd2381.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -3547,7 +3547,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4442dcdc262d32a369242bea6269c04a00b79d1a3d24a56a52041bdb87d5dbdf.zip",
+          "S3Key": "7e0b646807e5ff55e634d8c598d0622db410e8a408794f469d70fe488dfd2381.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -4642,7 +4642,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4442dcdc262d32a369242bea6269c04a00b79d1a3d24a56a52041bdb87d5dbdf.zip",
+          "S3Key": "7e0b646807e5ff55e634d8c598d0622db410e8a408794f469d70fe488dfd2381.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -5631,7 +5631,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4442dcdc262d32a369242bea6269c04a00b79d1a3d24a56a52041bdb87d5dbdf.zip",
+          "S3Key": "7e0b646807e5ff55e634d8c598d0622db410e8a408794f469d70fe488dfd2381.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -6877,7 +6877,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4442dcdc262d32a369242bea6269c04a00b79d1a3d24a56a52041bdb87d5dbdf.zip",
+          "S3Key": "7e0b646807e5ff55e634d8c598d0622db410e8a408794f469d70fe488dfd2381.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -7920,7 +7920,7 @@ Object {
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC47809cb301ccd50fb06bba4ef9cf72fbc73": Object {
+    "ApiTestDeployment153EC4789decd4fa5b57ab1113fd042548bfc841": Object {
       "DependsOn": Array [
         "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
@@ -7985,7 +7985,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment153EC47809cb301ccd50fb06bba4ef9cf72fbc73",
+          "Ref": "ApiTestDeployment153EC4789decd4fa5b57ab1113fd042548bfc841",
         },
         "MethodSettings": Array [
           Object {
@@ -8125,7 +8125,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4442dcdc262d32a369242bea6269c04a00b79d1a3d24a56a52041bdb87d5dbdf.zip",
+          "S3Key": "7e0b646807e5ff55e634d8c598d0622db410e8a408794f469d70fe488dfd2381.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -8172,7 +8172,7 @@ Object {
           "bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "key": "4bba3b8237606e019d0a6035ce147c1b5926d088e6810bbd3b0c25005d0f6edd.json",
+          "key": "6060611f34e7c9e9000a19922d48dfd8d47d66cbf3715fb30e173c4b51d9061b.json",
         },
         "integrations": Object {
           "testOperation": Object {
@@ -8216,7 +8216,7 @@ Object {
           "bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "key": "4bba3b8237606e019d0a6035ce147c1b5926d088e6810bbd3b0c25005d0f6edd.json-prepared",
+          "key": "6060611f34e7c9e9000a19922d48dfd8d47d66cbf3715fb30e173c4b51d9061b.json-prepared",
         },
         "securitySchemes": Object {},
       },
@@ -8550,7 +8550,7 @@ Object {
                         Object {
                           "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
                         },
-                        "/4bba3b8237606e019d0a6035ce147c1b5926d088e6810bbd3b0c25005d0f6edd.json",
+                        "/6060611f34e7c9e9000a19922d48dfd8d47d66cbf3715fb30e173c4b51d9061b.json",
                       ],
                     ],
                   },
@@ -8570,7 +8570,7 @@ Object {
                         Object {
                           "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
                         },
-                        "/4bba3b8237606e019d0a6035ce147c1b5926d088e6810bbd3b0c25005d0f6edd.json-prepared/*",
+                        "/6060611f34e7c9e9000a19922d48dfd8d47d66cbf3715fb30e173c4b51d9061b.json-prepared/*",
                       ],
                     ],
                   },
@@ -9170,7 +9170,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4442dcdc262d32a369242bea6269c04a00b79d1a3d24a56a52041bdb87d5dbdf.zip",
+          "S3Key": "7e0b646807e5ff55e634d8c598d0622db410e8a408794f469d70fe488dfd2381.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -10052,7 +10052,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "4442dcdc262d32a369242bea6269c04a00b79d1a3d24a56a52041bdb87d5dbdf.zip",
+          "S3Key": "7e0b646807e5ff55e634d8c598d0622db410e8a408794f469d70fe488dfd2381.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",


### PR DESCRIPTION
Unsupported http methods were silently dropped from the spec before deploying to api gateway. Throw an error if any unsupported methods are detected instead.

Fixes #179
