### PR TITLE
chore: workspace improvements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,7 +44,8 @@
     "*.generated.ts",
     "coverage",
     "!.projenrc.ts",
-    "!projenrc/**/*.ts"
+    "!projenrc/**/*.ts",
+    "packages/**/*.*"
   ],
   "rules": {
     "prettier/prettier": [

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,21 @@
 #!/bin/sh
+set -eo pipefail
+
 . "$(dirname "$0")/_/husky.sh"
 
+PRE_SHA="$(git diff HEAD --ignore-space-at-eol | shasum -a 256 --tag)"
+
 npx projen
-npx nx run-many --target=eslint --all && npx projen eslint
-git diff --ignore-space-at-eol --exit-code
+npx nx affected --target=eslint-staged --uncommitted
+npx projen eslint-staged
+
+POST_SHA="$(git diff HEAD --ignore-space-at-eol | shasum -a 256  --tag)"
+
+if [ "$PRE_SHA" != "$POST_SHA" ]
+then
+	RED='\033[0;31m'
+	NC='\033[0m' # No Color
+	echo "${RED}Pre-commit modified your working directory${NC} (eg: projen, eslint --fix)"
+	echo "${RED}Please verify and stage changed, then retry git commit${NC}"
+	exit 1
+fi

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -90,6 +90,15 @@
         }
       ]
     },
+    "eslint-staged": {
+      "name": "eslint-staged",
+      "description": "Run eslint against the workspace staged files only; excluding ./packages/ files.",
+      "steps": [
+        {
+          "exec": "eslint --fix --no-error-on-unmatched-pattern $(git diff --name-only --relative --staged HEAD . | grep -E '.(ts|tsx)$' | grep -v -E '^packages/' | xargs)"
+        }
+      ]
+    },
     "git-secrets-scan": {
       "name": "git-secrets-scan",
       "steps": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+	"search.exclude": {
+		"**/node_modules": true,
+		"**/*.code-search": true,
+		"**/bower_components": true,
+
+		"**/dist": true,
+		"**/lib": true,
+		"**/.*": true,
+		"**/*.snap": true,
+		"**/coverage/**": true,
+	},
+	"editor.insertSpaces": true,
+	"javascript.preferences.quoteStyle": "double",
+	"typescript.preferences.quoteStyle": "double"
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "default": "npx projen default",
     "eject": "npx projen eject",
     "eslint": "npx projen eslint",
+    "eslint-staged": "npx projen eslint-staged",
     "git-secrets-scan": "npx projen git-secrets-scan",
     "install": "npx projen install",
     "package": "npx projen package",

--- a/packages/aws-prototyping-sdk/.projen/tasks.json
+++ b/packages/aws-prototyping-sdk/.projen/tasks.json
@@ -121,6 +121,15 @@
         }
       ]
     },
+    "eslint-staged": {
+      "name": "eslint-staged",
+      "description": "Run eslint against the staged files only",
+      "steps": [
+        {
+          "exec": "eslint --fix --no-error-on-unmatched-pattern $(git diff --name-only --relative --staged HEAD . | grep -E '.(ts|tsx)$' | xargs)"
+        }
+      ]
+    },
     "package": {
       "name": "package",
       "description": "Creates the distribution package",

--- a/packages/aws-prototyping-sdk/package.json
+++ b/packages/aws-prototyping-sdk/package.json
@@ -14,6 +14,7 @@
     "default": "npx projen default",
     "eject": "npx projen eject",
     "eslint": "npx projen eslint",
+    "eslint-staged": "npx projen eslint-staged",
     "package": "npx projen package",
     "package-all": "npx projen package-all",
     "package:java": "npx projen package:java",

--- a/packages/cloudscape-react-ts-website/.projen/tasks.json
+++ b/packages/cloudscape-react-ts-website/.projen/tasks.json
@@ -113,6 +113,15 @@
         }
       ]
     },
+    "eslint-staged": {
+      "name": "eslint-staged",
+      "description": "Run eslint against the staged files only",
+      "steps": [
+        {
+          "exec": "eslint --fix --no-error-on-unmatched-pattern $(git diff --name-only --relative --staged HEAD . | grep -E '.(ts|tsx)$' | xargs)"
+        }
+      ]
+    },
     "package": {
       "name": "package",
       "description": "Creates the distribution package",

--- a/packages/cloudscape-react-ts-website/package.json
+++ b/packages/cloudscape-react-ts-website/package.json
@@ -13,6 +13,7 @@
     "default": "npx projen default",
     "eject": "npx projen eject",
     "eslint": "npx projen eslint",
+    "eslint-staged": "npx projen eslint-staged",
     "package": "npx projen package",
     "package-all": "npx projen package-all",
     "package:java": "npx projen package:java",

--- a/packages/identity/.projen/tasks.json
+++ b/packages/identity/.projen/tasks.json
@@ -113,6 +113,15 @@
         }
       ]
     },
+    "eslint-staged": {
+      "name": "eslint-staged",
+      "description": "Run eslint against the staged files only",
+      "steps": [
+        {
+          "exec": "eslint --fix --no-error-on-unmatched-pattern $(git diff --name-only --relative --staged HEAD . | grep -E '.(ts|tsx)$' | xargs)"
+        }
+      ]
+    },
     "package": {
       "name": "package",
       "description": "Creates the distribution package",

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -13,6 +13,7 @@
     "default": "npx projen default",
     "eject": "npx projen eject",
     "eslint": "npx projen eslint",
+    "eslint-staged": "npx projen eslint-staged",
     "package": "npx projen package",
     "package-all": "npx projen package-all",
     "package:java": "npx projen package:java",

--- a/packages/nx-monorepo/.projen/tasks.json
+++ b/packages/nx-monorepo/.projen/tasks.json
@@ -116,6 +116,15 @@
         }
       ]
     },
+    "eslint-staged": {
+      "name": "eslint-staged",
+      "description": "Run eslint against the staged files only",
+      "steps": [
+        {
+          "exec": "eslint --fix --no-error-on-unmatched-pattern $(git diff --name-only --relative --staged HEAD . | grep -E '.(ts|tsx)$' | xargs)"
+        }
+      ]
+    },
     "package": {
       "name": "package",
       "description": "Creates the distribution package",

--- a/packages/nx-monorepo/package.json
+++ b/packages/nx-monorepo/package.json
@@ -13,6 +13,7 @@
     "default": "npx projen default",
     "eject": "npx projen eject",
     "eslint": "npx projen eslint",
+    "eslint-staged": "npx projen eslint-staged",
     "package": "npx projen package",
     "package-all": "npx projen package-all",
     "package:java": "npx projen package:java",

--- a/packages/open-api-gateway/.projen/tasks.json
+++ b/packages/open-api-gateway/.projen/tasks.json
@@ -113,6 +113,15 @@
         }
       ]
     },
+    "eslint-staged": {
+      "name": "eslint-staged",
+      "description": "Run eslint against the staged files only",
+      "steps": [
+        {
+          "exec": "eslint --fix --no-error-on-unmatched-pattern $(git diff --name-only --relative --staged HEAD . | grep -E '.(ts|tsx)$' | xargs)"
+        }
+      ]
+    },
     "package": {
       "name": "package",
       "description": "Creates the distribution package",

--- a/packages/open-api-gateway/package.json
+++ b/packages/open-api-gateway/package.json
@@ -13,6 +13,7 @@
     "default": "npx projen default",
     "eject": "npx projen eject",
     "eslint": "npx projen eslint",
+    "eslint-staged": "npx projen eslint-staged",
     "package": "npx projen package",
     "package-all": "npx projen package-all",
     "package:java": "npx projen package:java",

--- a/packages/pdk-nag/.projen/tasks.json
+++ b/packages/pdk-nag/.projen/tasks.json
@@ -113,6 +113,15 @@
         }
       ]
     },
+    "eslint-staged": {
+      "name": "eslint-staged",
+      "description": "Run eslint against the staged files only",
+      "steps": [
+        {
+          "exec": "eslint --fix --no-error-on-unmatched-pattern $(git diff --name-only --relative --staged HEAD . | grep -E '.(ts|tsx)$' | xargs)"
+        }
+      ]
+    },
     "package": {
       "name": "package",
       "description": "Creates the distribution package",

--- a/packages/pdk-nag/package.json
+++ b/packages/pdk-nag/package.json
@@ -13,6 +13,7 @@
     "default": "npx projen default",
     "eject": "npx projen eject",
     "eslint": "npx projen eslint",
+    "eslint-staged": "npx projen eslint-staged",
     "package": "npx projen package",
     "package-all": "npx projen package-all",
     "package:java": "npx projen package:java",

--- a/packages/pipeline/.projen/tasks.json
+++ b/packages/pipeline/.projen/tasks.json
@@ -113,6 +113,15 @@
         }
       ]
     },
+    "eslint-staged": {
+      "name": "eslint-staged",
+      "description": "Run eslint against the staged files only",
+      "steps": [
+        {
+          "exec": "eslint --fix --no-error-on-unmatched-pattern $(git diff --name-only --relative --staged HEAD . | grep -E '.(ts|tsx)$' | xargs)"
+        }
+      ]
+    },
     "package": {
       "name": "package",
       "description": "Creates the distribution package",

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -13,6 +13,7 @@
     "default": "npx projen default",
     "eject": "npx projen eject",
     "eslint": "npx projen eslint",
+    "eslint-staged": "npx projen eslint-staged",
     "package": "npx projen package",
     "package-all": "npx projen package-all",
     "package:java": "npx projen package:java",

--- a/packages/static-website/.projen/tasks.json
+++ b/packages/static-website/.projen/tasks.json
@@ -113,6 +113,15 @@
         }
       ]
     },
+    "eslint-staged": {
+      "name": "eslint-staged",
+      "description": "Run eslint against the staged files only",
+      "steps": [
+        {
+          "exec": "eslint --fix --no-error-on-unmatched-pattern $(git diff --name-only --relative --staged HEAD . | grep -E '.(ts|tsx)$' | xargs)"
+        }
+      ]
+    },
     "package": {
       "name": "package",
       "description": "Creates the distribution package",

--- a/packages/static-website/package.json
+++ b/packages/static-website/package.json
@@ -13,6 +13,7 @@
     "default": "npx projen default",
     "eject": "npx projen eject",
     "eslint": "npx projen eslint",
+    "eslint-staged": "npx projen eslint-staged",
     "package": "npx projen package",
     "package-all": "npx projen package-all",
     "package:java": "npx projen package:java",

--- a/private/pdk-project.ts
+++ b/private/pdk-project.ts
@@ -134,6 +134,15 @@ export class PDKProject extends JsiiProject {
       });
     }
 
+    this.addTask("eslint-staged", {
+      description: "Run eslint against the staged files only",
+      steps: [
+        {
+          exec: "eslint --fix --no-error-on-unmatched-pattern $(git diff --name-only --relative --staged HEAD . | grep -E '.(ts|tsx)$' | xargs)",
+        },
+      ],
+    });
+
     this.pdkRelease = new PDKRelease(this);
   }
 }

--- a/private/projects/pdk-monorepo-project.ts
+++ b/private/projects/pdk-monorepo-project.ts
@@ -109,6 +109,20 @@ export class PDKMonorepoProject extends NxMonorepoProject {
     this.eslint?.addPlugins("header");
     this.eslint?.addRules({ "header/header": [2, "header.js"] });
 
+    // Do NOT lint packages files as they get linted by the package
+    this.eslint?.addIgnorePattern("packages/**/*.*");
+
+    this.addTask("eslint-staged", {
+      description:
+        "Run eslint against the workspace staged files only; excluding ./packages/ files.",
+      steps: [
+        {
+          // exlcude package files as they are run by the packages directly
+          exec: "eslint --fix --no-error-on-unmatched-pattern $(git diff --name-only --relative --staged HEAD . | grep -E '.(ts|tsx)$' | grep -v -E '^packages/' | xargs)",
+        },
+      ],
+    });
+
     this.addTask("prepare", {
       exec: "husky install",
     });


### PR DESCRIPTION
Several workspace improvements for consistency and developer ergonomics
- chore(ide): add .vscode settings
- ci(pre-commit): only lint staged files during pre-commit hook
  > Prevent running extraneous linting against the entire workspace
and instead only lint the staged files that will be part of the
commit. 
  > Using a pre/post linting sha we can verify if any pre-commit processing
has modified the working tree and block the commit - as the user
should verify those changes first.
- fix(nx-monorepo): prevent extraneous subProject node installs
  > When synthesizing a new project for the first time, the package was not installed as a "yarn workspace" package, caused by the root package.json being cleaned up before the subprojects are generated. This caused several issues with dependencies between projects and within new projects given they were not initializing as a workspace package.
