### PR TITLE
fix(open-api-gateway): fix python interceptor removal on successive lambda calls

### DIFF
--- a/packages/open-api-gateway/scripts/generators/python/templates/operationConfig.mustache
+++ b/packages/open-api-gateway/scripts/generators/python/templates/operationConfig.mustache
@@ -103,7 +103,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                 return handler(request)
         return BaseHandlerChain()
     else:
-        interceptor = _interceptors.pop(0)
+        interceptor = _interceptors[0]
 
         class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
             def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -114,7 +114,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                     event = request.event,
                     context = request.context,
                     interceptor_context = request.interceptor_context,
-                    chain = _build_handler_chain(_interceptors, handler),
+                    chain = _build_handler_chain(_interceptors[1:len(_interceptors)], handler),
                 ))
         return RemainingHandlerChain()
 

--- a/packages/open-api-gateway/src/project/samples/python.ts
+++ b/packages/open-api-gateway/src/project/samples/python.ts
@@ -112,7 +112,7 @@ class SampleApi(Construct):
 `,
         // Generate an example lambda handler
         "handlers/say_hello_handler_sample.py": `from ${options.pythonClientPackageName}.apis.tags.default_api_operation_config import say_hello_handler, SayHelloRequest, ApiResponse, SayHelloOperationResponses
-from ${options.pythonClientPackageName}.model.hello_response import SayHelloResponseContent
+from ${options.pythonClientPackageName}.model.say_hello_response_content import SayHelloResponseContent
 
 @say_hello_handler
 def handler(input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:

--- a/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-python-client-source-code.test.ts.snap
+++ b/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-python-client-source-code.test.ts.snap
@@ -2512,7 +2512,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                 return handler(request)
         return BaseHandlerChain()
     else:
-        interceptor = _interceptors.pop(0)
+        interceptor = _interceptors[0]
 
         class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
             def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -2523,7 +2523,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                     event = request.event,
                     context = request.context,
                     interceptor_context = request.interceptor_context,
-                    chain = _build_handler_chain(_interceptors, handler),
+                    chain = _build_handler_chain(_interceptors[1:len(_interceptors)], handler),
                 ))
         return RemainingHandlerChain()
 
@@ -9844,7 +9844,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                 return handler(request)
         return BaseHandlerChain()
     else:
-        interceptor = _interceptors.pop(0)
+        interceptor = _interceptors[0]
 
         class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
             def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -9855,7 +9855,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                     event = request.event,
                     context = request.context,
                     interceptor_context = request.interceptor_context,
-                    chain = _build_handler_chain(_interceptors, handler),
+                    chain = _build_handler_chain(_interceptors[1:len(_interceptors)], handler),
                 ))
         return RemainingHandlerChain()
 

--- a/packages/open-api-gateway/test/project/open-api-gateway-java-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-java-project/__snapshots__/monorepo.test.ts.snap
@@ -10158,7 +10158,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                 return handler(request)
         return BaseHandlerChain()
     else:
-        interceptor = _interceptors.pop(0)
+        interceptor = _interceptors[0]
 
         class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
             def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -10169,7 +10169,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                     event = request.event,
                     context = request.context,
                     interceptor_context = request.interceptor_context,
-                    chain = _build_handler_chain(_interceptors, handler),
+                    chain = _build_handler_chain(_interceptors[1:len(_interceptors)], handler),
                 ))
         return RemainingHandlerChain()
 

--- a/packages/open-api-gateway/test/project/open-api-gateway-java-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-java-project/__snapshots__/standalone.test.ts.snap
@@ -9274,7 +9274,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                 return handler(request)
         return BaseHandlerChain()
     else:
-        interceptor = _interceptors.pop(0)
+        interceptor = _interceptors[0]
 
         class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
             def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -9285,7 +9285,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                     event = request.event,
                     context = request.context,
                     interceptor_context = request.interceptor_context,
-                    chain = _build_handler_chain(_interceptors, handler),
+                    chain = _build_handler_chain(_interceptors[1:len(_interceptors)], handler),
                 ))
         return RemainingHandlerChain()
 

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
@@ -10132,7 +10132,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                 return handler(request)
         return BaseHandlerChain()
     else:
-        interceptor = _interceptors.pop(0)
+        interceptor = _interceptors[0]
 
         class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
             def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -10143,7 +10143,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                     event = request.event,
                     context = request.context,
                     interceptor_context = request.interceptor_context,
-                    chain = _build_handler_chain(_interceptors, handler),
+                    chain = _build_handler_chain(_interceptors[1:len(_interceptors)], handler),
                 ))
         return RemainingHandlerChain()
 
@@ -15788,7 +15788,7 @@ class Api(OpenApiGatewayRestApi):
         )
 ",
   "packages/my_api/my_api/api/handlers/say_hello_handler_sample.py": "from my_api_python.apis.tags.default_api_operation_config import say_hello_handler, SayHelloRequest, ApiResponse, SayHelloOperationResponses
-from my_api_python.model.hello_response import SayHelloResponseContent
+from my_api_python.model.say_hello_response_content import SayHelloResponseContent
 
 @say_hello_handler
 def handler(input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
@@ -9245,7 +9245,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                 return handler(request)
         return BaseHandlerChain()
     else:
-        interceptor = _interceptors.pop(0)
+        interceptor = _interceptors[0]
 
         class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
             def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -9256,7 +9256,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                     event = request.event,
                     context = request.context,
                     interceptor_context = request.interceptor_context,
-                    chain = _build_handler_chain(_interceptors, handler),
+                    chain = _build_handler_chain(_interceptors[1:len(_interceptors)], handler),
                 ))
         return RemainingHandlerChain()
 
@@ -14905,7 +14905,7 @@ class Api(OpenApiGatewayRestApi):
         )
 ",
   "my_api/api/handlers/say_hello_handler_sample.py": "from my_api_python.apis.tags.default_api_operation_config import say_hello_handler, SayHelloRequest, ApiResponse, SayHelloOperationResponses
-from my_api_python.model.hello_response import SayHelloResponseContent
+from my_api_python.model.say_hello_response_content import SayHelloResponseContent
 
 @say_hello_handler
 def handler(input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/with-docs.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/with-docs.test.ts.snap
@@ -5997,7 +5997,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                 return handler(request)
         return BaseHandlerChain()
     else:
-        interceptor = _interceptors.pop(0)
+        interceptor = _interceptors[0]
 
         class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
             def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -6008,7 +6008,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                     event = request.event,
                     context = request.context,
                     interceptor_context = request.interceptor_context,
-                    chain = _build_handler_chain(_interceptors, handler),
+                    chain = _build_handler_chain(_interceptors[1:len(_interceptors)], handler),
                 ))
         return RemainingHandlerChain()
 
@@ -10155,7 +10155,7 @@ class Api(OpenApiGatewayRestApi):
         )
 ",
   "my_api/api/handlers/say_hello_handler_sample.py": "from my_api_python.apis.tags.default_api_operation_config import say_hello_handler, SayHelloRequest, ApiResponse, SayHelloOperationResponses
-from my_api_python.model.hello_response import SayHelloResponseContent
+from my_api_python.model.say_hello_response_content import SayHelloResponseContent
 
 @say_hello_handler
 def handler(input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
@@ -10884,7 +10884,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                 return handler(request)
         return BaseHandlerChain()
     else:
-        interceptor = _interceptors.pop(0)
+        interceptor = _interceptors[0]
 
         class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
             def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -10895,7 +10895,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                     event = request.event,
                     context = request.context,
                     interceptor_context = request.interceptor_context,
-                    chain = _build_handler_chain(_interceptors, handler),
+                    chain = _build_handler_chain(_interceptors[1:len(_interceptors)], handler),
                 ))
         return RemainingHandlerChain()
 
@@ -27626,7 +27626,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                 return handler(request)
         return BaseHandlerChain()
     else:
-        interceptor = _interceptors.pop(0)
+        interceptor = _interceptors[0]
 
         class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
             def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -27637,7 +27637,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                     event = request.event,
                     context = request.context,
                     interceptor_context = request.interceptor_context,
-                    chain = _build_handler_chain(_interceptors, handler),
+                    chain = _build_handler_chain(_interceptors[1:len(_interceptors)], handler),
                 ))
         return RemainingHandlerChain()
 
@@ -44386,7 +44386,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                 return handler(request)
         return BaseHandlerChain()
     else:
-        interceptor = _interceptors.pop(0)
+        interceptor = _interceptors[0]
 
         class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
             def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -44397,7 +44397,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                     event = request.event,
                     context = request.context,
                     interceptor_context = request.interceptor_context,
-                    chain = _build_handler_chain(_interceptors, handler),
+                    chain = _build_handler_chain(_interceptors[1:len(_interceptors)], handler),
                 ))
         return RemainingHandlerChain()
 

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
@@ -10355,7 +10355,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                 return handler(request)
         return BaseHandlerChain()
     else:
-        interceptor = _interceptors.pop(0)
+        interceptor = _interceptors[0]
 
         class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
             def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -10366,7 +10366,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                     event = request.event,
                     context = request.context,
                     interceptor_context = request.interceptor_context,
-                    chain = _build_handler_chain(_interceptors, handler),
+                    chain = _build_handler_chain(_interceptors[1:len(_interceptors)], handler),
                 ))
         return RemainingHandlerChain()
 
@@ -26508,7 +26508,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                 return handler(request)
         return BaseHandlerChain()
     else:
-        interceptor = _interceptors.pop(0)
+        interceptor = _interceptors[0]
 
         class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
             def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -26519,7 +26519,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                     event = request.event,
                     context = request.context,
                     interceptor_context = request.interceptor_context,
-                    chain = _build_handler_chain(_interceptors, handler),
+                    chain = _build_handler_chain(_interceptors[1:len(_interceptors)], handler),
                 ))
         return RemainingHandlerChain()
 
@@ -42658,7 +42658,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                 return handler(request)
         return BaseHandlerChain()
     else:
-        interceptor = _interceptors.pop(0)
+        interceptor = _interceptors[0]
 
         class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
             def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -42669,7 +42669,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                     event = request.event,
                     context = request.context,
                     interceptor_context = request.interceptor_context,
-                    chain = _build_handler_chain(_interceptors, handler),
+                    chain = _build_handler_chain(_interceptors[1:len(_interceptors)], handler),
                 ))
         return RemainingHandlerChain()
 

--- a/packages/open-api-gateway/test/project/smithy-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/smithy-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
@@ -2992,7 +2992,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                 return handler(request)
         return BaseHandlerChain()
     else:
-        interceptor = _interceptors.pop(0)
+        interceptor = _interceptors[0]
 
         class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
             def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -3003,7 +3003,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                     event = request.event,
                     context = request.context,
                     interceptor_context = request.interceptor_context,
-                    chain = _build_handler_chain(_interceptors, handler),
+                    chain = _build_handler_chain(_interceptors[1:len(_interceptors)], handler),
                 ))
         return RemainingHandlerChain()
 
@@ -9463,7 +9463,7 @@ class Api(OpenApiGatewayRestApi):
         )
 ",
   "test/api/handlers/say_hello_handler_sample.py": "from test_python.apis.tags.default_api_operation_config import say_hello_handler, SayHelloRequest, ApiResponse, SayHelloOperationResponses
-from test_python.model.hello_response import SayHelloResponseContent
+from test_python.model.say_hello_response_content import SayHelloResponseContent
 
 @say_hello_handler
 def handler(input: SayHelloRequest, **kwargs) -> SayHelloOperationResponses:

--- a/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
@@ -10887,7 +10887,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                 return handler(request)
         return BaseHandlerChain()
     else:
-        interceptor = _interceptors.pop(0)
+        interceptor = _interceptors[0]
 
         class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
             def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -10898,7 +10898,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                     event = request.event,
                     context = request.context,
                     interceptor_context = request.interceptor_context,
-                    chain = _build_handler_chain(_interceptors, handler),
+                    chain = _build_handler_chain(_interceptors[1:len(_interceptors)], handler),
                 ))
         return RemainingHandlerChain()
 
@@ -30115,7 +30115,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                 return handler(request)
         return BaseHandlerChain()
     else:
-        interceptor = _interceptors.pop(0)
+        interceptor = _interceptors[0]
 
         class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
             def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -30126,7 +30126,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                     event = request.event,
                     context = request.context,
                     interceptor_context = request.interceptor_context,
-                    chain = _build_handler_chain(_interceptors, handler),
+                    chain = _build_handler_chain(_interceptors[1:len(_interceptors)], handler),
                 ))
         return RemainingHandlerChain()
 
@@ -49361,7 +49361,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                 return handler(request)
         return BaseHandlerChain()
     else:
-        interceptor = _interceptors.pop(0)
+        interceptor = _interceptors[0]
 
         class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
             def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -49372,7 +49372,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                     event = request.event,
                     context = request.context,
                     interceptor_context = request.interceptor_context,
-                    chain = _build_handler_chain(_interceptors, handler),
+                    chain = _build_handler_chain(_interceptors[1:len(_interceptors)], handler),
                 ))
         return RemainingHandlerChain()
 

--- a/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
@@ -10358,7 +10358,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                 return handler(request)
         return BaseHandlerChain()
     else:
-        interceptor = _interceptors.pop(0)
+        interceptor = _interceptors[0]
 
         class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
             def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -10369,7 +10369,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                     event = request.event,
                     context = request.context,
                     interceptor_context = request.interceptor_context,
-                    chain = _build_handler_chain(_interceptors, handler),
+                    chain = _build_handler_chain(_interceptors[1:len(_interceptors)], handler),
                 ))
         return RemainingHandlerChain()
 
@@ -28997,7 +28997,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                 return handler(request)
         return BaseHandlerChain()
     else:
-        interceptor = _interceptors.pop(0)
+        interceptor = _interceptors[0]
 
         class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
             def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -29008,7 +29008,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                     event = request.event,
                     context = request.context,
                     interceptor_context = request.interceptor_context,
-                    chain = _build_handler_chain(_interceptors, handler),
+                    chain = _build_handler_chain(_interceptors[1:len(_interceptors)], handler),
                 ))
         return RemainingHandlerChain()
 
@@ -47633,7 +47633,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                 return handler(request)
         return BaseHandlerChain()
     else:
-        interceptor = _interceptors.pop(0)
+        interceptor = _interceptors[0]
 
         class RemainingHandlerChain(HandlerChain[RequestParameters, RequestArrayParameters, RequestBody, StatusCode, ResponseBody]):
             def next(self, request: ChainedApiRequest[RequestParameters, RequestArrayParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -47644,7 +47644,7 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                     event = request.event,
                     context = request.context,
                     interceptor_context = request.interceptor_context,
-                    chain = _build_handler_chain(_interceptors, handler),
+                    chain = _build_handler_chain(_interceptors[1:len(_interceptors)], handler),
                 ))
         return RemainingHandlerChain()
 


### PR DESCRIPTION
Whenever lambda reused a container to service a request, interceptors were removed for the second call onwards. This is due to the input interceptors list being created once when declaring the handler wrapper decorator, but the handler chain build method mutating that list on every call, being called on each handler invocation. This was only an issue for python interceptors - typescript and java do not have this behaviour. This change ensures a new sublist is created rather than mutating the list of interceptors, ensuring that all interceptors are used for every request.

Additionally, this change fixes a broken import in the python sample lambda handler.
