### PR TITLE
fix(open-api-gateway): support primitive types in request and response body in lambda wrappers

### DIFF
--- a/packages/open-api-gateway/scripts/generators/java/templates/handlers.mustache
+++ b/packages/open-api-gateway/scripts/generators/java/templates/handlers.mustache
@@ -217,7 +217,7 @@ public class Handlers {
         private String body;
         private Map<String, String> headers;
 
-        private {{operationIdCamelCase}}{{code}}Response({{#dataType}}final {{.}} body, {{/dataType}}final Map<String, String> headers) {
+        private {{operationIdCamelCase}}{{code}}Response({{#dataType}}final {{#isPrimitiveType}}String{{/isPrimitiveType}}{{^isPrimitiveType}}{{.}}{{/isPrimitiveType}} body, {{/dataType}}final Map<String, String> headers) {
             this.body = {{#dataType}}{{#isPrimitiveType}}body{{/isPrimitiveType}}{{^isPrimitiveType}}body.toJson(){{/isPrimitiveType}}{{/dataType}}{{^dataType}}""{{/dataType}};
             this.headers = headers;
         }
@@ -240,14 +240,14 @@ public class Handlers {
         /**
          * Create a {{operationIdCamelCase}}{{code}}Response with{{^dataType}}out{{/dataType}} a body
          */
-        public static {{operationIdCamelCase}}{{code}}Response of({{#dataType}}final {{.}} body{{/dataType}}) {
+        public static {{operationIdCamelCase}}{{code}}Response of({{#dataType}}final {{#isPrimitiveType}}String{{/isPrimitiveType}}{{^isPrimitiveType}}{{.}}{{/isPrimitiveType}} body{{/dataType}}) {
             return new {{operationIdCamelCase}}{{code}}Response({{#dataType}}body, {{/dataType}}new HashMap<>());
         }
 
         /**
          * Create a {{operationIdCamelCase}}{{code}}Response with{{^dataType}}out{{/dataType}} a body and headers
          */
-        public static {{operationIdCamelCase}}{{code}}Response of({{#dataType}}final {{.}} body, {{/dataType}}final Map<String, String> headers) {
+        public static {{operationIdCamelCase}}{{code}}Response of({{#dataType}}final {{#isPrimitiveType}}String{{/isPrimitiveType}}{{^isPrimitiveType}}{{.}}{{/isPrimitiveType}} body, {{/dataType}}final Map<String, String> headers) {
             return new {{operationIdCamelCase}}{{code}}Response({{#dataType}}body, {{/dataType}}headers);
         }
     }

--- a/packages/open-api-gateway/scripts/generators/python/templates/operationConfig.mustache
+++ b/packages/open-api-gateway/scripts/generators/python/templates/operationConfig.mustache
@@ -143,11 +143,11 @@ class {{operationIdCamelCase}}RequestArrayParameters(TypedDict):
 {{/allParams}}
     ...
 
-# Request body type (default to Any when no body parameters exist)
-{{operationIdCamelCase}}RequestBody = {{^bodyParams.isEmpty}}{{#bodyParams.0}}{{dataType}}{{/bodyParams.0}}{{/bodyParams.isEmpty}}{{#bodyParams.isEmpty}}Any{{/bodyParams.isEmpty}}
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
+{{operationIdCamelCase}}RequestBody = {{^bodyParams.isEmpty}}{{#bodyParams.0}}{{^isPrimitiveType}}{{dataType}}{{/isPrimitiveType}}{{#isPrimitiveType}}str{{/isPrimitiveType}}{{/bodyParams.0}}{{/bodyParams.isEmpty}}{{#bodyParams.isEmpty}}Any{{/bodyParams.isEmpty}}
 
 {{#responses}}
-{{operationIdCamelCase}}{{code}}OperationResponse = ApiResponse[Literal[{{code}}], {{^simpleType}}{{dataType}}{{/simpleType}}{{#simpleType}}None{{/simpleType}}]
+{{operationIdCamelCase}}{{code}}OperationResponse = ApiResponse[Literal[{{code}}], {{^simpleType}}{{^isPrimitiveType}}{{dataType}}{{/isPrimitiveType}}{{#isPrimitiveType}}str{{/isPrimitiveType}}{{/simpleType}}{{#simpleType}}None{{/simpleType}}]
 {{/responses}}
 {{operationIdCamelCase}}OperationResponses = Union[{{#responses}}{{operationIdCamelCase}}{{code}}OperationResponse, {{/responses}}]
 
@@ -175,8 +175,21 @@ def {{operationId}}_handler(_handler: {{operationIdCamelCase}}HandlerFunction = 
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
+            {{^bodyParams.isEmpty}}
+            {{#bodyParams.0}}
+            {{^isPrimitiveType}}
+            # Non-primitive type so parse the body into the appropriate model
             body = parse_body(event['body'], [{{^consumes}}'application/json'{{/consumes}}{{#consumes}}{{#mediaType}}'{{{.}}}',{{/mediaType}}{{/consumes}}], {{operationIdCamelCase}}RequestBody)
-
+            {{/isPrimitiveType}}
+            {{#isPrimitiveType}}
+            # Primitive type so body is passed as the original string
+            body = event['body']
+            {{/isPrimitiveType}}
+            {{/bodyParams.0}}
+            {{/bodyParams.isEmpty}}
+            {{#bodyParams.isEmpty}}
+            body = {}
+            {{/bodyParams.isEmpty}}
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -188,10 +201,24 @@ def {{operationId}}_handler(_handler: {{operationIdCamelCase}}HandlerFunction = 
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            {{#responses}}
+            elif response.status_code == {{code}}:
+                {{^isPrimitiveType}}
+                response_body = json.dumps(JSONEncoder().default(response.body))
+                {{/isPrimitiveType}}
+                {{#isPrimitiveType}}
+                response_body = response.body
+                {{/isPrimitiveType}}
+            {{/responses}}
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 

--- a/packages/open-api-gateway/scripts/generators/typescript/templates/operationConfig.mustache
+++ b/packages/open-api-gateway/scripts/generators/typescript/templates/operationConfig.mustache
@@ -170,10 +170,10 @@ export interface {{operationIdCamelCase}}RequestArrayParameters {
 /**
  * Request body parameter for {{operationIdCamelCase}}
  */
-export type {{operationIdCamelCase}}RequestBody = {{#bodyParam}}{{dataType}}{{/bodyParam}}{{^bodyParam}}never{{/bodyParam}};
+export type {{operationIdCamelCase}}RequestBody = {{#bodyParam}}{{#isPrimitiveType}}string{{/isPrimitiveType}}{{^isPrimitiveType}}{{dataType}}{{/isPrimitiveType}}{{/bodyParam}}{{^bodyParam}}never{{/bodyParam}};
 
 {{#responses}}
-export type {{operationIdCamelCase}}{{code}}OperationResponse = OperationResponse<{{code}}, {{#dataType}}{{.}}{{/dataType}}{{^dataType}}undefined{{/dataType}}>;
+export type {{operationIdCamelCase}}{{code}}OperationResponse = OperationResponse<{{code}}, {{#dataType}}{{#isPrimitiveType}}string{{/isPrimitiveType}}{{^isPrimitiveType}}{{.}}{{/isPrimitiveType}}{{/dataType}}{{^dataType}}undefined{{/dataType}}>;
 {{/responses}}
 export type {{operationIdCamelCase}}OperationResponses = {{#responses}}| {{operationIdCamelCase}}{{code}}OperationResponse {{/responses}};
 
@@ -198,11 +198,17 @@ export const {{nickname}}Handler = (
     }) as unknown as {{operationIdCamelCase}}RequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
         {{#bodyParam}}
-        parsed = {{dataType}}FromJSON(parsed);
+        {{^isPrimitiveType}}
+        return {{dataType}}FromJSON(JSON.parse(bodyString));
+        {{/isPrimitiveType}}
+        {{#isPrimitiveType}}
+        return bodyString;
+        {{/isPrimitiveType}}
         {{/bodyParam}}
-        return parsed;
+        {{^bodyParam}}
+        return {};
+        {{/bodyParam}}
     };
     const body = parseBody(event.body, demarshal, [{{^consumes}}'application/json'{{/consumes}}{{#consumes}}{{#mediaType}}'{{{.}}}',{{/mediaType}}{{/consumes}}]) as {{operationIdCamelCase}}RequestBody;
 

--- a/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-java-client-source-code.test.ts.snap
+++ b/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-java-client-source-code.test.ts.snap
@@ -7896,11 +7896,14 @@ public class Example {
     defaultClient.setBasePath(\\"http://localhost\\");
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
+    Object body = null; // Object | 
     try {
-      apiInstance.empty()
+      Object result = apiInstance.anyRequestResponse()
+            .body(body)
             .execute();
+      System.out.println(result);
     } catch (ApiException e) {
-      System.err.println(\\"Exception when calling DefaultApi#empty\\");
+      System.err.println(\\"Exception when calling DefaultApi#anyRequestResponse\\");
       System.err.println(\\"Status code: \\" + e.getCode());
       System.err.println(\\"Reason: \\" + e.getResponseBody());
       System.err.println(\\"Response headers: \\" + e.getResponseHeaders());
@@ -7917,6 +7920,7 @@ All URIs are relative to *http://localhost*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
+*DefaultApi* | [**anyRequestResponse**](docs/DefaultApi.md#anyRequestResponse) | **PUT** /any-request-response | 
 *DefaultApi* | [**empty**](docs/DefaultApi.md#empty) | **PUT** /empty-response | 
 *DefaultApi* | [**mediaTypes**](docs/DefaultApi.md#mediaTypes) | **POST** /different-media-type | 
 *DefaultApi* | [**operationOne**](docs/DefaultApi.md#operationOne) | **POST** /path/{pathParam} | 
@@ -8030,6 +8034,21 @@ paths:
       responses:
         \\"204\\":
           description: No response body!
+      x-accepts: application/json
+  /any-request-response:
+    put:
+      operationId: anyRequestResponse
+      requestBody:
+        content:
+          application/json:
+            schema: {}
+      responses:
+        \\"200\\":
+          content:
+            application/json:
+              schema: {}
+          description: Any response
+      x-content-type: application/json
       x-accepts: application/json
   /different-media-type:
     post:
@@ -8312,11 +8331,74 @@ All URIs are relative to *http://localhost*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
+| [**anyRequestResponse**](DefaultApi.md#anyRequestResponse) | **PUT** /any-request-response |  |
 | [**empty**](DefaultApi.md#empty) | **PUT** /empty-response |  |
 | [**mediaTypes**](DefaultApi.md#mediaTypes) | **POST** /different-media-type |  |
 | [**operationOne**](DefaultApi.md#operationOne) | **POST** /path/{pathParam} |  |
 | [**withoutOperationIdDelete**](DefaultApi.md#withoutOperationIdDelete) | **DELETE** /without-operation-id |  |
 
+
+<a name=\\"anyRequestResponse\\"></a>
+# **anyRequestResponse**
+> Object anyRequestResponse().body(body).execute();
+
+
+
+### Example
+\`\`\`java
+// Import classes:
+import test.test.client.ApiClient;
+import test.test.client.ApiException;
+import test.test.client.Configuration;
+import test.test.client.models.*;
+import test.test.client.api.DefaultApi;
+
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath(\\"http://localhost\\");
+
+    DefaultApi apiInstance = new DefaultApi(defaultClient);
+    Object body = null; // Object | 
+    try {
+      Object result = apiInstance.anyRequestResponse()
+            .body(body)
+            .execute();
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println(\\"Exception when calling DefaultApi#anyRequestResponse\\");
+      System.err.println(\\"Status code: \\" + e.getCode());
+      System.err.println(\\"Reason: \\" + e.getResponseBody());
+      System.err.println(\\"Response headers: \\" + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
+}
+\`\`\`
+
+### Parameters
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **body** | **Object**|  | [optional] |
+
+### Return type
+
+**Object**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | Any response |  -  |
 
 <a name=\\"empty\\"></a>
 # **empty**
@@ -12665,6 +12747,164 @@ public class DefaultApi {
         this.localCustomBaseUrl = customBaseUrl;
     }
 
+    private okhttp3.Call anyRequestResponseCall(Object body, final ApiCallback _callback) throws ApiException {
+        String basePath = null;
+        // Operation Servers
+        String[] localBasePaths = new String[] {  };
+
+        // Determine Base Path to Use
+        if (localCustomBaseUrl != null){
+            basePath = localCustomBaseUrl;
+        } else if ( localBasePaths.length > 0 ) {
+            basePath = localBasePaths[localHostIndex];
+        } else {
+            basePath = null;
+        }
+
+        Object localVarPostBody = body;
+
+        // create path and map variables
+        String localVarPath = \\"/any-request-response\\";
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        final String[] localVarAccepts = {
+            \\"application/json\\"
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put(\\"Accept\\", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+            \\"application/json\\"
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        if (localVarContentType != null) {
+            localVarHeaderParams.put(\\"Content-Type\\", localVarContentType);
+        }
+
+        String[] localVarAuthNames = new String[] {  };
+        return localVarApiClient.buildCall(basePath, localVarPath, \\"PUT\\", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    @SuppressWarnings(\\"rawtypes\\")
+    private okhttp3.Call anyRequestResponseValidateBeforeCall(Object body, final ApiCallback _callback) throws ApiException {
+        
+
+        okhttp3.Call localVarCall = anyRequestResponseCall(body, _callback);
+        return localVarCall;
+
+    }
+
+
+    private ApiResponse<Object> anyRequestResponseWithHttpInfo(Object body) throws ApiException {
+        okhttp3.Call localVarCall = anyRequestResponseValidateBeforeCall(body, null);
+        Type localVarReturnType = new TypeToken<Object>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    private okhttp3.Call anyRequestResponseAsync(Object body, final ApiCallback<Object> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = anyRequestResponseValidateBeforeCall(body, _callback);
+        Type localVarReturnType = new TypeToken<Object>(){}.getType();
+        localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+        return localVarCall;
+    }
+
+    public class APIanyRequestResponseRequest {
+        private Object body;
+
+        private APIanyRequestResponseRequest() {
+        }
+
+        /**
+         * Set body
+         * @param body  (optional)
+         * @return APIanyRequestResponseRequest
+         */
+        public APIanyRequestResponseRequest body(Object body) {
+            this.body = body;
+            return this;
+        }
+
+        /**
+         * Build call for anyRequestResponse
+         * @param _callback ApiCallback API callback
+         * @return Call to execute
+         * @throws ApiException If fail to serialize the request body object
+         * @http.response.details
+         <table summary=\\"Response Details\\" border=\\"1\\">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> Any response </td><td>  -  </td></tr>
+         </table>
+         */
+        public okhttp3.Call buildCall(final ApiCallback _callback) throws ApiException {
+            return anyRequestResponseCall(body, _callback);
+        }
+
+        /**
+         * Execute anyRequestResponse request
+         * @return Object
+         * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+         * @http.response.details
+         <table summary=\\"Response Details\\" border=\\"1\\">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> Any response </td><td>  -  </td></tr>
+         </table>
+         */
+        public Object execute() throws ApiException {
+            ApiResponse<Object> localVarResp = anyRequestResponseWithHttpInfo(body);
+            return localVarResp.getData();
+        }
+
+        /**
+         * Execute anyRequestResponse request with HTTP info returned
+         * @return ApiResponse&lt;Object&gt;
+         * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+         * @http.response.details
+         <table summary=\\"Response Details\\" border=\\"1\\">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> Any response </td><td>  -  </td></tr>
+         </table>
+         */
+        public ApiResponse<Object> executeWithHttpInfo() throws ApiException {
+            return anyRequestResponseWithHttpInfo(body);
+        }
+
+        /**
+         * Execute anyRequestResponse request (asynchronously)
+         * @param _callback The callback to be executed when the API call finishes
+         * @return The request call
+         * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+         * @http.response.details
+         <table summary=\\"Response Details\\" border=\\"1\\">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> Any response </td><td>  -  </td></tr>
+         </table>
+         */
+        public okhttp3.Call executeAsync(final ApiCallback<Object> _callback) throws ApiException {
+            return anyRequestResponseAsync(body, _callback);
+        }
+    }
+
+    /**
+     * 
+     * 
+     * @return APIanyRequestResponseRequest
+     * @http.response.details
+     <table summary=\\"Response Details\\" border=\\"1\\">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> Any response </td><td>  -  </td></tr>
+     </table>
+     */
+    public APIanyRequestResponseRequest anyRequestResponse() {
+        return new APIanyRequestResponseRequest();
+    }
     private okhttp3.Call emptyCall(final ApiCallback _callback) throws ApiException {
         String basePath = null;
         // Operation Servers
@@ -13536,6 +13776,234 @@ public class Handlers {
                     });
                 }
             };
+        }
+    }
+
+    /**
+     * Response for the anyRequestResponse operation
+     */
+    public static interface AnyRequestResponseResponse extends Response {}
+
+    /**
+     * Response with status code 200 for the anyRequestResponse operation
+     */
+    public static class AnyRequestResponse200Response implements AnyRequestResponseResponse {
+        private String body;
+        private Map<String, String> headers;
+
+        private AnyRequestResponse200Response(final String body, final Map<String, String> headers) {
+            this.body = body;
+            this.headers = headers;
+        }
+
+        @Override
+        public int getStatusCode() {
+            return 200;
+        }
+
+        @Override
+        public String getBody() {
+            return this.body;
+        }
+
+        @Override
+        public Map<String, String> getHeaders() {
+            return this.headers;
+        }
+
+        /**
+         * Create a AnyRequestResponse200Response with a body
+         */
+        public static AnyRequestResponse200Response of(final String body) {
+            return new AnyRequestResponse200Response(body, new HashMap<>());
+        }
+
+        /**
+         * Create a AnyRequestResponse200Response with a body and headers
+         */
+        public static AnyRequestResponse200Response of(final String body, final Map<String, String> headers) {
+            return new AnyRequestResponse200Response(body, headers);
+        }
+    }
+
+    /**
+     * Single-value query and path parameters for the anyRequestResponse operation
+     */
+    public static class AnyRequestResponseRequestParameters {
+
+        public AnyRequestResponseRequestParameters(final APIGatewayProxyRequestEvent event) {
+            Map<String, String> parameters = new HashMap<>();
+            putAllFromNullableMap(event.getPathParameters(), parameters);
+            putAllFromNullableMap(event.getQueryStringParameters(), parameters);
+            Map<String, String> decodedParameters = decodeRequestParameters(parameters);
+
+        }
+
+    }
+
+    /**
+     * Multi-value query parameters for the anyRequestResponse operation
+     */
+    public static class AnyRequestResponseRequestArrayParameters {
+
+        public AnyRequestResponseRequestArrayParameters(final APIGatewayProxyRequestEvent event) {
+            Map<String, List<String>> parameters = new HashMap<>();
+            putAllFromNullableMap(event.getMultiValueQueryStringParameters(), parameters);
+            Map<String, List<String>> decodedParameters = decodeRequestArrayParameters(parameters);
+
+        }
+
+    }
+
+    /**
+     * Input for the anyRequestResponse operation
+     */
+    public static class AnyRequestResponseInput {
+        private AnyRequestResponseRequestParameters requestParameters;
+        private AnyRequestResponseRequestArrayParameters requestArrayParameters;
+        private String body;
+
+        public AnyRequestResponseInput(final APIGatewayProxyRequestEvent event) {
+            this.requestParameters = new AnyRequestResponseRequestParameters(event);
+            this.requestArrayParameters = new AnyRequestResponseRequestArrayParameters(event);
+            this.body = event.getBody();
+        }
+
+        public AnyRequestResponseRequestParameters getRequestParameters() {
+            return this.requestParameters;
+        }
+
+        public AnyRequestResponseRequestArrayParameters getRequestArrayParameters() {
+            return this.requestArrayParameters;
+        }
+
+        public String getBody() {
+            return this.body;
+        }
+    }
+
+    /**
+     * Full request input for the anyRequestResponse operation, including the raw API Gateway event
+     */
+    public static class AnyRequestResponseRequestInput implements RequestInput<AnyRequestResponseInput> {
+        private APIGatewayProxyRequestEvent event;
+        private Context context;
+        private Map<String, Object> interceptorContext;
+        private AnyRequestResponseInput input;
+
+        public AnyRequestResponseRequestInput(final APIGatewayProxyRequestEvent event, final Context context, final Map<String, Object> interceptorContext, final AnyRequestResponseInput input) {
+            this.event = event;
+            this.context = context;
+            this.interceptorContext = interceptorContext;
+            this.input = input;
+        }
+
+        /**
+         * Returns the typed request input, with path, query and body parameters
+         */
+        public AnyRequestResponseInput getInput() {
+            return this.input;
+        }
+
+        /**
+         * Returns the raw API Gateway event
+         */
+        public APIGatewayProxyRequestEvent getEvent() {
+            return this.event;
+        }
+
+        /**
+         * Returns the lambda context
+         */
+        public Context getContext() {
+            return this.context;
+        }
+
+        /**
+         * Returns the interceptor context, which may contain values set by request interceptors
+         */
+        public Map<String, Object> getInterceptorContext() {
+            return this.interceptorContext;
+        }
+    }
+
+    /**
+     * Lambda handler wrapper for the anyRequestResponse operation
+     */
+    public static abstract class AnyRequestResponse implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        /**
+         * Handle the request for the anyRequestResponse operation
+         */
+        public abstract AnyRequestResponseResponse handle(final AnyRequestResponseRequestInput request);
+
+        /**
+         * For more complex interceptors that require instantiation with parameters, you may override this method to
+         * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+         * prefer the @Interceptors annotation.
+         */
+        public List<Interceptor<AnyRequestResponseInput>> getInterceptors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            final Map<String, Object> interceptorContext = new HashMap<>();
+
+            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
+            List<Interceptor<AnyRequestResponseInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
+                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
+                        try {
+                            return (Interceptor<AnyRequestResponseInput>) clazz.getDeclaredConstructor().newInstance();
+                        } catch (Exception e) {
+                            throw new RuntimeException(String.format(
+                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
+                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
+                        }
+                     }).collect(Collectors.toList())
+                    : new ArrayList<>();
+
+            interceptors.addAll(this.getInterceptors());
+
+            final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<AnyRequestResponseInput>() {
+                @Override
+                public Response next(ChainedRequestInput<AnyRequestResponseInput> input) {
+                    return handle(new AnyRequestResponseRequestInput(input.getEvent(), input.getContext(), input.getInterceptorContext(), input.getInput()));
+                }
+            });
+
+            final Response response = chain.next(new ChainedRequestInput<AnyRequestResponseInput>() {
+                @Override
+                public HandlerChain getChain() {
+                    // The chain's next method ignores the chain given as input, and is pre-built to follow the remaining
+                    // chain.
+                    return null;
+                }
+
+                @Override
+                public APIGatewayProxyRequestEvent getEvent() {
+                    return event;
+                }
+
+                @Override
+                public Context getContext() {
+                    return context;
+                }
+
+                @Override
+                public AnyRequestResponseInput getInput() {
+                    return new AnyRequestResponseInput(event);
+                }
+
+                @Override
+                public Map<String, Object> getInterceptorContext() {
+                    return interceptorContext;
+                }
+            });
+
+            return new APIGatewayProxyResponseEvent()
+                    .withStatusCode(response.getStatusCode())
+                    .withHeaders(response.getHeaders())
+                    .withBody(response.getBody());
         }
     }
 
@@ -14530,6 +14998,7 @@ import java.util.Map;
 @javax.annotation.Generated(value = \\"org.openapitools.codegen.languages.JavaClientCodegen\\")
 @lombok.Builder @lombok.Getter
 public class OperationConfig<T> {
+    private T anyRequestResponse;
     private T empty;
     private T mediaTypes;
     private T operationOne;
@@ -14537,6 +15006,7 @@ public class OperationConfig<T> {
 
     public Map<String, T> asMap() {
         Map<String, T> map = new HashMap<>();
+        map.put(\\"anyRequestResponse\\", this.anyRequestResponse);
         map.put(\\"empty\\", this.empty);
         map.put(\\"mediaTypes\\", this.mediaTypes);
         map.put(\\"operationOne\\", this.operationOne);
@@ -14568,6 +15038,7 @@ public class OperationLookup {
     public static Map<String, Map<String, String>> getOperationLookup() {
         final Map<String, Map<String, String>> config = new HashMap<>();
 
+        config.put(\\"anyRequestResponse\\", new HashMap<String, String>() { { put(\\"path\\", \\"/any-request-response\\"); put(\\"method\\", \\"PUT\\"); } });
         config.put(\\"empty\\", new HashMap<String, String>() { { put(\\"path\\", \\"/empty-response\\"); put(\\"method\\", \\"PUT\\"); } });
         config.put(\\"mediaTypes\\", new HashMap<String, String>() { { put(\\"path\\", \\"/different-media-type\\"); put(\\"method\\", \\"POST\\"); } });
         config.put(\\"operationOne\\", new HashMap<String, String>() { { put(\\"path\\", \\"/path/{pathParam}\\"); put(\\"method\\", \\"POST\\"); } });
@@ -15927,6 +16398,18 @@ import java.util.Map;
 public class DefaultApiTest {
 
     private final DefaultApi api = new DefaultApi();
+
+    /**
+     * @throws ApiException if the Api call fails
+     */
+    @Test
+    public void anyRequestResponseTest() throws ApiException {
+        Object body = null;
+        Object response = api.anyRequestResponse()
+                .body(body)
+                .execute();
+        // TODO: test validations
+    }
 
     /**
      * @throws ApiException if the Api call fails

--- a/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-python-client-source-code.test.ts.snap
+++ b/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-python-client-source-code.test.ts.snap
@@ -2537,7 +2537,7 @@ class SomeTestOperationRequestParameters(TypedDict):
 class SomeTestOperationRequestArrayParameters(TypedDict):
     ...
 
-# Request body type (default to Any when no body parameters exist)
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 SomeTestOperationRequestBody = TestRequest
 
 SomeTestOperation200OperationResponse = ApiResponse[Literal[200], TestResponse]
@@ -2568,8 +2568,8 @@ def some_test_operation_handler(_handler: SomeTestOperationHandlerFunction = Non
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
+            # Non-primitive type so parse the body into the appropriate model
             body = parse_body(event['body'], ['application/json',], SomeTestOperationRequestBody)
-
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -2581,10 +2581,19 @@ def some_test_operation_handler(_handler: SomeTestOperationHandlerFunction = Non
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+            elif response.status_code == 400:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 
@@ -7524,11 +7533,13 @@ configuration = test.Configuration(
 with test.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = default_api.DefaultApi(api_client)
-    
+    body = None # bool, date, datetime, dict, float, int, list, str, none_type |  (optional)
+
     try:
-        api_instance.empty()
+        api_response = api_instance.any_request_response(body=body)
+        pprint(api_response)
     except test.ApiException as e:
-        print(\\"Exception when calling DefaultApi->empty: %s\\\\n\\" % e)
+        print(\\"Exception when calling DefaultApi->any_request_response: %s\\\\n\\" % e)
 \`\`\`
 
 ## Documentation for API Endpoints
@@ -7537,6 +7548,7 @@ All URIs are relative to *http://localhost*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
+*DefaultApi* | [**any_request_response**](docs/apis/tags/DefaultApi.md#any_request_response) | **put** /any-request-response | 
 *DefaultApi* | [**empty**](docs/apis/tags/DefaultApi.md#empty) | **put** /empty-response | 
 *DefaultApi* | [**media_types**](docs/apis/tags/DefaultApi.md#media_types) | **post** /different-media-type | 
 *DefaultApi* | [**operation_one**](docs/apis/tags/DefaultApi.md#operation_one) | **post** /path/{pathParam} | 
@@ -7582,10 +7594,92 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**any_request_response**](#any_request_response) | **put** /any-request-response | 
 [**empty**](#empty) | **put** /empty-response | 
 [**media_types**](#media_types) | **post** /different-media-type | 
 [**operation_one**](#operation_one) | **post** /path/{pathParam} | 
 [**without_operation_id_delete**](#without_operation_id_delete) | **delete** /without-operation-id | 
+
+# **any_request_response**
+<a name=\\"any_request_response\\"></a>
+> bool, date, datetime, dict, float, int, list, str, none_type any_request_response()
+
+
+
+### Example
+
+\`\`\`python
+import test
+from test.apis.tags import default_api
+from pprint import pprint
+# Defining the host is optional and defaults to http://localhost
+# See configuration.py for a list of all supported configuration parameters.
+configuration = test.Configuration(
+    host = \\"http://localhost\\"
+)
+
+# Enter a context with an instance of the API client
+with test.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = default_api.DefaultApi(api_client)
+
+    # example passing only optional values
+    body = None
+    try:
+        api_response = api_instance.any_request_response(
+            body=body,
+        )
+        pprint(api_response)
+    except test.ApiException as e:
+        print(\\"Exception when calling DefaultApi->any_request_response: %s\\\\n\\" % e)
+\`\`\`
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+body | typing.Union[SchemaForRequestBodyApplicationJson, Unset] | optional, default is unset |
+content_type | str | optional, default is 'application/json' | Selects the schema and serialization of the request body
+accept_content_types | typing.Tuple[str] | default is ('application/json', ) | Tells the server the content type(s) that are accepted by the client
+stream | bool | default is False | if True then the response.content will be streamed and loaded from a file like object. When downloading a file, set this to True to force the code to deserialize the content to a FileSchema file
+timeout | typing.Optional[typing.Union[int, typing.Tuple]] | default is None | the timeout used by the rest client
+skip_deserialization | bool | default is False | when True, headers and body will be unset and an instance of api_client.ApiResponseWithoutDeserialization will be returned
+
+### body
+
+#### SchemaForRequestBodyApplicationJson
+
+Type | Description | Notes
+------------- | ------------- | -------------
+typing.Union[dict, frozendict, str, date, datetime, int, float, bool, Decimal, None, list, tuple, bytes] | |
+
+### Return Types, Responses
+
+Code | Class | Description
+------------- | ------------- | -------------
+n/a | api_client.ApiResponseWithoutDeserialization | When skip_deserialization is True this response is returned
+200 | ApiResponseFor200 | Any response
+
+#### ApiResponseFor200
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+response | urllib3.HTTPResponse | Raw response |
+body | typing.Union[SchemaFor200ResponseBodyApplicationJson, ] |  |
+headers | Unset | headers were not defined |
+
+#### SchemaFor200ResponseBodyApplicationJson
+
+Type | Description | Notes
+------------- | ------------- | -------------
+typing.Union[dict, frozendict, str, date, datetime, int, float, bool, Decimal, None, list, tuple, bytes] | |
+
+
+**bool, date, datetime, dict, float, int, list, str, none_type**
+
+### Authorization
+
+No authorization required
+
+[[Back to top]](#__pageTop) [[Back to API list]](../../../README.md#documentation-for-api-endpoints) [[Back to Model list]](../../../README.md#documentation-for-models) [[Back to README]](../../../README.md)
 
 # **empty**
 <a name=\\"empty\\"></a>
@@ -9617,6 +9711,7 @@ from test.paths import PathValues
 from test.apis.paths.path_path_param import PathPathParam
 from test.apis.paths.without_operation_id import WithoutOperationId
 from test.apis.paths.empty_response import EmptyResponse
+from test.apis.paths.any_request_response import AnyRequestResponse
 from test.apis.paths.different_media_type import DifferentMediaType
 
 PathToApi = typing.TypedDict(
@@ -9625,6 +9720,7 @@ PathToApi = typing.TypedDict(
         PathValues.PATH_PATH_PARAM: PathPathParam,
         PathValues.WITHOUTOPERATIONID: WithoutOperationId,
         PathValues.EMPTYRESPONSE: EmptyResponse,
+        PathValues.ANYREQUESTRESPONSE: AnyRequestResponse,
         PathValues.DIFFERENTMEDIATYPE: DifferentMediaType,
     }
 )
@@ -9634,6 +9730,7 @@ path_to_api = PathToApi(
         PathValues.PATH_PATH_PARAM: PathPathParam,
         PathValues.WITHOUTOPERATIONID: WithoutOperationId,
         PathValues.EMPTYRESPONSE: EmptyResponse,
+        PathValues.ANYREQUESTRESPONSE: AnyRequestResponse,
         PathValues.DIFFERENTMEDIATYPE: DifferentMediaType,
     }
 )
@@ -9641,6 +9738,14 @@ path_to_api = PathToApi(
   "test/apis/paths/__init__.py": "# do not import all endpoints into this module because that uses a lot of memory and stack frames
 # if you need the ability to import all endpoints from this module, import them with
 # from test.apis.path_to_api import path_to_api
+",
+  "test/apis/paths/any_request_response.py": "from test.paths.any_request_response.put import ApiForput
+
+
+class AnyRequestResponse(
+    ApiForput,
+):
+    pass
 ",
   "test/apis/paths/different_media_type.py": "from test.paths.different_media_type.post import ApiForpost
 
@@ -9713,6 +9818,7 @@ class TagValues(str, enum.Enum):
     Generated by: https://openapi-generator.tech
 \\"\\"\\"
 
+from test.paths.any_request_response.put import AnyRequestResponse
 from test.paths.empty_response.put import Empty
 from test.paths.different_media_type.post import MediaTypes
 from test.paths.path_path_param.post import OperationOne
@@ -9720,6 +9826,7 @@ from test.paths.without_operation_id.delete import WithoutOperationIdDelete
 
 
 class DefaultApi(
+    AnyRequestResponse,
     Empty,
     MediaTypes,
     OperationOne,
@@ -9755,6 +9862,7 @@ T = TypeVar('T')
 # Generic type for object keyed by operation names
 @dataclass
 class OperationConfig(Generic[T]):
+    any_request_response: T
     empty: T
     media_types: T
     operation_one: T
@@ -9763,6 +9871,10 @@ class OperationConfig(Generic[T]):
 
 # Look up path and http method for a given operation name
 OperationLookup = {
+    \\"any_request_response\\": {
+        \\"path\\": \\"/any-request-response\\",
+        \\"method\\": \\"put\\",
+    },
     \\"empty\\": {
         \\"path\\": \\"/empty-response\\",
         \\"method\\": \\"put\\",
@@ -9861,6 +9973,79 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
 
 
 # Request parameters are single value query params or path params
+class AnyRequestResponseRequestParameters(TypedDict):
+    ...
+
+# Request array parameters are multi-value query params
+class AnyRequestResponseRequestArrayParameters(TypedDict):
+    ...
+
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
+AnyRequestResponseRequestBody = str
+
+AnyRequestResponse200OperationResponse = ApiResponse[Literal[200], str]
+AnyRequestResponseOperationResponses = Union[AnyRequestResponse200OperationResponse, ]
+
+# Request type for any_request_response
+AnyRequestResponseRequest = ApiRequest[AnyRequestResponseRequestParameters, AnyRequestResponseRequestArrayParameters, AnyRequestResponseRequestBody]
+AnyRequestResponseChainedRequest = ChainedApiRequest[AnyRequestResponseRequestParameters, AnyRequestResponseRequestArrayParameters, AnyRequestResponseRequestBody]
+
+class AnyRequestResponseHandlerFunction(Protocol):
+    def __call__(self, input: AnyRequestResponseRequest, **kwargs) -> AnyRequestResponseOperationResponses:
+        ...
+
+AnyRequestResponseInterceptor = Callable[[AnyRequestResponseChainedRequest], AnyRequestResponseOperationResponses]
+
+def any_request_response_handler(_handler: AnyRequestResponseHandlerFunction = None, interceptors: List[AnyRequestResponseInterceptor] = []):
+    \\"\\"\\"
+    Decorator for an api handler for the any_request_response operation, providing a typed interface for inputs and outputs
+    \\"\\"\\"
+    def _handler_wrapper(handler: AnyRequestResponseHandlerFunction):
+        @wraps(handler)
+        def wrapper(event, context, **kwargs):
+            request_parameters = decode_request_parameters({
+                **(event['pathParameters'] or {}),
+                **(event['queryStringParameters'] or {}),
+            })
+            request_array_parameters = decode_request_parameters({
+                **(event['multiValueQueryStringParameters'] or {}),
+            })
+            # Primitive type so body is passed as the original string
+            body = event['body']
+            interceptor_context = {}
+
+            chain = _build_handler_chain(interceptors, handler)
+            response = chain.next(ApiRequest(
+                request_parameters,
+                request_array_parameters,
+                body,
+                event,
+                context,
+                interceptor_context,
+            ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = response.body
+
+            return {
+                'statusCode': response.status_code,
+                'headers': response.headers,
+                'body': response_body,
+            }
+        return wrapper
+
+    # Support use as a decorator with no arguments, or with interceptor arguments
+    if callable(_handler):
+        return _handler_wrapper(_handler)
+    elif _handler is None:
+        return _handler_wrapper
+    else:
+        raise Exception(\\"Positional arguments are not supported by any_request_response_handler.\\")
+
+# Request parameters are single value query params or path params
 class EmptyRequestParameters(TypedDict):
     ...
 
@@ -9868,7 +10053,7 @@ class EmptyRequestParameters(TypedDict):
 class EmptyRequestArrayParameters(TypedDict):
     ...
 
-# Request body type (default to Any when no body parameters exist)
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 EmptyRequestBody = Any
 
 Empty204OperationResponse = ApiResponse[Literal[204], None]
@@ -9898,8 +10083,7 @@ def empty_handler(_handler: EmptyHandlerFunction = None, interceptors: List[Empt
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
-            body = parse_body(event['body'], [], EmptyRequestBody)
-
+            body = {}
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -9911,10 +10095,17 @@ def empty_handler(_handler: EmptyHandlerFunction = None, interceptors: List[Empt
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 204:
+                response_body = response.body
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 
@@ -9934,8 +10125,8 @@ class MediaTypesRequestParameters(TypedDict):
 class MediaTypesRequestArrayParameters(TypedDict):
     ...
 
-# Request body type (default to Any when no body parameters exist)
-MediaTypesRequestBody = file_type
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
+MediaTypesRequestBody = str
 
 MediaTypes200OperationResponse = ApiResponse[Literal[200], str]
 MediaTypesOperationResponses = Union[MediaTypes200OperationResponse, ]
@@ -9964,8 +10155,8 @@ def media_types_handler(_handler: MediaTypesHandlerFunction = None, interceptors
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
-            body = parse_body(event['body'], ['application/pdf',], MediaTypesRequestBody)
-
+            # Primitive type so body is passed as the original string
+            body = event['body']
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -9977,10 +10168,17 @@ def media_types_handler(_handler: MediaTypesHandlerFunction = None, interceptors
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = response.body
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 
@@ -10005,7 +10203,7 @@ class OperationOneRequestArrayParameters(TypedDict):
     param2: List[str]
     ...
 
-# Request body type (default to Any when no body parameters exist)
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 OperationOneRequestBody = TestRequest
 
 OperationOne200OperationResponse = ApiResponse[Literal[200], TestResponse]
@@ -10036,8 +10234,8 @@ def operation_one_handler(_handler: OperationOneHandlerFunction = None, intercep
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
+            # Non-primitive type so parse the body into the appropriate model
             body = parse_body(event['body'], ['application/json',], OperationOneRequestBody)
-
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -10049,10 +10247,19 @@ def operation_one_handler(_handler: OperationOneHandlerFunction = None, intercep
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+            elif response.status_code == 400:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 
@@ -10072,7 +10279,7 @@ class WithoutOperationIdDeleteRequestParameters(TypedDict):
 class WithoutOperationIdDeleteRequestArrayParameters(TypedDict):
     ...
 
-# Request body type (default to Any when no body parameters exist)
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 WithoutOperationIdDeleteRequestBody = Any
 
 WithoutOperationIdDelete200OperationResponse = ApiResponse[Literal[200], TestResponse]
@@ -10102,8 +10309,7 @@ def without_operation_id_delete_handler(_handler: WithoutOperationIdDeleteHandle
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
-            body = parse_body(event['body'], [], WithoutOperationIdDeleteRequestBody)
-
+            body = {}
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -10115,10 +10321,17 @@ def without_operation_id_delete_handler(_handler: WithoutOperationIdDeleteHandle
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 
@@ -11403,7 +11616,336 @@ class PathValues(str, enum.Enum):
     PATH_PATH_PARAM = \\"/path/{pathParam}\\"
     WITHOUTOPERATIONID = \\"/without-operation-id\\"
     EMPTYRESPONSE = \\"/empty-response\\"
+    ANYREQUESTRESPONSE = \\"/any-request-response\\"
     DIFFERENTMEDIATYPE = \\"/different-media-type\\"
+",
+  "test/paths/any_request_response/__init__.py": "# do not import all endpoints into this module because that uses a lot of memory and stack frames
+# if you need the ability to import all endpoints from this module, import them with
+# from test.paths.any_request_response import Api
+
+from test.paths import PathValues
+
+path = PathValues.ANYREQUESTRESPONSE",
+  "test/paths/any_request_response/put.py": "# coding: utf-8
+
+\\"\\"\\"
+
+
+    Generated by: https://openapi-generator.tech
+\\"\\"\\"
+
+from dataclasses import dataclass
+import urllib3
+from urllib3._collections import HTTPHeaderDict
+
+from test import api_client, exceptions
+from datetime import date, datetime  # noqa: F401
+import decimal  # noqa: F401
+import functools  # noqa: F401
+import io  # noqa: F401
+import re  # noqa: F401
+import typing  # noqa: F401
+import uuid  # noqa: F401
+
+import frozendict  # noqa: F401
+
+from test import schemas  # noqa: F401
+
+from . import path
+
+# body param
+SchemaForRequestBodyApplicationJson = schemas.AnyTypeSchema
+
+
+request_body_body = api_client.RequestBody(
+    content={
+        'application/json': api_client.MediaType(
+            schema=SchemaForRequestBodyApplicationJson),
+    },
+)
+SchemaFor200ResponseBodyApplicationJson = schemas.AnyTypeSchema
+
+
+@dataclass
+class ApiResponseFor200(api_client.ApiResponse):
+    response: urllib3.HTTPResponse
+    body: typing.Union[
+        SchemaFor200ResponseBodyApplicationJson,
+    ]
+    headers: schemas.Unset = schemas.unset
+
+
+_response_for_200 = api_client.OpenApiResponse(
+    response_cls=ApiResponseFor200,
+    content={
+        'application/json': api_client.MediaType(
+            schema=SchemaFor200ResponseBodyApplicationJson),
+    },
+)
+_status_code_to_response = {
+    '200': _response_for_200,
+}
+_all_accept_content_types = (
+    'application/json',
+)
+
+
+class BaseApi(api_client.Api):
+
+    def _any_request_response_oapg(
+        self: api_client.Api,
+        body: typing.Union[SchemaForRequestBodyApplicationJson, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, None, list, tuple, bytes, schemas.Unset] = schemas.unset,
+        content_type: str = 'application/json',
+        accept_content_types: typing.Tuple[str] = _all_accept_content_types,
+        stream: bool = False,
+        timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
+        skip_deserialization: bool = False,
+    ) -> typing.Union[
+        ApiResponseFor200,
+        api_client.ApiResponseWithoutDeserialization
+    ]:
+        \\"\\"\\"
+        :param skip_deserialization: If true then api_response.response will be set but
+            api_response.body and api_response.headers will not be deserialized into schema
+            class instances
+        \\"\\"\\"
+        used_path = path.value
+
+        _headers = HTTPHeaderDict()
+        # TODO add cookie handling
+        if accept_content_types:
+            for accept_content_type in accept_content_types:
+                _headers.add('Accept', accept_content_type)
+
+        _fields = None
+        _body = None
+        if body is not schemas.unset:
+            serialized_data = request_body_body.serialize(body, content_type)
+            _headers.add('Content-Type', content_type)
+            if 'fields' in serialized_data:
+                _fields = serialized_data['fields']
+            elif 'body' in serialized_data:
+                _body = serialized_data['body']
+        response = self.api_client.call_api(
+            resource_path=used_path,
+            method='put'.upper(),
+            headers=_headers,
+            fields=_fields,
+            body=_body,
+            stream=stream,
+            timeout=timeout,
+        )
+
+        if skip_deserialization:
+            api_response = api_client.ApiResponseWithoutDeserialization(response=response)
+        else:
+            response_for_status = _status_code_to_response.get(str(response.status))
+            if response_for_status:
+                api_response = response_for_status.deserialize(response, self.api_client.configuration)
+            else:
+                api_response = api_client.ApiResponseWithoutDeserialization(response=response)
+
+        if not 200 <= response.status <= 299:
+            raise exceptions.ApiException(api_response=api_response)
+
+        return api_response
+
+
+class AnyRequestResponse(BaseApi):
+    # this class is used by api classes that refer to endpoints with operationId fn names
+
+    def any_request_response(
+        self: BaseApi,
+        body: typing.Union[SchemaForRequestBodyApplicationJson, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, None, list, tuple, bytes, schemas.Unset] = schemas.unset,
+        content_type: str = 'application/json',
+        accept_content_types: typing.Tuple[str] = _all_accept_content_types,
+        stream: bool = False,
+        timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
+        skip_deserialization: bool = False,
+    ) -> typing.Union[
+        ApiResponseFor200,
+        api_client.ApiResponseWithoutDeserialization
+    ]:
+        return self._any_request_response_oapg(
+            body=body,
+            content_type=content_type,
+            accept_content_types=accept_content_types,
+            stream=stream,
+            timeout=timeout,
+            skip_deserialization=skip_deserialization
+        )
+
+
+class ApiForput(BaseApi):
+    # this class is used by api classes that refer to endpoints by path and http method names
+
+    def put(
+        self: BaseApi,
+        body: typing.Union[SchemaForRequestBodyApplicationJson, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, None, list, tuple, bytes, schemas.Unset] = schemas.unset,
+        content_type: str = 'application/json',
+        accept_content_types: typing.Tuple[str] = _all_accept_content_types,
+        stream: bool = False,
+        timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
+        skip_deserialization: bool = False,
+    ) -> typing.Union[
+        ApiResponseFor200,
+        api_client.ApiResponseWithoutDeserialization
+    ]:
+        return self._any_request_response_oapg(
+            body=body,
+            content_type=content_type,
+            accept_content_types=accept_content_types,
+            stream=stream,
+            timeout=timeout,
+            skip_deserialization=skip_deserialization
+        )
+
+
+",
+  "test/paths/any_request_response/put.pyi": "# coding: utf-8
+
+\\"\\"\\"
+
+
+    Generated by: https://openapi-generator.tech
+\\"\\"\\"
+
+from dataclasses import dataclass
+import urllib3
+from urllib3._collections import HTTPHeaderDict
+
+from test import api_client, exceptions
+from datetime import date, datetime  # noqa: F401
+import decimal  # noqa: F401
+import functools  # noqa: F401
+import io  # noqa: F401
+import re  # noqa: F401
+import typing  # noqa: F401
+import uuid  # noqa: F401
+
+import frozendict  # noqa: F401
+
+from test import schemas  # noqa: F401
+
+# body param
+SchemaForRequestBodyApplicationJson = schemas.AnyTypeSchema
+SchemaFor200ResponseBodyApplicationJson = schemas.AnyTypeSchema
+_all_accept_content_types = (
+    'application/json',
+)
+
+
+class BaseApi(api_client.Api):
+
+    def _any_request_response_oapg(
+        self: api_client.Api,
+        body: typing.Union[SchemaForRequestBodyApplicationJson, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, None, list, tuple, bytes, schemas.Unset] = schemas.unset,
+        content_type: str = 'application/json',
+        accept_content_types: typing.Tuple[str] = _all_accept_content_types,
+        stream: bool = False,
+        timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
+        skip_deserialization: bool = False,
+    ) -> typing.Union[
+        ApiResponseFor200,
+        api_client.ApiResponseWithoutDeserialization
+    ]:
+        \\"\\"\\"
+        :param skip_deserialization: If true then api_response.response will be set but
+            api_response.body and api_response.headers will not be deserialized into schema
+            class instances
+        \\"\\"\\"
+        used_path = path.value
+
+        _headers = HTTPHeaderDict()
+        # TODO add cookie handling
+        if accept_content_types:
+            for accept_content_type in accept_content_types:
+                _headers.add('Accept', accept_content_type)
+
+        _fields = None
+        _body = None
+        if body is not schemas.unset:
+            serialized_data = request_body_body.serialize(body, content_type)
+            _headers.add('Content-Type', content_type)
+            if 'fields' in serialized_data:
+                _fields = serialized_data['fields']
+            elif 'body' in serialized_data:
+                _body = serialized_data['body']
+        response = self.api_client.call_api(
+            resource_path=used_path,
+            method='put'.upper(),
+            headers=_headers,
+            fields=_fields,
+            body=_body,
+            stream=stream,
+            timeout=timeout,
+        )
+
+        if skip_deserialization:
+            api_response = api_client.ApiResponseWithoutDeserialization(response=response)
+        else:
+            response_for_status = _status_code_to_response.get(str(response.status))
+            if response_for_status:
+                api_response = response_for_status.deserialize(response, self.api_client.configuration)
+            else:
+                api_response = api_client.ApiResponseWithoutDeserialization(response=response)
+
+        if not 200 <= response.status <= 299:
+            raise exceptions.ApiException(api_response=api_response)
+
+        return api_response
+
+
+class AnyRequestResponse(BaseApi):
+    # this class is used by api classes that refer to endpoints with operationId fn names
+
+    def any_request_response(
+        self: BaseApi,
+        body: typing.Union[SchemaForRequestBodyApplicationJson, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, None, list, tuple, bytes, schemas.Unset] = schemas.unset,
+        content_type: str = 'application/json',
+        accept_content_types: typing.Tuple[str] = _all_accept_content_types,
+        stream: bool = False,
+        timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
+        skip_deserialization: bool = False,
+    ) -> typing.Union[
+        ApiResponseFor200,
+        api_client.ApiResponseWithoutDeserialization
+    ]:
+        return self._any_request_response_oapg(
+            body=body,
+            content_type=content_type,
+            accept_content_types=accept_content_types,
+            stream=stream,
+            timeout=timeout,
+            skip_deserialization=skip_deserialization
+        )
+
+
+class ApiForput(BaseApi):
+    # this class is used by api classes that refer to endpoints by path and http method names
+
+    def put(
+        self: BaseApi,
+        body: typing.Union[SchemaForRequestBodyApplicationJson, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, None, list, tuple, bytes, schemas.Unset] = schemas.unset,
+        content_type: str = 'application/json',
+        accept_content_types: typing.Tuple[str] = _all_accept_content_types,
+        stream: bool = False,
+        timeout: typing.Optional[typing.Union[int, typing.Tuple]] = None,
+        skip_deserialization: bool = False,
+    ) -> typing.Union[
+        ApiResponseFor200,
+        api_client.ApiResponseWithoutDeserialization
+    ]:
+        return self._any_request_response_oapg(
+            body=body,
+            content_type=content_type,
+            accept_content_types=accept_content_types,
+            stream=stream,
+            timeout=timeout,
+            skip_deserialization=skip_deserialization
+        )
+
+
 ",
   "test/paths/different_media_type/__init__.py": "# do not import all endpoints into this module because that uses a lot of memory and stack frames
 # if you need the ability to import all endpoints from this module, import them with
@@ -15464,6 +16006,48 @@ class ApiTestMixin:
     @staticmethod
     def json_bytes(in_data: typing.Any) -> bytes:
         return json.dumps(in_data, separators=(\\",\\", \\":\\"), ensure_ascii=False).encode('utf-8')
+",
+  "test/test_paths/test_any_request_response/__init__.py": "",
+  "test/test_paths/test_any_request_response/test_put.py": "# coding: utf-8
+
+\\"\\"\\"
+
+
+    Generated by: https://openapi-generator.tech
+\\"\\"\\"
+
+import unittest
+from unittest.mock import patch
+
+import urllib3
+
+import test
+from test.paths.any_request_response import put  # noqa: E501
+from test import configuration, schemas, api_client
+
+from .. import ApiTestMixin
+
+
+class TestAnyRequestResponse(ApiTestMixin, unittest.TestCase):
+    \\"\\"\\"
+    AnyRequestResponse unit test stubs
+    \\"\\"\\"
+    _configuration = configuration.Configuration()
+
+    def setUp(self):
+        used_api_client = api_client.ApiClient(configuration=self._configuration)
+        self.api = put.ApiForput(api_client=used_api_client)  # noqa: E501
+
+    def tearDown(self):
+        pass
+
+    response_status = 200
+
+
+
+
+if __name__ == '__main__':
+    unittest.main()
 ",
   "test/test_paths/test_different_media_type/__init__.py": "",
   "test/test_paths/test_different_media_type/test_post.py": "# coding: utf-8

--- a/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-typescript-client-source-code.test.ts.snap
+++ b/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-typescript-client-source-code.test.ts.snap
@@ -1475,9 +1475,7 @@ export const someTestOperationHandler = (
     }) as unknown as SomeTestOperationRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        parsed = TestRequestFromJSON(parsed);
-        return parsed;
+        return TestRequestFromJSON(JSON.parse(bodyString));
     };
     const body = parseBody(event.body, demarshal, ['application/json',]) as SomeTestOperationRequestBody;
 
@@ -3470,6 +3468,10 @@ import {
     TestResponseToJSON,
 } from '../models';
 
+export interface AnyRequestResponseRequest {
+    body?: any | null;
+}
+
 export interface MediaTypesRequest {
     body: Blob;
 }
@@ -3487,6 +3489,33 @@ export interface OperationOneRequest {
  * 
  */
 export class DefaultApi extends runtime.BaseAPI {
+
+    /**
+     */
+    async anyRequestResponseRaw(requestParameters: AnyRequestResponseRequest, initOverrides?: RequestInit | runtime.InitOverideFunction): Promise<runtime.ApiResponse<any>> {
+        const queryParameters: any = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        headerParameters['Content-Type'] = 'application/json';
+
+        const response = await this.request({
+            path: \`/any-request-response\`,
+            method: 'PUT',
+            headers: headerParameters,
+            query: queryParameters,
+            body: requestParameters.body as any,
+        }, initOverrides);
+
+        return new runtime.TextApiResponse(response) as any;
+    }
+
+    /**
+     */
+    async anyRequestResponse(requestParameters: AnyRequestResponseRequest = {}, initOverrides?: RequestInit | runtime.InitOverideFunction): Promise<any> {
+        const response = await this.anyRequestResponseRaw(requestParameters, initOverrides);
+        return await response.value();
+    }
 
     /**
      */
@@ -3645,6 +3674,7 @@ import {
 } from '../../models';
 // Import request parameter interfaces
 import {
+    AnyRequestResponseRequest,
     
     MediaTypesRequest,
     OperationOneRequest,
@@ -3656,6 +3686,7 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from \\"aws-lamb
 
 // Generic type for object keyed by operation names
 export interface OperationConfig<T> {
+    anyRequestResponse: T;
     empty: T;
     mediaTypes: T;
     operationOne: T;
@@ -3664,6 +3695,10 @@ export interface OperationConfig<T> {
 
 // Look up path and http method for a given operation name
 export const OperationLookup = {
+    anyRequestResponse: {
+        path: '/any-request-response',
+        method: 'PUT',
+    },
     empty: {
         path: '/empty-response',
         method: 'PUT',
@@ -3781,6 +3816,80 @@ const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBod
 };
 
 /**
+ * Single-value path/query parameters for AnyRequestResponse
+ */
+export interface AnyRequestResponseRequestParameters {
+}
+
+/**
+ * Multi-value query parameters for AnyRequestResponse
+ */
+export interface AnyRequestResponseRequestArrayParameters {
+}
+
+/**
+ * Request body parameter for AnyRequestResponse
+ */
+export type AnyRequestResponseRequestBody = string;
+
+export type AnyRequestResponse200OperationResponse = OperationResponse<200, string>;
+export type AnyRequestResponseOperationResponses = | AnyRequestResponse200OperationResponse ;
+
+// Type that the handler function provided to the wrapper must conform to
+export type AnyRequestResponseHandlerFunction = LambdaHandlerFunction<AnyRequestResponseRequestParameters, AnyRequestResponseRequestArrayParameters, AnyRequestResponseRequestBody, AnyRequestResponseOperationResponses>;
+export type AnyRequestResponseChainedHandlerFunction = ChainedLambdaHandlerFunction<AnyRequestResponseRequestParameters, AnyRequestResponseRequestArrayParameters, AnyRequestResponseRequestBody, AnyRequestResponseOperationResponses>;
+
+/**
+ * Lambda handler wrapper to provide typed interface for the implementation of anyRequestResponse
+ */
+export const anyRequestResponseHandler = (
+    firstHandler: AnyRequestResponseChainedHandlerFunction,
+    ...remainingHandlers: AnyRequestResponseChainedHandlerFunction[]
+): ApiGatewayLambdaHandler => async (event: any, context: any): Promise<any> => {
+    const requestParameters = decodeRequestParameters({
+        ...(event.pathParameters || {}),
+        ...(event.queryStringParameters || {}),
+    }) as unknown as AnyRequestResponseRequestParameters;
+
+    const requestArrayParameters = decodeRequestParameters({
+        ...(event.multiValueQueryStringParameters || {}),
+    }) as unknown as AnyRequestResponseRequestArrayParameters;
+
+    const demarshal = (bodyString: string): any => {
+        return bodyString;
+    };
+    const body = parseBody(event.body, demarshal, ['application/json',]) as AnyRequestResponseRequestBody;
+
+    const chain = buildHandlerChain(firstHandler, ...remainingHandlers);
+    const response = await chain.next({
+        input: {
+            requestParameters,
+            requestArrayParameters,
+            body,
+        },
+        event,
+        context,
+        interceptorContext: {},
+    });
+
+    const marshal = (statusCode: number, responseBody: any): string => {
+        let marshalledBody = responseBody;
+        switch(statusCode) {
+            case 200:
+                break;
+            default:
+                break;
+        }
+
+        return marshalledBody;
+    };
+
+    return {
+        ...response,
+        body: response.body ? marshal(response.statusCode, response.body) : '',
+    };
+};
+/**
  * Single-value path/query parameters for Empty
  */
 export interface EmptyRequestParameters {
@@ -3821,8 +3930,7 @@ export const emptyHandler = (
     }) as unknown as EmptyRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        return parsed;
+        return {};
     };
     const body = parseBody(event.body, demarshal, ['application/json']) as EmptyRequestBody;
 
@@ -3870,7 +3978,7 @@ export interface MediaTypesRequestArrayParameters {
 /**
  * Request body parameter for MediaTypes
  */
-export type MediaTypesRequestBody = Blob;
+export type MediaTypesRequestBody = string;
 
 export type MediaTypes200OperationResponse = OperationResponse<200, string>;
 export type MediaTypesOperationResponses = | MediaTypes200OperationResponse ;
@@ -3896,9 +4004,7 @@ export const mediaTypesHandler = (
     }) as unknown as MediaTypesRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        parsed = BlobFromJSON(parsed);
-        return parsed;
+        return bodyString;
     };
     const body = parseBody(event.body, demarshal, ['application/pdf',]) as MediaTypesRequestBody;
 
@@ -3978,9 +4084,7 @@ export const operationOneHandler = (
     }) as unknown as OperationOneRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        parsed = TestRequestFromJSON(parsed);
-        return parsed;
+        return TestRequestFromJSON(JSON.parse(bodyString));
     };
     const body = parseBody(event.body, demarshal, ['application/json',]) as OperationOneRequestBody;
 
@@ -4058,8 +4162,7 @@ export const withoutOperationIdDeleteHandler = (
     }) as unknown as WithoutOperationIdDeleteRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        return parsed;
+        return {};
     };
     const body = parseBody(event.body, demarshal, ['application/json']) as WithoutOperationIdDeleteRequestBody;
 

--- a/packages/open-api-gateway/test/project/codegen/components/docs/__snapshots__/generated-html2-docs.test.ts.snap
+++ b/packages/open-api-gateway/test/project/codegen/components/docs/__snapshots__/generated-html2-docs.test.ts.snap
@@ -4286,6 +4286,9 @@ ul.nav-tabs {
             <li class=\\"nav-fixed nav-header active\\" data-group=\\"_\\"><a href=\\"#api-_\\">API Summary</a></li>
 
                   <li class=\\"nav-header\\" data-group=\\"Default\\"><a href=\\"#api-Default\\">API Methods - Default</a></li>
+                    <li data-group=\\"Default\\" data-name=\\"anyRequestResponse\\" class=\\"\\">
+                      <a href=\\"#api-Default-anyRequestResponse\\">anyRequestResponse</a>
+                    </li>
                     <li data-group=\\"Default\\" data-name=\\"empty\\" class=\\"\\">
                       <a href=\\"#api-Default-empty\\">empty</a>
                     </li>
@@ -4321,6 +4324,359 @@ ul.nav-tabs {
         <div id=\\"sections\\">
                 <section id=\\"api-Default\\">
                   <h1>Default</h1>
+                    <div id=\\"api-Default-anyRequestResponse\\">
+                      <article id=\\"api-Default-anyRequestResponse-0\\" data-group=\\"User\\" data-name=\\"anyRequestResponse\\" data-version=\\"0\\">
+                        <div class=\\"pull-left\\">
+                          <h1>anyRequestResponse</h1>
+                          <p></p>
+                        </div>
+                        <div class=\\"pull-right\\"></div>
+                        <div class=\\"clearfix\\"></div>
+                        <p></p>
+                        <p class=\\"marked\\"></p>
+                        <p></p>
+                        <br />
+                        <pre class=\\"prettyprint language-html prettyprinted\\" data-type=\\"put\\"><code><span class=\\"pln\\">/any-request-response</span></code></pre>
+                        <p>
+                          <h3>Usage and SDK Samples</h3>
+                        </p>
+                        <ul class=\\"nav nav-tabs nav-tabs-examples\\">
+                          <li class=\\"active\\"><a href=\\"#examples-Default-anyRequestResponse-0-curl\\">Curl</a></li>
+                          <li class=\\"\\"><a href=\\"#examples-Default-anyRequestResponse-0-java\\">Java</a></li>
+                          <li class=\\"\\"><a href=\\"#examples-Default-anyRequestResponse-0-android\\">Android</a></li>
+                          <!--<li class=\\"\\"><a href=\\"#examples-Default-anyRequestResponse-0-groovy\\">Groovy</a></li>-->
+                          <li class=\\"\\"><a href=\\"#examples-Default-anyRequestResponse-0-objc\\">Obj-C</a></li>
+                          <li class=\\"\\"><a href=\\"#examples-Default-anyRequestResponse-0-javascript\\">JavaScript</a></li>
+                          <!--<li class=\\"\\"><a href=\\"#examples-Default-anyRequestResponse-0-angular\\">Angular</a></li>-->
+                          <li class=\\"\\"><a href=\\"#examples-Default-anyRequestResponse-0-csharp\\">C#</a></li>
+                          <li class=\\"\\"><a href=\\"#examples-Default-anyRequestResponse-0-php\\">PHP</a></li>
+                          <li class=\\"\\"><a href=\\"#examples-Default-anyRequestResponse-0-perl\\">Perl</a></li>
+                          <li class=\\"\\"><a href=\\"#examples-Default-anyRequestResponse-0-python\\">Python</a></li>
+                          <li class=\\"\\"><a href=\\"#examples-Default-anyRequestResponse-0-rust\\">Rust</a></li>
+                        </ul>
+
+                        <div class=\\"tab-content\\">
+                          <div class=\\"tab-pane active\\" id=\\"examples-Default-anyRequestResponse-0-curl\\">
+                            <pre class=\\"prettyprint\\"><code class=\\"language-bsh\\">curl -X PUT \\\\
+ -H \\"Accept: application/json\\" \\\\
+ -H \\"Content-Type: application/json\\" \\\\
+ \\"http://localhost/any-request-response\\" \\\\
+ -d ''
+</code></pre>
+                          </div>
+                          <div class=\\"tab-pane\\" id=\\"examples-Default-anyRequestResponse-0-java\\">
+                            <pre class=\\"prettyprint\\"><code class=\\"language-java\\">import org.openapitools.client.*;
+import org.openapitools.client.auth.*;
+import org.openapitools.client.model.*;
+import org.openapitools.client.api.DefaultApi;
+
+import java.io.File;
+import java.util.*;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+
+        // Create an instance of the API class
+        DefaultApi apiInstance = new DefaultApi();
+        oas_any_type_not_mapped body = ; // oas_any_type_not_mapped | 
+
+        try {
+            oas_any_type_not_mapped result = apiInstance.anyRequestResponse(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println(\\"Exception when calling DefaultApi#anyRequestResponse\\");
+            e.printStackTrace();
+        }
+    }
+}
+</code></pre>
+                          </div>
+
+                          <div class=\\"tab-pane\\" id=\\"examples-Default-anyRequestResponse-0-android\\">
+                            <pre class=\\"prettyprint\\"><code class=\\"language-java\\">import org.openapitools.client.api.DefaultApi;
+
+public class DefaultApiExample {
+    public static void main(String[] args) {
+        DefaultApi apiInstance = new DefaultApi();
+        oas_any_type_not_mapped body = ; // oas_any_type_not_mapped | 
+
+        try {
+            oas_any_type_not_mapped result = apiInstance.anyRequestResponse(body);
+            System.out.println(result);
+        } catch (ApiException e) {
+            System.err.println(\\"Exception when calling DefaultApi#anyRequestResponse\\");
+            e.printStackTrace();
+        }
+    }
+}</code></pre>
+                          </div>
+  <!--
+  <div class=\\"tab-pane\\" id=\\"examples-Default-anyRequestResponse-0-groovy\\">
+  <pre class=\\"prettyprint language-json prettyprinted\\" data-type=\\"json\\"><code>Coming Soon!</code></pre>
+  </div> -->
+                            <div class=\\"tab-pane\\" id=\\"examples-Default-anyRequestResponse-0-objc\\">
+                              <pre class=\\"prettyprint\\"><code class=\\"language-cpp\\">
+
+// Create an instance of the API class
+DefaultApi *apiInstance = [[DefaultApi alloc] init];
+oas_any_type_not_mapped *body = ; //  (optional)
+
+[apiInstance anyRequestResponseWith:body
+              completionHandler: ^(oas_any_type_not_mapped output, NSError* error) {
+    if (output) {
+        NSLog(@\\"%@\\", output);
+    }
+    if (error) {
+        NSLog(@\\"Error: %@\\", error);
+    }
+}];
+</code></pre>
+                            </div>
+
+                            <div class=\\"tab-pane\\" id=\\"examples-Default-anyRequestResponse-0-javascript\\">
+                              <pre class=\\"prettyprint\\"><code class=\\"language-js\\">var ExampleApi = require('example_api');
+
+// Create an instance of the API class
+var api = new ExampleApi.DefaultApi()
+var opts = {
+  'body':  // {oas_any_type_not_mapped} 
+};
+
+var callback = function(error, data, response) {
+  if (error) {
+    console.error(error);
+  } else {
+    console.log('API called successfully. Returned data: ' + data);
+  }
+};
+api.anyRequestResponse(opts, callback);
+</code></pre>
+                            </div>
+
+                            <!--<div class=\\"tab-pane\\" id=\\"examples-Default-anyRequestResponse-0-angular\\">
+              <pre class=\\"prettyprint language-json prettyprinted\\" data-type=\\"json\\"><code>Coming Soon!</code></pre>
+            </div>-->
+                            <div class=\\"tab-pane\\" id=\\"examples-Default-anyRequestResponse-0-csharp\\">
+                              <pre class=\\"prettyprint\\"><code class=\\"language-cs\\">using System;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+    public class anyRequestResponseExample
+    {
+        public void main()
+        {
+
+            // Create an instance of the API class
+            var apiInstance = new DefaultApi();
+            var body = ;  // oas_any_type_not_mapped |  (optional) 
+
+            try {
+                oas_any_type_not_mapped result = apiInstance.anyRequestResponse(body);
+                Debug.WriteLine(result);
+            } catch (Exception e) {
+                Debug.Print(\\"Exception when calling DefaultApi.anyRequestResponse: \\" + e.Message );
+            }
+        }
+    }
+}
+</code></pre>
+                            </div>
+
+                            <div class=\\"tab-pane\\" id=\\"examples-Default-anyRequestResponse-0-php\\">
+                              <pre class=\\"prettyprint\\"><code class=\\"language-php\\"><&#63;php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+// Create an instance of the API class
+$api_instance = new OpenAPITools\\\\Client\\\\Api\\\\DefaultApi();
+$body = ; // oas_any_type_not_mapped | 
+
+try {
+    $result = $api_instance->anyRequestResponse($body);
+    print_r($result);
+} catch (Exception $e) {
+    echo 'Exception when calling DefaultApi->anyRequestResponse: ', $e->getMessage(), PHP_EOL;
+}
+?></code></pre>
+                            </div>
+
+                            <div class=\\"tab-pane\\" id=\\"examples-Default-anyRequestResponse-0-perl\\">
+                              <pre class=\\"prettyprint\\"><code class=\\"language-perl\\">use Data::Dumper;
+use WWW::OPenAPIClient::Configuration;
+use WWW::OPenAPIClient::DefaultApi;
+
+# Create an instance of the API class
+my $api_instance = WWW::OPenAPIClient::DefaultApi->new();
+my $body = WWW::OPenAPIClient::Object::oas_any_type_not_mapped->new(); # oas_any_type_not_mapped | 
+
+eval {
+    my $result = $api_instance->anyRequestResponse(body => $body);
+    print Dumper($result);
+};
+if ($@) {
+    warn \\"Exception when calling DefaultApi->anyRequestResponse: $@\\\\n\\";
+}</code></pre>
+                            </div>
+
+                            <div class=\\"tab-pane\\" id=\\"examples-Default-anyRequestResponse-0-python\\">
+                              <pre class=\\"prettyprint\\"><code class=\\"language-python\\">from __future__ import print_statement
+import time
+import openapi_client
+from openapi_client.rest import ApiException
+from pprint import pprint
+
+# Create an instance of the API class
+api_instance = openapi_client.DefaultApi()
+body =  # oas_any_type_not_mapped |  (optional)
+
+try:
+    api_response = api_instance.any_request_response(body=body)
+    pprint(api_response)
+except ApiException as e:
+    print(\\"Exception when calling DefaultApi->anyRequestResponse: %s\\\\n\\" % e)</code></pre>
+                            </div>
+
+                            <div class=\\"tab-pane\\" id=\\"examples-Default-anyRequestResponse-0-rust\\">
+                              <pre class=\\"prettyprint\\"><code class=\\"language-rust\\">extern crate DefaultApi;
+
+pub fn main() {
+    let body = ; // oas_any_type_not_mapped
+
+    let mut context = DefaultApi::Context::default();
+    let result = client.anyRequestResponse(body, &context).wait();
+
+    println!(\\"{:?}\\", result);
+}
+</code></pre>
+                            </div>
+                          </div>
+
+                          <h2>Scopes</h2>
+                          <table>
+                            
+                          </table>
+
+                          <h2>Parameters</h2>
+
+
+
+                            <div class=\\"methodsubtabletitle\\">Body parameters</div>
+                            <table id=\\"methodsubtable\\">
+                              <tr>
+                                <th width=\\"150px\\">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                <tr><td style=\\"width:150px;\\">body </td>
+<td>
+<p class=\\"marked\\"></p>
+<script>
+$(document).ready(function() {
+  var schemaWrapper = {
+  \\"content\\" : {
+    \\"application/json\\" : {
+      \\"schema\\" : { }
+    }
+  }
+};
+
+  var schema = findNode('schema',schemaWrapper).schema;
+  if (!schema) {
+    schema = schemaWrapper.schema;
+  }
+  if (schema.$ref != null) {
+    schema = defsParser.$refs.get(schema.$ref);
+  } else {
+    schemaWrapper.definitions = Object.assign({}, defs);
+    $RefParser.dereference(schemaWrapper).catch(function(err) {
+      console.log(err);
+    });
+  }
+
+  var view = new JSONSchemaView(schema,2,{isBodyParam: true});
+  var result = $('#d2e199_anyRequestResponse_body');
+  result.empty();
+  result.append(view.render());
+});
+</script>
+<div id=\\"d2e199_anyRequestResponse_body\\"></div>
+</td>
+</tr>
+
+                            </table>
+
+
+
+                          <h2>Responses</h2>
+                            <h3 id=\\"examples-Default-anyRequestResponse-title-200\\"></h3>
+                            <p id=\\"examples-Default-anyRequestResponse-description-200\\" class=\\"marked\\"></p>
+                            <script>
+                              var responseDefault200_description = \`Any response\`;
+                              var responseDefault200_description_break = responseDefault200_description.indexOf('\\\\n');
+                              if (responseDefault200_description_break == -1) {
+                                $(\\"#examples-Default-anyRequestResponse-title-200\\").text(\\"Status: 200 - \\" + responseDefault200_description);
+                              } else {
+                                $(\\"#examples-Default-anyRequestResponse-title-200\\").text(\\"Status: 200 - \\" + responseDefault200_description.substring(0, responseDefault200_description_break));
+                                $(\\"#examples-Default-anyRequestResponse-description-200\\").html(responseDefault200_description.substring(responseDefault200_description_break));
+                              }
+                            </script>
+
+
+                            <ul id=\\"responses-detail-Default-anyRequestResponse-200\\" class=\\"nav nav-tabs nav-tabs-examples\\" >
+                                <li class=\\"active\\">
+                                  <a data-toggle=\\"tab\\" href=\\"#responses-Default-anyRequestResponse-200-schema\\">Schema</a>
+                                </li>
+
+
+
+
+                            </ul>
+
+
+                            <div class=\\"tab-content\\" id=\\"responses-Default-anyRequestResponse-200-wrapper\\" style='margin-bottom: 10px;'>
+                                <div class=\\"tab-pane active\\" id=\\"responses-Default-anyRequestResponse-200-schema\\">
+                                  <div id=\\"responses-Default-anyRequestResponse-schema-200\\" class=\\"exampleStyle\\">
+                                    <script>
+                                      $(document).ready(function() {
+                                        var schemaWrapper = {
+  \\"description\\" : \\"Any response\\",
+  \\"content\\" : {
+    \\"application/json\\" : {
+      \\"schema\\" : { }
+    }
+  }
+};
+                                        var schema = findNode('schema',schemaWrapper).schema;
+                                        if (!schema) {
+                                          schema = schemaWrapper.schema;
+                                        }
+                                        if (schema.$ref != null) {
+                                          schema = defsParser.$refs.get(schema.$ref);
+                                        } else if (schema.items != null && schema.items.$ref != null) {
+                                            schema.items = defsParser.$refs.get(schema.items.$ref);
+                                        } else {
+                                          schemaWrapper.definitions = Object.assign({}, defs);
+                                          $RefParser.dereference(schemaWrapper).catch(function(err) {
+                                            console.log(err);
+                                          });
+                                        }
+
+                                        var view = new JSONSchemaView(schema, 3);
+                                        $('#responses-Default-anyRequestResponse-200-schema-data').val(JSON.stringify(schema));
+                                        var result = $('#responses-Default-anyRequestResponse-schema-200');
+                                        result.empty();
+                                        result.append(view.render());
+                                      });
+                                    </script>
+                                  </div>
+                                  <input id='responses-Default-anyRequestResponse-200-schema-data' type='hidden' value=''></input>
+                                </div>
+                            </div>
+                        </article>
+                      </div>
+                      <hr>
                     <div id=\\"api-Default-empty\\">
                       <article id=\\"api-Default-empty-0\\" data-group=\\"User\\" data-name=\\"empty\\" data-version=\\"0\\">
                         <div class=\\"pull-left\\">

--- a/packages/open-api-gateway/test/project/codegen/components/docs/__snapshots__/generated-markdown-docs.test.ts.snap
+++ b/packages/open-api-gateway/test/project/codegen/components/docs/__snapshots__/generated-markdown-docs.test.ts.snap
@@ -346,11 +346,37 @@ All URIs are relative to *http://localhost*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
+| [**anyRequestResponse**](DefaultApi.md#anyRequestResponse) | **PUT** /any-request-response |  |
 | [**empty**](DefaultApi.md#empty) | **PUT** /empty-response |  |
 | [**mediaTypes**](DefaultApi.md#mediaTypes) | **POST** /different-media-type |  |
 | [**operationOne**](DefaultApi.md#operationOne) | **POST** /path/{pathParam} |  |
 | [**withoutOperationIdDelete**](DefaultApi.md#withoutOperationIdDelete) | **DELETE** /without-operation-id |  |
 
+
+<a name=\\"anyRequestResponse\\"></a>
+# **anyRequestResponse**
+> oas_any_type_not_mapped anyRequestResponse(body)
+
+
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **body** | **oas_any_type_not_mapped**|  | [optional] |
+
+### Return type
+
+[**oas_any_type_not_mapped**](../Models/AnyType.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: application/json
+- **Accept**: application/json
 
 <a name=\\"empty\\"></a>
 # **empty**
@@ -502,7 +528,8 @@ All URIs are relative to *http://localhost*
 
 | Class | Method | HTTP request | Description |
 |------------ | ------------- | ------------- | -------------|
-| *DefaultApi* | [**empty**](Apis/DefaultApi.md#empty) | **PUT** /empty-response |  |
+| *DefaultApi* | [**anyRequestResponse**](Apis/DefaultApi.md#anyrequestresponse) | **PUT** /any-request-response |  |
+*DefaultApi* | [**empty**](Apis/DefaultApi.md#empty) | **PUT** /empty-response |  |
 *DefaultApi* | [**mediaTypes**](Apis/DefaultApi.md#mediatypes) | **POST** /different-media-type |  |
 *DefaultApi* | [**operationOne**](Apis/DefaultApi.md#operationone) | **POST** /path/{pathParam} |  |
 *DefaultApi* | [**withoutOperationIdDelete**](Apis/DefaultApi.md#withoutoperationiddelete) | **DELETE** /without-operation-id |  |

--- a/packages/open-api-gateway/test/project/open-api-gateway-java-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-java-project/__snapshots__/monorepo.test.ts.snap
@@ -10183,7 +10183,7 @@ class SayHelloRequestParameters(TypedDict):
 class SayHelloRequestArrayParameters(TypedDict):
     ...
 
-# Request body type (default to Any when no body parameters exist)
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 SayHelloRequestBody = Any
 
 SayHello200OperationResponse = ApiResponse[Literal[200], SayHelloResponseContent]
@@ -10214,8 +10214,7 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
-            body = parse_body(event['body'], [], SayHelloRequestBody)
-
+            body = {}
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -10227,10 +10226,19 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+            elif response.status_code == 400:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 
@@ -15180,8 +15188,7 @@ export const sayHelloHandler = (
     }) as unknown as SayHelloRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        return parsed;
+        return {};
     };
     const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 

--- a/packages/open-api-gateway/test/project/open-api-gateway-java-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-java-project/__snapshots__/standalone.test.ts.snap
@@ -9299,7 +9299,7 @@ class SayHelloRequestParameters(TypedDict):
 class SayHelloRequestArrayParameters(TypedDict):
     ...
 
-# Request body type (default to Any when no body parameters exist)
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 SayHelloRequestBody = Any
 
 SayHello200OperationResponse = ApiResponse[Literal[200], SayHelloResponseContent]
@@ -9330,8 +9330,7 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
-            body = parse_body(event['body'], [], SayHelloRequestBody)
-
+            body = {}
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -9343,10 +9342,19 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+            elif response.status_code == 400:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 
@@ -14300,8 +14308,7 @@ export const sayHelloHandler = (
     }) as unknown as SayHelloRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        return parsed;
+        return {};
     };
     const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
@@ -10157,7 +10157,7 @@ class SayHelloRequestParameters(TypedDict):
 class SayHelloRequestArrayParameters(TypedDict):
     ...
 
-# Request body type (default to Any when no body parameters exist)
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 SayHelloRequestBody = Any
 
 SayHello200OperationResponse = ApiResponse[Literal[200], SayHelloResponseContent]
@@ -10188,8 +10188,7 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
-            body = parse_body(event['body'], [], SayHelloRequestBody)
-
+            body = {}
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -10201,10 +10200,19 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+            elif response.status_code == 400:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 
@@ -15154,8 +15162,7 @@ export const sayHelloHandler = (
     }) as unknown as SayHelloRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        return parsed;
+        return {};
     };
     const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
@@ -9270,7 +9270,7 @@ class SayHelloRequestParameters(TypedDict):
 class SayHelloRequestArrayParameters(TypedDict):
     ...
 
-# Request body type (default to Any when no body parameters exist)
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 SayHelloRequestBody = Any
 
 SayHello200OperationResponse = ApiResponse[Literal[200], SayHelloResponseContent]
@@ -9301,8 +9301,7 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
-            body = parse_body(event['body'], [], SayHelloRequestBody)
-
+            body = {}
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -9314,10 +9313,19 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+            elif response.status_code == 400:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 
@@ -14271,8 +14279,7 @@ export const sayHelloHandler = (
     }) as unknown as SayHelloRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        return parsed;
+        return {};
     };
     const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/with-docs.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/with-docs.test.ts.snap
@@ -6022,7 +6022,7 @@ class SayHelloRequestParameters(TypedDict):
 class SayHelloRequestArrayParameters(TypedDict):
     ...
 
-# Request body type (default to Any when no body parameters exist)
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 SayHelloRequestBody = Any
 
 SayHello200OperationResponse = ApiResponse[Literal[200], SayHelloResponseContent]
@@ -6053,8 +6053,7 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
-            body = parse_body(event['body'], [], SayHelloRequestBody)
-
+            body = {}
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -6066,10 +6065,19 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+            elif response.status_code == 400:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/custom-directories.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/custom-directories.test.ts.snap
@@ -2115,8 +2115,7 @@ export const sayHelloHandler = (
     }) as unknown as SayHelloRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        return parsed;
+        return {};
     };
     const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
@@ -10909,7 +10909,7 @@ class SayHelloRequestParameters(TypedDict):
 class SayHelloRequestArrayParameters(TypedDict):
     ...
 
-# Request body type (default to Any when no body parameters exist)
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 SayHelloRequestBody = Any
 
 SayHello200OperationResponse = ApiResponse[Literal[200], SayHelloResponseContent]
@@ -10940,8 +10940,7 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
-            body = parse_body(event['body'], [], SayHelloRequestBody)
-
+            body = {}
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -10953,10 +10952,19 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+            elif response.status_code == 400:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 
@@ -15665,8 +15673,7 @@ export const sayHelloHandler = (
     }) as unknown as SayHelloRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        return parsed;
+        return {};
     };
     const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 
@@ -27651,7 +27658,7 @@ class SayHelloRequestParameters(TypedDict):
 class SayHelloRequestArrayParameters(TypedDict):
     ...
 
-# Request body type (default to Any when no body parameters exist)
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 SayHelloRequestBody = Any
 
 SayHello200OperationResponse = ApiResponse[Literal[200], SayHelloResponseContent]
@@ -27682,8 +27689,7 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
-            body = parse_body(event['body'], [], SayHelloRequestBody)
-
+            body = {}
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -27695,10 +27701,19 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+            elif response.status_code == 400:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 
@@ -32415,8 +32430,7 @@ export const sayHelloHandler = (
     }) as unknown as SayHelloRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        return parsed;
+        return {};
     };
     const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 
@@ -44411,7 +44425,7 @@ class SayHelloRequestParameters(TypedDict):
 class SayHelloRequestArrayParameters(TypedDict):
     ...
 
-# Request body type (default to Any when no body parameters exist)
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 SayHelloRequestBody = Any
 
 SayHello200OperationResponse = ApiResponse[Literal[200], SayHelloResponseContent]
@@ -44442,8 +44456,7 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
-            body = parse_body(event['body'], [], SayHelloRequestBody)
-
+            body = {}
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -44455,10 +44468,19 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+            elif response.status_code == 400:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 
@@ -49167,8 +49189,7 @@ export const sayHelloHandler = (
     }) as unknown as SayHelloRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        return parsed;
+        return {};
     };
     const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
@@ -10380,7 +10380,7 @@ class SayHelloRequestParameters(TypedDict):
 class SayHelloRequestArrayParameters(TypedDict):
     ...
 
-# Request body type (default to Any when no body parameters exist)
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 SayHelloRequestBody = Any
 
 SayHello200OperationResponse = ApiResponse[Literal[200], SayHelloResponseContent]
@@ -10411,8 +10411,7 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
-            body = parse_body(event['body'], [], SayHelloRequestBody)
-
+            body = {}
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -10424,10 +10423,19 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+            elif response.status_code == 400:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 
@@ -15136,8 +15144,7 @@ export const sayHelloHandler = (
     }) as unknown as SayHelloRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        return parsed;
+        return {};
     };
     const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 
@@ -26533,7 +26540,7 @@ class SayHelloRequestParameters(TypedDict):
 class SayHelloRequestArrayParameters(TypedDict):
     ...
 
-# Request body type (default to Any when no body parameters exist)
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 SayHelloRequestBody = Any
 
 SayHello200OperationResponse = ApiResponse[Literal[200], SayHelloResponseContent]
@@ -26564,8 +26571,7 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
-            body = parse_body(event['body'], [], SayHelloRequestBody)
-
+            body = {}
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -26577,10 +26583,19 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+            elif response.status_code == 400:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 
@@ -31297,8 +31312,7 @@ export const sayHelloHandler = (
     }) as unknown as SayHelloRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        return parsed;
+        return {};
     };
     const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 
@@ -42683,7 +42697,7 @@ class SayHelloRequestParameters(TypedDict):
 class SayHelloRequestArrayParameters(TypedDict):
     ...
 
-# Request body type (default to Any when no body parameters exist)
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 SayHelloRequestBody = Any
 
 SayHello200OperationResponse = ApiResponse[Literal[200], SayHelloResponseContent]
@@ -42714,8 +42728,7 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
-            body = parse_body(event['body'], [], SayHelloRequestBody)
-
+            body = {}
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -42727,10 +42740,19 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+            elif response.status_code == 400:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 
@@ -47439,8 +47461,7 @@ export const sayHelloHandler = (
     }) as unknown as SayHelloRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        return parsed;
+        return {};
     };
     const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/with-docs.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/with-docs.test.ts.snap
@@ -5368,8 +5368,7 @@ export const sayHelloHandler = (
     }) as unknown as SayHelloRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        return parsed;
+        return {};
     };
     const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/without-sample-code.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/without-sample-code.test.ts.snap
@@ -2115,8 +2115,7 @@ export const sayHelloHandler = (
     }) as unknown as SayHelloRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        return parsed;
+        return {};
     };
     const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 

--- a/packages/open-api-gateway/test/project/smithy-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/smithy-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
@@ -3017,7 +3017,7 @@ class SayHelloRequestParameters(TypedDict):
 class SayHelloRequestArrayParameters(TypedDict):
     ...
 
-# Request body type (default to Any when no body parameters exist)
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 SayHelloRequestBody = Any
 
 SayHello200OperationResponse = ApiResponse[Literal[200], SayHelloResponseContent]
@@ -3048,8 +3048,7 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
-            body = parse_body(event['body'], [], SayHelloRequestBody)
-
+            body = {}
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -3061,10 +3060,19 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+            elif response.status_code == 400:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 

--- a/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
@@ -10912,7 +10912,7 @@ class SayHelloRequestParameters(TypedDict):
 class SayHelloRequestArrayParameters(TypedDict):
     ...
 
-# Request body type (default to Any when no body parameters exist)
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 SayHelloRequestBody = Any
 
 SayHello200OperationResponse = ApiResponse[Literal[200], SayHelloResponseContent]
@@ -10943,8 +10943,7 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
-            body = parse_body(event['body'], [], SayHelloRequestBody)
-
+            body = {}
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -10956,10 +10955,19 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+            elif response.status_code == 400:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 
@@ -15668,8 +15676,7 @@ export const sayHelloHandler = (
     }) as unknown as SayHelloRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        return parsed;
+        return {};
     };
     const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 
@@ -30140,7 +30147,7 @@ class SayHelloRequestParameters(TypedDict):
 class SayHelloRequestArrayParameters(TypedDict):
     ...
 
-# Request body type (default to Any when no body parameters exist)
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 SayHelloRequestBody = Any
 
 SayHello200OperationResponse = ApiResponse[Literal[200], SayHelloResponseContent]
@@ -30171,8 +30178,7 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
-            body = parse_body(event['body'], [], SayHelloRequestBody)
-
+            body = {}
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -30184,10 +30190,19 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+            elif response.status_code == 400:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 
@@ -34904,8 +34919,7 @@ export const sayHelloHandler = (
     }) as unknown as SayHelloRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        return parsed;
+        return {};
     };
     const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 
@@ -49386,7 +49400,7 @@ class SayHelloRequestParameters(TypedDict):
 class SayHelloRequestArrayParameters(TypedDict):
     ...
 
-# Request body type (default to Any when no body parameters exist)
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 SayHelloRequestBody = Any
 
 SayHello200OperationResponse = ApiResponse[Literal[200], SayHelloResponseContent]
@@ -49417,8 +49431,7 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
-            body = parse_body(event['body'], [], SayHelloRequestBody)
-
+            body = {}
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -49430,10 +49443,19 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+            elif response.status_code == 400:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 
@@ -54142,8 +54164,7 @@ export const sayHelloHandler = (
     }) as unknown as SayHelloRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        return parsed;
+        return {};
     };
     const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 

--- a/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
@@ -10383,7 +10383,7 @@ class SayHelloRequestParameters(TypedDict):
 class SayHelloRequestArrayParameters(TypedDict):
     ...
 
-# Request body type (default to Any when no body parameters exist)
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 SayHelloRequestBody = Any
 
 SayHello200OperationResponse = ApiResponse[Literal[200], SayHelloResponseContent]
@@ -10414,8 +10414,7 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
-            body = parse_body(event['body'], [], SayHelloRequestBody)
-
+            body = {}
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -10427,10 +10426,19 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+            elif response.status_code == 400:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 
@@ -15139,8 +15147,7 @@ export const sayHelloHandler = (
     }) as unknown as SayHelloRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        return parsed;
+        return {};
     };
     const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 
@@ -29022,7 +29029,7 @@ class SayHelloRequestParameters(TypedDict):
 class SayHelloRequestArrayParameters(TypedDict):
     ...
 
-# Request body type (default to Any when no body parameters exist)
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 SayHelloRequestBody = Any
 
 SayHello200OperationResponse = ApiResponse[Literal[200], SayHelloResponseContent]
@@ -29053,8 +29060,7 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
-            body = parse_body(event['body'], [], SayHelloRequestBody)
-
+            body = {}
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -29066,10 +29072,19 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+            elif response.status_code == 400:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 
@@ -33786,8 +33801,7 @@ export const sayHelloHandler = (
     }) as unknown as SayHelloRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        return parsed;
+        return {};
     };
     const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 
@@ -47658,7 +47672,7 @@ class SayHelloRequestParameters(TypedDict):
 class SayHelloRequestArrayParameters(TypedDict):
     ...
 
-# Request body type (default to Any when no body parameters exist)
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 SayHelloRequestBody = Any
 
 SayHello200OperationResponse = ApiResponse[Literal[200], SayHelloResponseContent]
@@ -47689,8 +47703,7 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
             })
-            body = parse_body(event['body'], [], SayHelloRequestBody)
-
+            body = {}
             interceptor_context = {}
 
             chain = _build_handler_chain(interceptors, handler)
@@ -47702,10 +47715,19 @@ def say_hello_handler(_handler: SayHelloHandlerFunction = None, interceptors: Li
                 context,
                 interceptor_context,
             ), **kwargs)
+
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+            elif response.status_code == 400:
+                response_body = json.dumps(JSONEncoder().default(response.body))
+
             return {
                 'statusCode': response.status_code,
                 'headers': response.headers,
-                'body': json.dumps(JSONEncoder().default(response.body)) if response.body is not None else '',
+                'body': response_body,
             }
         return wrapper
 
@@ -52414,8 +52436,7 @@ export const sayHelloHandler = (
     }) as unknown as SayHelloRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        return parsed;
+        return {};
     };
     const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 

--- a/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/with-smithy-build-options.test.ts.snap
+++ b/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/with-smithy-build-options.test.ts.snap
@@ -2639,8 +2639,7 @@ export const sayHelloHandler = (
     }) as unknown as SayHelloRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
-        let parsed = JSON.parse(bodyString);
-        return parsed;
+        return {};
     };
     const body = parseBody(event.body, demarshal, ['application/json']) as SayHelloRequestBody;
 

--- a/packages/open-api-gateway/test/project/spec/components/__snapshots__/parsed-spec.test.ts.snap
+++ b/packages/open-api-gateway/test/project/spec/components/__snapshots__/parsed-spec.test.ts.snap
@@ -330,6 +330,28 @@ node_modules/
     },
     "openapi": "3.0.3",
     "paths": Object {
+      "/any-request-response": Object {
+        "put": Object {
+          "operationId": "anyRequestResponse",
+          "requestBody": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {},
+              },
+            },
+          },
+          "responses": Object {
+            "200": Object {
+              "content": Object {
+                "application/json": Object {
+                  "schema": Object {},
+                },
+              },
+              "description": "Any response",
+            },
+          },
+        },
+      },
       "/different-media-type": Object {
         "post": Object {
           "operationId": "mediaTypes",

--- a/packages/open-api-gateway/test/resources/specs/single.yaml
+++ b/packages/open-api-gateway/test/resources/specs/single.yaml
@@ -68,6 +68,19 @@ paths:
       responses:
         204:
           description: No response body!
+  /any-request-response:
+    put:
+      operationId: anyRequestResponse
+      requestBody:
+        content:
+          application/json:
+            schema: {}
+      responses:
+        200:
+          description: Any response
+          content:
+            'application/json':
+              schema: {}
   /different-media-type:
     post:
       operationId: mediaTypes


### PR DESCRIPTION
Using primitive types, including `any`, for the top level type of the request/response body caused the TypeScript and Java lambda handler wrappers to fail to compile (and the Python one would fail at runtime).

Address this by ensuring no marshalling/demarshalling is performed when the request/response body is a primitive type, treating it as the raw string received in the api gateway event and returned in the api gateway result. This also ensures that the request/response body for primitive types is correctly typed as a string - previously eg an `application/pdf` request might be incorrectly typed as a `Blob` without it actually being coerced into one.

Responsibility is then delegated to the implementer of the lambda handler to transform the primitive type correctly.
