### PR TITLE
fix: Identity construct - Add equivalent suppression reasons in AwsPrototyping namespace

### DIFF
--- a/packages/identity/src/user-identity.ts
+++ b/packages/identity/src/user-identity.ts
@@ -66,17 +66,22 @@ export class UserIdentity extends Construct {
       };
 
       const stack = Stack.of(this);
-      PDKNag.addResourceSuppressionsByPathNoThrow(
-        stack,
-        `${PDKNag.getStackPrefix(stack)}${id}/UserPool/smsRole/Resource`,
-        [
-          {
-            id: "AwsSolutions-IAM5",
-            reason:
-              "MFA requires sending a text to a users phone number which cannot be known at deployment time.",
-            appliesTo: ["Resource::*"],
-          },
-        ]
+
+      ["AwsSolutions-IAM5", "AwsPrototyping-IAMNoWildcardPermissions"].forEach(
+        (RuleId) => {
+          PDKNag.addResourceSuppressionsByPathNoThrow(
+            stack,
+            `${PDKNag.getStackPrefix(stack)}${id}/UserPool/smsRole/Resource`,
+            [
+              {
+                id: RuleId,
+                reason:
+                  "MFA requires sending a text to a users phone number which cannot be known at deployment time.",
+                appliesTo: ["Resource::*"],
+              },
+            ]
+          );
+        }
       );
 
       this.userPoolClient = this.userPool.addClient("WebClient", {

--- a/packages/identity/test/__snapshots__/user-identity.test.ts.snap
+++ b/packages/identity/test/__snapshots__/user-identity.test.ts.snap
@@ -257,6 +257,13 @@ Object {
               "id": "AwsSolutions-IAM5",
               "reason": "MFA requires sending a text to a users phone number which cannot be known at deployment time.",
             },
+            Object {
+              "applies_to": Array [
+                "Resource::*",
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "MFA requires sending a text to a users phone number which cannot be known at deployment time.",
+            },
           ],
         },
       },
@@ -562,6 +569,13 @@ Object {
                 "Resource::*",
               ],
               "id": "AwsSolutions-IAM5",
+              "reason": "MFA requires sending a text to a users phone number which cannot be known at deployment time.",
+            },
+            Object {
+              "applies_to": Array [
+                "Resource::*",
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
               "reason": "MFA requires sending a text to a users phone number which cannot be known at deployment time.",
             },
           ],


### PR DESCRIPTION
Added the equivalent suppression reasons for the [AwsPrototyping NagPack](https://github.com/aws/aws-prototyping-sdk/tree/mainline/packages/pdk-nag/src/packs#readme) namespace.