### PR TITLE
fix(contructs): AwsPrototyping equivalent suppressions

### DIFF
--- a/packages/open-api-gateway/src/construct/open-api-gateway-rest-api.ts
+++ b/packages/open-api-gateway/src/construct/open-api-gateway-rest-api.ts
@@ -148,25 +148,29 @@ export class OpenApiGatewayRestApi extends Construct {
       },
     });
 
-    NagSuppressions.addResourceSuppressions(
-      prepareSpecRole,
-      [
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
-          appliesTo: [
+    ["AwsSolutions-IAM5", "AwsPrototyping-IAMNoWildcardPermissions"].forEach(
+      (RuleId) => {
+        NagSuppressions.addResourceSuppressions(
+          prepareSpecRole,
+          [
             {
-              regex: `/^Resource::arn:aws:logs:${PDKNag.getStackRegionRegex(
-                stack
-              )}:${PDKNag.getStackAccountRegex(
-                stack
-              )}:log-group:/aws/lambda/${prepareSpecLambdaName}:\*/g`,
+              id: RuleId,
+              reason:
+                "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+              appliesTo: [
+                {
+                  regex: `/^Resource::arn:aws:logs:${PDKNag.getStackRegionRegex(
+                    stack
+                  )}:${PDKNag.getStackAccountRegex(
+                    stack
+                  )}:log-group:/aws/lambda/${prepareSpecLambdaName}:\*/g`,
+                },
+              ],
             },
           ],
-        },
-      ],
-      true
+          true
+        );
+      }
     );
 
     // Create a custom resource for preparing the spec for deployment (adding integrations, authorizers, etc)
@@ -210,27 +214,36 @@ export class OpenApiGatewayRestApi extends Construct {
       providerFunctionName,
     });
 
-    NagSuppressions.addResourceSuppressions(
-      providerRole,
-      [
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
-        },
-      ],
-      true
+    ["AwsSolutions-IAM5", "AwsPrototyping-IAMNoWildcardPermissions"].forEach(
+      (RuleId) => {
+        NagSuppressions.addResourceSuppressions(
+          providerRole,
+          [
+            {
+              id: RuleId,
+              reason:
+                "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+          ],
+          true
+        );
+      }
     );
-    NagSuppressions.addResourceSuppressions(
-      provider,
-      [
-        {
-          id: "AwsSolutions-L1",
-          reason:
-            "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
-        },
-      ],
-      true
+
+    ["AwsSolutions-L1", "AwsPrototyping-LambdaLatestVersion"].forEach(
+      (RuleId) => {
+        NagSuppressions.addResourceSuppressions(
+          provider,
+          [
+            {
+              id: RuleId,
+              reason:
+                "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
+            },
+          ],
+          true
+        );
+      }
     );
 
     const prepareSpecOptions: PrepareApiSpecOptions = {
@@ -351,35 +364,43 @@ export class OpenApiGatewayRestApi extends Construct {
       this.webAclAssociation = acl.webAclAssociation;
     }
 
-    NagSuppressions.addResourceSuppressions(
-      this,
-      [
-        {
-          id: "AwsSolutions-IAM4",
-          reason:
-            "Cloudwatch Role requires access to create/read groups at the root level.",
-          appliesTo: [
+    ["AwsSolutions-IAM4", "AwsPrototyping-IAMNoManagedPolicies"].forEach(
+      (RuleId) => {
+        NagSuppressions.addResourceSuppressions(
+          this,
+          [
             {
-              regex: `/^Policy::arn:${PDKNag.getStackPartitionRegex(
-                stack
-              )}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g`,
+              id: RuleId,
+              reason:
+                "Cloudwatch Role requires access to create/read groups at the root level.",
+              appliesTo: [
+                {
+                  regex: `/^Policy::arn:${PDKNag.getStackPartitionRegex(
+                    stack
+                  )}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g`,
+                },
+              ],
             },
           ],
-        },
-      ],
-      true
+          true
+        );
+      }
     );
 
-    NagSuppressions.addResourceSuppressions(
-      this,
-      [
-        {
-          id: "AwsSolutions-APIG2",
-          reason:
-            "This construct implements fine grained validation via OpenApi.",
-        },
-      ],
-      true
+    ["AwsSolutions-APIG2", "AwsPrototyping-APIGWRequestValidation"].forEach(
+      (RuleId) => {
+        NagSuppressions.addResourceSuppressions(
+          this,
+          [
+            {
+              id: RuleId,
+              reason:
+                "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+          true
+        );
+      }
     );
   }
 }

--- a/packages/open-api-gateway/test/construct/__snapshots__/open-api-gateway-rest-api.test.ts.snap
+++ b/packages/open-api-gateway/test/construct/__snapshots__/open-api-gateway-rest-api.test.ts.snap
@@ -567,7 +567,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "712ec0546e7d545ed5b3a28ae45693b13a453da698a690e2af3ed372bde8451e.zip",
+          "S3Key": "3e7b6d1146d8dc592557812a3e65293273e8620d1b901b4542215bec35383f55.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -1763,7 +1763,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "712ec0546e7d545ed5b3a28ae45693b13a453da698a690e2af3ed372bde8451e.zip",
+          "S3Key": "3e7b6d1146d8dc592557812a3e65293273e8620d1b901b4542215bec35383f55.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -2984,7 +2984,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "712ec0546e7d545ed5b3a28ae45693b13a453da698a690e2af3ed372bde8451e.zip",
+          "S3Key": "3e7b6d1146d8dc592557812a3e65293273e8620d1b901b4542215bec35383f55.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -4298,7 +4298,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "712ec0546e7d545ed5b3a28ae45693b13a453da698a690e2af3ed372bde8451e.zip",
+          "S3Key": "3e7b6d1146d8dc592557812a3e65293273e8620d1b901b4542215bec35383f55.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -5597,7 +5597,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "712ec0546e7d545ed5b3a28ae45693b13a453da698a690e2af3ed372bde8451e.zip",
+          "S3Key": "3e7b6d1146d8dc592557812a3e65293273e8620d1b901b4542215bec35383f55.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -6790,7 +6790,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "712ec0546e7d545ed5b3a28ae45693b13a453da698a690e2af3ed372bde8451e.zip",
+          "S3Key": "3e7b6d1146d8dc592557812a3e65293273e8620d1b901b4542215bec35383f55.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -8292,7 +8292,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "712ec0546e7d545ed5b3a28ae45693b13a453da698a690e2af3ed372bde8451e.zip",
+          "S3Key": "3e7b6d1146d8dc592557812a3e65293273e8620d1b901b4542215bec35383f55.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -9744,7 +9744,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "712ec0546e7d545ed5b3a28ae45693b13a453da698a690e2af3ed372bde8451e.zip",
+          "S3Key": "3e7b6d1146d8dc592557812a3e65293273e8620d1b901b4542215bec35383f55.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -11006,7 +11006,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "712ec0546e7d545ed5b3a28ae45693b13a453da698a690e2af3ed372bde8451e.zip",
+          "S3Key": "3e7b6d1146d8dc592557812a3e65293273e8620d1b901b4542215bec35383f55.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -12066,7 +12066,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "712ec0546e7d545ed5b3a28ae45693b13a453da698a690e2af3ed372bde8451e.zip",
+          "S3Key": "3e7b6d1146d8dc592557812a3e65293273e8620d1b901b4542215bec35383f55.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",

--- a/packages/open-api-gateway/test/construct/__snapshots__/open-api-gateway-rest-api.test.ts.snap
+++ b/packages/open-api-gateway/test/construct/__snapshots__/open-api-gateway-rest-api.test.ts.snap
@@ -65,7 +65,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -96,7 +109,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -150,7 +176,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -207,7 +246,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -244,7 +296,7 @@ Object {
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC47863e164b191d96a25f0f7552aebaa750f": Object {
+    "ApiTestDeployment153EC478cf0ffda1ebdf50e204e4bb9601cf40bc": Object {
       "DependsOn": Array [
         "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
@@ -261,7 +313,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -293,7 +358,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -310,7 +388,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment153EC47863e164b191d96a25f0f7552aebaa750f",
+          "Ref": "ApiTestDeployment153EC478cf0ffda1ebdf50e204e4bb9601cf40bc",
         },
         "MethodSettings": Array [
           Object {
@@ -344,7 +422,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -380,7 +471,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -439,7 +543,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -450,7 +567,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3e7b6d1146d8dc592557812a3e65293273e8620d1b901b4542215bec35383f55.zip",
+          "S3Key": "712ec0546e7d545ed5b3a28ae45693b13a453da698a690e2af3ed372bde8451e.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -480,7 +597,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -560,6 +690,10 @@ Object {
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
             Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -569,7 +703,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -625,6 +772,10 @@ Object {
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
             Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -634,7 +785,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -721,6 +885,10 @@ Object {
               "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
             },
             Object {
+              "id": "AwsPrototyping-LambdaLatestVersion",
+              "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -730,7 +898,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -783,6 +964,15 @@ Object {
             Object {
               "applies_to": Array [
                 Object {
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
                 },
               ],
@@ -790,7 +980,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -1058,7 +1261,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -1089,7 +1305,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -1143,7 +1372,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -1200,7 +1442,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -1237,7 +1492,7 @@ Object {
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC478825dde08e33eace611a686b6a5dd10f3": Object {
+    "ApiTestDeployment153EC478ba688c73ecd411d6bc46f33941546de6": Object {
       "DependsOn": Array [
         "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
@@ -1254,7 +1509,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -1286,7 +1554,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -1303,7 +1584,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment153EC478825dde08e33eace611a686b6a5dd10f3",
+          "Ref": "ApiTestDeployment153EC478ba688c73ecd411d6bc46f33941546de6",
         },
         "MethodSettings": Array [
           Object {
@@ -1337,7 +1618,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -1373,7 +1667,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -1432,7 +1739,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -1443,7 +1763,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3e7b6d1146d8dc592557812a3e65293273e8620d1b901b4542215bec35383f55.zip",
+          "S3Key": "712ec0546e7d545ed5b3a28ae45693b13a453da698a690e2af3ed372bde8451e.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -1473,7 +1793,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -1550,6 +1883,10 @@ Object {
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
             Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -1559,7 +1896,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -1615,6 +1965,10 @@ Object {
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
             Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -1624,7 +1978,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -1711,6 +2078,10 @@ Object {
               "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
             },
             Object {
+              "id": "AwsPrototyping-LambdaLatestVersion",
+              "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -1720,7 +2091,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -1773,6 +2157,15 @@ Object {
             Object {
               "applies_to": Array [
                 Object {
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
                 },
               ],
@@ -1780,7 +2173,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -1913,6 +2319,10 @@ Object {
               "id": "AwsSolutions-IAM4",
               "reason": "This is a test construct.",
             },
+            Object {
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "This is a test construct.",
+            },
           ],
         },
       },
@@ -1937,6 +2347,10 @@ Object {
           "rules_to_suppress": Array [
             Object {
               "id": "AwsSolutions-IAM4",
+              "reason": "This is a test construct.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
               "reason": "This is a test construct.",
             },
           ],
@@ -2068,7 +2482,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -2099,7 +2526,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -2153,7 +2593,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -2210,7 +2663,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -2247,7 +2713,7 @@ Object {
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC4780f4232a97f4706e0e0c9fdac2476f8ba": Object {
+    "ApiTestDeployment153EC47863776976cc0e88744938e9841a6d2672": Object {
       "DependsOn": Array [
         "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
@@ -2264,7 +2730,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -2296,7 +2775,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -2313,7 +2805,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment153EC4780f4232a97f4706e0e0c9fdac2476f8ba",
+          "Ref": "ApiTestDeployment153EC47863776976cc0e88744938e9841a6d2672",
         },
         "MethodSettings": Array [
           Object {
@@ -2347,7 +2839,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -2383,7 +2888,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -2442,7 +2960,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -2453,7 +2984,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3e7b6d1146d8dc592557812a3e65293273e8620d1b901b4542215bec35383f55.zip",
+          "S3Key": "712ec0546e7d545ed5b3a28ae45693b13a453da698a690e2af3ed372bde8451e.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -2483,7 +3014,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -2581,6 +3125,10 @@ Object {
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
             Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -2590,7 +3138,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -2646,6 +3207,10 @@ Object {
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
             Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -2655,7 +3220,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -2742,6 +3320,10 @@ Object {
               "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
             },
             Object {
+              "id": "AwsPrototyping-LambdaLatestVersion",
+              "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -2751,7 +3333,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -2804,6 +3399,15 @@ Object {
             Object {
               "applies_to": Array [
                 Object {
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
                 },
               ],
@@ -2811,7 +3415,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -3110,7 +3727,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -3141,7 +3771,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -3195,7 +3838,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -3252,7 +3908,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -3289,7 +3958,7 @@ Object {
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC4780ac398b3650ad5daed204fb3cdbee9cc": Object {
+    "ApiTestDeployment153EC478098a9965c461523b7750d682a61a3826": Object {
       "DependsOn": Array [
         "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
@@ -3306,7 +3975,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -3338,7 +4020,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -3355,7 +4050,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment153EC4780ac398b3650ad5daed204fb3cdbee9cc",
+          "Ref": "ApiTestDeployment153EC478098a9965c461523b7750d682a61a3826",
         },
         "MethodSettings": Array [
           Object {
@@ -3389,7 +4084,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -3425,7 +4133,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -3481,7 +4202,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -3540,7 +4274,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -3551,7 +4298,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3e7b6d1146d8dc592557812a3e65293273e8620d1b901b4542215bec35383f55.zip",
+          "S3Key": "712ec0546e7d545ed5b3a28ae45693b13a453da698a690e2af3ed372bde8451e.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -3581,7 +4328,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -3696,6 +4456,10 @@ Object {
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
             Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -3705,7 +4469,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -3761,6 +4538,10 @@ Object {
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
             Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -3770,7 +4551,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -3857,6 +4651,10 @@ Object {
               "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
             },
             Object {
+              "id": "AwsPrototyping-LambdaLatestVersion",
+              "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -3866,7 +4664,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -3919,6 +4730,15 @@ Object {
             Object {
               "applies_to": Array [
                 Object {
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
                 },
               ],
@@ -3926,7 +4746,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -4244,7 +5077,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -4275,7 +5121,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -4347,7 +5206,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -4404,7 +5276,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -4441,7 +5326,7 @@ Object {
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC478825dde08e33eace611a686b6a5dd10f3": Object {
+    "ApiTestDeployment153EC478ba688c73ecd411d6bc46f33941546de6": Object {
       "DependsOn": Array [
         "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
@@ -4458,7 +5343,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -4490,7 +5388,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -4507,7 +5418,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment153EC478825dde08e33eace611a686b6a5dd10f3",
+          "Ref": "ApiTestDeployment153EC478ba688c73ecd411d6bc46f33941546de6",
         },
         "MethodSettings": Array [
           Object {
@@ -4541,7 +5452,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -4577,7 +5501,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -4636,7 +5573,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -4647,7 +5597,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3e7b6d1146d8dc592557812a3e65293273e8620d1b901b4542215bec35383f55.zip",
+          "S3Key": "712ec0546e7d545ed5b3a28ae45693b13a453da698a690e2af3ed372bde8451e.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -4677,7 +5627,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -4754,6 +5717,10 @@ Object {
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
             Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -4763,7 +5730,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -4819,6 +5799,10 @@ Object {
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
             Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -4828,7 +5812,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -4915,6 +5912,10 @@ Object {
               "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
             },
             Object {
+              "id": "AwsPrototyping-LambdaLatestVersion",
+              "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -4924,7 +5925,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -4977,6 +5991,15 @@ Object {
             Object {
               "applies_to": Array [
                 Object {
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
                 },
               ],
@@ -4984,7 +6007,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -5252,7 +6288,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -5283,7 +6332,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -5337,7 +6399,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -5394,7 +6469,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -5431,7 +6519,7 @@ Object {
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC4781fd0330a24a90a9d5cce712b647e79f0": Object {
+    "ApiTestDeployment153EC478c3d7b9ef89b3ebd4ebe91f7143275c03": Object {
       "DependsOn": Array [
         "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
@@ -5448,7 +6536,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -5480,7 +6581,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -5497,7 +6611,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment153EC4781fd0330a24a90a9d5cce712b647e79f0",
+          "Ref": "ApiTestDeployment153EC478c3d7b9ef89b3ebd4ebe91f7143275c03",
         },
         "MethodSettings": Array [
           Object {
@@ -5531,7 +6645,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -5567,7 +6694,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -5626,7 +6766,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -5637,7 +6790,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3e7b6d1146d8dc592557812a3e65293273e8620d1b901b4542215bec35383f55.zip",
+          "S3Key": "712ec0546e7d545ed5b3a28ae45693b13a453da698a690e2af3ed372bde8451e.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -5667,7 +6820,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -5777,6 +6943,10 @@ Object {
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
             Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -5786,7 +6956,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -5842,6 +7025,10 @@ Object {
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
             Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -5851,7 +7038,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -5938,6 +7138,10 @@ Object {
               "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
             },
             Object {
+              "id": "AwsPrototyping-LambdaLatestVersion",
+              "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -5947,7 +7151,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -6000,6 +7217,15 @@ Object {
             Object {
               "applies_to": Array [
                 Object {
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
                 },
               ],
@@ -6007,7 +7233,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -6275,7 +7514,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -6306,7 +7558,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -6360,7 +7625,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -6417,7 +7695,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -6454,7 +7745,7 @@ Object {
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC47888c4ea06556add6bd68a4559b47b8739": Object {
+    "ApiTestDeployment153EC47860a1edc076720b97c2bb9bf1a3d9c1e4": Object {
       "DependsOn": Array [
         "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
@@ -6471,7 +7762,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -6503,7 +7807,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -6520,7 +7837,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment153EC47888c4ea06556add6bd68a4559b47b8739",
+          "Ref": "ApiTestDeployment153EC47860a1edc076720b97c2bb9bf1a3d9c1e4",
         },
         "MethodSettings": Array [
           Object {
@@ -6554,7 +7871,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -6590,7 +7920,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -6646,7 +7989,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -6702,7 +8058,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -6758,7 +8127,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -6814,7 +8196,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -6873,7 +8268,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -6884,7 +8292,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3e7b6d1146d8dc592557812a3e65293273e8620d1b901b4542215bec35383f55.zip",
+          "S3Key": "712ec0546e7d545ed5b3a28ae45693b13a453da698a690e2af3ed372bde8451e.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -6914,7 +8322,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -7169,6 +8590,10 @@ Object {
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
             Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -7178,7 +8603,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -7234,6 +8672,10 @@ Object {
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
             Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -7243,7 +8685,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -7330,6 +8785,10 @@ Object {
               "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
             },
             Object {
+              "id": "AwsPrototyping-LambdaLatestVersion",
+              "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -7339,7 +8798,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -7392,6 +8864,15 @@ Object {
             Object {
               "applies_to": Array [
                 Object {
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
                 },
               ],
@@ -7399,7 +8880,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -7748,7 +9242,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -7779,7 +9286,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -7833,7 +9353,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -7890,7 +9423,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -7927,7 +9473,7 @@ Object {
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC4789decd4fa5b57ab1113fd042548bfc841": Object {
+    "ApiTestDeployment153EC478ed5e71f4a5bc4f71e07a9dafbe8ea425": Object {
       "DependsOn": Array [
         "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
@@ -7944,7 +9490,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -7976,7 +9535,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -7993,7 +9565,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment153EC4789decd4fa5b57ab1113fd042548bfc841",
+          "Ref": "ApiTestDeployment153EC478ed5e71f4a5bc4f71e07a9dafbe8ea425",
         },
         "MethodSettings": Array [
           Object {
@@ -8027,7 +9599,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -8063,7 +9648,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -8122,7 +9720,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -8133,7 +9744,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3e7b6d1146d8dc592557812a3e65293273e8620d1b901b4542215bec35383f55.zip",
+          "S3Key": "712ec0546e7d545ed5b3a28ae45693b13a453da698a690e2af3ed372bde8451e.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -8163,7 +9774,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -8240,6 +9864,10 @@ Object {
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
             Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -8249,7 +9877,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -8305,6 +9946,10 @@ Object {
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
             Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -8314,7 +9959,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -8401,6 +10059,10 @@ Object {
               "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
             },
             Object {
+              "id": "AwsPrototyping-LambdaLatestVersion",
+              "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -8410,7 +10072,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -8463,6 +10138,15 @@ Object {
             Object {
               "applies_to": Array [
                 Object {
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
                 },
               ],
@@ -8470,7 +10154,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -8738,7 +10435,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -8769,7 +10479,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -8799,7 +10522,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -8879,7 +10615,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -8936,7 +10685,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -8973,7 +10735,7 @@ Object {
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC478825dde08e33eace611a686b6a5dd10f3": Object {
+    "ApiTestDeployment153EC478ba688c73ecd411d6bc46f33941546de6": Object {
       "DependsOn": Array [
         "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
@@ -8990,7 +10752,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -9022,7 +10797,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -9039,7 +10827,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment153EC478825dde08e33eace611a686b6a5dd10f3",
+          "Ref": "ApiTestDeployment153EC478ba688c73ecd411d6bc46f33941546de6",
         },
         "MethodSettings": Array [
           Object {
@@ -9073,7 +10861,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -9109,7 +10910,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -9168,7 +10982,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -9179,7 +11006,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3e7b6d1146d8dc592557812a3e65293273e8620d1b901b4542215bec35383f55.zip",
+          "S3Key": "712ec0546e7d545ed5b3a28ae45693b13a453da698a690e2af3ed372bde8451e.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -9209,7 +11036,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -9286,6 +11126,10 @@ Object {
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
             Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -9295,7 +11139,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -9351,6 +11208,10 @@ Object {
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
             Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -9360,7 +11221,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -9447,6 +11321,10 @@ Object {
               "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
             },
             Object {
+              "id": "AwsPrototyping-LambdaLatestVersion",
+              "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -9456,7 +11334,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -9509,6 +11400,15 @@ Object {
             Object {
               "applies_to": Array [
                 Object {
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
                 },
               ],
@@ -9516,7 +11416,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -9784,7 +11697,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -9819,7 +11745,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -9856,7 +11795,7 @@ Object {
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC478825dde08e33eace611a686b6a5dd10f3": Object {
+    "ApiTestDeployment153EC478ba688c73ecd411d6bc46f33941546de6": Object {
       "DependsOn": Array [
         "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
@@ -9873,7 +11812,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -9905,7 +11857,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -9922,7 +11887,7 @@ Object {
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \\"$context.httpMethod $context.resourcePath $context.protocol\\" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": Object {
-          "Ref": "ApiTestDeployment153EC478825dde08e33eace611a686b6a5dd10f3",
+          "Ref": "ApiTestDeployment153EC478ba688c73ecd411d6bc46f33941546de6",
         },
         "MethodSettings": Array [
           Object {
@@ -9956,7 +11921,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -9992,7 +11970,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -10051,7 +12042,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -10062,7 +12066,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "3e7b6d1146d8dc592557812a3e65293273e8620d1b901b4542215bec35383f55.zip",
+          "S3Key": "712ec0546e7d545ed5b3a28ae45693b13a453da698a690e2af3ed372bde8451e.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -10092,7 +12096,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -10169,6 +12186,10 @@ Object {
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
             Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -10178,7 +12199,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -10234,6 +12268,10 @@ Object {
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
             Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -10243,7 +12281,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -10330,6 +12381,10 @@ Object {
               "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
             },
             Object {
+              "id": "AwsPrototyping-LambdaLatestVersion",
+              "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
+            },
+            Object {
               "applies_to": Array [
                 Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
@@ -10339,7 +12394,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],
@@ -10392,6 +12460,15 @@ Object {
             Object {
               "applies_to": Array [
                 Object {
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
                   "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
                 },
               ],
@@ -10399,7 +12476,20 @@ Object {
               "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
             },
             Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            Object {
               "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            Object {
+              "id": "AwsPrototyping-APIGWRequestValidation",
               "reason": "This construct implements fine grained validation via OpenApi.",
             },
           ],

--- a/packages/open-api-gateway/test/construct/open-api-gateway-rest-api.test.ts
+++ b/packages/open-api-gateway/test/construct/open-api-gateway-rest-api.test.ts
@@ -134,15 +134,19 @@ describe("OpenAPI Gateway Rest Api Construct Unit Tests", () => {
           },
         },
       });
-      NagSuppressions.addResourceSuppressions(
-        func,
-        [
-          {
-            id: "AwsSolutions-IAM4",
-            reason: "This is a test construct.",
-          },
-        ],
-        true
+      ["AwsSolutions-IAM4", "AwsPrototyping-IAMNoManagedPolicies"].forEach(
+        (RuleId) => {
+          NagSuppressions.addResourceSuppressions(
+            func,
+            [
+              {
+                id: RuleId,
+                reason: "This is a test construct.",
+              },
+            ],
+            true
+          );
+        }
       );
       expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
     });

--- a/packages/pipeline/samples/typescript/test/__snapshots__/pipeline.test.ts.snap
+++ b/packages/pipeline/samples/typescript/test/__snapshots__/pipeline.test.ts.snap
@@ -9,6 +9,10 @@ Object {
           "id": "AwsSolutions-CB4",
           "reason": "Encryption of Codebuild is not required.",
         },
+        Object {
+          "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+          "reason": "Encryption of Codebuild is not required.",
+        },
       ],
     },
   },
@@ -283,6 +287,95 @@ Object {
                 },
               ],
               "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<ApplicationPipelineUpdatePipelineSelfMutation.*>-\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:\\\\*:iam::<AWS::AccountId>:role/\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to assume a role from within the current account in order to deploy.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to list all buckets and stacks.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        "):log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\*$/g",
+                      ],
+                    ],
+                  },
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
               "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
             },
           ],
@@ -935,6 +1028,48 @@ Object {
               "id": "AwsSolutions-IAM5",
               "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
             },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
+            },
           ],
         },
       },
@@ -1226,6 +1361,39 @@ Object {
               "id": "AwsSolutions-IAM5",
               "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
             },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
           ],
         },
       },
@@ -1375,6 +1543,30 @@ Object {
                 },
               ],
               "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
               "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
             },
           ],

--- a/packages/pipeline/src/code_scanner/sonar-code-scanner.ts
+++ b/packages/pipeline/src/code_scanner/sonar-code-scanner.ts
@@ -229,51 +229,61 @@ export class SonarCodeScanner extends Construct {
       value: sonarQubeToken.secretArn,
     });
 
-    NagSuppressions.addResourceSuppressions(sonarQubeToken, [
-      {
-        id: "AwsSolutions-SMG4",
-        reason:
-          "Key rotation is not possible as a user token needs to be generated from Sonarqube",
-      },
-    ]);
+    [
+      "AwsSolutions-SMG4",
+      "AwsPrototyping-SecretsManagerRotationEnabled",
+    ].forEach((RuleId) => {
+      NagSuppressions.addResourceSuppressions(sonarQubeToken, [
+        {
+          id: RuleId,
+          reason:
+            "Key rotation is not possible as a user token needs to be generated from Sonarqube",
+        },
+      ]);
+    });
 
     const stack = Stack.of(this);
-    NagSuppressions.addResourceSuppressions(
-      validationProject.role!,
-      [
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
-          appliesTo: [
+
+    ["AwsSolutions-IAM5", "AwsPrototyping-IAMNoWildcardPermissions"].forEach(
+      (RuleId) => {
+        NagSuppressions.addResourceSuppressions(
+          validationProject.role!,
+          [
             {
-              regex: `/^Resource::arn:${PDKNag.getStackPartitionRegex(
-                stack
-              )}:logs:${PDKNag.getStackRegionRegex(
-                stack
-              )}:${PDKNag.getStackAccountRegex(
-                stack
-              )}:log-group:/aws/codebuild/<.*SonarCodeScannerValidationProject.*>:\\*$/g`,
-            },
-            {
-              regex: `/^Resource::arn:${PDKNag.getStackPartitionRegex(
-                stack
-              )}:codebuild:${PDKNag.getStackRegionRegex(
-                stack
-              )}:${PDKNag.getStackAccountRegex(
-                stack
-              )}:report-group/<.*SonarCodeScannerValidationProject.*>-\\*$/g`,
-            },
-            {
-              regex: `/^Action::s3:GetObject\\*$/g`,
-            },
-            {
-              regex: "/^Resource::<ArtifactsBucket.*.Arn>/\\*\\*$/g",
+              id: RuleId,
+              reason:
+                "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
+              appliesTo: [
+                {
+                  regex: `/^Resource::arn:${PDKNag.getStackPartitionRegex(
+                    stack
+                  )}:logs:${PDKNag.getStackRegionRegex(
+                    stack
+                  )}:${PDKNag.getStackAccountRegex(
+                    stack
+                  )}:log-group:/aws/codebuild/<.*SonarCodeScannerValidationProject.*>:\\*$/g`,
+                },
+                {
+                  regex: `/^Resource::arn:${PDKNag.getStackPartitionRegex(
+                    stack
+                  )}:codebuild:${PDKNag.getStackRegionRegex(
+                    stack
+                  )}:${PDKNag.getStackAccountRegex(
+                    stack
+                  )}:report-group/<.*SonarCodeScannerValidationProject.*>-\\*$/g`,
+                },
+                {
+                  regex: `/^Action::s3:GetObject\\*$/g`,
+                },
+                {
+                  regex: "/^Resource::<ArtifactsBucket.*.Arn>/\\*\\*$/g",
+                },
+              ],
             },
           ],
-        },
-      ],
-      true
+          true
+        );
+      }
     );
   }
 }

--- a/packages/pipeline/src/pdk-pipeline.ts
+++ b/packages/pipeline/src/pdk-pipeline.ts
@@ -204,350 +204,365 @@ export class PDKPipeline extends CodePipeline {
   suppressCDKViolations() {
     const stack = Stack.of(this);
 
-    PDKNag.addResourceSuppressionsByPathNoThrow(
-      stack,
-      `${PDKNag.getStackPrefix(stack)}CodePipeline/Role/DefaultPolicy/Resource`,
-      [
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
-          appliesTo: [
+    ["AwsSolutions-IAM5", "AwsPrototyping-IAMNoWildcardPermissions"].forEach(
+      (RuleId) => {
+        PDKNag.addResourceSuppressionsByPathNoThrow(
+          stack,
+          `${PDKNag.getStackPrefix(
+            stack
+          )}CodePipeline/Role/DefaultPolicy/Resource`,
+          [
             {
-              regex: "/^Action::s3:.*$/g",
-            },
-          ],
-        },
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-          appliesTo: [
-            {
-              regex: "/^Resource::<ArtifactsBucket.*.Arn>/\\*$/g",
+              id: RuleId,
+              reason:
+                "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              appliesTo: [
+                {
+                  regex: "/^Action::s3:.*$/g",
+                },
+              ],
             },
             {
-              regex: "/^Action::kms:ReEncrypt\\*$/g",
+              id: RuleId,
+              reason:
+                "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              appliesTo: [
+                {
+                  regex: "/^Resource::<ArtifactsBucket.*.Arn>/\\*$/g",
+                },
+                {
+                  regex: "/^Action::kms:ReEncrypt\\*$/g",
+                },
+                {
+                  regex: "/^Action::kms:GenerateDataKey\\*$/g",
+                },
+              ],
+            },
+          ]
+        );
+
+        PDKNag.addResourceSuppressionsByPathNoThrow(
+          stack,
+          `${PDKNag.getStackPrefix(
+            stack
+          )}CodePipeline/Role/DefaultPolicy/Resource`,
+          [
+            {
+              id: RuleId,
+              reason:
+                "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              appliesTo: [
+                {
+                  regex: "/^Action::s3:.*$/g",
+                },
+              ],
             },
             {
-              regex: "/^Action::kms:GenerateDataKey\\*$/g",
+              id: RuleId,
+              reason:
+                "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              appliesTo: [
+                {
+                  regex: "/^Resource::<ArtifactsBucket.*.Arn>/\\*$/g",
+                },
+              ],
             },
-          ],
-        },
-      ]
+          ]
+        );
+
+        PDKNag.addResourceSuppressionsByPathNoThrow(
+          stack,
+          `${PDKNag.getStackPrefix(
+            stack
+          )}CodePipeline/Source/CodeCommit/CodePipelineActionRole/DefaultPolicy/Resource`,
+          [
+            {
+              id: RuleId,
+              reason:
+                "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              appliesTo: [
+                {
+                  regex: "/^Action::s3:.*$/g",
+                },
+              ],
+            },
+            {
+              id: RuleId,
+              reason:
+                "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              appliesTo: [
+                {
+                  regex: "/^Resource::<ArtifactsBucket.*.Arn>/\\*$/g",
+                },
+                {
+                  regex: "/^Action::kms:ReEncrypt\\*$/g",
+                },
+                {
+                  regex: "/^Action::kms:GenerateDataKey\\*$/g",
+                },
+              ],
+            },
+          ]
+        );
+
+        PDKNag.addResourceSuppressionsByPathNoThrow(
+          stack,
+          `${PDKNag.getStackPrefix(
+            stack
+          )}CodePipeline/Build/Synth/CdkBuildProject/Role/DefaultPolicy/Resource`,
+          [
+            {
+              id: RuleId,
+              reason:
+                "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              appliesTo: [
+                {
+                  regex: "/^Action::s3:.*$/g",
+                },
+              ],
+            },
+            {
+              id: RuleId,
+              reason:
+                "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              appliesTo: [
+                {
+                  regex: "/^Resource::<ArtifactsBucket.*.Arn>/\\*$/g",
+                },
+                {
+                  regex: "/^Action::kms:ReEncrypt\\*$/g",
+                },
+                {
+                  regex: "/^Action::kms:GenerateDataKey\\*$/g",
+                },
+              ],
+            },
+            {
+              id: RuleId,
+              reason:
+                "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+              appliesTo: [
+                {
+                  regex: `/^Resource::arn:${PDKNag.getStackPartitionRegex(
+                    stack
+                  )}:logs:${PDKNag.getStackRegionRegex(
+                    stack
+                  )}:${PDKNag.getStackAccountRegex(
+                    stack
+                  )}:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\*$/g`,
+                },
+              ],
+            },
+            {
+              id: RuleId,
+              reason:
+                "CodePipeline requires access to create report groups that are dynamically determined.",
+              appliesTo: [
+                {
+                  regex: `/^Resource::arn:${PDKNag.getStackPartitionRegex(
+                    stack
+                  )}:codebuild:${PDKNag.getStackRegionRegex(
+                    stack
+                  )}:${PDKNag.getStackAccountRegex(
+                    stack
+                  )}:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\*$/g`,
+                },
+              ],
+            },
+          ]
+        );
+
+        PDKNag.addResourceSuppressionsByPathNoThrow(
+          stack,
+          `${PDKNag.getStackPrefix(stack)}${
+            this.id
+          }/UpdatePipeline/SelfMutation/Role/DefaultPolicy/Resource`,
+          [
+            {
+              id: RuleId,
+              reason:
+                "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+              appliesTo: [
+                {
+                  regex: `/^Resource::arn:${PDKNag.getStackPartitionRegex(
+                    stack
+                  )}:logs:${PDKNag.getStackRegionRegex(
+                    stack
+                  )}:${PDKNag.getStackAccountRegex(
+                    stack
+                  )}:log-group:/aws/codebuild/<${
+                    this.id
+                  }UpdatePipelineSelfMutation.*>:\\*$/g`,
+                },
+              ],
+            },
+            {
+              id: RuleId,
+              reason:
+                "CodePipeline requires access to create report groups that are dynamically determined.",
+              appliesTo: [
+                {
+                  regex: `/^Resource::arn:${PDKNag.getStackPartitionRegex(
+                    stack
+                  )}:codebuild:${PDKNag.getStackRegionRegex(
+                    stack
+                  )}:${PDKNag.getStackAccountRegex(stack)}:report-group/<${
+                    this.id
+                  }UpdatePipelineSelfMutation.*>-\\*$/g`,
+                },
+              ],
+            },
+            {
+              id: RuleId,
+              reason:
+                "CodePipeline requires access to assume a role from within the current account in order to deploy.",
+              appliesTo: [
+                {
+                  regex: `/^Resource::arn:\\*:iam::${PDKNag.getStackAccountRegex(
+                    stack
+                  )}:role/\\*$/g`,
+                },
+              ],
+            },
+            {
+              id: RuleId,
+              reason:
+                "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              appliesTo: [
+                {
+                  regex: "/^Resource::<ArtifactsBucket.*.Arn>/\\*$/g",
+                },
+              ],
+            },
+            {
+              id: RuleId,
+              reason:
+                "CodePipeline requires access to list all buckets and stacks.",
+              appliesTo: [
+                {
+                  regex: "/^Resource::\\*$/g",
+                },
+              ],
+            },
+          ]
+        );
+
+        PDKNag.addResourceSuppressionsByPathNoThrow(
+          stack,
+          `${PDKNag.getStackPrefix(stack)}${
+            this.id
+          }/UpdatePipeline/SelfMutation/Role/DefaultPolicy/Resource`,
+          [
+            {
+              id: RuleId,
+              reason:
+                "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              appliesTo: [
+                {
+                  regex: "/^Action::s3:.*$/g",
+                },
+              ],
+            },
+            {
+              id: RuleId,
+              reason:
+                "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+              appliesTo: [
+                {
+                  regex: `/^Resource::arn:${PDKNag.getStackPartitionRegex(
+                    stack
+                  )}:logs:${PDKNag.getStackRegionRegex(
+                    stack
+                  )}:(<AWS::AccountId>|${
+                    stack.account
+                  }):log-group:/aws/codebuild/<${
+                    this.id
+                  }UpdatePipelineSelfMutation.*>:\\*$/g`,
+                },
+              ],
+            },
+            {
+              id: RuleId,
+              reason:
+                "CodePipeline requires access to create report groups that are dynamically determined.",
+              appliesTo: [
+                {
+                  regex: `/^Resource::arn:${PDKNag.getStackPartitionRegex(
+                    stack
+                  )}:codebuild:${PDKNag.getStackRegionRegex(
+                    stack
+                  )}:${PDKNag.getStackAccountRegex(stack)}:report-group/<${
+                    this.id
+                  }UpdatePipelineSelfMutation.*>-\\*$/g`,
+                },
+              ],
+            },
+            {
+              id: RuleId,
+              reason:
+                "CodePipeline requires access to assume a role from within the current account in order to deploy.",
+              appliesTo: [
+                {
+                  regex: `/^Resource::arn:\\*:iam::${PDKNag.getStackAccountRegex(
+                    stack
+                  )}:role/\\*$/g`,
+                },
+              ],
+            },
+            {
+              id: RuleId,
+              reason:
+                "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              appliesTo: [
+                {
+                  regex: "/^Resource::<ArtifactsBucket.*.Arn>/\\*$/g",
+                },
+                {
+                  regex: "/^Action::kms:ReEncrypt\\*$/g",
+                },
+                {
+                  regex: "/^Action::kms:GenerateDataKey\\*$/g",
+                },
+              ],
+            },
+            {
+              id: RuleId,
+              reason:
+                "CodePipeline requires access to list all buckets and stacks.",
+              appliesTo: [
+                {
+                  regex: "/^Resource::\\*$/g",
+                },
+              ],
+            },
+          ]
+        );
+
+        PDKNag.addResourceSuppressionsByPathNoThrow(
+          stack,
+          `${PDKNag.getStackPrefix(stack)}${
+            this.id
+          }/Assets/FileRole/DefaultPolicy/Resource`,
+          [
+            {
+              id: RuleId,
+              reason: "Asset role requires access to the Artifacts Bucket",
+            },
+          ]
+        );
+      }
     );
 
-    PDKNag.addResourceSuppressionsByPathNoThrow(
-      stack,
-      `${PDKNag.getStackPrefix(stack)}CodePipeline/Role/DefaultPolicy/Resource`,
-      [
+    [
+      "AwsSolutions-CB4",
+      "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+    ].forEach((RuleId) => {
+      NagSuppressions.addStackSuppressions(stack, [
         {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
-          appliesTo: [
-            {
-              regex: "/^Action::s3:.*$/g",
-            },
-          ],
+          id: RuleId,
+          reason: "Encryption of Codebuild is not required.",
         },
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-          appliesTo: [
-            {
-              regex: "/^Resource::<ArtifactsBucket.*.Arn>/\\*$/g",
-            },
-          ],
-        },
-      ]
-    );
-
-    PDKNag.addResourceSuppressionsByPathNoThrow(
-      stack,
-      `${PDKNag.getStackPrefix(
-        stack
-      )}CodePipeline/Source/CodeCommit/CodePipelineActionRole/DefaultPolicy/Resource`,
-      [
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
-          appliesTo: [
-            {
-              regex: "/^Action::s3:.*$/g",
-            },
-          ],
-        },
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-          appliesTo: [
-            {
-              regex: "/^Resource::<ArtifactsBucket.*.Arn>/\\*$/g",
-            },
-            {
-              regex: "/^Action::kms:ReEncrypt\\*$/g",
-            },
-            {
-              regex: "/^Action::kms:GenerateDataKey\\*$/g",
-            },
-          ],
-        },
-      ]
-    );
-
-    PDKNag.addResourceSuppressionsByPathNoThrow(
-      stack,
-      `${PDKNag.getStackPrefix(
-        stack
-      )}CodePipeline/Build/Synth/CdkBuildProject/Role/DefaultPolicy/Resource`,
-      [
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
-          appliesTo: [
-            {
-              regex: "/^Action::s3:.*$/g",
-            },
-          ],
-        },
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-          appliesTo: [
-            {
-              regex: "/^Resource::<ArtifactsBucket.*.Arn>/\\*$/g",
-            },
-            {
-              regex: "/^Action::kms:ReEncrypt\\*$/g",
-            },
-            {
-              regex: "/^Action::kms:GenerateDataKey\\*$/g",
-            },
-          ],
-        },
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
-          appliesTo: [
-            {
-              regex: `/^Resource::arn:${PDKNag.getStackPartitionRegex(
-                stack
-              )}:logs:${PDKNag.getStackRegionRegex(
-                stack
-              )}:${PDKNag.getStackAccountRegex(
-                stack
-              )}:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\*$/g`,
-            },
-          ],
-        },
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "CodePipeline requires access to create report groups that are dynamically determined.",
-          appliesTo: [
-            {
-              regex: `/^Resource::arn:${PDKNag.getStackPartitionRegex(
-                stack
-              )}:codebuild:${PDKNag.getStackRegionRegex(
-                stack
-              )}:${PDKNag.getStackAccountRegex(
-                stack
-              )}:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\*$/g`,
-            },
-          ],
-        },
-      ]
-    );
-
-    PDKNag.addResourceSuppressionsByPathNoThrow(
-      stack,
-      `${PDKNag.getStackPrefix(stack)}${
-        this.id
-      }/UpdatePipeline/SelfMutation/Role/DefaultPolicy/Resource`,
-      [
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
-          appliesTo: [
-            {
-              regex: `/^Resource::arn:${PDKNag.getStackPartitionRegex(
-                stack
-              )}:logs:${PDKNag.getStackRegionRegex(
-                stack
-              )}:${PDKNag.getStackAccountRegex(
-                stack
-              )}:log-group:/aws/codebuild/<${
-                this.id
-              }UpdatePipelineSelfMutation.*>:\\*$/g`,
-            },
-          ],
-        },
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "CodePipeline requires access to create report groups that are dynamically determined.",
-          appliesTo: [
-            {
-              regex: `/^Resource::arn:${PDKNag.getStackPartitionRegex(
-                stack
-              )}:codebuild:${PDKNag.getStackRegionRegex(
-                stack
-              )}:${PDKNag.getStackAccountRegex(stack)}:report-group/<${
-                this.id
-              }UpdatePipelineSelfMutation.*>-\\*$/g`,
-            },
-          ],
-        },
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "CodePipeline requires access to assume a role from within the current account in order to deploy.",
-          appliesTo: [
-            {
-              regex: `/^Resource::arn:\\*:iam::${PDKNag.getStackAccountRegex(
-                stack
-              )}:role/\\*$/g`,
-            },
-          ],
-        },
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-          appliesTo: [
-            {
-              regex: "/^Resource::<ArtifactsBucket.*.Arn>/\\*$/g",
-            },
-          ],
-        },
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "CodePipeline requires access to list all buckets and stacks.",
-          appliesTo: [
-            {
-              regex: "/^Resource::\\*$/g",
-            },
-          ],
-        },
-      ]
-    );
-
-    PDKNag.addResourceSuppressionsByPathNoThrow(
-      stack,
-      `${PDKNag.getStackPrefix(stack)}${
-        this.id
-      }/UpdatePipeline/SelfMutation/Role/DefaultPolicy/Resource`,
-      [
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
-          appliesTo: [
-            {
-              regex: "/^Action::s3:.*$/g",
-            },
-          ],
-        },
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
-          appliesTo: [
-            {
-              regex: `/^Resource::arn:${PDKNag.getStackPartitionRegex(
-                stack
-              )}:logs:${PDKNag.getStackRegionRegex(stack)}:(<AWS::AccountId>|${
-                stack.account
-              }):log-group:/aws/codebuild/<${
-                this.id
-              }UpdatePipelineSelfMutation.*>:\\*$/g`,
-            },
-          ],
-        },
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "CodePipeline requires access to create report groups that are dynamically determined.",
-          appliesTo: [
-            {
-              regex: `/^Resource::arn:${PDKNag.getStackPartitionRegex(
-                stack
-              )}:codebuild:${PDKNag.getStackRegionRegex(
-                stack
-              )}:${PDKNag.getStackAccountRegex(stack)}:report-group/<${
-                this.id
-              }UpdatePipelineSelfMutation.*>-\\*$/g`,
-            },
-          ],
-        },
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "CodePipeline requires access to assume a role from within the current account in order to deploy.",
-          appliesTo: [
-            {
-              regex: `/^Resource::arn:\\*:iam::${PDKNag.getStackAccountRegex(
-                stack
-              )}:role/\\*$/g`,
-            },
-          ],
-        },
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-          appliesTo: [
-            {
-              regex: "/^Resource::<ArtifactsBucket.*.Arn>/\\*$/g",
-            },
-            {
-              regex: "/^Action::kms:ReEncrypt\\*$/g",
-            },
-            {
-              regex: "/^Action::kms:GenerateDataKey\\*$/g",
-            },
-          ],
-        },
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "CodePipeline requires access to list all buckets and stacks.",
-          appliesTo: [
-            {
-              regex: "/^Resource::\\*$/g",
-            },
-          ],
-        },
-      ]
-    );
-
-    PDKNag.addResourceSuppressionsByPathNoThrow(
-      stack,
-      `${PDKNag.getStackPrefix(stack)}${
-        this.id
-      }/Assets/FileRole/DefaultPolicy/Resource`,
-      [
-        {
-          id: "AwsSolutions-IAM5",
-          reason: "Asset role requires access to the Artifacts Bucket",
-        },
-      ]
-    );
-
-    NagSuppressions.addStackSuppressions(stack, [
-      {
-        id: "AwsSolutions-CB4",
-        reason: "Encryption of Codebuild is not required.",
-      },
-    ]);
+      ]);
+    });
   }
 }

--- a/packages/pipeline/test/__snapshots__/pdk-pipeline-ts-project.test.ts.snap
+++ b/packages/pipeline/test/__snapshots__/pdk-pipeline-ts-project.test.ts.snap
@@ -1028,6 +1028,10 @@ Object {
           \\"id\\": \\"AwsSolutions-CB4\\",
           \\"reason\\": \\"Encryption of Codebuild is not required.\\",
         },
+        Object {
+          \\"id\\": \\"AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts\\",
+          \\"reason\\": \\"Encryption of Codebuild is not required.\\",
+        },
       ],
     },
   },
@@ -1302,6 +1306,95 @@ Object {
                 },
               ],
               \\"id\\": \\"AwsSolutions-IAM5\\",
+              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<ApplicationPipelineUpdatePipelineSelfMutation.*>-\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to create report groups that are dynamically determined.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::arn:\\\\\\\\\\\\\\\\*:iam::<AWS::AccountId>:role/\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to assume a role from within the current account in order to deploy.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to list all buckets and stacks.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": Object {
+                    \\"Fn::Join\\": Array [
+                      \\"\\",
+                      Array [
+                        \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|\\",
+                        Object {
+                          \\"Ref\\": \\"AWS::AccountId\\",
+                        },
+                        \\"):log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\\\\\\\\\\\\\*$/g\\",
+                      ],
+                    ],
+                  },
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
               \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
             },
           ],
@@ -1954,6 +2047,48 @@ Object {
               \\"id\\": \\"AwsSolutions-IAM5\\",
               \\"reason\\": \\"CodePipeline requires access to create report groups that are dynamically determined.\\",
             },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to create report groups that are dynamically determined.\\",
+            },
           ],
         },
       },
@@ -2245,6 +2380,39 @@ Object {
               \\"id\\": \\"AwsSolutions-IAM5\\",
               \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
             },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
+            },
           ],
         },
       },
@@ -2394,6 +2562,30 @@ Object {
                 },
               ],
               \\"id\\": \\"AwsSolutions-IAM5\\",
+              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
               \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
             },
           ],
@@ -3768,6 +3960,10 @@ Object {
           \\"id\\": \\"AwsSolutions-CB4\\",
           \\"reason\\": \\"Encryption of Codebuild is not required.\\",
         },
+        Object {
+          \\"id\\": \\"AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts\\",
+          \\"reason\\": \\"Encryption of Codebuild is not required.\\",
+        },
       ],
     },
   },
@@ -4042,6 +4238,95 @@ Object {
                 },
               ],
               \\"id\\": \\"AwsSolutions-IAM5\\",
+              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<ApplicationPipelineUpdatePipelineSelfMutation.*>-\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to create report groups that are dynamically determined.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::arn:\\\\\\\\\\\\\\\\*:iam::<AWS::AccountId>:role/\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to assume a role from within the current account in order to deploy.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to list all buckets and stacks.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": Object {
+                    \\"Fn::Join\\": Array [
+                      \\"\\",
+                      Array [
+                        \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|\\",
+                        Object {
+                          \\"Ref\\": \\"AWS::AccountId\\",
+                        },
+                        \\"):log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\\\\\\\\\\\\\*$/g\\",
+                      ],
+                    ],
+                  },
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
               \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
             },
           ],
@@ -4694,6 +4979,48 @@ Object {
               \\"id\\": \\"AwsSolutions-IAM5\\",
               \\"reason\\": \\"CodePipeline requires access to create report groups that are dynamically determined.\\",
             },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to create report groups that are dynamically determined.\\",
+            },
           ],
         },
       },
@@ -4985,6 +5312,39 @@ Object {
               \\"id\\": \\"AwsSolutions-IAM5\\",
               \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
             },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
+            },
           ],
         },
       },
@@ -5134,6 +5494,30 @@ Object {
                 },
               ],
               \\"id\\": \\"AwsSolutions-IAM5\\",
+              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
               \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
             },
           ],
@@ -6523,6 +6907,10 @@ Object {
           \\"id\\": \\"AwsSolutions-CB4\\",
           \\"reason\\": \\"Encryption of Codebuild is not required.\\",
         },
+        Object {
+          \\"id\\": \\"AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts\\",
+          \\"reason\\": \\"Encryption of Codebuild is not required.\\",
+        },
       ],
     },
   },
@@ -6797,6 +7185,95 @@ Object {
                 },
               ],
               \\"id\\": \\"AwsSolutions-IAM5\\",
+              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<ApplicationPipelineUpdatePipelineSelfMutation.*>-\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to create report groups that are dynamically determined.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::arn:\\\\\\\\\\\\\\\\*:iam::<AWS::AccountId>:role/\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to assume a role from within the current account in order to deploy.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to list all buckets and stacks.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": Object {
+                    \\"Fn::Join\\": Array [
+                      \\"\\",
+                      Array [
+                        \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|\\",
+                        Object {
+                          \\"Ref\\": \\"AWS::AccountId\\",
+                        },
+                        \\"):log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\\\\\\\\\\\\\*$/g\\",
+                      ],
+                    ],
+                  },
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
               \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
             },
           ],
@@ -7449,6 +7926,48 @@ Object {
               \\"id\\": \\"AwsSolutions-IAM5\\",
               \\"reason\\": \\"CodePipeline requires access to create report groups that are dynamically determined.\\",
             },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to create report groups that are dynamically determined.\\",
+            },
           ],
         },
       },
@@ -7740,6 +8259,39 @@ Object {
               \\"id\\": \\"AwsSolutions-IAM5\\",
               \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
             },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
+            },
           ],
         },
       },
@@ -7889,6 +8441,30 @@ Object {
                 },
               ],
               \\"id\\": \\"AwsSolutions-IAM5\\",
+              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
+              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
+            },
+            Object {
+              \\"applies_to\\": Array [
+                Object {
+                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
+                },
+                Object {
+                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
+                },
+              ],
+              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
               \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
             },
           ],

--- a/packages/pipeline/test/__snapshots__/pdk-pipeline.test.ts.snap
+++ b/packages/pipeline/test/__snapshots__/pdk-pipeline.test.ts.snap
@@ -1,12 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PDK Pipeline Unit Tests CrossAccount 1`] = `
+exports[`PDK Pipeline Unit Tests CrossAccount - using AwsPrototyping NagPack 1`] = `
 Object {
   "Metadata": Object {
     "cdk_nag": Object {
       "rules_to_suppress": Array [
         Object {
           "id": "AwsSolutions-CB4",
+          "reason": "Encryption of Codebuild is not required.",
+        },
+        Object {
+          "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
           "reason": "Encryption of Codebuild is not required.",
         },
       ],
@@ -731,6 +735,48 @@ Object {
               "id": "AwsSolutions-IAM5",
               "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
             },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
+            },
           ],
         },
       },
@@ -1022,6 +1068,39 @@ Object {
               "id": "AwsSolutions-IAM5",
               "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
             },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
           ],
         },
       },
@@ -1198,6 +1277,30 @@ Object {
                 },
               ],
               "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
               "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
             },
           ],
@@ -1399,7 +1502,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-Stage/StageAppStack7618C9EF.assets.json\\\\\\" --verbose publish \\\\\\"729608d47960b953f2edbfc7974d9c0fcf1c033c3c48573d154bc286b18505df:current_account-current_region\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-Stage/StageAppStack7618C9EF.assets.json\\\\\\" --verbose publish \\\\\\"824fe84db24bbf4d297bea3c89c9f634f2379cc336ccbe96772c4cc0eab472e3:current_account-current_region\\\\\\"\\"
       ]
     }
   }
@@ -1454,6 +1557,10 @@ Object {
           "rules_to_suppress": Array [
             Object {
               "id": "AwsSolutions-IAM5",
+              "reason": "Asset role requires access to the Artifacts Bucket",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
               "reason": "Asset role requires access to the Artifacts Bucket",
             },
           ],
@@ -1695,6 +1802,10 @@ Object {
               "id": "AwsSolutions-SMG4",
               "reason": "Key rotation is not possible as a user token needs to be generated from Sonarqube",
             },
+            Object {
+              "id": "AwsPrototyping-SecretsManagerRotationEnabled",
+              "reason": "Key rotation is not possible as a user token needs to be generated from Sonarqube",
+            },
           ],
         },
       },
@@ -1923,6 +2034,24 @@ Object {
               "id": "AwsSolutions-IAM5",
               "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
             },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<.*SonarCodeScannerValidationProject.*>:\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<.*SonarCodeScannerValidationProject.*>-\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::s3:GetObject\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
+            },
           ],
         },
       },
@@ -1962,6 +2091,24 @@ Object {
                 },
               ],
               "id": "AwsSolutions-IAM5",
+              "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<.*SonarCodeScannerValidationProject.*>:\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<.*SonarCodeScannerValidationProject.*>-\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::s3:GetObject\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
               "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
             },
           ],
@@ -2288,6 +2435,95 @@ Object {
               "id": "AwsSolutions-IAM5",
               "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
             },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CrossAccountUpdatePipelineSelfMutation.*>:\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CrossAccountUpdatePipelineSelfMutation.*>-\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:\\\\*:iam::<AWS::AccountId>:role/\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to assume a role from within the current account in order to deploy.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to list all buckets and stacks.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        "):log-group:/aws/codebuild/<CrossAccountUpdatePipelineSelfMutation.*>:\\\\*$/g",
+                      ],
+                    ],
+                  },
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
           ],
         },
       },
@@ -2579,13 +2815,2832 @@ Object {
 }
 `;
 
-exports[`PDK Pipeline Unit Tests Defaults 1`] = `
+exports[`PDK Pipeline Unit Tests CrossAccount 1`] = `
 Object {
   "Metadata": Object {
     "cdk_nag": Object {
       "rules_to_suppress": Array [
         Object {
           "id": "AwsSolutions-CB4",
+          "reason": "Encryption of Codebuild is not required.",
+        },
+        Object {
+          "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+          "reason": "Encryption of Codebuild is not required.",
+        },
+      ],
+    },
+  },
+  "Outputs": Object {
+    "CodeRepositoryGRCUrl": Object {
+      "Export": Object {
+        "Name": "CodeRepositoryGRCUrl",
+      },
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "codecommit::",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            "://",
+            Object {
+              "Fn::GetAtt": Array [
+                "CodeRepositoryBA42F94A",
+                "Name",
+              ],
+            },
+          ],
+        ],
+      },
+    },
+    "CrossAccountSonarCodeScannerSonarqubeSecretArn67524D2A": Object {
+      "Export": Object {
+        "Name": "SonarqubeSecretArn",
+      },
+      "Value": Object {
+        "Ref": "CrossAccountSonarCodeScannerSonarQubeToken76921F1B",
+      },
+    },
+  },
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "ArtifactKey8D84C5F0": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "EnableKeyRotation": true,
+        "KeyPolicy": Object {
+          "Statement": Array [
+            Object {
+              "Action": "kms:*",
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+              "Resource": "*",
+            },
+            Object {
+              "Action": Array [
+                "kms:Decrypt",
+                "kms:DescribeKey",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":role/cdk-hnb659fds-deploy-role-",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      "-",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                    ],
+                  ],
+                },
+              },
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::KMS::Key",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ArtifactsBucket2AAC5544": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "BucketEncryption": Object {
+          "ServerSideEncryptionConfiguration": Array [
+            Object {
+              "ServerSideEncryptionByDefault": Object {
+                "KMSMasterKeyID": Object {
+                  "Fn::GetAtt": Array [
+                    "ArtifactKey8D84C5F0",
+                    "Arn",
+                  ],
+                },
+                "SSEAlgorithm": "aws:kms",
+              },
+            },
+          ],
+        },
+        "LoggingConfiguration": Object {
+          "LogFilePrefix": "access-logs",
+        },
+        "PublicAccessBlockConfiguration": Object {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ArtifactsBucketAutoDeleteObjectsCustomResource0E3B4320": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "ArtifactsBucketPolicy852CB646",
+      ],
+      "Properties": Object {
+        "BucketName": Object {
+          "Ref": "ArtifactsBucket2AAC5544",
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ArtifactsBucketPolicy852CB646": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "ArtifactsBucket2AAC5544",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":role/cdk-hnb659fds-deploy-role-",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      "-",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                    ],
+                  ],
+                },
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "CodePipelineB74E5936": Object {
+      "DependsOn": Array [
+        "CodePipelineRoleDefaultPolicy8D520A8D",
+        "CodePipelineRoleB3A660B4",
+      ],
+      "Properties": Object {
+        "ArtifactStore": Object {
+          "EncryptionKey": Object {
+            "Id": Object {
+              "Fn::GetAtt": Array [
+                "ArtifactKey8D84C5F0",
+                "Arn",
+              ],
+            },
+            "Type": "KMS",
+          },
+          "Location": Object {
+            "Ref": "ArtifactsBucket2AAC5544",
+          },
+          "Type": "S3",
+        },
+        "RestartExecutionOnUpdate": true,
+        "RoleArn": Object {
+          "Fn::GetAtt": Array [
+            "CodePipelineRoleB3A660B4",
+            "Arn",
+          ],
+        },
+        "Stages": Array [
+          Object {
+            "Actions": Array [
+              Object {
+                "ActionTypeId": Object {
+                  "Category": "Source",
+                  "Owner": "AWS",
+                  "Provider": "CodeCommit",
+                  "Version": "1",
+                },
+                "Configuration": Object {
+                  "BranchName": "mainline",
+                  "PollForSourceChanges": false,
+                  "RepositoryName": Object {
+                    "Fn::GetAtt": Array [
+                      "CodeRepositoryBA42F94A",
+                      "Name",
+                    ],
+                  },
+                },
+                "Name": Object {
+                  "Fn::GetAtt": Array [
+                    "CodeRepositoryBA42F94A",
+                    "Name",
+                  ],
+                },
+                "OutputArtifacts": Array [
+                  Object {
+                    "Name": "c8b95ca81f750a44513d18b27868db0afa191aa92e_Source",
+                  },
+                ],
+                "RoleArn": Object {
+                  "Fn::GetAtt": Array [
+                    "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70",
+                    "Arn",
+                  ],
+                },
+                "RunOrder": 1,
+              },
+            ],
+            "Name": "Source",
+          },
+          Object {
+            "Actions": Array [
+              Object {
+                "ActionTypeId": Object {
+                  "Category": "Build",
+                  "Owner": "AWS",
+                  "Provider": "CodeBuild",
+                  "Version": "1",
+                },
+                "Configuration": Object {
+                  "EnvironmentVariables": "[{\\"name\\":\\"_PROJECT_CONFIG_HASH\\",\\"type\\":\\"PLAINTEXT\\",\\"value\\":\\"695a7330a2c9bebdb22e3baca36a4c397c9091b9e57d871d29047d7333b61977\\"}]",
+                  "ProjectName": Object {
+                    "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                  },
+                },
+                "InputArtifacts": Array [
+                  Object {
+                    "Name": "c8b95ca81f750a44513d18b27868db0afa191aa92e_Source",
+                  },
+                ],
+                "Name": "Synth",
+                "OutputArtifacts": Array [
+                  Object {
+                    "Name": "Synth_Output",
+                  },
+                  Object {
+                    "Name": "Synth__",
+                  },
+                ],
+                "RoleArn": Object {
+                  "Fn::GetAtt": Array [
+                    "CrossAccountCodeBuildActionRoleAAA68524",
+                    "Arn",
+                  ],
+                },
+                "RunOrder": 1,
+              },
+            ],
+            "Name": "Build",
+          },
+          Object {
+            "Actions": Array [
+              Object {
+                "ActionTypeId": Object {
+                  "Category": "Build",
+                  "Owner": "AWS",
+                  "Provider": "CodeBuild",
+                  "Version": "1",
+                },
+                "Configuration": Object {
+                  "EnvironmentVariables": "[{\\"name\\":\\"_PROJECT_CONFIG_HASH\\",\\"type\\":\\"PLAINTEXT\\",\\"value\\":\\"de1738b881d2f46e53ab02de31ca684f8741d030cff96e621e2ce465b5d9c6a7\\"}]",
+                  "ProjectName": Object {
+                    "Ref": "CrossAccountUpdatePipelineSelfMutation8D616EE5",
+                  },
+                },
+                "InputArtifacts": Array [
+                  Object {
+                    "Name": "Synth_Output",
+                  },
+                ],
+                "Name": "SelfMutate",
+                "RoleArn": Object {
+                  "Fn::GetAtt": Array [
+                    "CrossAccountCodeBuildActionRoleAAA68524",
+                    "Arn",
+                  ],
+                },
+                "RunOrder": 1,
+              },
+            ],
+            "Name": "UpdatePipeline",
+          },
+          Object {
+            "Actions": Array [
+              Object {
+                "ActionTypeId": Object {
+                  "Category": "Build",
+                  "Owner": "AWS",
+                  "Provider": "CodeBuild",
+                  "Version": "1",
+                },
+                "Configuration": Object {
+                  "ProjectName": Object {
+                    "Ref": "CrossAccountAssetsFileAsset11C4C6E29",
+                  },
+                },
+                "InputArtifacts": Array [
+                  Object {
+                    "Name": "Synth_Output",
+                  },
+                ],
+                "Name": "FileAsset1",
+                "RoleArn": Object {
+                  "Fn::GetAtt": Array [
+                    "CrossAccountCodeBuildActionRoleAAA68524",
+                    "Arn",
+                  ],
+                },
+                "RunOrder": 1,
+              },
+            ],
+            "Name": "Assets",
+          },
+          Object {
+            "Actions": Array [
+              Object {
+                "ActionTypeId": Object {
+                  "Category": "Deploy",
+                  "Owner": "AWS",
+                  "Provider": "CloudFormation",
+                  "Version": "1",
+                },
+                "Configuration": Object {
+                  "ActionMode": "CHANGE_SET_REPLACE",
+                  "Capabilities": "CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND",
+                  "ChangeSetName": "PipelineChange",
+                  "RoleArn": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "arn:",
+                        Object {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":iam::",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        ":role/cdk-hnb659fds-cfn-exec-role-",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        "-",
+                        Object {
+                          "Ref": "AWS::Region",
+                        },
+                      ],
+                    ],
+                  },
+                  "StackName": "Stage-AppStack",
+                  "TemplatePath": "Synth_Output::assembly-Stage/StageAppStack7618C9EF.template.json",
+                },
+                "InputArtifacts": Array [
+                  Object {
+                    "Name": "Synth_Output",
+                  },
+                ],
+                "Name": "Prepare",
+                "RoleArn": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":role/cdk-hnb659fds-deploy-role-",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      "-",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                    ],
+                  ],
+                },
+                "RunOrder": 1,
+              },
+              Object {
+                "ActionTypeId": Object {
+                  "Category": "Deploy",
+                  "Owner": "AWS",
+                  "Provider": "CloudFormation",
+                  "Version": "1",
+                },
+                "Configuration": Object {
+                  "ActionMode": "CHANGE_SET_EXECUTE",
+                  "ChangeSetName": "PipelineChange",
+                  "StackName": "Stage-AppStack",
+                },
+                "Name": "Deploy",
+                "RoleArn": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":role/cdk-hnb659fds-deploy-role-",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      "-",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                    ],
+                  ],
+                },
+                "RunOrder": 2,
+              },
+            ],
+            "Name": "Stage",
+          },
+        ],
+      },
+      "Type": "AWS::CodePipeline::Pipeline",
+    },
+    "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6": Object {
+      "Properties": Object {
+        "Artifacts": Object {
+          "Type": "CODEPIPELINE",
+        },
+        "Cache": Object {
+          "Type": "NO_CACHE",
+        },
+        "Description": "Pipeline step Default/CodePipeline/Build/Synth",
+        "EncryptionKey": Object {
+          "Fn::GetAtt": Array [
+            "ArtifactKey8D84C5F0",
+            "Arn",
+          ],
+        },
+        "Environment": Object {
+          "ComputeType": "BUILD_GENERAL1_SMALL",
+          "Image": "aws/codebuild/standard:5.0",
+          "ImagePullCredentialsType": "CODEBUILD",
+          "PrivilegedMode": false,
+          "Type": "LINUX_CONTAINER",
+        },
+        "ServiceRole": Object {
+          "Fn::GetAtt": Array [
+            "CodePipelineBuildSynthCdkBuildProjectRoleB73287D4",
+            "Arn",
+          ],
+        },
+        "Source": Object {
+          "BuildSpec": "{
+  \\"version\\": \\"0.2\\",
+  \\"phases\\": {
+    \\"install\\": {
+      \\"commands\\": [
+        \\"npm install -g aws-cdk\\",
+        \\"yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile\\"
+      ]
+    },
+    \\"build\\": {
+      \\"commands\\": [
+        \\"npx nx run-many --target=build --all\\"
+      ]
+    }
+  },
+  \\"artifacts\\": {
+    \\"secondary-artifacts\\": {
+      \\"Synth_Output\\": {
+        \\"base-directory\\": \\"cdk.out\\",
+        \\"files\\": \\"**/*\\"
+      },
+      \\"Synth__\\": {
+        \\"base-directory\\": \\".\\",
+        \\"files\\": \\"**/*\\"
+      }
+    }
+  }
+}",
+          "Type": "CODEPIPELINE",
+        },
+      },
+      "Type": "AWS::CodeBuild::Project",
+    },
+    "CodePipelineBuildSynthCdkBuildProjectRoleB73287D4": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "codebuild.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyB7EDB705": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":logs:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":log-group:/aws/codebuild/",
+                      Object {
+                        "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":logs:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":log-group:/aws/codebuild/",
+                      Object {
+                        "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "codebuild:CreateReportGroup",
+                "codebuild:CreateReport",
+                "codebuild:UpdateReport",
+                "codebuild:BatchPutTestCases",
+                "codebuild:BatchPutCodeCoverages",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":codebuild:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":report-group/",
+                    Object {
+                      "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                    },
+                    "-*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "kms:Decrypt",
+                "kms:DescribeKey",
+                "kms:Encrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ArtifactKey8D84C5F0",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "kms:Decrypt",
+                "kms:Encrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ArtifactKey8D84C5F0",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyB7EDB705",
+        "Roles": Array [
+          Object {
+            "Ref": "CodePipelineBuildSynthCdkBuildProjectRoleB73287D4",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CodePipelineEventsRole4196480D": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CodePipelineEventsRoleDefaultPolicy13DBD2D2": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "codepipeline:StartPipelineExecution",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":codepipeline:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "CodePipelineB74E5936",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CodePipelineEventsRoleDefaultPolicy13DBD2D2",
+        "Roles": Array [
+          Object {
+            "Ref": "CodePipelineEventsRole4196480D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CodePipelineRoleB3A660B4": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "codepipeline.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CodePipelineRoleDefaultPolicy8D520A8D": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "kms:Decrypt",
+                "kms:DescribeKey",
+                "kms:Encrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ArtifactKey8D84C5F0",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CrossAccountCodeBuildActionRoleAAA68524",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":iam::",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":role/cdk-hnb659fds-deploy-role-",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    "-",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CodePipelineRoleDefaultPolicy8D520A8D",
+        "Roles": Array [
+          Object {
+            "Ref": "CodePipelineRoleB3A660B4",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyAFBD34E4": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "kms:Decrypt",
+                "kms:DescribeKey",
+                "kms:Encrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ArtifactKey8D84C5F0",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codecommit:GetBranch",
+                "codecommit:GetCommit",
+                "codecommit:UploadArchive",
+                "codecommit:GetUploadArchiveStatus",
+                "codecommit:CancelUploadArchive",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CodeRepositoryBA42F94A",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyAFBD34E4",
+        "Roles": Array [
+          Object {
+            "Ref": "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CodeRepositoryBA42F94A": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "RepositoryName": "Defaults",
+      },
+      "Type": "AWS::CodeCommit::Repository",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "CodeRepositoryCodePipelinemainlineEventRuleEDE9EDAA": Object {
+      "Properties": Object {
+        "EventPattern": Object {
+          "detail": Object {
+            "event": Array [
+              "referenceCreated",
+              "referenceUpdated",
+            ],
+            "referenceName": Array [
+              "mainline",
+            ],
+          },
+          "detail-type": Array [
+            "CodeCommit Repository State Change",
+          ],
+          "resources": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "CodeRepositoryBA42F94A",
+                "Arn",
+              ],
+            },
+          ],
+          "source": Array [
+            "aws.codecommit",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": Array [
+          Object {
+            "Arn": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "arn:",
+                  Object {
+                    "Ref": "AWS::Partition",
+                  },
+                  ":codepipeline:",
+                  Object {
+                    "Ref": "AWS::Region",
+                  },
+                  ":",
+                  Object {
+                    "Ref": "AWS::AccountId",
+                  },
+                  ":",
+                  Object {
+                    "Ref": "CodePipelineB74E5936",
+                  },
+                ],
+              ],
+            },
+            "Id": "Target0",
+            "RoleArn": Object {
+              "Fn::GetAtt": Array [
+                "CodePipelineEventsRole4196480D",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "CrossAccountAssetsFileAsset11C4C6E29": Object {
+      "Properties": Object {
+        "Artifacts": Object {
+          "Type": "CODEPIPELINE",
+        },
+        "Cache": Object {
+          "Type": "NO_CACHE",
+        },
+        "Description": "Pipeline step Default/CodePipeline/Assets/FileAsset1",
+        "EncryptionKey": Object {
+          "Fn::GetAtt": Array [
+            "ArtifactKey8D84C5F0",
+            "Arn",
+          ],
+        },
+        "Environment": Object {
+          "ComputeType": "BUILD_GENERAL1_SMALL",
+          "Image": "aws/codebuild/standard:5.0",
+          "ImagePullCredentialsType": "CODEBUILD",
+          "PrivilegedMode": false,
+          "Type": "LINUX_CONTAINER",
+        },
+        "ServiceRole": Object {
+          "Fn::GetAtt": Array [
+            "CrossAccountAssetsFileRole790499C9",
+            "Arn",
+          ],
+        },
+        "Source": Object {
+          "BuildSpec": "{
+  \\"version\\": \\"0.2\\",
+  \\"phases\\": {
+    \\"install\\": {
+      \\"commands\\": [
+        \\"npm install -g cdk-assets@2\\"
+      ]
+    },
+    \\"build\\": {
+      \\"commands\\": [
+        \\"cdk-assets --path \\\\\\"assembly-Stage/StageAppStack7618C9EF.assets.json\\\\\\" --verbose publish \\\\\\"824fe84db24bbf4d297bea3c89c9f634f2379cc336ccbe96772c4cc0eab472e3:current_account-current_region\\\\\\"\\"
+      ]
+    }
+  }
+}",
+          "Type": "CODEPIPELINE",
+        },
+      },
+      "Type": "AWS::CodeBuild::Project",
+    },
+    "CrossAccountAssetsFileRole790499C9": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "codebuild.amazonaws.com",
+              },
+            },
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CrossAccountAssetsFileRoleDefaultPolicy70E781AB": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Asset role requires access to the Artifacts Bucket",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Asset role requires access to the Artifacts Bucket",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":logs:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":log-group:/aws/codebuild/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:CreateReportGroup",
+                "codebuild:CreateReport",
+                "codebuild:UpdateReport",
+                "codebuild:BatchPutTestCases",
+                "codebuild:BatchPutCodeCoverages",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":codebuild:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":report-group/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Sub": "arn:\${AWS::Partition}:iam::\${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-\${AWS::AccountId}-\${AWS::Region}",
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "kms:Decrypt",
+                "kms:DescribeKey",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ArtifactKey8D84C5F0",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CrossAccountAssetsFileRoleDefaultPolicy70E781AB",
+        "Roles": Array [
+          Object {
+            "Ref": "CrossAccountAssetsFileRole790499C9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CrossAccountCodeBuildActionRoleAAA68524": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:ViaAWSService": "codepipeline.amazonaws.com",
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CrossAccountCodeBuildActionRoleDefaultPolicyCD3511D6": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CrossAccountUpdatePipelineSelfMutation8D616EE5",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CrossAccountAssetsFileAsset11C4C6E29",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CrossAccountCodeBuildActionRoleDefaultPolicyCD3511D6",
+        "Roles": Array [
+          Object {
+            "Ref": "CrossAccountCodeBuildActionRoleAAA68524",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CrossAccountSonarCodeScannerSonarQubeToken76921F1B": Object {
+      "DeletionPolicy": "Delete",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-SMG4",
+              "reason": "Key rotation is not possible as a user token needs to be generated from Sonarqube",
+            },
+            Object {
+              "id": "AwsPrototyping-SecretsManagerRotationEnabled",
+              "reason": "Key rotation is not possible as a user token needs to be generated from Sonarqube",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "GenerateSecretString": Object {},
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "CrossAccountSonarCodeScannerSynthBuildProjectOnSynthSuccessD24D011A": Object {
+      "Properties": Object {
+        "EventPattern": Object {
+          "detail": Object {
+            "build-status": Array [
+              "SUCCEEDED",
+            ],
+            "project-name": Array [
+              Object {
+                "Fn::Select": Array [
+                  1,
+                  Object {
+                    "Fn::Split": Array [
+                      "/",
+                      Object {
+                        "Fn::Select": Array [
+                          5,
+                          Object {
+                            "Fn::Split": Array [
+                              ":",
+                              Object {
+                                "Fn::GetAtt": Array [
+                                  "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                                  "Arn",
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          "detail-type": Array [
+            "CodeBuild Build State Change",
+          ],
+          "source": Array [
+            "aws.codebuild",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": Array [
+          Object {
+            "Arn": Object {
+              "Fn::GetAtt": Array [
+                "CrossAccountSonarCodeScannerValidationProjectAA1083C3",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+            "InputTransformer": Object {
+              "InputPathsMap": Object {
+                "detail-build-id": "$.detail.build-id",
+              },
+              "InputTemplate": "{\\"environmentVariablesOverride\\":[{\\"name\\":\\"SYNTH_BUILD_ID\\",\\"type\\":\\"PLAINTEXT\\",\\"value\\":<detail-build-id>}]}",
+            },
+            "RoleArn": Object {
+              "Fn::GetAtt": Array [
+                "CrossAccountSonarCodeScannerValidationProjectEventsRole551D56DA",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "CrossAccountSonarCodeScannerValidationProjectAA1083C3": Object {
+      "Properties": Object {
+        "Artifacts": Object {
+          "Type": "NO_ARTIFACTS",
+        },
+        "Cache": Object {
+          "Type": "NO_CACHE",
+        },
+        "EncryptionKey": "alias/aws/s3",
+        "Environment": Object {
+          "ComputeType": "BUILD_GENERAL1_SMALL",
+          "EnvironmentVariables": Array [
+            Object {
+              "Name": "SONARQUBE_TOKEN",
+              "Type": "SECRETS_MANAGER",
+              "Value": Object {
+                "Ref": "CrossAccountSonarCodeScannerSonarQubeToken76921F1B",
+              },
+            },
+            Object {
+              "Name": "SONARQUBE_ENDPOINT",
+              "Type": "PLAINTEXT",
+              "Value": "https://sonar.dev",
+            },
+            Object {
+              "Name": "PROJECT_NAME",
+              "Type": "PLAINTEXT",
+              "Value": "Default",
+            },
+          ],
+          "Image": "aws/codebuild/standard:5.0",
+          "ImagePullCredentialsType": "CODEBUILD",
+          "PrivilegedMode": false,
+          "Type": "LINUX_CONTAINER",
+        },
+        "ServiceRole": Object {
+          "Fn::GetAtt": Array [
+            "CrossAccountSonarCodeScannerValidationProjectRole25023DA5",
+            "Arn",
+          ],
+        },
+        "Source": Object {
+          "BuildSpec": "{
+  \\"version\\": \\"0.2\\",
+  \\"env\\": {
+    \\"shell\\": \\"bash\\"
+  },
+  \\"phases\\": {
+    \\"install\\": {
+      \\"commands\\": [
+        \\"npm install -g aws-cdk\\",
+        \\"gem install cfn-nag\\"
+      ]
+    },
+    \\"build\\": {
+      \\"commands\\": [
+        \\"export RESOLVED_SOURCE_VERSION=\`aws codebuild batch-get-builds --ids $SYNTH_BUILD_ID | jq -r '.builds[0].resolvedSourceVersion'\`\\",
+        \\"export BUILT_ARTIFACT_URI=\`aws codebuild batch-get-builds --ids $SYNTH_BUILD_ID | jq -r '.builds[0].secondaryArtifacts[] | select(.artifactIdentifier == \\\\\\"Synth__\\\\\\") | .location' | awk '{sub(\\\\\\"arn:aws:s3:::\\\\\\",\\\\\\"s3://\\\\\\")}1' $1\`\\",
+        \\"export SYNTH_SOURCE_URI=\`aws codebuild batch-get-builds --ids $SYNTH_BUILD_ID | jq -r '.builds[0].sourceVersion' | awk '{sub(\\\\\\"arn:aws:s3:::\\\\\\",\\\\\\"s3://\\\\\\")}1' $1\`\\",
+        \\"aws s3 cp $SYNTH_SOURCE_URI source.zip\\",
+        \\"aws s3 cp $BUILT_ARTIFACT_URI built.zip\\",
+        \\"unzip source.zip -d src\\",
+        \\"unzip built.zip -d built\\",
+        \\"rm source.zip built.zip\\",
+        \\"rsync -a built/* src --include=\\\\\\"*/\\\\\\"  --include=\\\\\\"**/coverage/**\\\\\\" --include=\\\\\\"**/cdk.out/**\\\\\\" --exclude=\\\\\\"**/node_modules/**/*\\\\\\" --exclude=\\\\\\"**/.env/**\\\\\\" --exclude=\\\\\\"*\\\\\\" --prune-empty-dirs\\",
+        \\"CREATE_PROJECT_OUTPUT=\`curl -X POST -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/projects/create?name=$PROJECT_NAME&project=$PROJECT_NAME&visibility=private\\\\\\" \`\\",
+        \\"if [[ \\\\\\"$(echo $CREATE_PROJECT_OUTPUT | jq .errors)\\\\\\" == \\\\\\"null\\\\\\" ]]; then curl -X POST -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/permissions/add_group?projectKey=$PROJECT_NAME&groupName=dev&permission=admin\\\\\\" ;curl -X POST -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/permissions/add_group?projectKey=$PROJECT_NAME&groupName=dev&permission=codeviewer\\\\\\" ;curl -X POST -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/permissions/add_group?projectKey=$PROJECT_NAME&groupName=dev&permission=issueadmin\\\\\\" ;curl -X POST -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/permissions/add_group?projectKey=$PROJECT_NAME&groupName=dev&permission=securityhotspotadmin\\\\\\" ;curl -X POST -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/permissions/add_group?projectKey=$PROJECT_NAME&groupName=dev&permission=scan\\\\\\" ;curl -X POST -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/permissions/add_group?projectKey=$PROJECT_NAME&groupName=dev&permission=user\\\\\\" ;curl -X POST -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/project_branches/rename?project=$PROJECT_NAME&name=mainline\\\\\\" ;curl -X POST -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/project_tags/set?project=$PROJECT_NAME&tags=dev\\\\\\" ;export DEFAULT_PROFILE=\`curl -X GET -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/qualityprofiles/search?qualityProfile=dev\\\\\\"  | jq .profiles\`;export SPECIFIC_PROFILE=\`curl -X GET -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/qualityprofiles/search?qualityProfile=undefined\\\\\\"  | jq .profiles\`;export MERGED_PROFILES=\`jq --argjson arr1 \\\\\\"$DEFAULT_PROFILE\\\\\\" --argjson arr2 \\\\\\"$SPECIFIC_PROFILE\\\\\\" -n '$arr1 + $arr2 | group_by(.language) | map(.[-1])'\`;echo $MERGED_PROFILES | jq -c '.[]' | while read i; do curl -X POST -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/qualityprofiles/add_project?project=$PROJECT_NAME&language=\`echo $i | jq -r .language\`&qualityProfile=\`echo $i | jq -r .name\`\\\\\\" ; done;export DEFAULT_GATE=\`curl -X GET -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/qualitygates/search?gateName=dev\\\\\\" \`;export SPECIFIC_GATE=\`curl -X GET -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/qualitygates/search?gateName=undefined\\\\\\" \`;if [[ \\\\\\"$(echo $SPECIFIC_GATE | jq .errors)\\\\\\" == \\\\\\"null\\\\\\" && \\\\\\"$(echo $SPECIFIC_GATE | jq '.results | length')\\\\\\" -gt 0 ]]; then export GATE_NAME=undefined; else export GATE_NAME=dev; fi;curl -X POST -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/qualitygates/select?projectKey=$PROJECT_NAME&gateName=$GATE_NAME\\\\\\" ; fi;\\",
+        \\"mkdir -p src/reports\\",
+        \\"npx owasp-dependency-check --format HTML --out src/reports --exclude '**/.git/**/*' --scan src --enableExperimental --bin /tmp/dep-check --disableRetireJS\\",
+        \\"cfn_nag  built/cdk.out/**/*.template.json --output-format=json > src/reports/cfn-nag-report.json\\",
+        \\"cd src\\",
+        \\"npx sonarqube-scanner -Dsonar.login=$SONARQUBE_TOKEN -Dsonar.projectKey=$PROJECT_NAME -Dsonar.projectName=$PROJECT_NAME -Dsonar.projectVersion=\`echo $RESOLVED_SOURCE_VERSION | cut -c1-7\` -Dsonar.branch.name=mainline -Dsonar.host.url=$SONARQUBE_ENDPOINT -Dsonar.cfn.nag.reportFiles=reports/cfn-nag-report.json -Dsonar.dependencyCheck.htmlReportPath=reports/dependency-check-report.html -Dsonar.javascript.lcov.reportPaths=**/coverage/lcov.info -Dsonar.clover.reportPath=**/coverage/clover.xml -Dsonar.exclusions=\\\\\\"**/reports/**,**/coverage/**\\\\\\" -Dsonar.sources=.\\",
+        \\"curl -X GET -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/bitegarden/report/pdf_issues_breakdown?resource=$PROJECT_NAME&branch=mainline\\\\\\" --output reports/prototype-issues-report.pdf\\",
+        \\"curl -X GET -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/bitegarden/report/pdf?resource=$PROJECT_NAME&branch=mainline\\\\\\" --output reports/prototype-executive-report.pdf\\",
+        \\"curl -X GET -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/security_reports/download?project=$PROJECT_NAME\\\\\\" --output reports/prototype-security-report.pdf\\"
+      ]
+    }
+  }
+}",
+          "Type": "NO_SOURCE",
+        },
+      },
+      "Type": "AWS::CodeBuild::Project",
+    },
+    "CrossAccountSonarCodeScannerValidationProjectEventsRole551D56DA": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CrossAccountSonarCodeScannerValidationProjectEventsRoleDefaultPolicy1B23C513": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "codebuild:StartBuild",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CrossAccountSonarCodeScannerValidationProjectAA1083C3",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CrossAccountSonarCodeScannerValidationProjectEventsRoleDefaultPolicy1B23C513",
+        "Roles": Array [
+          Object {
+            "Ref": "CrossAccountSonarCodeScannerValidationProjectEventsRole551D56DA",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CrossAccountSonarCodeScannerValidationProjectRole25023DA5": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<.*SonarCodeScannerValidationProject.*>:\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<.*SonarCodeScannerValidationProject.*>-\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::s3:GetObject\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<.*SonarCodeScannerValidationProject.*>:\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<.*SonarCodeScannerValidationProject.*>-\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::s3:GetObject\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "codebuild.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CrossAccountSonarCodeScannerValidationProjectRoleDefaultPolicy225AB8B2": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<.*SonarCodeScannerValidationProject.*>:\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<.*SonarCodeScannerValidationProject.*>-\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::s3:GetObject\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<.*SonarCodeScannerValidationProject.*>:\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<.*SonarCodeScannerValidationProject.*>-\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::s3:GetObject\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Ref": "CrossAccountSonarCodeScannerSonarQubeToken76921F1B",
+              },
+            },
+            Object {
+              "Action": Array [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":logs:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":log-group:/aws/codebuild/",
+                      Object {
+                        "Ref": "CrossAccountSonarCodeScannerValidationProjectAA1083C3",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":logs:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":log-group:/aws/codebuild/",
+                      Object {
+                        "Ref": "CrossAccountSonarCodeScannerValidationProjectAA1083C3",
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "codebuild:CreateReportGroup",
+                "codebuild:CreateReport",
+                "codebuild:UpdateReport",
+                "codebuild:BatchPutTestCases",
+                "codebuild:BatchPutCodeCoverages",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":codebuild:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":report-group/",
+                    Object {
+                      "Ref": "CrossAccountSonarCodeScannerValidationProjectAA1083C3",
+                    },
+                    "-*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "codebuild:BatchGetBuilds",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:GetObject*",
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn",
+                        ],
+                      },
+                      "/**",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "kms:Decrypt",
+                "kms:DescribeKey",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ArtifactKey8D84C5F0",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CrossAccountSonarCodeScannerValidationProjectRoleDefaultPolicy225AB8B2",
+        "Roles": Array [
+          Object {
+            "Ref": "CrossAccountSonarCodeScannerValidationProjectRole25023DA5",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CrossAccountUpdatePipelineSelfMutation8D616EE5": Object {
+      "Properties": Object {
+        "Artifacts": Object {
+          "Type": "CODEPIPELINE",
+        },
+        "Cache": Object {
+          "Type": "NO_CACHE",
+        },
+        "Description": "Pipeline step Default/CodePipeline/UpdatePipeline/SelfMutate",
+        "EncryptionKey": Object {
+          "Fn::GetAtt": Array [
+            "ArtifactKey8D84C5F0",
+            "Arn",
+          ],
+        },
+        "Environment": Object {
+          "ComputeType": "BUILD_GENERAL1_SMALL",
+          "Image": "aws/codebuild/standard:5.0",
+          "ImagePullCredentialsType": "CODEBUILD",
+          "PrivilegedMode": false,
+          "Type": "LINUX_CONTAINER",
+        },
+        "ServiceRole": Object {
+          "Fn::GetAtt": Array [
+            "CrossAccountUpdatePipelineSelfMutationRoleBEAB3750",
+            "Arn",
+          ],
+        },
+        "Source": Object {
+          "BuildSpec": "{
+  \\"version\\": \\"0.2\\",
+  \\"phases\\": {
+    \\"install\\": {
+      \\"commands\\": [
+        \\"npm install -g aws-cdk@2\\"
+      ]
+    },
+    \\"build\\": {
+      \\"commands\\": [
+        \\"cdk -a . deploy Default --require-approval=never --verbose\\"
+      ]
+    }
+  }
+}",
+          "Type": "CODEPIPELINE",
+        },
+      },
+      "Type": "AWS::CodeBuild::Project",
+    },
+    "CrossAccountUpdatePipelineSelfMutationRoleBEAB3750": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "codebuild.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CrossAccountUpdatePipelineSelfMutationRoleDefaultPolicy53F5B99B": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CrossAccountUpdatePipelineSelfMutation.*>:\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CrossAccountUpdatePipelineSelfMutation.*>-\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:\\\\*:iam::<AWS::AccountId>:role/\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to assume a role from within the current account in order to deploy.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to list all buckets and stacks.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        "):log-group:/aws/codebuild/<CrossAccountUpdatePipelineSelfMutation.*>:\\\\*$/g",
+                      ],
+                    ],
+                  },
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CrossAccountUpdatePipelineSelfMutation.*>:\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CrossAccountUpdatePipelineSelfMutation.*>-\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:\\\\*:iam::<AWS::AccountId>:role/\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to assume a role from within the current account in order to deploy.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to list all buckets and stacks.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        "):log-group:/aws/codebuild/<CrossAccountUpdatePipelineSelfMutation.*>:\\\\*$/g",
+                      ],
+                    ],
+                  },
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":logs:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":log-group:/aws/codebuild/",
+                      Object {
+                        "Ref": "CrossAccountUpdatePipelineSelfMutation8D616EE5",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":logs:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":log-group:/aws/codebuild/",
+                      Object {
+                        "Ref": "CrossAccountUpdatePipelineSelfMutation8D616EE5",
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "codebuild:CreateReportGroup",
+                "codebuild:CreateReport",
+                "codebuild:UpdateReport",
+                "codebuild:BatchPutTestCases",
+                "codebuild:BatchPutCodeCoverages",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":codebuild:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":report-group/",
+                    Object {
+                      "Ref": "CrossAccountUpdatePipelineSelfMutation8D616EE5",
+                    },
+                    "-*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "sts:AssumeRole",
+              "Condition": Object {
+                "ForAnyValue:StringEquals": Object {
+                  "iam:ResourceTag/aws-cdk:bootstrap-role": Array [
+                    "image-publishing",
+                    "file-publishing",
+                    "deploy",
+                  ],
+                },
+              },
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:*:iam::",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":role/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "cloudformation:DescribeStacks",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": "s3:ListBucket",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "kms:Decrypt",
+                "kms:DescribeKey",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ArtifactKey8D84C5F0",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "kms:Decrypt",
+                "kms:Encrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ArtifactKey8D84C5F0",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CrossAccountUpdatePipelineSelfMutationRoleDefaultPolicy53F5B99B",
+        "Roles": Array [
+          Object {
+            "Ref": "CrossAccountUpdatePipelineSelfMutationRoleBEAB3750",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F": Object {
+      "DependsOn": Array [
+        "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "3f51abb709b8e65167a45aeed02bab11540603d909005d7148230ba5ce6c74d7.zip",
+        },
+        "Description": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "Lambda function for auto-deleting objects in ",
+              Object {
+                "Ref": "ArtifactsBucket2AAC5544",
+              },
+              " S3 bucket.",
+            ],
+          ],
+        },
+        "Handler": "__entrypoint__.handler",
+        "MemorySize": 128,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`PDK Pipeline Unit Tests Defaults - using AwsPrototyping NagPack 1`] = `
+Object {
+  "Metadata": Object {
+    "cdk_nag": Object {
+      "rules_to_suppress": Array [
+        Object {
+          "id": "AwsSolutions-CB4",
+          "reason": "Encryption of Codebuild is not required.",
+        },
+        Object {
+          "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
           "reason": "Encryption of Codebuild is not required.",
         },
       ],
@@ -3221,6 +6276,48 @@ Object {
               "id": "AwsSolutions-IAM5",
               "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
             },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
+            },
           ],
         },
       },
@@ -3481,6 +6578,39 @@ Object {
               "id": "AwsSolutions-IAM5",
               "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
             },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
           ],
         },
       },
@@ -3641,6 +6771,30 @@ Object {
                 },
               ],
               "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
               "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
             },
           ],
@@ -3879,7 +7033,7 @@ Object {
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-Stage/StageAppStack7618C9EF.assets.json\\\\\\" --verbose publish \\\\\\"729608d47960b953f2edbfc7974d9c0fcf1c033c3c48573d154bc286b18505df:current_account-current_region\\\\\\"\\"
+        \\"cdk-assets --path \\\\\\"assembly-Stage/StageAppStack7618C9EF.assets.json\\\\\\" --verbose publish \\\\\\"824fe84db24bbf4d297bea3c89c9f634f2379cc336ccbe96772c4cc0eab472e3:current_account-current_region\\\\\\"\\"
       ]
     }
   }
@@ -3934,6 +7088,10 @@ Object {
           "rules_to_suppress": Array [
             Object {
               "id": "AwsSolutions-IAM5",
+              "reason": "Asset role requires access to the Artifacts Bucket",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
               "reason": "Asset role requires access to the Artifacts Bucket",
             },
           ],
@@ -4160,6 +7318,10 @@ Object {
           "rules_to_suppress": Array [
             Object {
               "id": "AwsSolutions-SMG4",
+              "reason": "Key rotation is not possible as a user token needs to be generated from Sonarqube",
+            },
+            Object {
+              "id": "AwsPrototyping-SecretsManagerRotationEnabled",
               "reason": "Key rotation is not possible as a user token needs to be generated from Sonarqube",
             },
           ],
@@ -4390,6 +7552,24 @@ Object {
               "id": "AwsSolutions-IAM5",
               "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
             },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<.*SonarCodeScannerValidationProject.*>:\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<.*SonarCodeScannerValidationProject.*>-\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::s3:GetObject\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
+            },
           ],
         },
       },
@@ -4429,6 +7609,24 @@ Object {
                 },
               ],
               "id": "AwsSolutions-IAM5",
+              "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<.*SonarCodeScannerValidationProject.*>:\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<.*SonarCodeScannerValidationProject.*>-\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::s3:GetObject\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
               "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
             },
           ],
@@ -4735,6 +7933,2694 @@ Object {
                 },
               ],
               "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<DefaultsUpdatePipelineSelfMutation.*>:\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<DefaultsUpdatePipelineSelfMutation.*>-\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:\\\\*:iam::<AWS::AccountId>:role/\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to assume a role from within the current account in order to deploy.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to list all buckets and stacks.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        "):log-group:/aws/codebuild/<DefaultsUpdatePipelineSelfMutation.*>:\\\\*$/g",
+                      ],
+                    ],
+                  },
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":logs:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":log-group:/aws/codebuild/",
+                      Object {
+                        "Ref": "DefaultsUpdatePipelineSelfMutation28F7C994",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":logs:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":log-group:/aws/codebuild/",
+                      Object {
+                        "Ref": "DefaultsUpdatePipelineSelfMutation28F7C994",
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "codebuild:CreateReportGroup",
+                "codebuild:CreateReport",
+                "codebuild:UpdateReport",
+                "codebuild:BatchPutTestCases",
+                "codebuild:BatchPutCodeCoverages",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":codebuild:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":report-group/",
+                    Object {
+                      "Ref": "DefaultsUpdatePipelineSelfMutation28F7C994",
+                    },
+                    "-*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "sts:AssumeRole",
+              "Condition": Object {
+                "ForAnyValue:StringEquals": Object {
+                  "iam:ResourceTag/aws-cdk:bootstrap-role": Array [
+                    "image-publishing",
+                    "file-publishing",
+                    "deploy",
+                  ],
+                },
+              },
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:*:iam::",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":role/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "cloudformation:DescribeStacks",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": "s3:ListBucket",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DefaultsUpdatePipelineSelfMutationRoleDefaultPolicyB0C671E4",
+        "Roles": Array [
+          Object {
+            "Ref": "DefaultsUpdatePipelineSelfMutationRole2FF40065",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`PDK Pipeline Unit Tests Defaults 1`] = `
+Object {
+  "Metadata": Object {
+    "cdk_nag": Object {
+      "rules_to_suppress": Array [
+        Object {
+          "id": "AwsSolutions-CB4",
+          "reason": "Encryption of Codebuild is not required.",
+        },
+        Object {
+          "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+          "reason": "Encryption of Codebuild is not required.",
+        },
+      ],
+    },
+  },
+  "Outputs": Object {
+    "CodeRepositoryGRCUrl": Object {
+      "Export": Object {
+        "Name": "CodeRepositoryGRCUrl",
+      },
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "codecommit::",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            "://",
+            Object {
+              "Fn::GetAtt": Array [
+                "CodeRepositoryBA42F94A",
+                "Name",
+              ],
+            },
+          ],
+        ],
+      },
+    },
+    "DefaultsSonarCodeScannerSonarqubeSecretArn61BE693F": Object {
+      "Export": Object {
+        "Name": "SonarqubeSecretArn",
+      },
+      "Value": Object {
+        "Ref": "DefaultsSonarCodeScannerSonarQubeTokenD1898305",
+      },
+    },
+  },
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "ArtifactsBucket2AAC5544": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "BucketEncryption": Object {
+          "ServerSideEncryptionConfiguration": Array [
+            Object {
+              "ServerSideEncryptionByDefault": Object {
+                "SSEAlgorithm": "AES256",
+              },
+            },
+          ],
+        },
+        "LoggingConfiguration": Object {
+          "LogFilePrefix": "access-logs",
+        },
+        "PublicAccessBlockConfiguration": Object {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ArtifactsBucketAutoDeleteObjectsCustomResource0E3B4320": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "ArtifactsBucketPolicy852CB646",
+      ],
+      "Properties": Object {
+        "BucketName": Object {
+          "Ref": "ArtifactsBucket2AAC5544",
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ArtifactsBucketPolicy852CB646": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "ArtifactsBucket2AAC5544",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":role/cdk-hnb659fds-deploy-role-",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      "-",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                    ],
+                  ],
+                },
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "CodePipelineB74E5936": Object {
+      "DependsOn": Array [
+        "CodePipelineRoleDefaultPolicy8D520A8D",
+        "CodePipelineRoleB3A660B4",
+      ],
+      "Properties": Object {
+        "ArtifactStore": Object {
+          "Location": Object {
+            "Ref": "ArtifactsBucket2AAC5544",
+          },
+          "Type": "S3",
+        },
+        "RestartExecutionOnUpdate": true,
+        "RoleArn": Object {
+          "Fn::GetAtt": Array [
+            "CodePipelineRoleB3A660B4",
+            "Arn",
+          ],
+        },
+        "Stages": Array [
+          Object {
+            "Actions": Array [
+              Object {
+                "ActionTypeId": Object {
+                  "Category": "Source",
+                  "Owner": "AWS",
+                  "Provider": "CodeCommit",
+                  "Version": "1",
+                },
+                "Configuration": Object {
+                  "BranchName": "mainline",
+                  "PollForSourceChanges": false,
+                  "RepositoryName": Object {
+                    "Fn::GetAtt": Array [
+                      "CodeRepositoryBA42F94A",
+                      "Name",
+                    ],
+                  },
+                },
+                "Name": Object {
+                  "Fn::GetAtt": Array [
+                    "CodeRepositoryBA42F94A",
+                    "Name",
+                  ],
+                },
+                "OutputArtifacts": Array [
+                  Object {
+                    "Name": "c8b95ca81f750a44513d18b27868db0afa191aa92e_Source",
+                  },
+                ],
+                "RoleArn": Object {
+                  "Fn::GetAtt": Array [
+                    "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70",
+                    "Arn",
+                  ],
+                },
+                "RunOrder": 1,
+              },
+            ],
+            "Name": "Source",
+          },
+          Object {
+            "Actions": Array [
+              Object {
+                "ActionTypeId": Object {
+                  "Category": "Build",
+                  "Owner": "AWS",
+                  "Provider": "CodeBuild",
+                  "Version": "1",
+                },
+                "Configuration": Object {
+                  "EnvironmentVariables": "[{\\"name\\":\\"_PROJECT_CONFIG_HASH\\",\\"type\\":\\"PLAINTEXT\\",\\"value\\":\\"695a7330a2c9bebdb22e3baca36a4c397c9091b9e57d871d29047d7333b61977\\"}]",
+                  "ProjectName": Object {
+                    "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                  },
+                },
+                "InputArtifacts": Array [
+                  Object {
+                    "Name": "c8b95ca81f750a44513d18b27868db0afa191aa92e_Source",
+                  },
+                ],
+                "Name": "Synth",
+                "OutputArtifacts": Array [
+                  Object {
+                    "Name": "Synth_Output",
+                  },
+                  Object {
+                    "Name": "Synth__",
+                  },
+                ],
+                "RoleArn": Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsCodeBuildActionRole4BF10433",
+                    "Arn",
+                  ],
+                },
+                "RunOrder": 1,
+              },
+            ],
+            "Name": "Build",
+          },
+          Object {
+            "Actions": Array [
+              Object {
+                "ActionTypeId": Object {
+                  "Category": "Build",
+                  "Owner": "AWS",
+                  "Provider": "CodeBuild",
+                  "Version": "1",
+                },
+                "Configuration": Object {
+                  "EnvironmentVariables": "[{\\"name\\":\\"_PROJECT_CONFIG_HASH\\",\\"type\\":\\"PLAINTEXT\\",\\"value\\":\\"de1738b881d2f46e53ab02de31ca684f8741d030cff96e621e2ce465b5d9c6a7\\"}]",
+                  "ProjectName": Object {
+                    "Ref": "DefaultsUpdatePipelineSelfMutation28F7C994",
+                  },
+                },
+                "InputArtifacts": Array [
+                  Object {
+                    "Name": "Synth_Output",
+                  },
+                ],
+                "Name": "SelfMutate",
+                "RoleArn": Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsCodeBuildActionRole4BF10433",
+                    "Arn",
+                  ],
+                },
+                "RunOrder": 1,
+              },
+            ],
+            "Name": "UpdatePipeline",
+          },
+          Object {
+            "Actions": Array [
+              Object {
+                "ActionTypeId": Object {
+                  "Category": "Build",
+                  "Owner": "AWS",
+                  "Provider": "CodeBuild",
+                  "Version": "1",
+                },
+                "Configuration": Object {
+                  "ProjectName": Object {
+                    "Ref": "DefaultsAssetsFileAsset189C03802",
+                  },
+                },
+                "InputArtifacts": Array [
+                  Object {
+                    "Name": "Synth_Output",
+                  },
+                ],
+                "Name": "FileAsset1",
+                "RoleArn": Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsCodeBuildActionRole4BF10433",
+                    "Arn",
+                  ],
+                },
+                "RunOrder": 1,
+              },
+            ],
+            "Name": "Assets",
+          },
+          Object {
+            "Actions": Array [
+              Object {
+                "ActionTypeId": Object {
+                  "Category": "Deploy",
+                  "Owner": "AWS",
+                  "Provider": "CloudFormation",
+                  "Version": "1",
+                },
+                "Configuration": Object {
+                  "ActionMode": "CHANGE_SET_REPLACE",
+                  "Capabilities": "CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND",
+                  "ChangeSetName": "PipelineChange",
+                  "RoleArn": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "arn:",
+                        Object {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":iam::",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        ":role/cdk-hnb659fds-cfn-exec-role-",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        "-",
+                        Object {
+                          "Ref": "AWS::Region",
+                        },
+                      ],
+                    ],
+                  },
+                  "StackName": "Stage-AppStack",
+                  "TemplatePath": "Synth_Output::assembly-Stage/StageAppStack7618C9EF.template.json",
+                },
+                "InputArtifacts": Array [
+                  Object {
+                    "Name": "Synth_Output",
+                  },
+                ],
+                "Name": "Prepare",
+                "RoleArn": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":role/cdk-hnb659fds-deploy-role-",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      "-",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                    ],
+                  ],
+                },
+                "RunOrder": 1,
+              },
+              Object {
+                "ActionTypeId": Object {
+                  "Category": "Deploy",
+                  "Owner": "AWS",
+                  "Provider": "CloudFormation",
+                  "Version": "1",
+                },
+                "Configuration": Object {
+                  "ActionMode": "CHANGE_SET_EXECUTE",
+                  "ChangeSetName": "PipelineChange",
+                  "StackName": "Stage-AppStack",
+                },
+                "Name": "Deploy",
+                "RoleArn": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":role/cdk-hnb659fds-deploy-role-",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      "-",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                    ],
+                  ],
+                },
+                "RunOrder": 2,
+              },
+            ],
+            "Name": "Stage",
+          },
+        ],
+      },
+      "Type": "AWS::CodePipeline::Pipeline",
+    },
+    "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6": Object {
+      "Properties": Object {
+        "Artifacts": Object {
+          "Type": "CODEPIPELINE",
+        },
+        "Cache": Object {
+          "Type": "NO_CACHE",
+        },
+        "Description": "Pipeline step Default/CodePipeline/Build/Synth",
+        "EncryptionKey": "alias/aws/s3",
+        "Environment": Object {
+          "ComputeType": "BUILD_GENERAL1_SMALL",
+          "Image": "aws/codebuild/standard:5.0",
+          "ImagePullCredentialsType": "CODEBUILD",
+          "PrivilegedMode": false,
+          "Type": "LINUX_CONTAINER",
+        },
+        "ServiceRole": Object {
+          "Fn::GetAtt": Array [
+            "CodePipelineBuildSynthCdkBuildProjectRoleB73287D4",
+            "Arn",
+          ],
+        },
+        "Source": Object {
+          "BuildSpec": "{
+  \\"version\\": \\"0.2\\",
+  \\"phases\\": {
+    \\"install\\": {
+      \\"commands\\": [
+        \\"npm install -g aws-cdk\\",
+        \\"yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile\\"
+      ]
+    },
+    \\"build\\": {
+      \\"commands\\": [
+        \\"npx nx run-many --target=build --all\\"
+      ]
+    }
+  },
+  \\"artifacts\\": {
+    \\"secondary-artifacts\\": {
+      \\"Synth_Output\\": {
+        \\"base-directory\\": \\"cdk.out\\",
+        \\"files\\": \\"**/*\\"
+      },
+      \\"Synth__\\": {
+        \\"base-directory\\": \\".\\",
+        \\"files\\": \\"**/*\\"
+      }
+    }
+  }
+}",
+          "Type": "CODEPIPELINE",
+        },
+      },
+      "Type": "AWS::CodeBuild::Project",
+    },
+    "CodePipelineBuildSynthCdkBuildProjectRoleB73287D4": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "codebuild.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyB7EDB705": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":logs:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":log-group:/aws/codebuild/",
+                      Object {
+                        "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":logs:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":log-group:/aws/codebuild/",
+                      Object {
+                        "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "codebuild:CreateReportGroup",
+                "codebuild:CreateReport",
+                "codebuild:UpdateReport",
+                "codebuild:BatchPutTestCases",
+                "codebuild:BatchPutCodeCoverages",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":codebuild:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":report-group/",
+                    Object {
+                      "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                    },
+                    "-*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyB7EDB705",
+        "Roles": Array [
+          Object {
+            "Ref": "CodePipelineBuildSynthCdkBuildProjectRoleB73287D4",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CodePipelineEventsRole4196480D": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CodePipelineEventsRoleDefaultPolicy13DBD2D2": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "codepipeline:StartPipelineExecution",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":codepipeline:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "CodePipelineB74E5936",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CodePipelineEventsRoleDefaultPolicy13DBD2D2",
+        "Roles": Array [
+          Object {
+            "Ref": "CodePipelineEventsRole4196480D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CodePipelineRoleB3A660B4": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "codepipeline.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CodePipelineRoleDefaultPolicy8D520A8D": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "DefaultsCodeBuildActionRole4BF10433",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":iam::",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":role/cdk-hnb659fds-deploy-role-",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    "-",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CodePipelineRoleDefaultPolicy8D520A8D",
+        "Roles": Array [
+          Object {
+            "Ref": "CodePipelineRoleB3A660B4",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyAFBD34E4": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "codecommit:GetBranch",
+                "codecommit:GetCommit",
+                "codecommit:UploadArchive",
+                "codecommit:GetUploadArchiveStatus",
+                "codecommit:CancelUploadArchive",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CodeRepositoryBA42F94A",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyAFBD34E4",
+        "Roles": Array [
+          Object {
+            "Ref": "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CodeRepositoryBA42F94A": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "RepositoryName": "Defaults",
+      },
+      "Type": "AWS::CodeCommit::Repository",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "CodeRepositoryCodePipelinemainlineEventRuleEDE9EDAA": Object {
+      "Properties": Object {
+        "EventPattern": Object {
+          "detail": Object {
+            "event": Array [
+              "referenceCreated",
+              "referenceUpdated",
+            ],
+            "referenceName": Array [
+              "mainline",
+            ],
+          },
+          "detail-type": Array [
+            "CodeCommit Repository State Change",
+          ],
+          "resources": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "CodeRepositoryBA42F94A",
+                "Arn",
+              ],
+            },
+          ],
+          "source": Array [
+            "aws.codecommit",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": Array [
+          Object {
+            "Arn": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "arn:",
+                  Object {
+                    "Ref": "AWS::Partition",
+                  },
+                  ":codepipeline:",
+                  Object {
+                    "Ref": "AWS::Region",
+                  },
+                  ":",
+                  Object {
+                    "Ref": "AWS::AccountId",
+                  },
+                  ":",
+                  Object {
+                    "Ref": "CodePipelineB74E5936",
+                  },
+                ],
+              ],
+            },
+            "Id": "Target0",
+            "RoleArn": Object {
+              "Fn::GetAtt": Array [
+                "CodePipelineEventsRole4196480D",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F": Object {
+      "DependsOn": Array [
+        "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "3f51abb709b8e65167a45aeed02bab11540603d909005d7148230ba5ce6c74d7.zip",
+        },
+        "Description": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "Lambda function for auto-deleting objects in ",
+              Object {
+                "Ref": "ArtifactsBucket2AAC5544",
+              },
+              " S3 bucket.",
+            ],
+          ],
+        },
+        "Handler": "__entrypoint__.handler",
+        "MemorySize": 128,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsAssetsFileAsset189C03802": Object {
+      "Properties": Object {
+        "Artifacts": Object {
+          "Type": "CODEPIPELINE",
+        },
+        "Cache": Object {
+          "Type": "NO_CACHE",
+        },
+        "Description": "Pipeline step Default/CodePipeline/Assets/FileAsset1",
+        "EncryptionKey": "alias/aws/s3",
+        "Environment": Object {
+          "ComputeType": "BUILD_GENERAL1_SMALL",
+          "Image": "aws/codebuild/standard:5.0",
+          "ImagePullCredentialsType": "CODEBUILD",
+          "PrivilegedMode": false,
+          "Type": "LINUX_CONTAINER",
+        },
+        "ServiceRole": Object {
+          "Fn::GetAtt": Array [
+            "DefaultsAssetsFileRole6F73FFFF",
+            "Arn",
+          ],
+        },
+        "Source": Object {
+          "BuildSpec": "{
+  \\"version\\": \\"0.2\\",
+  \\"phases\\": {
+    \\"install\\": {
+      \\"commands\\": [
+        \\"npm install -g cdk-assets@2\\"
+      ]
+    },
+    \\"build\\": {
+      \\"commands\\": [
+        \\"cdk-assets --path \\\\\\"assembly-Stage/StageAppStack7618C9EF.assets.json\\\\\\" --verbose publish \\\\\\"824fe84db24bbf4d297bea3c89c9f634f2379cc336ccbe96772c4cc0eab472e3:current_account-current_region\\\\\\"\\"
+      ]
+    }
+  }
+}",
+          "Type": "CODEPIPELINE",
+        },
+      },
+      "Type": "AWS::CodeBuild::Project",
+    },
+    "DefaultsAssetsFileRole6F73FFFF": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "codebuild.amazonaws.com",
+              },
+            },
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsAssetsFileRoleDefaultPolicy62E6E856": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Asset role requires access to the Artifacts Bucket",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Asset role requires access to the Artifacts Bucket",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":logs:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":log-group:/aws/codebuild/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:CreateReportGroup",
+                "codebuild:CreateReport",
+                "codebuild:UpdateReport",
+                "codebuild:BatchPutTestCases",
+                "codebuild:BatchPutCodeCoverages",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":codebuild:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":report-group/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Sub": "arn:\${AWS::Partition}:iam::\${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-\${AWS::AccountId}-\${AWS::Region}",
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DefaultsAssetsFileRoleDefaultPolicy62E6E856",
+        "Roles": Array [
+          Object {
+            "Ref": "DefaultsAssetsFileRole6F73FFFF",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DefaultsCodeBuildActionRole4BF10433": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:ViaAWSService": "codepipeline.amazonaws.com",
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsCodeBuildActionRoleDefaultPolicyB6B439B3": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "DefaultsUpdatePipelineSelfMutation28F7C994",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "DefaultsAssetsFileAsset189C03802",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DefaultsCodeBuildActionRoleDefaultPolicyB6B439B3",
+        "Roles": Array [
+          Object {
+            "Ref": "DefaultsCodeBuildActionRole4BF10433",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DefaultsSonarCodeScannerSonarQubeTokenD1898305": Object {
+      "DeletionPolicy": "Delete",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-SMG4",
+              "reason": "Key rotation is not possible as a user token needs to be generated from Sonarqube",
+            },
+            Object {
+              "id": "AwsPrototyping-SecretsManagerRotationEnabled",
+              "reason": "Key rotation is not possible as a user token needs to be generated from Sonarqube",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "GenerateSecretString": Object {},
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DefaultsSonarCodeScannerSynthBuildProjectOnSynthSuccessE7E65027": Object {
+      "Properties": Object {
+        "EventPattern": Object {
+          "detail": Object {
+            "build-status": Array [
+              "SUCCEEDED",
+            ],
+            "project-name": Array [
+              Object {
+                "Fn::Select": Array [
+                  1,
+                  Object {
+                    "Fn::Split": Array [
+                      "/",
+                      Object {
+                        "Fn::Select": Array [
+                          5,
+                          Object {
+                            "Fn::Split": Array [
+                              ":",
+                              Object {
+                                "Fn::GetAtt": Array [
+                                  "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                                  "Arn",
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          "detail-type": Array [
+            "CodeBuild Build State Change",
+          ],
+          "source": Array [
+            "aws.codebuild",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": Array [
+          Object {
+            "Arn": Object {
+              "Fn::GetAtt": Array [
+                "DefaultsSonarCodeScannerValidationProjectFAE7BAD0",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+            "InputTransformer": Object {
+              "InputPathsMap": Object {
+                "detail-build-id": "$.detail.build-id",
+              },
+              "InputTemplate": "{\\"environmentVariablesOverride\\":[{\\"name\\":\\"SYNTH_BUILD_ID\\",\\"type\\":\\"PLAINTEXT\\",\\"value\\":<detail-build-id>}]}",
+            },
+            "RoleArn": Object {
+              "Fn::GetAtt": Array [
+                "DefaultsSonarCodeScannerValidationProjectEventsRole18DD9D4A",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "DefaultsSonarCodeScannerValidationProjectEventsRole18DD9D4A": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsSonarCodeScannerValidationProjectEventsRoleDefaultPolicy6C4FE447": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "codebuild:StartBuild",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "DefaultsSonarCodeScannerValidationProjectFAE7BAD0",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DefaultsSonarCodeScannerValidationProjectEventsRoleDefaultPolicy6C4FE447",
+        "Roles": Array [
+          Object {
+            "Ref": "DefaultsSonarCodeScannerValidationProjectEventsRole18DD9D4A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DefaultsSonarCodeScannerValidationProjectFAE7BAD0": Object {
+      "Properties": Object {
+        "Artifacts": Object {
+          "Type": "NO_ARTIFACTS",
+        },
+        "Cache": Object {
+          "Type": "NO_CACHE",
+        },
+        "EncryptionKey": "alias/aws/s3",
+        "Environment": Object {
+          "ComputeType": "BUILD_GENERAL1_SMALL",
+          "EnvironmentVariables": Array [
+            Object {
+              "Name": "SONARQUBE_TOKEN",
+              "Type": "SECRETS_MANAGER",
+              "Value": Object {
+                "Ref": "DefaultsSonarCodeScannerSonarQubeTokenD1898305",
+              },
+            },
+            Object {
+              "Name": "SONARQUBE_ENDPOINT",
+              "Type": "PLAINTEXT",
+              "Value": "https://sonar.dev",
+            },
+            Object {
+              "Name": "PROJECT_NAME",
+              "Type": "PLAINTEXT",
+              "Value": "Default",
+            },
+          ],
+          "Image": "aws/codebuild/standard:5.0",
+          "ImagePullCredentialsType": "CODEBUILD",
+          "PrivilegedMode": false,
+          "Type": "LINUX_CONTAINER",
+        },
+        "ServiceRole": Object {
+          "Fn::GetAtt": Array [
+            "DefaultsSonarCodeScannerValidationProjectRole6AF1A9E5",
+            "Arn",
+          ],
+        },
+        "Source": Object {
+          "BuildSpec": "{
+  \\"version\\": \\"0.2\\",
+  \\"env\\": {
+    \\"shell\\": \\"bash\\"
+  },
+  \\"phases\\": {
+    \\"install\\": {
+      \\"commands\\": [
+        \\"npm install -g aws-cdk\\",
+        \\"gem install cfn-nag\\"
+      ]
+    },
+    \\"build\\": {
+      \\"commands\\": [
+        \\"export RESOLVED_SOURCE_VERSION=\`aws codebuild batch-get-builds --ids $SYNTH_BUILD_ID | jq -r '.builds[0].resolvedSourceVersion'\`\\",
+        \\"export BUILT_ARTIFACT_URI=\`aws codebuild batch-get-builds --ids $SYNTH_BUILD_ID | jq -r '.builds[0].secondaryArtifacts[] | select(.artifactIdentifier == \\\\\\"Synth__\\\\\\") | .location' | awk '{sub(\\\\\\"arn:aws:s3:::\\\\\\",\\\\\\"s3://\\\\\\")}1' $1\`\\",
+        \\"export SYNTH_SOURCE_URI=\`aws codebuild batch-get-builds --ids $SYNTH_BUILD_ID | jq -r '.builds[0].sourceVersion' | awk '{sub(\\\\\\"arn:aws:s3:::\\\\\\",\\\\\\"s3://\\\\\\")}1' $1\`\\",
+        \\"aws s3 cp $SYNTH_SOURCE_URI source.zip\\",
+        \\"aws s3 cp $BUILT_ARTIFACT_URI built.zip\\",
+        \\"unzip source.zip -d src\\",
+        \\"unzip built.zip -d built\\",
+        \\"rm source.zip built.zip\\",
+        \\"rsync -a built/* src --include=\\\\\\"*/\\\\\\"  --include=\\\\\\"**/coverage/**\\\\\\" --include=\\\\\\"**/cdk.out/**\\\\\\" --exclude=\\\\\\"**/node_modules/**/*\\\\\\" --exclude=\\\\\\"**/.env/**\\\\\\" --exclude=\\\\\\"*\\\\\\" --prune-empty-dirs\\",
+        \\"CREATE_PROJECT_OUTPUT=\`curl -X POST -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/projects/create?name=$PROJECT_NAME&project=$PROJECT_NAME&visibility=private\\\\\\" \`\\",
+        \\"if [[ \\\\\\"$(echo $CREATE_PROJECT_OUTPUT | jq .errors)\\\\\\" == \\\\\\"null\\\\\\" ]]; then curl -X POST -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/permissions/add_group?projectKey=$PROJECT_NAME&groupName=dev&permission=admin\\\\\\" ;curl -X POST -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/permissions/add_group?projectKey=$PROJECT_NAME&groupName=dev&permission=codeviewer\\\\\\" ;curl -X POST -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/permissions/add_group?projectKey=$PROJECT_NAME&groupName=dev&permission=issueadmin\\\\\\" ;curl -X POST -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/permissions/add_group?projectKey=$PROJECT_NAME&groupName=dev&permission=securityhotspotadmin\\\\\\" ;curl -X POST -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/permissions/add_group?projectKey=$PROJECT_NAME&groupName=dev&permission=scan\\\\\\" ;curl -X POST -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/permissions/add_group?projectKey=$PROJECT_NAME&groupName=dev&permission=user\\\\\\" ;curl -X POST -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/project_branches/rename?project=$PROJECT_NAME&name=mainline\\\\\\" ;curl -X POST -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/project_tags/set?project=$PROJECT_NAME&tags=dev\\\\\\" ;export DEFAULT_PROFILE=\`curl -X GET -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/qualityprofiles/search?qualityProfile=dev\\\\\\"  | jq .profiles\`;export SPECIFIC_PROFILE=\`curl -X GET -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/qualityprofiles/search?qualityProfile=undefined\\\\\\"  | jq .profiles\`;export MERGED_PROFILES=\`jq --argjson arr1 \\\\\\"$DEFAULT_PROFILE\\\\\\" --argjson arr2 \\\\\\"$SPECIFIC_PROFILE\\\\\\" -n '$arr1 + $arr2 | group_by(.language) | map(.[-1])'\`;echo $MERGED_PROFILES | jq -c '.[]' | while read i; do curl -X POST -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/qualityprofiles/add_project?project=$PROJECT_NAME&language=\`echo $i | jq -r .language\`&qualityProfile=\`echo $i | jq -r .name\`\\\\\\" ; done;export DEFAULT_GATE=\`curl -X GET -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/qualitygates/search?gateName=dev\\\\\\" \`;export SPECIFIC_GATE=\`curl -X GET -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/qualitygates/search?gateName=undefined\\\\\\" \`;if [[ \\\\\\"$(echo $SPECIFIC_GATE | jq .errors)\\\\\\" == \\\\\\"null\\\\\\" && \\\\\\"$(echo $SPECIFIC_GATE | jq '.results | length')\\\\\\" -gt 0 ]]; then export GATE_NAME=undefined; else export GATE_NAME=dev; fi;curl -X POST -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/qualitygates/select?projectKey=$PROJECT_NAME&gateName=$GATE_NAME\\\\\\" ; fi;\\",
+        \\"mkdir -p src/reports\\",
+        \\"npx owasp-dependency-check --format HTML --out src/reports --exclude '**/.git/**/*' --scan src --enableExperimental --bin /tmp/dep-check --disableRetireJS\\",
+        \\"cfn_nag  built/cdk.out/**/*.template.json --output-format=json > src/reports/cfn-nag-report.json\\",
+        \\"cd src\\",
+        \\"npx sonarqube-scanner -Dsonar.login=$SONARQUBE_TOKEN -Dsonar.projectKey=$PROJECT_NAME -Dsonar.projectName=$PROJECT_NAME -Dsonar.projectVersion=\`echo $RESOLVED_SOURCE_VERSION | cut -c1-7\` -Dsonar.branch.name=mainline -Dsonar.host.url=$SONARQUBE_ENDPOINT -Dsonar.cfn.nag.reportFiles=reports/cfn-nag-report.json -Dsonar.dependencyCheck.htmlReportPath=reports/dependency-check-report.html -Dsonar.javascript.lcov.reportPaths=**/coverage/lcov.info -Dsonar.clover.reportPath=**/coverage/clover.xml -Dsonar.exclusions=\\\\\\"**/reports/**,**/coverage/**\\\\\\" -Dsonar.sources=.\\",
+        \\"curl -X GET -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/bitegarden/report/pdf_issues_breakdown?resource=$PROJECT_NAME&branch=mainline\\\\\\" --output reports/prototype-issues-report.pdf\\",
+        \\"curl -X GET -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/bitegarden/report/pdf?resource=$PROJECT_NAME&branch=mainline\\\\\\" --output reports/prototype-executive-report.pdf\\",
+        \\"curl -X GET -u $SONARQUBE_TOKEN: \\\\\\"$SONARQUBE_ENDPOINT/api/security_reports/download?project=$PROJECT_NAME\\\\\\" --output reports/prototype-security-report.pdf\\"
+      ]
+    }
+  }
+}",
+          "Type": "NO_SOURCE",
+        },
+      },
+      "Type": "AWS::CodeBuild::Project",
+    },
+    "DefaultsSonarCodeScannerValidationProjectRole6AF1A9E5": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<.*SonarCodeScannerValidationProject.*>:\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<.*SonarCodeScannerValidationProject.*>-\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::s3:GetObject\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<.*SonarCodeScannerValidationProject.*>:\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<.*SonarCodeScannerValidationProject.*>-\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::s3:GetObject\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "codebuild.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsSonarCodeScannerValidationProjectRoleDefaultPolicyF147A45E": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<.*SonarCodeScannerValidationProject.*>:\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<.*SonarCodeScannerValidationProject.*>-\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::s3:GetObject\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<.*SonarCodeScannerValidationProject.*>:\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<.*SonarCodeScannerValidationProject.*>-\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::s3:GetObject\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Ref": "DefaultsSonarCodeScannerSonarQubeTokenD1898305",
+              },
+            },
+            Object {
+              "Action": Array [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":logs:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":log-group:/aws/codebuild/",
+                      Object {
+                        "Ref": "DefaultsSonarCodeScannerValidationProjectFAE7BAD0",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":logs:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":log-group:/aws/codebuild/",
+                      Object {
+                        "Ref": "DefaultsSonarCodeScannerValidationProjectFAE7BAD0",
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "codebuild:CreateReportGroup",
+                "codebuild:CreateReport",
+                "codebuild:UpdateReport",
+                "codebuild:BatchPutTestCases",
+                "codebuild:BatchPutCodeCoverages",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":codebuild:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":report-group/",
+                    Object {
+                      "Ref": "DefaultsSonarCodeScannerValidationProjectFAE7BAD0",
+                    },
+                    "-*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "codebuild:BatchGetBuilds",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:GetObject*",
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn",
+                        ],
+                      },
+                      "/**",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DefaultsSonarCodeScannerValidationProjectRoleDefaultPolicyF147A45E",
+        "Roles": Array [
+          Object {
+            "Ref": "DefaultsSonarCodeScannerValidationProjectRole6AF1A9E5",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DefaultsUpdatePipelineSelfMutation28F7C994": Object {
+      "Properties": Object {
+        "Artifacts": Object {
+          "Type": "CODEPIPELINE",
+        },
+        "Cache": Object {
+          "Type": "NO_CACHE",
+        },
+        "Description": "Pipeline step Default/CodePipeline/UpdatePipeline/SelfMutate",
+        "EncryptionKey": "alias/aws/s3",
+        "Environment": Object {
+          "ComputeType": "BUILD_GENERAL1_SMALL",
+          "Image": "aws/codebuild/standard:5.0",
+          "ImagePullCredentialsType": "CODEBUILD",
+          "PrivilegedMode": false,
+          "Type": "LINUX_CONTAINER",
+        },
+        "ServiceRole": Object {
+          "Fn::GetAtt": Array [
+            "DefaultsUpdatePipelineSelfMutationRole2FF40065",
+            "Arn",
+          ],
+        },
+        "Source": Object {
+          "BuildSpec": "{
+  \\"version\\": \\"0.2\\",
+  \\"phases\\": {
+    \\"install\\": {
+      \\"commands\\": [
+        \\"npm install -g aws-cdk@2\\"
+      ]
+    },
+    \\"build\\": {
+      \\"commands\\": [
+        \\"cdk -a . deploy Default --require-approval=never --verbose\\"
+      ]
+    }
+  }
+}",
+          "Type": "CODEPIPELINE",
+        },
+      },
+      "Type": "AWS::CodeBuild::Project",
+    },
+    "DefaultsUpdatePipelineSelfMutationRole2FF40065": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "codebuild.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsUpdatePipelineSelfMutationRoleDefaultPolicyB0C671E4": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<DefaultsUpdatePipelineSelfMutation.*>:\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<DefaultsUpdatePipelineSelfMutation.*>-\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:\\\\*:iam::<AWS::AccountId>:role/\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to assume a role from within the current account in order to deploy.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to list all buckets and stacks.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        "):log-group:/aws/codebuild/<DefaultsUpdatePipelineSelfMutation.*>:\\\\*$/g",
+                      ],
+                    ],
+                  },
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<DefaultsUpdatePipelineSelfMutation.*>:\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<DefaultsUpdatePipelineSelfMutation.*>-\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:\\\\*:iam::<AWS::AccountId>:role/\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to assume a role from within the current account in order to deploy.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to list all buckets and stacks.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Action::s3:.*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        "):log-group:/aws/codebuild/<DefaultsUpdatePipelineSelfMutation.*>:\\\\*$/g",
+                      ],
+                    ],
+                  },
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
+                },
+                Object {
+                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
               "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
             },
           ],

--- a/packages/pipeline/test/pdk-pipeline.test.ts
+++ b/packages/pipeline/test/pdk-pipeline.test.ts
@@ -1,7 +1,7 @@
 /*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0 */
 import * as path from "path";
-import { PDKNag } from "@aws-prototyping-sdk/pdk-nag";
+import { AwsPrototypingChecks, PDKNag } from "@aws-prototyping-sdk/pdk-nag";
 import { Stack, Stage } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 import { Bucket } from "aws-cdk-lib/aws-s3";
@@ -11,6 +11,37 @@ import { PDKPipeline } from "../src";
 describe("PDK Pipeline Unit Tests", () => {
   it("Defaults", () => {
     const app = PDKNag.app();
+    const stack = new Stack(app);
+
+    const pipeline = new PDKPipeline(stack, "Defaults", {
+      primarySynthDirectory: "cdk.out",
+      repositoryName: "Defaults",
+      synth: {},
+      crossAccountKeys: false,
+      sonarCodeScannerConfig: {
+        sonarqubeAuthorizedGroup: "dev",
+        sonarqubeDefaultProfileOrGateName: "dev",
+        sonarqubeEndpoint: "https://sonar.dev",
+        sonarqubeProjectName: "Default",
+      },
+    });
+
+    const stage = new Stage(app, "Stage");
+    const appStack = new Stack(stage, "AppStack");
+    new Asset(appStack, "Asset", {
+      path: path.join(__dirname, "pdk-pipeline.test.ts"),
+    });
+
+    pipeline.addStage(stage);
+    pipeline.buildPipeline();
+
+    app.synth();
+    expect(app.nagResults().length).toEqual(0);
+    expect(Template.fromStack(stack)).toMatchSnapshot();
+  });
+
+  it("Defaults - using AwsPrototyping NagPack", () => {
+    const app = PDKNag.app({ nagPacks: [new AwsPrototypingChecks()] });
     const stack = new Stack(app);
 
     const pipeline = new PDKPipeline(stack, "Defaults", {
@@ -67,13 +98,76 @@ describe("PDK Pipeline Unit Tests", () => {
     pipeline.buildPipeline();
 
     app.synth();
-    console.log(JSON.stringify(app.nagResults()));
+    expect(app.nagResults().length).toEqual(0);
+    expect(Template.fromStack(stack)).toMatchSnapshot();
+  });
+
+  it("CrossAccount - using AwsPrototyping NagPack", () => {
+    const app = PDKNag.app({ nagPacks: [new AwsPrototypingChecks()] });
+    const stack = new Stack(app);
+
+    const pipeline = new PDKPipeline(stack, "CrossAccount", {
+      primarySynthDirectory: "cdk.out",
+      repositoryName: "Defaults",
+      synth: {},
+      crossAccountKeys: true,
+      sonarCodeScannerConfig: {
+        sonarqubeAuthorizedGroup: "dev",
+        sonarqubeDefaultProfileOrGateName: "dev",
+        sonarqubeEndpoint: "https://sonar.dev",
+        sonarqubeProjectName: "Default",
+      },
+    });
+
+    const stage = new Stage(app, "Stage");
+    const appStack = new Stack(stage, "AppStack");
+    new Asset(appStack, "Asset", {
+      path: path.join(__dirname, "pdk-pipeline.test.ts"),
+    });
+
+    pipeline.addStage(stage);
+    pipeline.buildPipeline();
+
+    app.synth();
     expect(app.nagResults().length).toEqual(0);
     expect(Template.fromStack(stack)).toMatchSnapshot();
   });
 
   it("StageNagRuns", () => {
     const app = PDKNag.app({ failOnError: false });
+    const stack = new Stack(app);
+
+    const pipeline = new PDKPipeline(stack, "StageNagRuns", {
+      primarySynthDirectory: "cdk.out",
+      repositoryName: "StageNagRuns",
+      synth: {},
+      sonarCodeScannerConfig: {
+        sonarqubeAuthorizedGroup: "dev",
+        sonarqubeDefaultProfileOrGateName: "dev",
+        sonarqubeEndpoint: "https://sonar.dev",
+        sonarqubeProjectName: "Default",
+      },
+    });
+
+    const stage = new Stage(app, "Stage");
+    const appStack = new Stack(stage, "AppStack");
+    new Bucket(appStack, "Non-Compliant");
+
+    pipeline.addStage(stage);
+    pipeline.buildPipeline();
+
+    app.synth();
+
+    expect(app.nagResults()[0].resource).toEqual(
+      "Stage/AppStack/Non-Compliant/Resource"
+    );
+  });
+
+  it("StageNagRuns - using AwsPrototyping NagPack", () => {
+    const app = PDKNag.app({
+      failOnError: false,
+      nagPacks: [new AwsPrototypingChecks()],
+    });
     const stack = new Stack(app);
 
     const pipeline = new PDKPipeline(stack, "StageNagRuns", {

--- a/packages/static-website/src/cloudfront-web-acl.ts
+++ b/packages/static-website/src/cloudfront-web-acl.ts
@@ -180,37 +180,41 @@ export class CloudfrontWebAcl extends Construct {
       }
     );
 
-    NagSuppressions.addResourceSuppressions(
-      onEventHandlerRole,
-      [
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "WafV2 resources have been scoped down to the ACL/IPSet level, however * is still needed as resource id's are created just in time.",
-          appliesTo: [
+    ["AwsSolutions-IAM5", "AwsPrototyping-IAMNoWildcardPermissions"].forEach(
+      (RuleId) => {
+        NagSuppressions.addResourceSuppressions(
+          onEventHandlerRole,
+          [
             {
-              regex: `/^Resource::arn:aws:wafv2:us-east-1:${PDKNag.getStackAccountRegex(
-                stack
-              )}:global/(.*)$/g`,
+              id: RuleId,
+              reason:
+                "WafV2 resources have been scoped down to the ACL/IPSet level, however * is still needed as resource id's are created just in time.",
+              appliesTo: [
+                {
+                  regex: `/^Resource::arn:aws:wafv2:us-east-1:${PDKNag.getStackAccountRegex(
+                    stack
+                  )}:global/(.*)$/g`,
+                },
+              ],
+            },
+            {
+              id: RuleId,
+              reason:
+                "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+              appliesTo: [
+                {
+                  regex: `/^Resource::arn:aws:logs:${PDKNag.getStackRegionRegex(
+                    stack
+                  )}:${PDKNag.getStackAccountRegex(
+                    stack
+                  )}:log-group:/aws/lambda/${onEventHandlerName}:\*/g`,
+                },
+              ],
             },
           ],
-        },
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
-          appliesTo: [
-            {
-              regex: `/^Resource::arn:aws:logs:${PDKNag.getStackRegionRegex(
-                stack
-              )}:${PDKNag.getStackAccountRegex(
-                stack
-              )}:log-group:/aws/lambda/${onEventHandlerName}:\*/g`,
-            },
-          ],
-        },
-      ],
-      true
+          true
+        );
+      }
     );
 
     return onEventHandler;
@@ -259,27 +263,36 @@ export class CloudfrontWebAcl extends Construct {
       providerFunctionName,
     });
 
-    NagSuppressions.addResourceSuppressions(
-      providerRole,
-      [
-        {
-          id: "AwsSolutions-IAM5",
-          reason:
-            "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
-        },
-      ],
-      true
+    ["AwsSolutions-IAM5", "AwsPrototyping-IAMNoWildcardPermissions"].forEach(
+      (RuleId) => {
+        NagSuppressions.addResourceSuppressions(
+          providerRole,
+          [
+            {
+              id: RuleId,
+              reason:
+                "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+          ],
+          true
+        );
+      }
     );
-    NagSuppressions.addResourceSuppressions(
-      provider,
-      [
-        {
-          id: "AwsSolutions-L1",
-          reason:
-            "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
-        },
-      ],
-      true
+
+    ["AwsSolutions-L1", "AwsPrototyping-LambdaLatestVersion"].forEach(
+      (RuleId) => {
+        NagSuppressions.addResourceSuppressions(
+          provider,
+          [
+            {
+              id: RuleId,
+              reason:
+                "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
+            },
+          ],
+          true
+        );
+      }
     );
 
     return new CustomResource(this, "CFWebAclCustomResource", {

--- a/packages/static-website/src/static-website.ts
+++ b/packages/static-website/src/static-website.ts
@@ -279,49 +279,69 @@ export class StaticWebsite extends Construct {
   private suppressCDKNagViolations = (props: StaticWebsiteProps) => {
     const stack = Stack.of(this);
     !props.distributionProps?.certificate &&
-      NagSuppressions.addResourceSuppressions(this.cloudFrontDistribution, [
-        {
-          id: "AwsSolutions-CFR4",
-          reason:
-            "Certificate is not mandatory therefore the Cloudfront certificate will be used.",
-        },
-      ]);
-    NagSuppressions.addStackSuppressions(stack, [
-      {
-        id: "AwsSolutions-L1",
-        reason:
-          "Latest runtime cannot be configured. CDK will need to upgrade the BucketDeployment construct accordingly.",
-      },
-    ]);
-    NagSuppressions.addStackSuppressions(stack, [
-      {
-        id: "AwsSolutions-IAM5",
-        reason:
-          "All Policies have been scoped to a Bucket. Given Buckets can contain arbitrary content, wildcard resources with bucket scope are required.",
-        appliesTo: [
+      [
+        "AwsSolutions-CFR4",
+        "AwsPrototyping-CloudFrontDistributionHttpsViewerNoOutdatedSSL",
+      ].forEach((RuleId) => {
+        NagSuppressions.addResourceSuppressions(this.cloudFrontDistribution, [
           {
-            regex: "/^Action::s3:.*$/g",
+            id: RuleId,
+            reason:
+              "Certificate is not mandatory therefore the Cloudfront certificate will be used.",
           },
+        ]);
+      });
+
+    ["AwsSolutions-L1", "AwsPrototyping-LambdaLatestVersion"].forEach(
+      (RuleId) => {
+        NagSuppressions.addStackSuppressions(stack, [
           {
-            regex: `/^Resource::.*$/g`,
+            id: RuleId,
+            reason:
+              "Latest runtime cannot be configured. CDK will need to upgrade the BucketDeployment construct accordingly.",
           },
-        ],
-      },
-    ]);
-    NagSuppressions.addStackSuppressions(stack, [
-      {
-        id: "AwsSolutions-IAM4",
-        reason:
-          "Buckets can contain arbitrary content, therefore wildcard resources under a bucket are required.",
-        appliesTo: [
+        ]);
+      }
+    );
+
+    ["AwsSolutions-IAM5", "AwsPrototyping-IAMNoWildcardPermissions"].forEach(
+      (RuleId) => {
+        NagSuppressions.addStackSuppressions(stack, [
           {
-            regex: `/^Policy::arn:${PDKNag.getStackPartitionRegex(
-              stack
-            )}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole$/g`,
+            id: RuleId,
+            reason:
+              "All Policies have been scoped to a Bucket. Given Buckets can contain arbitrary content, wildcard resources with bucket scope are required.",
+            appliesTo: [
+              {
+                regex: "/^Action::s3:.*$/g",
+              },
+              {
+                regex: `/^Resource::.*$/g`,
+              },
+            ],
           },
-        ],
-      },
-    ]);
+        ]);
+      }
+    );
+
+    ["AwsSolutions-IAM4", "AwsPrototyping-IAMNoManagedPolicies"].forEach(
+      (RuleId) => {
+        NagSuppressions.addStackSuppressions(stack, [
+          {
+            id: RuleId,
+            reason:
+              "Buckets can contain arbitrary content, therefore wildcard resources under a bucket are required.",
+            appliesTo: [
+              {
+                regex: `/^Policy::arn:${PDKNag.getStackPartitionRegex(
+                  stack
+                )}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole$/g`,
+              },
+            ],
+          },
+        ]);
+      }
+    );
   };
 }
 

--- a/packages/static-website/test/__snapshots__/static-website.test.ts.snap
+++ b/packages/static-website/test/__snapshots__/static-website.test.ts.snap
@@ -10,6 +10,10 @@ Object {
           "reason": "Latest runtime cannot be configured. CDK will need to upgrade the BucketDeployment construct accordingly.",
         },
         Object {
+          "id": "AwsPrototyping-LambdaLatestVersion",
+          "reason": "Latest runtime cannot be configured. CDK will need to upgrade the BucketDeployment construct accordingly.",
+        },
+        Object {
           "applies_to": Array [
             Object {
               "regex": "/^Action::s3:.*$/g",
@@ -24,10 +28,31 @@ Object {
         Object {
           "applies_to": Array [
             Object {
+              "regex": "/^Action::s3:.*$/g",
+            },
+            Object {
+              "regex": "/^Resource::.*$/g",
+            },
+          ],
+          "id": "AwsPrototyping-IAMNoWildcardPermissions",
+          "reason": "All Policies have been scoped to a Bucket. Given Buckets can contain arbitrary content, wildcard resources with bucket scope are required.",
+        },
+        Object {
+          "applies_to": Array [
+            Object {
               "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole$/g",
             },
           ],
           "id": "AwsSolutions-IAM4",
+          "reason": "Buckets can contain arbitrary content, therefore wildcard resources under a bucket are required.",
+        },
+        Object {
+          "applies_to": Array [
+            Object {
+              "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole$/g",
+            },
+          ],
+          "id": "AwsPrototyping-IAMNoManagedPolicies",
           "reason": "Buckets can contain arbitrary content, therefore wildcard resources under a bucket are required.",
         },
       ],
@@ -260,6 +285,10 @@ Object {
           "rules_to_suppress": Array [
             Object {
               "id": "AwsSolutions-CFR4",
+              "reason": "Certificate is not mandatory therefore the Cloudfront certificate will be used.",
+            },
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionHttpsViewerNoOutdatedSSL",
               "reason": "Certificate is not mandatory therefore the Cloudfront certificate will be used.",
             },
           ],
@@ -531,6 +560,10 @@ Object {
               "id": "AwsSolutions-IAM5",
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
           ],
         },
       },
@@ -618,6 +651,10 @@ Object {
               "id": "AwsSolutions-IAM5",
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
           ],
         },
       },
@@ -672,6 +709,10 @@ Object {
           "rules_to_suppress": Array [
             Object {
               "id": "AwsSolutions-L1",
+              "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
+            },
+            Object {
+              "id": "AwsPrototyping-LambdaLatestVersion",
               "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
             },
           ],
@@ -738,6 +779,24 @@ Object {
                 },
               ],
               "id": "AwsSolutions-IAM5",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:aws:wafv2:us-east-1:<AWS::AccountId>:global/(.*)$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "WafV2 resources have been scoped down to the ACL/IPSet level, however * is still needed as resource id's are created just in time.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-Nested-Stack-OnEventHandler:*/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
           ],
@@ -1129,13 +1188,17 @@ Object {
 }
 `;
 
-exports[`Static Website Unit Tests Defaults 1`] = `
+exports[`Static Website Unit Tests Defaults - using AwsPrototyping NagPack 1`] = `
 Object {
   "Metadata": Object {
     "cdk_nag": Object {
       "rules_to_suppress": Array [
         Object {
           "id": "AwsSolutions-L1",
+          "reason": "Latest runtime cannot be configured. CDK will need to upgrade the BucketDeployment construct accordingly.",
+        },
+        Object {
+          "id": "AwsPrototyping-LambdaLatestVersion",
           "reason": "Latest runtime cannot be configured. CDK will need to upgrade the BucketDeployment construct accordingly.",
         },
         Object {
@@ -1153,10 +1216,31 @@ Object {
         Object {
           "applies_to": Array [
             Object {
+              "regex": "/^Action::s3:.*$/g",
+            },
+            Object {
+              "regex": "/^Resource::.*$/g",
+            },
+          ],
+          "id": "AwsPrototyping-IAMNoWildcardPermissions",
+          "reason": "All Policies have been scoped to a Bucket. Given Buckets can contain arbitrary content, wildcard resources with bucket scope are required.",
+        },
+        Object {
+          "applies_to": Array [
+            Object {
               "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole$/g",
             },
           ],
           "id": "AwsSolutions-IAM4",
+          "reason": "Buckets can contain arbitrary content, therefore wildcard resources under a bucket are required.",
+        },
+        Object {
+          "applies_to": Array [
+            Object {
+              "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole$/g",
+            },
+          ],
+          "id": "AwsPrototyping-IAMNoManagedPolicies",
           "reason": "Buckets can contain arbitrary content, therefore wildcard resources under a bucket are required.",
         },
       ],
@@ -1396,6 +1480,10 @@ Object {
           "rules_to_suppress": Array [
             Object {
               "id": "AwsSolutions-CFR4",
+              "reason": "Certificate is not mandatory therefore the Cloudfront certificate will be used.",
+            },
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionHttpsViewerNoOutdatedSSL",
               "reason": "Certificate is not mandatory therefore the Cloudfront certificate will be used.",
             },
           ],
@@ -1657,6 +1745,10 @@ Object {
               "id": "AwsSolutions-IAM5",
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
           ],
         },
       },
@@ -1744,6 +1836,10 @@ Object {
               "id": "AwsSolutions-IAM5",
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
           ],
         },
       },
@@ -1798,6 +1894,10 @@ Object {
           "rules_to_suppress": Array [
             Object {
               "id": "AwsSolutions-L1",
+              "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
+            },
+            Object {
+              "id": "AwsPrototyping-LambdaLatestVersion",
               "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
             },
           ],
@@ -1864,6 +1964,24 @@ Object {
                 },
               ],
               "id": "AwsSolutions-IAM5",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:aws:wafv2:us-east-1:<AWS::AccountId>:global/(.*)$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "WafV2 resources have been scoped down to the ACL/IPSet level, however * is still needed as resource id's are created just in time.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-OnEventHandler:*/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
               "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
             },
           ],
@@ -2213,6 +2331,3795 @@ Object {
     },
     "DefaultsWebsiteDeploymentCustomResource326CD6C1": Object {
       "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "DestinationBucketName": Object {
+          "Ref": "DefaultsWebsiteBucket3263D025",
+        },
+        "DistributionId": Object {
+          "Ref": "DefaultsCloudfrontDistributionF4EA1054",
+        },
+        "Prune": true,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
+            "Arn",
+          ],
+        },
+        "SourceBucketNames": Array [
+          Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+        ],
+        "SourceObjectKeys": Array [
+          "a79f62b4071246acc1e8e834ba67dc3bbf15a3662e39d31667fa59315ef86f56.zip",
+        ],
+      },
+      "Type": "Custom::CDKBucketDeployment",
+      "UpdateReplacePolicy": "Delete",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`Static Website Unit Tests Defaults 1`] = `
+Object {
+  "Metadata": Object {
+    "cdk_nag": Object {
+      "rules_to_suppress": Array [
+        Object {
+          "id": "AwsSolutions-L1",
+          "reason": "Latest runtime cannot be configured. CDK will need to upgrade the BucketDeployment construct accordingly.",
+        },
+        Object {
+          "id": "AwsPrototyping-LambdaLatestVersion",
+          "reason": "Latest runtime cannot be configured. CDK will need to upgrade the BucketDeployment construct accordingly.",
+        },
+        Object {
+          "applies_to": Array [
+            Object {
+              "regex": "/^Action::s3:.*$/g",
+            },
+            Object {
+              "regex": "/^Resource::.*$/g",
+            },
+          ],
+          "id": "AwsSolutions-IAM5",
+          "reason": "All Policies have been scoped to a Bucket. Given Buckets can contain arbitrary content, wildcard resources with bucket scope are required.",
+        },
+        Object {
+          "applies_to": Array [
+            Object {
+              "regex": "/^Action::s3:.*$/g",
+            },
+            Object {
+              "regex": "/^Resource::.*$/g",
+            },
+          ],
+          "id": "AwsPrototyping-IAMNoWildcardPermissions",
+          "reason": "All Policies have been scoped to a Bucket. Given Buckets can contain arbitrary content, wildcard resources with bucket scope are required.",
+        },
+        Object {
+          "applies_to": Array [
+            Object {
+              "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole$/g",
+            },
+          ],
+          "id": "AwsSolutions-IAM4",
+          "reason": "Buckets can contain arbitrary content, therefore wildcard resources under a bucket are required.",
+        },
+        Object {
+          "applies_to": Array [
+            Object {
+              "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole$/g",
+            },
+          ],
+          "id": "AwsPrototyping-IAMNoManagedPolicies",
+          "reason": "Buckets can contain arbitrary content, therefore wildcard resources under a bucket are required.",
+        },
+      ],
+    },
+  },
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536": Object {
+      "DependsOn": Array [
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "6ddcf10002539818a9256eff3fb2b22aa09298d8f946e26ba121c175a600c44e.zip",
+        },
+        "Handler": "index.handler",
+        "Layers": Array [
+          Object {
+            "Ref": "DefaultsWebsiteDeploymentAwsCliLayerD5AA12CC",
+          },
+        ],
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+            "Arn",
+          ],
+        },
+        "Runtime": "python3.9",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsWebsiteBucket3263D025",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DefaultsWebsiteBucket3263D025",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "cloudfront:GetInvalidation",
+                "cloudfront:CreateInvalidation",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
+        "Roles": Array [
+          Object {
+            "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F": Object {
+      "DependsOn": Array [
+        "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "3f51abb709b8e65167a45aeed02bab11540603d909005d7148230ba5ce6c74d7.zip",
+        },
+        "Description": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "Lambda function for auto-deleting objects in ",
+              Object {
+                "Ref": "DefaultsWebsiteBucket3263D025",
+              },
+              " S3 bucket.",
+            ],
+          ],
+        },
+        "Handler": "__entrypoint__.handler",
+        "MemorySize": 128,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsCloudfrontDistributionF4EA1054": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-CFR4",
+              "reason": "Certificate is not mandatory therefore the Cloudfront certificate will be used.",
+            },
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionHttpsViewerNoOutdatedSSL",
+              "reason": "Certificate is not mandatory therefore the Cloudfront certificate will be used.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "DistributionConfig": Object {
+          "CustomErrorResponses": Array [
+            Object {
+              "ErrorCode": 404,
+              "ResponseCode": 200,
+              "ResponsePagePath": "/index.html",
+            },
+          ],
+          "DefaultCacheBehavior": Object {
+            "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+            "Compress": true,
+            "TargetOriginId": "DefaultsCloudfrontDistributionOrigin1BA23CD94",
+            "ViewerProtocolPolicy": "redirect-to-https",
+          },
+          "DefaultRootObject": "index.html",
+          "Enabled": true,
+          "HttpVersion": "http2",
+          "IPV6Enabled": true,
+          "Logging": Object {
+            "Bucket": Object {
+              "Fn::GetAtt": Array [
+                "DefaultsDistributionLogBucket7EA741E2",
+                "RegionalDomainName",
+              ],
+            },
+          },
+          "Origins": Array [
+            Object {
+              "DomainName": Object {
+                "Fn::GetAtt": Array [
+                  "DefaultsWebsiteBucket3263D025",
+                  "RegionalDomainName",
+                ],
+              },
+              "Id": "DefaultsCloudfrontDistributionOrigin1BA23CD94",
+              "S3OriginConfig": Object {
+                "OriginAccessIdentity": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "origin-access-identity/cloudfront/",
+                      Object {
+                        "Ref": "DefaultsOriginAccessIdentity7F5D47DF",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "WebACLId": Object {
+            "Fn::GetAtt": Array [
+              "DefaultsWebsiteAclCFWebAclCustomResourceB050DB2C",
+              "WebAclArn",
+            ],
+          },
+        },
+      },
+      "Type": "AWS::CloudFront::Distribution",
+    },
+    "DefaultsDistributionLogBucket7EA741E2": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "BucketEncryption": Object {
+          "ServerSideEncryptionConfiguration": Array [
+            Object {
+              "ServerSideEncryptionByDefault": Object {
+                "SSEAlgorithm": "AES256",
+              },
+            },
+          ],
+        },
+        "LoggingConfiguration": Object {
+          "LogFilePrefix": "access-logs",
+        },
+        "PublicAccessBlockConfiguration": Object {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DefaultsDistributionLogBucketAutoDeleteObjectsCustomResource7370C612": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "DefaultsDistributionLogBucketPolicyC6D11E8F",
+      ],
+      "Properties": Object {
+        "BucketName": Object {
+          "Ref": "DefaultsDistributionLogBucket7EA741E2",
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DefaultsDistributionLogBucketPolicyC6D11E8F": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "DefaultsDistributionLogBucket7EA741E2",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsDistributionLogBucket7EA741E2",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DefaultsDistributionLogBucket7EA741E2",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsDistributionLogBucket7EA741E2",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DefaultsDistributionLogBucket7EA741E2",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "DefaultsOriginAccessIdentity7F5D47DF": Object {
+      "Properties": Object {
+        "CloudFrontOriginAccessIdentityConfig": Object {
+          "Comment": "Allows CloudFront to reach the bucket",
+        },
+      },
+      "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
+    },
+    "DefaultsWebsiteAclCFWebAclCustomResourceB050DB2C": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "ID": "Default-WebsiteAcl",
+        "MANAGED_RULES": Array [
+          Object {
+            "name": "AWSManagedRulesCommonRuleSet",
+            "vendor": "AWS",
+          },
+        ],
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "DefaultsWebsiteAclCloudfrontWebAclProviderframeworkonEvent595963CB",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DefaultsWebsiteAclCloudfrontWebAclOnEventHandlerEC085AE0": Object {
+      "DependsOn": Array [
+        "DefaultsWebsiteAclOnEventHandlerRole83BC6E99",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "f9a4e3a2d1dd90ac1bfaec793acad708d019b35402700253f45a40ada6d2786a.zip",
+        },
+        "FunctionName": "Default-OnEventHandler",
+        "Handler": "index.onEvent",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DefaultsWebsiteAclOnEventHandlerRole83BC6E99",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs16.x",
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DefaultsWebsiteAclCloudfrontWebAclProviderRoleD884ECCA": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Policies": Array [
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Array [
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "arn:aws:logs:",
+                          Object {
+                            "Ref": "AWS::Region",
+                          },
+                          ":",
+                          Object {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":log-group:/aws/lambda/",
+                          Object {
+                            "Ref": "DefaultsWebsiteAclCloudfrontWebAclOnEventHandlerEC085AE0",
+                          },
+                          "-Provider",
+                        ],
+                      ],
+                    },
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "arn:aws:logs:",
+                          Object {
+                            "Ref": "AWS::Region",
+                          },
+                          ":",
+                          Object {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":log-group:/aws/lambda/",
+                          Object {
+                            "Ref": "DefaultsWebsiteAclCloudfrontWebAclOnEventHandlerEC085AE0",
+                          },
+                          "-Provider:*",
+                        ],
+                      ],
+                    },
+                  ],
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "logs",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsWebsiteAclCloudfrontWebAclProviderRoleDefaultPolicy0BEB9831": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsWebsiteAclCloudfrontWebAclOnEventHandlerEC085AE0",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DefaultsWebsiteAclCloudfrontWebAclOnEventHandlerEC085AE0",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DefaultsWebsiteAclCloudfrontWebAclProviderRoleDefaultPolicy0BEB9831",
+        "Roles": Array [
+          Object {
+            "Ref": "DefaultsWebsiteAclCloudfrontWebAclProviderRoleD884ECCA",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DefaultsWebsiteAclCloudfrontWebAclProviderframeworkonEvent595963CB": Object {
+      "DependsOn": Array [
+        "DefaultsWebsiteAclCloudfrontWebAclProviderRoleDefaultPolicy0BEB9831",
+        "DefaultsWebsiteAclCloudfrontWebAclProviderRoleD884ECCA",
+      ],
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-L1",
+              "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
+            },
+            Object {
+              "id": "AwsPrototyping-LambdaLatestVersion",
+              "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "6ff23d2800aac27308e31c227529dc13854507c3b2598d2433fcf82604fa054d.zip",
+        },
+        "Description": "AWS CDK resource provider framework - onEvent (Default/Defaults/WebsiteAcl/CloudfrontWebAclProvider)",
+        "Environment": Object {
+          "Variables": Object {
+            "USER_ON_EVENT_FUNCTION_ARN": Object {
+              "Fn::GetAtt": Array [
+                "DefaultsWebsiteAclCloudfrontWebAclOnEventHandlerEC085AE0",
+                "Arn",
+              ],
+            },
+          },
+        },
+        "FunctionName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              Object {
+                "Ref": "DefaultsWebsiteAclCloudfrontWebAclOnEventHandlerEC085AE0",
+              },
+              "-Provider",
+            ],
+          ],
+        },
+        "Handler": "framework.onEvent",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DefaultsWebsiteAclCloudfrontWebAclProviderRoleD884ECCA",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DefaultsWebsiteAclOnEventHandlerRole83BC6E99": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:aws:wafv2:us-east-1:<AWS::AccountId>:global/(.*)$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "WafV2 resources have been scoped down to the ACL/IPSet level, however * is still needed as resource id's are created just in time.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-OnEventHandler:*/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:aws:wafv2:us-east-1:<AWS::AccountId>:global/(.*)$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "WafV2 resources have been scoped down to the ACL/IPSet level, however * is still needed as resource id's are created just in time.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-OnEventHandler:*/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Policies": Array [
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Array [
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "arn:aws:logs:",
+                          Object {
+                            "Ref": "AWS::Region",
+                          },
+                          ":",
+                          Object {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":log-group:/aws/lambda/Default-OnEventHandler",
+                        ],
+                      ],
+                    },
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "arn:aws:logs:",
+                          Object {
+                            "Ref": "AWS::Region",
+                          },
+                          ":",
+                          Object {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":log-group:/aws/lambda/Default-OnEventHandler:*",
+                        ],
+                      ],
+                    },
+                  ],
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "logs",
+          },
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "wafv2:CreateWebACL",
+                    "wafv2:DeleteWebACL",
+                    "wafv2:UpdateWebACL",
+                    "wafv2:GetWebACL",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Array [
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "arn:aws:wafv2:us-east-1:",
+                          Object {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":global/ipset/Default-WebsiteAcl-IPSet/*",
+                        ],
+                      ],
+                    },
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "arn:aws:wafv2:us-east-1:",
+                          Object {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":global/webacl/Default-WebsiteAcl/*",
+                        ],
+                      ],
+                    },
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "arn:aws:wafv2:us-east-1:",
+                          Object {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":global/managedruleset/*/*",
+                        ],
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Action": Array [
+                    "wafv2:CreateIPSet",
+                    "wafv2:DeleteIPSet",
+                    "wafv2:UpdateIPSet",
+                    "wafv2:GetIPSet",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "arn:aws:wafv2:us-east-1:",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        ":global/ipset/Default-WebsiteAcl-IPSet/*",
+                      ],
+                    ],
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "wafv2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsWebsiteBucket3263D025": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "BucketEncryption": Object {
+          "ServerSideEncryptionConfiguration": Array [
+            Object {
+              "ServerSideEncryptionByDefault": Object {
+                "SSEAlgorithm": "AES256",
+              },
+            },
+          ],
+        },
+        "LoggingConfiguration": Object {
+          "LogFilePrefix": "access-logs",
+        },
+        "PublicAccessBlockConfiguration": Object {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true",
+          },
+          Object {
+            "Key": "aws-cdk:cr-owned:fb67e0d5",
+            "Value": "true",
+          },
+        ],
+        "VersioningConfiguration": Object {
+          "Status": "Enabled",
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DefaultsWebsiteBucketAutoDeleteObjectsCustomResourceD840F8F2": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "DefaultsWebsiteBucketPolicy594E6643",
+      ],
+      "Properties": Object {
+        "BucketName": Object {
+          "Ref": "DefaultsWebsiteBucket3263D025",
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DefaultsWebsiteBucketPolicy594E6643": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "DefaultsWebsiteBucket3263D025",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsWebsiteBucket3263D025",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DefaultsWebsiteBucket3263D025",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsWebsiteBucket3263D025",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DefaultsWebsiteBucket3263D025",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:ListBucket",
+              "Effect": "Allow",
+              "Principal": Object {
+                "CanonicalUser": Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsOriginAccessIdentity7F5D47DF",
+                    "S3CanonicalUserId",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "DefaultsWebsiteBucket3263D025",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Principal": Object {
+                "CanonicalUser": Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsOriginAccessIdentity7F5D47DF",
+                    "S3CanonicalUserId",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "DefaultsWebsiteBucket3263D025",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "DefaultsWebsiteDeploymentAwsCliLayerD5AA12CC": Object {
+      "Properties": Object {
+        "Content": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "c409e6c5845f1f349df8cd84e160bf6f1c35d2b060b63e1f032f9bd39d4542cc.zip",
+        },
+        "Description": "/opt/awscli/aws",
+      },
+      "Type": "AWS::Lambda::LayerVersion",
+    },
+    "DefaultsWebsiteDeploymentCustomResource326CD6C1": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "DestinationBucketName": Object {
+          "Ref": "DefaultsWebsiteBucket3263D025",
+        },
+        "DistributionId": Object {
+          "Ref": "DefaultsCloudfrontDistributionF4EA1054",
+        },
+        "Prune": true,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
+            "Arn",
+          ],
+        },
+        "SourceBucketNames": Array [
+          Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+        ],
+        "SourceObjectKeys": Array [
+          "a79f62b4071246acc1e8e834ba67dc3bbf15a3662e39d31667fa59315ef86f56.zip",
+        ],
+      },
+      "Type": "Custom::CDKBucketDeployment",
+      "UpdateReplacePolicy": "Delete",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`Static Website Unit Tests Defaults and Geoblocking - using AwsPrototyping NagPack 1`] = `
+Object {
+  "Metadata": Object {
+    "cdk_nag": Object {
+      "rules_to_suppress": Array [
+        Object {
+          "id": "AwsSolutions-L1",
+          "reason": "Latest runtime cannot be configured. CDK will need to upgrade the BucketDeployment construct accordingly.",
+        },
+        Object {
+          "id": "AwsPrototyping-LambdaLatestVersion",
+          "reason": "Latest runtime cannot be configured. CDK will need to upgrade the BucketDeployment construct accordingly.",
+        },
+        Object {
+          "applies_to": Array [
+            Object {
+              "regex": "/^Action::s3:.*$/g",
+            },
+            Object {
+              "regex": "/^Resource::.*$/g",
+            },
+          ],
+          "id": "AwsSolutions-IAM5",
+          "reason": "All Policies have been scoped to a Bucket. Given Buckets can contain arbitrary content, wildcard resources with bucket scope are required.",
+        },
+        Object {
+          "applies_to": Array [
+            Object {
+              "regex": "/^Action::s3:.*$/g",
+            },
+            Object {
+              "regex": "/^Resource::.*$/g",
+            },
+          ],
+          "id": "AwsPrototyping-IAMNoWildcardPermissions",
+          "reason": "All Policies have been scoped to a Bucket. Given Buckets can contain arbitrary content, wildcard resources with bucket scope are required.",
+        },
+        Object {
+          "applies_to": Array [
+            Object {
+              "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole$/g",
+            },
+          ],
+          "id": "AwsSolutions-IAM4",
+          "reason": "Buckets can contain arbitrary content, therefore wildcard resources under a bucket are required.",
+        },
+        Object {
+          "applies_to": Array [
+            Object {
+              "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole$/g",
+            },
+          ],
+          "id": "AwsPrototyping-IAMNoManagedPolicies",
+          "reason": "Buckets can contain arbitrary content, therefore wildcard resources under a bucket are required.",
+        },
+      ],
+    },
+  },
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536": Object {
+      "DependsOn": Array [
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "6ddcf10002539818a9256eff3fb2b22aa09298d8f946e26ba121c175a600c44e.zip",
+        },
+        "Handler": "index.handler",
+        "Layers": Array [
+          Object {
+            "Ref": "DefaultsWebsiteDeploymentAwsCliLayerD5AA12CC",
+          },
+        ],
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+            "Arn",
+          ],
+        },
+        "Runtime": "python3.9",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsWebsiteBucket3263D025",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DefaultsWebsiteBucket3263D025",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "cloudfront:GetInvalidation",
+                "cloudfront:CreateInvalidation",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
+        "Roles": Array [
+          Object {
+            "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F": Object {
+      "DependsOn": Array [
+        "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "3f51abb709b8e65167a45aeed02bab11540603d909005d7148230ba5ce6c74d7.zip",
+        },
+        "Description": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "Lambda function for auto-deleting objects in ",
+              Object {
+                "Ref": "DefaultsWebsiteBucket3263D025",
+              },
+              " S3 bucket.",
+            ],
+          ],
+        },
+        "Handler": "__entrypoint__.handler",
+        "MemorySize": 128,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsCloudfrontDistributionF4EA1054": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-CFR4",
+              "reason": "Certificate is not mandatory therefore the Cloudfront certificate will be used.",
+            },
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionHttpsViewerNoOutdatedSSL",
+              "reason": "Certificate is not mandatory therefore the Cloudfront certificate will be used.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "DistributionConfig": Object {
+          "CustomErrorResponses": Array [
+            Object {
+              "ErrorCode": 404,
+              "ResponseCode": 200,
+              "ResponsePagePath": "/index.html",
+            },
+          ],
+          "DefaultCacheBehavior": Object {
+            "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+            "Compress": true,
+            "TargetOriginId": "DefaultsCloudfrontDistributionOrigin1BA23CD94",
+            "ViewerProtocolPolicy": "redirect-to-https",
+          },
+          "DefaultRootObject": "index.html",
+          "Enabled": true,
+          "HttpVersion": "http2",
+          "IPV6Enabled": true,
+          "Logging": Object {
+            "Bucket": Object {
+              "Fn::GetAtt": Array [
+                "DefaultsDistributionLogBucket7EA741E2",
+                "RegionalDomainName",
+              ],
+            },
+          },
+          "Origins": Array [
+            Object {
+              "DomainName": Object {
+                "Fn::GetAtt": Array [
+                  "DefaultsWebsiteBucket3263D025",
+                  "RegionalDomainName",
+                ],
+              },
+              "Id": "DefaultsCloudfrontDistributionOrigin1BA23CD94",
+              "S3OriginConfig": Object {
+                "OriginAccessIdentity": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "origin-access-identity/cloudfront/",
+                      Object {
+                        "Ref": "DefaultsOriginAccessIdentity7F5D47DF",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Restrictions": Object {
+            "GeoRestriction": Object {
+              "Locations": Array [
+                "AU",
+                "SG",
+              ],
+              "RestrictionType": "whitelist",
+            },
+          },
+          "WebACLId": Object {
+            "Fn::GetAtt": Array [
+              "DefaultsWebsiteAclCFWebAclCustomResourceB050DB2C",
+              "WebAclArn",
+            ],
+          },
+        },
+      },
+      "Type": "AWS::CloudFront::Distribution",
+    },
+    "DefaultsDistributionLogBucket7EA741E2": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "BucketEncryption": Object {
+          "ServerSideEncryptionConfiguration": Array [
+            Object {
+              "ServerSideEncryptionByDefault": Object {
+                "SSEAlgorithm": "AES256",
+              },
+            },
+          ],
+        },
+        "LoggingConfiguration": Object {
+          "LogFilePrefix": "access-logs",
+        },
+        "PublicAccessBlockConfiguration": Object {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DefaultsDistributionLogBucketAutoDeleteObjectsCustomResource7370C612": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "DefaultsDistributionLogBucketPolicyC6D11E8F",
+      ],
+      "Properties": Object {
+        "BucketName": Object {
+          "Ref": "DefaultsDistributionLogBucket7EA741E2",
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DefaultsDistributionLogBucketPolicyC6D11E8F": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "DefaultsDistributionLogBucket7EA741E2",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsDistributionLogBucket7EA741E2",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DefaultsDistributionLogBucket7EA741E2",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsDistributionLogBucket7EA741E2",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DefaultsDistributionLogBucket7EA741E2",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "DefaultsOriginAccessIdentity7F5D47DF": Object {
+      "Properties": Object {
+        "CloudFrontOriginAccessIdentityConfig": Object {
+          "Comment": "Allows CloudFront to reach the bucket",
+        },
+      },
+      "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
+    },
+    "DefaultsWebsiteAclCFWebAclCustomResourceB050DB2C": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "ID": "Default-WebsiteAcl",
+        "MANAGED_RULES": Array [
+          Object {
+            "name": "AWSManagedRulesCommonRuleSet",
+            "vendor": "AWS",
+          },
+        ],
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "DefaultsWebsiteAclCloudfrontWebAclProviderframeworkonEvent595963CB",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DefaultsWebsiteAclCloudfrontWebAclOnEventHandlerEC085AE0": Object {
+      "DependsOn": Array [
+        "DefaultsWebsiteAclOnEventHandlerRole83BC6E99",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "f9a4e3a2d1dd90ac1bfaec793acad708d019b35402700253f45a40ada6d2786a.zip",
+        },
+        "FunctionName": "Default-OnEventHandler",
+        "Handler": "index.onEvent",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DefaultsWebsiteAclOnEventHandlerRole83BC6E99",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs16.x",
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DefaultsWebsiteAclCloudfrontWebAclProviderRoleD884ECCA": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Policies": Array [
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Array [
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "arn:aws:logs:",
+                          Object {
+                            "Ref": "AWS::Region",
+                          },
+                          ":",
+                          Object {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":log-group:/aws/lambda/",
+                          Object {
+                            "Ref": "DefaultsWebsiteAclCloudfrontWebAclOnEventHandlerEC085AE0",
+                          },
+                          "-Provider",
+                        ],
+                      ],
+                    },
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "arn:aws:logs:",
+                          Object {
+                            "Ref": "AWS::Region",
+                          },
+                          ":",
+                          Object {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":log-group:/aws/lambda/",
+                          Object {
+                            "Ref": "DefaultsWebsiteAclCloudfrontWebAclOnEventHandlerEC085AE0",
+                          },
+                          "-Provider:*",
+                        ],
+                      ],
+                    },
+                  ],
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "logs",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsWebsiteAclCloudfrontWebAclProviderRoleDefaultPolicy0BEB9831": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsWebsiteAclCloudfrontWebAclOnEventHandlerEC085AE0",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DefaultsWebsiteAclCloudfrontWebAclOnEventHandlerEC085AE0",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DefaultsWebsiteAclCloudfrontWebAclProviderRoleDefaultPolicy0BEB9831",
+        "Roles": Array [
+          Object {
+            "Ref": "DefaultsWebsiteAclCloudfrontWebAclProviderRoleD884ECCA",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DefaultsWebsiteAclCloudfrontWebAclProviderframeworkonEvent595963CB": Object {
+      "DependsOn": Array [
+        "DefaultsWebsiteAclCloudfrontWebAclProviderRoleDefaultPolicy0BEB9831",
+        "DefaultsWebsiteAclCloudfrontWebAclProviderRoleD884ECCA",
+      ],
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-L1",
+              "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
+            },
+            Object {
+              "id": "AwsPrototyping-LambdaLatestVersion",
+              "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "6ff23d2800aac27308e31c227529dc13854507c3b2598d2433fcf82604fa054d.zip",
+        },
+        "Description": "AWS CDK resource provider framework - onEvent (Default/Defaults/WebsiteAcl/CloudfrontWebAclProvider)",
+        "Environment": Object {
+          "Variables": Object {
+            "USER_ON_EVENT_FUNCTION_ARN": Object {
+              "Fn::GetAtt": Array [
+                "DefaultsWebsiteAclCloudfrontWebAclOnEventHandlerEC085AE0",
+                "Arn",
+              ],
+            },
+          },
+        },
+        "FunctionName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              Object {
+                "Ref": "DefaultsWebsiteAclCloudfrontWebAclOnEventHandlerEC085AE0",
+              },
+              "-Provider",
+            ],
+          ],
+        },
+        "Handler": "framework.onEvent",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DefaultsWebsiteAclCloudfrontWebAclProviderRoleD884ECCA",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DefaultsWebsiteAclOnEventHandlerRole83BC6E99": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:aws:wafv2:us-east-1:<AWS::AccountId>:global/(.*)$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "WafV2 resources have been scoped down to the ACL/IPSet level, however * is still needed as resource id's are created just in time.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-OnEventHandler:*/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:aws:wafv2:us-east-1:<AWS::AccountId>:global/(.*)$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "WafV2 resources have been scoped down to the ACL/IPSet level, however * is still needed as resource id's are created just in time.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-OnEventHandler:*/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Policies": Array [
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Array [
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "arn:aws:logs:",
+                          Object {
+                            "Ref": "AWS::Region",
+                          },
+                          ":",
+                          Object {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":log-group:/aws/lambda/Default-OnEventHandler",
+                        ],
+                      ],
+                    },
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "arn:aws:logs:",
+                          Object {
+                            "Ref": "AWS::Region",
+                          },
+                          ":",
+                          Object {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":log-group:/aws/lambda/Default-OnEventHandler:*",
+                        ],
+                      ],
+                    },
+                  ],
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "logs",
+          },
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "wafv2:CreateWebACL",
+                    "wafv2:DeleteWebACL",
+                    "wafv2:UpdateWebACL",
+                    "wafv2:GetWebACL",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Array [
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "arn:aws:wafv2:us-east-1:",
+                          Object {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":global/ipset/Default-WebsiteAcl-IPSet/*",
+                        ],
+                      ],
+                    },
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "arn:aws:wafv2:us-east-1:",
+                          Object {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":global/webacl/Default-WebsiteAcl/*",
+                        ],
+                      ],
+                    },
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "arn:aws:wafv2:us-east-1:",
+                          Object {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":global/managedruleset/*/*",
+                        ],
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Action": Array [
+                    "wafv2:CreateIPSet",
+                    "wafv2:DeleteIPSet",
+                    "wafv2:UpdateIPSet",
+                    "wafv2:GetIPSet",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "arn:aws:wafv2:us-east-1:",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        ":global/ipset/Default-WebsiteAcl-IPSet/*",
+                      ],
+                    ],
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "wafv2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsWebsiteBucket3263D025": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "BucketEncryption": Object {
+          "ServerSideEncryptionConfiguration": Array [
+            Object {
+              "ServerSideEncryptionByDefault": Object {
+                "SSEAlgorithm": "AES256",
+              },
+            },
+          ],
+        },
+        "LoggingConfiguration": Object {
+          "LogFilePrefix": "access-logs",
+        },
+        "PublicAccessBlockConfiguration": Object {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true",
+          },
+          Object {
+            "Key": "aws-cdk:cr-owned:fb67e0d5",
+            "Value": "true",
+          },
+        ],
+        "VersioningConfiguration": Object {
+          "Status": "Enabled",
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DefaultsWebsiteBucketAutoDeleteObjectsCustomResourceD840F8F2": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "DefaultsWebsiteBucketPolicy594E6643",
+      ],
+      "Properties": Object {
+        "BucketName": Object {
+          "Ref": "DefaultsWebsiteBucket3263D025",
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DefaultsWebsiteBucketPolicy594E6643": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "DefaultsWebsiteBucket3263D025",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsWebsiteBucket3263D025",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DefaultsWebsiteBucket3263D025",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsWebsiteBucket3263D025",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DefaultsWebsiteBucket3263D025",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:ListBucket",
+              "Effect": "Allow",
+              "Principal": Object {
+                "CanonicalUser": Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsOriginAccessIdentity7F5D47DF",
+                    "S3CanonicalUserId",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "DefaultsWebsiteBucket3263D025",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Principal": Object {
+                "CanonicalUser": Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsOriginAccessIdentity7F5D47DF",
+                    "S3CanonicalUserId",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "DefaultsWebsiteBucket3263D025",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "DefaultsWebsiteDeploymentAwsCliLayerD5AA12CC": Object {
+      "Properties": Object {
+        "Content": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "c409e6c5845f1f349df8cd84e160bf6f1c35d2b060b63e1f032f9bd39d4542cc.zip",
+        },
+        "Description": "/opt/awscli/aws",
+      },
+      "Type": "AWS::Lambda::LayerVersion",
+    },
+    "DefaultsWebsiteDeploymentCustomResource326CD6C1": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "DestinationBucketName": Object {
+          "Ref": "DefaultsWebsiteBucket3263D025",
+        },
+        "DistributionId": Object {
+          "Ref": "DefaultsCloudfrontDistributionF4EA1054",
+        },
+        "Prune": true,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
+            "Arn",
+          ],
+        },
+        "SourceBucketNames": Array [
+          Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+        ],
+        "SourceObjectKeys": Array [
+          "a79f62b4071246acc1e8e834ba67dc3bbf15a3662e39d31667fa59315ef86f56.zip",
+        ],
+      },
+      "Type": "Custom::CDKBucketDeployment",
+      "UpdateReplacePolicy": "Delete",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`Static Website Unit Tests Defaults with suppression rule - using AwsPrototyping NagPack 1`] = `
+Object {
+  "Metadata": Object {
+    "cdk_nag": Object {
+      "rules_to_suppress": Array [
+        Object {
+          "id": "AwsSolutions-L1",
+          "reason": "Latest runtime cannot be configured. CDK will need to upgrade the BucketDeployment construct accordingly.",
+        },
+        Object {
+          "id": "AwsPrototyping-LambdaLatestVersion",
+          "reason": "Latest runtime cannot be configured. CDK will need to upgrade the BucketDeployment construct accordingly.",
+        },
+        Object {
+          "applies_to": Array [
+            Object {
+              "regex": "/^Action::s3:.*$/g",
+            },
+            Object {
+              "regex": "/^Resource::.*$/g",
+            },
+          ],
+          "id": "AwsSolutions-IAM5",
+          "reason": "All Policies have been scoped to a Bucket. Given Buckets can contain arbitrary content, wildcard resources with bucket scope are required.",
+        },
+        Object {
+          "applies_to": Array [
+            Object {
+              "regex": "/^Action::s3:.*$/g",
+            },
+            Object {
+              "regex": "/^Resource::.*$/g",
+            },
+          ],
+          "id": "AwsPrototyping-IAMNoWildcardPermissions",
+          "reason": "All Policies have been scoped to a Bucket. Given Buckets can contain arbitrary content, wildcard resources with bucket scope are required.",
+        },
+        Object {
+          "applies_to": Array [
+            Object {
+              "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole$/g",
+            },
+          ],
+          "id": "AwsSolutions-IAM4",
+          "reason": "Buckets can contain arbitrary content, therefore wildcard resources under a bucket are required.",
+        },
+        Object {
+          "applies_to": Array [
+            Object {
+              "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole$/g",
+            },
+          ],
+          "id": "AwsPrototyping-IAMNoManagedPolicies",
+          "reason": "Buckets can contain arbitrary content, therefore wildcard resources under a bucket are required.",
+        },
+      ],
+    },
+  },
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536": Object {
+      "DependsOn": Array [
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+      ],
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionGeoRestrictions",
+              "reason": "This is a supression reason",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "6ddcf10002539818a9256eff3fb2b22aa09298d8f946e26ba121c175a600c44e.zip",
+        },
+        "Handler": "index.handler",
+        "Layers": Array [
+          Object {
+            "Ref": "DefaultsWebsiteDeploymentAwsCliLayerD5AA12CC",
+          },
+        ],
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+            "Arn",
+          ],
+        },
+        "Runtime": "python3.9",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionGeoRestrictions",
+              "reason": "This is a supression reason",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionGeoRestrictions",
+              "reason": "This is a supression reason",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      Object {
+                        "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsWebsiteBucket3263D025",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DefaultsWebsiteBucket3263D025",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "cloudfront:GetInvalidation",
+                "cloudfront:CreateInvalidation",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
+        "Roles": Array [
+          Object {
+            "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F": Object {
+      "DependsOn": Array [
+        "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+      ],
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionGeoRestrictions",
+              "reason": "This is a supression reason",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "3f51abb709b8e65167a45aeed02bab11540603d909005d7148230ba5ce6c74d7.zip",
+        },
+        "Description": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "Lambda function for auto-deleting objects in ",
+              Object {
+                "Ref": "DefaultsWebsiteBucket3263D025",
+              },
+              " S3 bucket.",
+            ],
+          ],
+        },
+        "Handler": "__entrypoint__.handler",
+        "MemorySize": 128,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionGeoRestrictions",
+              "reason": "This is a supression reason",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsCloudfrontDistributionF4EA1054": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-CFR4",
+              "reason": "Certificate is not mandatory therefore the Cloudfront certificate will be used.",
+            },
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionHttpsViewerNoOutdatedSSL",
+              "reason": "Certificate is not mandatory therefore the Cloudfront certificate will be used.",
+            },
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionGeoRestrictions",
+              "reason": "This is a supression reason",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "DistributionConfig": Object {
+          "CustomErrorResponses": Array [
+            Object {
+              "ErrorCode": 404,
+              "ResponseCode": 200,
+              "ResponsePagePath": "/index.html",
+            },
+          ],
+          "DefaultCacheBehavior": Object {
+            "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+            "Compress": true,
+            "TargetOriginId": "DefaultsCloudfrontDistributionOrigin1BA23CD94",
+            "ViewerProtocolPolicy": "redirect-to-https",
+          },
+          "DefaultRootObject": "index.html",
+          "Enabled": true,
+          "HttpVersion": "http2",
+          "IPV6Enabled": true,
+          "Logging": Object {
+            "Bucket": Object {
+              "Fn::GetAtt": Array [
+                "DefaultsDistributionLogBucket7EA741E2",
+                "RegionalDomainName",
+              ],
+            },
+          },
+          "Origins": Array [
+            Object {
+              "DomainName": Object {
+                "Fn::GetAtt": Array [
+                  "DefaultsWebsiteBucket3263D025",
+                  "RegionalDomainName",
+                ],
+              },
+              "Id": "DefaultsCloudfrontDistributionOrigin1BA23CD94",
+              "S3OriginConfig": Object {
+                "OriginAccessIdentity": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "origin-access-identity/cloudfront/",
+                      Object {
+                        "Ref": "DefaultsOriginAccessIdentity7F5D47DF",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "WebACLId": Object {
+            "Fn::GetAtt": Array [
+              "DefaultsWebsiteAclCFWebAclCustomResourceB050DB2C",
+              "WebAclArn",
+            ],
+          },
+        },
+      },
+      "Type": "AWS::CloudFront::Distribution",
+    },
+    "DefaultsDistributionLogBucket7EA741E2": Object {
+      "DeletionPolicy": "Delete",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionGeoRestrictions",
+              "reason": "This is a supression reason",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "BucketEncryption": Object {
+          "ServerSideEncryptionConfiguration": Array [
+            Object {
+              "ServerSideEncryptionByDefault": Object {
+                "SSEAlgorithm": "AES256",
+              },
+            },
+          ],
+        },
+        "LoggingConfiguration": Object {
+          "LogFilePrefix": "access-logs",
+        },
+        "PublicAccessBlockConfiguration": Object {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DefaultsDistributionLogBucketAutoDeleteObjectsCustomResource7370C612": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "DefaultsDistributionLogBucketPolicyC6D11E8F",
+      ],
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionGeoRestrictions",
+              "reason": "This is a supression reason",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "BucketName": Object {
+          "Ref": "DefaultsDistributionLogBucket7EA741E2",
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DefaultsDistributionLogBucketPolicyC6D11E8F": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionGeoRestrictions",
+              "reason": "This is a supression reason",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "DefaultsDistributionLogBucket7EA741E2",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsDistributionLogBucket7EA741E2",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DefaultsDistributionLogBucket7EA741E2",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsDistributionLogBucket7EA741E2",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DefaultsDistributionLogBucket7EA741E2",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "DefaultsOriginAccessIdentity7F5D47DF": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionGeoRestrictions",
+              "reason": "This is a supression reason",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "CloudFrontOriginAccessIdentityConfig": Object {
+          "Comment": "Allows CloudFront to reach the bucket",
+        },
+      },
+      "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
+    },
+    "DefaultsWebsiteAclCFWebAclCustomResourceB050DB2C": Object {
+      "DeletionPolicy": "Delete",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionGeoRestrictions",
+              "reason": "This is a supression reason",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "ID": "Default-WebsiteAcl",
+        "MANAGED_RULES": Array [
+          Object {
+            "name": "AWSManagedRulesCommonRuleSet",
+            "vendor": "AWS",
+          },
+        ],
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "DefaultsWebsiteAclCloudfrontWebAclProviderframeworkonEvent595963CB",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DefaultsWebsiteAclCloudfrontWebAclOnEventHandlerEC085AE0": Object {
+      "DependsOn": Array [
+        "DefaultsWebsiteAclOnEventHandlerRole83BC6E99",
+      ],
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionGeoRestrictions",
+              "reason": "This is a supression reason",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "f9a4e3a2d1dd90ac1bfaec793acad708d019b35402700253f45a40ada6d2786a.zip",
+        },
+        "FunctionName": "Default-OnEventHandler",
+        "Handler": "index.onEvent",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DefaultsWebsiteAclOnEventHandlerRole83BC6E99",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs16.x",
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DefaultsWebsiteAclCloudfrontWebAclProviderRoleD884ECCA": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionGeoRestrictions",
+              "reason": "This is a supression reason",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Policies": Array [
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Array [
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "arn:aws:logs:",
+                          Object {
+                            "Ref": "AWS::Region",
+                          },
+                          ":",
+                          Object {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":log-group:/aws/lambda/",
+                          Object {
+                            "Ref": "DefaultsWebsiteAclCloudfrontWebAclOnEventHandlerEC085AE0",
+                          },
+                          "-Provider",
+                        ],
+                      ],
+                    },
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "arn:aws:logs:",
+                          Object {
+                            "Ref": "AWS::Region",
+                          },
+                          ":",
+                          Object {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":log-group:/aws/lambda/",
+                          Object {
+                            "Ref": "DefaultsWebsiteAclCloudfrontWebAclOnEventHandlerEC085AE0",
+                          },
+                          "-Provider:*",
+                        ],
+                      ],
+                    },
+                  ],
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "logs",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsWebsiteAclCloudfrontWebAclProviderRoleDefaultPolicy0BEB9831": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionGeoRestrictions",
+              "reason": "This is a supression reason",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsWebsiteAclCloudfrontWebAclOnEventHandlerEC085AE0",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DefaultsWebsiteAclCloudfrontWebAclOnEventHandlerEC085AE0",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DefaultsWebsiteAclCloudfrontWebAclProviderRoleDefaultPolicy0BEB9831",
+        "Roles": Array [
+          Object {
+            "Ref": "DefaultsWebsiteAclCloudfrontWebAclProviderRoleD884ECCA",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DefaultsWebsiteAclCloudfrontWebAclProviderframeworkonEvent595963CB": Object {
+      "DependsOn": Array [
+        "DefaultsWebsiteAclCloudfrontWebAclProviderRoleDefaultPolicy0BEB9831",
+        "DefaultsWebsiteAclCloudfrontWebAclProviderRoleD884ECCA",
+      ],
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-L1",
+              "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
+            },
+            Object {
+              "id": "AwsPrototyping-LambdaLatestVersion",
+              "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
+            },
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionGeoRestrictions",
+              "reason": "This is a supression reason",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "6ff23d2800aac27308e31c227529dc13854507c3b2598d2433fcf82604fa054d.zip",
+        },
+        "Description": "AWS CDK resource provider framework - onEvent (Default/Defaults/WebsiteAcl/CloudfrontWebAclProvider)",
+        "Environment": Object {
+          "Variables": Object {
+            "USER_ON_EVENT_FUNCTION_ARN": Object {
+              "Fn::GetAtt": Array [
+                "DefaultsWebsiteAclCloudfrontWebAclOnEventHandlerEC085AE0",
+                "Arn",
+              ],
+            },
+          },
+        },
+        "FunctionName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              Object {
+                "Ref": "DefaultsWebsiteAclCloudfrontWebAclOnEventHandlerEC085AE0",
+              },
+              "-Provider",
+            ],
+          ],
+        },
+        "Handler": "framework.onEvent",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "DefaultsWebsiteAclCloudfrontWebAclProviderRoleD884ECCA",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DefaultsWebsiteAclOnEventHandlerRole83BC6E99": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:aws:wafv2:us-east-1:<AWS::AccountId>:global/(.*)$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "WafV2 resources have been scoped down to the ACL/IPSet level, however * is still needed as resource id's are created just in time.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-OnEventHandler:*/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:aws:wafv2:us-east-1:<AWS::AccountId>:global/(.*)$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "WafV2 resources have been scoped down to the ACL/IPSet level, however * is still needed as resource id's are created just in time.",
+            },
+            Object {
+              "applies_to": Array [
+                Object {
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-OnEventHandler:*/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionGeoRestrictions",
+              "reason": "This is a supression reason",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Policies": Array [
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Array [
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "arn:aws:logs:",
+                          Object {
+                            "Ref": "AWS::Region",
+                          },
+                          ":",
+                          Object {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":log-group:/aws/lambda/Default-OnEventHandler",
+                        ],
+                      ],
+                    },
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "arn:aws:logs:",
+                          Object {
+                            "Ref": "AWS::Region",
+                          },
+                          ":",
+                          Object {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":log-group:/aws/lambda/Default-OnEventHandler:*",
+                        ],
+                      ],
+                    },
+                  ],
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "logs",
+          },
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": Array [
+                    "wafv2:CreateWebACL",
+                    "wafv2:DeleteWebACL",
+                    "wafv2:UpdateWebACL",
+                    "wafv2:GetWebACL",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Array [
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "arn:aws:wafv2:us-east-1:",
+                          Object {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":global/ipset/Default-WebsiteAcl-IPSet/*",
+                        ],
+                      ],
+                    },
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "arn:aws:wafv2:us-east-1:",
+                          Object {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":global/webacl/Default-WebsiteAcl/*",
+                        ],
+                      ],
+                    },
+                    Object {
+                      "Fn::Join": Array [
+                        "",
+                        Array [
+                          "arn:aws:wafv2:us-east-1:",
+                          Object {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":global/managedruleset/*/*",
+                        ],
+                      ],
+                    },
+                  ],
+                },
+                Object {
+                  "Action": Array [
+                    "wafv2:CreateIPSet",
+                    "wafv2:DeleteIPSet",
+                    "wafv2:UpdateIPSet",
+                    "wafv2:GetIPSet",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": Object {
+                    "Fn::Join": Array [
+                      "",
+                      Array [
+                        "arn:aws:wafv2:us-east-1:",
+                        Object {
+                          "Ref": "AWS::AccountId",
+                        },
+                        ":global/ipset/Default-WebsiteAcl-IPSet/*",
+                      ],
+                    ],
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "wafv2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsWebsiteBucket3263D025": Object {
+      "DeletionPolicy": "Delete",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionGeoRestrictions",
+              "reason": "This is a supression reason",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "BucketEncryption": Object {
+          "ServerSideEncryptionConfiguration": Array [
+            Object {
+              "ServerSideEncryptionByDefault": Object {
+                "SSEAlgorithm": "AES256",
+              },
+            },
+          ],
+        },
+        "LoggingConfiguration": Object {
+          "LogFilePrefix": "access-logs",
+        },
+        "PublicAccessBlockConfiguration": Object {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true",
+          },
+          Object {
+            "Key": "aws-cdk:cr-owned:fb67e0d5",
+            "Value": "true",
+          },
+        ],
+        "VersioningConfiguration": Object {
+          "Status": "Enabled",
+        },
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DefaultsWebsiteBucketAutoDeleteObjectsCustomResourceD840F8F2": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "DefaultsWebsiteBucketPolicy594E6643",
+      ],
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionGeoRestrictions",
+              "reason": "This is a supression reason",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "BucketName": Object {
+          "Ref": "DefaultsWebsiteBucket3263D025",
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "DefaultsWebsiteBucketPolicy594E6643": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionGeoRestrictions",
+              "reason": "This is a supression reason",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "DefaultsWebsiteBucket3263D025",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsWebsiteBucket3263D025",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DefaultsWebsiteBucket3263D025",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsWebsiteBucket3263D025",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DefaultsWebsiteBucket3263D025",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:ListBucket",
+              "Effect": "Allow",
+              "Principal": Object {
+                "CanonicalUser": Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsOriginAccessIdentity7F5D47DF",
+                    "S3CanonicalUserId",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "DefaultsWebsiteBucket3263D025",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Principal": Object {
+                "CanonicalUser": Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsOriginAccessIdentity7F5D47DF",
+                    "S3CanonicalUserId",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "DefaultsWebsiteBucket3263D025",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "DefaultsWebsiteDeploymentAwsCliLayerD5AA12CC": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionGeoRestrictions",
+              "reason": "This is a supression reason",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Content": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "c409e6c5845f1f349df8cd84e160bf6f1c35d2b060b63e1f032f9bd39d4542cc.zip",
+        },
+        "Description": "/opt/awscli/aws",
+      },
+      "Type": "AWS::Lambda::LayerVersion",
+    },
+    "DefaultsWebsiteDeploymentCustomResource326CD6C1": Object {
+      "DeletionPolicy": "Delete",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsPrototyping-CloudFrontDistributionGeoRestrictions",
+              "reason": "This is a supression reason",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "DestinationBucketName": Object {
           "Ref": "DefaultsWebsiteBucket3263D025",

--- a/packages/static-website/test/static-website.test.ts
+++ b/packages/static-website/test/static-website.test.ts
@@ -1,10 +1,13 @@
 /*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0 */
 import path from "path";
-import { PDKNag } from "@aws-prototyping-sdk/pdk-nag";
+//import { SynthUtils } from "@aws-cdk/assert";
+import { PDKNag, AwsPrototypingChecks } from "@aws-prototyping-sdk/pdk-nag";
 import { NestedStack, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { StaticWebsite } from "../src";
+import { GeoRestriction } from "aws-cdk-lib/aws-cloudfront";
+import { NagSuppressions } from "cdk-nag";
+import { StaticWebsite, StaticWebsiteOrigin } from "../src";
 
 describe("Static Website Unit Tests", () => {
   it("Defaults", () => {
@@ -13,6 +16,84 @@ describe("Static Website Unit Tests", () => {
       websiteContentPath: path.join(__dirname, "./sample-website"),
     });
 
+    expect(Template.fromStack(stack)).toMatchSnapshot();
+  });
+
+  it("Defaults - using AwsPrototyping NagPack", () => {
+    const app = PDKNag.app({ nagPacks: [new AwsPrototypingChecks()] });
+    const stack = new Stack(app);
+
+    new StaticWebsite(stack, "Defaults", {
+      websiteContentPath: path.join(__dirname, "./sample-website"),
+    });
+
+    app.synth();
+
+    const message = app
+      .nagResults()
+      .flatMap((r) => r.messages.map((m) => m.messageDescription))
+      .find((desc) =>
+        desc.startsWith("AwsPrototyping-CloudFrontDistributionGeoRestrictions:")
+      );
+
+    expect(message).toBeTruthy();
+    expect(Template.fromStack(stack)).toMatchSnapshot();
+  });
+
+  it("Defaults with suppression rule - using AwsPrototyping NagPack", () => {
+    const app = PDKNag.app({ nagPacks: [new AwsPrototypingChecks()] });
+    const stack = new Stack(app);
+
+    new StaticWebsite(stack, "Defaults", {
+      websiteContentPath: path.join(__dirname, "./sample-website"),
+    });
+
+    NagSuppressions.addResourceSuppressions(
+      stack,
+      [
+        {
+          id: "AwsPrototyping-CloudFrontDistributionGeoRestrictions",
+          reason: "This is a supression reason",
+        },
+      ],
+      true
+    );
+
+    app.synth();
+
+    const message = app
+      .nagResults()
+      .flatMap((r) => r.messages.map((m) => m.messageDescription))
+      .find((desc) =>
+        desc.startsWith("AwsPrototyping-CloudFrontDistributionGeoRestrictions:")
+      );
+
+    expect(message).not.toBeTruthy();
+    expect(Template.fromStack(stack)).toMatchSnapshot();
+  });
+
+  it("Defaults and Geoblocking - using AwsPrototyping NagPack", () => {
+    const app = PDKNag.app({ nagPacks: [new AwsPrototypingChecks()] });
+    const stack = new Stack(app);
+
+    new StaticWebsite(stack, "Defaults", {
+      websiteContentPath: path.join(__dirname, "./sample-website"),
+      distributionProps: {
+        defaultBehavior: { origin: StaticWebsiteOrigin },
+        geoRestriction: GeoRestriction.allowlist("AU", "SG"),
+      },
+    });
+
+    app.synth();
+
+    const message = app
+      .nagResults()
+      .flatMap((r) => r.messages.map((m) => m.messageDescription))
+      .find((desc) =>
+        desc.startsWith("AwsPrototyping-CloudFrontDistributionGeoRestrictions:")
+      );
+
+    expect(message).not.toBeTruthy();
     expect(Template.fromStack(stack)).toMatchSnapshot();
   });
 


### PR DESCRIPTION
Added `AwsPrototyping` equivalent suppressions (and test cases) for PDK constructs:
- `open-api-gateway`
- `pipeline`
- `static-website`