### PR TITLE
feat(open-api-gateway): make service name a required property for smithy projects

### DIFF
--- a/packages/open-api-gateway/src/project/smithy-api-gateway-java-project.ts
+++ b/packages/open-api-gateway/src/project/smithy-api-gateway-java-project.ts
@@ -49,7 +49,8 @@ export class SmithyApiGatewayJavaProject extends OpenApiGatewayJavaProject {
   ): OpenApiGatewayJavaProjectOptions {
     const { modelDir, generatedSpecFilePath } = setupSmithyBuild(
       this,
-      options as SmithyApiGatewayProjectOptions
+      // Options are the same as those in the constructor, so it is safe to cast to SmithyApiGatewayProjectOptions
+      options as unknown as SmithyApiGatewayProjectOptions
     );
 
     // @ts-ignore this method is called by the constructor

--- a/packages/open-api-gateway/src/project/smithy-api-gateway-python-project.ts
+++ b/packages/open-api-gateway/src/project/smithy-api-gateway-python-project.ts
@@ -49,7 +49,8 @@ export class SmithyApiGatewayPythonProject extends OpenApiGatewayPythonProject {
   ): OpenApiGatewayPythonProjectOptions {
     const { modelDir, generatedSpecFilePath } = setupSmithyBuild(
       this,
-      options as SmithyApiGatewayProjectOptions
+      // Options are the same as those in the constructor, so it is safe to cast to SmithyApiGatewayProjectOptions
+      options as unknown as SmithyApiGatewayProjectOptions
     );
 
     // @ts-ignore this method is called by the constructor

--- a/packages/open-api-gateway/src/project/smithy-api-gateway-ts-project.ts
+++ b/packages/open-api-gateway/src/project/smithy-api-gateway-ts-project.ts
@@ -49,7 +49,8 @@ export class SmithyApiGatewayTsProject extends OpenApiGatewayTsProject {
   ): OpenApiGatewayTsProjectOptions {
     const { modelDir, generatedSpecFilePath } = setupSmithyBuild(
       this,
-      options as SmithyApiGatewayProjectOptions
+      // Options are the same as those in the constructor, so it is safe to cast to SmithyApiGatewayProjectOptions
+      options as unknown as SmithyApiGatewayProjectOptions
     );
 
     // @ts-ignore this method is called by the constructor

--- a/packages/open-api-gateway/src/project/smithy/setup-smithy-build.ts
+++ b/packages/open-api-gateway/src/project/smithy/setup-smithy-build.ts
@@ -41,10 +41,8 @@ export const setupSmithyBuild = (
   options: SmithyApiGatewayProjectOptions
 ): SmithyBuildProjectResult => {
   const modelDir = options.modelDir ?? "model";
-  const fullyQualifiedServiceName =
-    options.serviceName ?? "example.hello#Hello";
-
-  const [serviceNamespace, serviceName] = fullyQualifiedServiceName.split("#");
+  const { namespace: serviceNamespace, serviceName } = options.serviceName;
+  const fullyQualifiedServiceName = `${serviceNamespace}#${serviceName}`;
 
   const smithyBuildDir = "smithy-build";
 

--- a/packages/open-api-gateway/src/project/types.ts
+++ b/packages/open-api-gateway/src/project/types.ts
@@ -31,15 +31,36 @@ export interface OpenApiGatewayProjectOptions extends CommonApiProjectOptions {
 }
 
 /**
+ * Represents a fully qualified name of a Smithy service.
+ * @see https://awslabs.github.io/smithy/2.0/spec/service-types.html
+ */
+export interface SmithyServiceName {
+  /**
+   * The service namespace. Nested namespaces are separated by '.', for example com.company
+   * @see https://awslabs.github.io/smithy/2.0/spec/model.html#shape-id
+   */
+  readonly namespace: string;
+  /**
+   * The service name. Should be PascalCase, for example HelloService
+   * @see https://awslabs.github.io/smithy/2.0/spec/model.html#shape-id
+   */
+  readonly serviceName: string;
+}
+
+/**
  * Options common to all smithy api gateway projects
  */
 export interface SmithyApiGatewayProjectOptions
   extends CommonApiProjectOptions {
   /**
-   * The fully qualified name of the service. Change this if you change the service or namespace in your model.
+   * The name of the Smithy service from your model which will be targeted for deployment and client generation.
+   * On initial project synthesis this service name will be written to the sample "hello world" model. If you change
+   * this value after initial synthesis you will need to manually update your Smithy models to match, unless you delete
+   * the "model" directory. Likewise, if you change the namespace or service name in your Smithy models you will need to
+   * update this value to ensure your service can be found.
    * @default "example.hello#Hello"
    */
-  readonly serviceName?: string;
+  readonly serviceName: SmithyServiceName;
   /**
    * The path to the Smithy model directory, relative to the project source directory (srcdir).
    * @default "model"

--- a/packages/open-api-gateway/test/project/smithy-api-gateway-java-project/standalone.test.ts
+++ b/packages/open-api-gateway/test/project/smithy-api-gateway-java-project/standalone.test.ts
@@ -24,6 +24,7 @@ describe("Smithy Api Gateway Java Standalone Unit Tests", () => {
       version: "1.0.0",
       name: "test",
       clientLanguages: [],
+      serviceName: { namespace: "example.hello", serviceName: "Hello" },
     });
     expect(synthSmithyCodeProject(project)).toMatchSnapshot();
   });

--- a/packages/open-api-gateway/test/project/smithy-api-gateway-python-project/standalone.test.ts
+++ b/packages/open-api-gateway/test/project/smithy-api-gateway-python-project/standalone.test.ts
@@ -25,6 +25,7 @@ describe("Smithy Api Gateway Python Standalone Unit Tests", () => {
       version: "1.0.0",
       name: "test",
       clientLanguages: [],
+      serviceName: { namespace: "example.hello", serviceName: "Hello" },
     });
     expect(synthSmithyCodeProject(project)).toMatchSnapshot();
   });

--- a/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/monorepo.test.ts
+++ b/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/monorepo.test.ts
@@ -44,6 +44,7 @@ describe("Smithy Api Gateway Ts Monorepo Unit Tests", () => {
       ],
       outdir: "packages/api",
       packageManager,
+      serviceName: { namespace: "example.hello", serviceName: "Hello" },
     });
     expect(synthSmithyCodeProject(monorepo)).toMatchSnapshot();
   });

--- a/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/standalone.test.ts
+++ b/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/standalone.test.ts
@@ -32,6 +32,7 @@ describe("Smithy Api Gateway Ts Standalone Unit Tests", () => {
         ClientLanguage.JAVA,
       ],
       packageManager,
+      serviceName: { namespace: "example.hello", serviceName: "Hello" },
     });
     expect(synthSmithyCodeProject(project)).toMatchSnapshot();
   });

--- a/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/with-smithy-build-options.test.ts
+++ b/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/with-smithy-build-options.test.ts
@@ -31,7 +31,7 @@ describe("Smithy Api Gateway Ts Build Options Test", () => {
       clientLanguages: [],
       outdir: "packages/api",
       modelDir: "service",
-      serviceName: "my.test.service#TestService",
+      serviceName: { namespace: "my.test.service", serviceName: "TestService" },
       smithyBuildOptions: {
         projections: {
           openapi: {


### PR DESCRIPTION
Since in practice users are unlikely to want to name their service `example.hello#Hello`, we make `serviceName` a required field. This ensures that users define their own service name upfront, and the hello-world sample model will be generated with that name. Additionally, this change makes the documentation around changes to the `serviceName` clearer.

BREAKING CHANGE: `serviceName` is now a required property for Smithy projects. Additionally its components have been split into an object, for example `example.hello#HelloService` becomes `{ namespace: 'example.hello', serviceName: 'HelloService' }`

Fixes #176