### PR TITLE
feat(open-api-gateway): java support for router for using single lambda function for all operations

### DIFF
--- a/packages/open-api-gateway/README.md
+++ b/packages/open-api-gateway/README.md
@@ -834,6 +834,35 @@ public class SayHelloHandler extends SayHello {
 }
 ```
 
+##### Handler Router
+
+The lambda handler wrappers can be used in isolation as handler methods for separate lambdas. If you would like to use a single lambda function to serve all requests, you can do so by extending the `HandlerRouter` class.
+
+```java
+import com.generated.api.myapijava.client.api.Handlers.SayGoodbye;
+import com.generated.api.myapijava.client.api.Handlers.HandlerRouter;
+import com.generated.api.myapijava.client.api.Handlers.Interceptors;
+import com.generated.api.myapijava.client.api.Handlers.SayHello;
+
+import java.util.Arrays;
+import java.util.List;
+
+// Interceptors defined here apply to all operations
+@Interceptors({ TimingInterceptor.class })
+public class ApiHandlerRouter extends HandlerRouter {
+    // You must implement a method to return a handler for every operation
+    @Override
+    public SayHello sayHello() {
+        return new SayHelloHandler();
+    }
+
+    @Override
+    public SayGoodbye sayGoodbye() {
+        return new SayGoodbyeHandler();
+    }
+}
+```
+
 ### Interceptors
 
 The lambda handler wrappers allow you to pass in a _chain_ of handler functions to handle the request. This allows you to implement middleware / interceptors for handling requests. Each handler function may choose whether or not to continue the handler chain by invoking `chain.next`.

--- a/packages/open-api-gateway/scripts/generators/java/config.yaml
+++ b/packages/open-api-gateway/scripts/generators/java/config.yaml
@@ -2,6 +2,9 @@ files:
   operationConfig.mustache:
     destinationFilename: /OperationConfig.java
     templateType: API
+  operations.mustache:
+    destinationFilename: /Operations.java
+    templateType: API
   operationLookup.mustache:
     destinationFilename: /OperationLookup.java
     templateType: API

--- a/packages/open-api-gateway/scripts/generators/java/templates/handlers.mustache
+++ b/packages/open-api-gateway/scripts/generators/java/templates/handlers.mustache
@@ -69,6 +69,25 @@ public class Handlers {
         }
     }
 
+    private static String concatMethodAndPath(final String method, final String path) {
+        return String.format("%s||%s", method.toLowerCase(), path);
+    }
+
+    private static <T, I> List<Interceptor<I>> getAnnotationInterceptors(Class<T> clazz) {
+        // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
+        return clazz.isAnnotationPresent(Interceptors.class)
+                ? Arrays.stream(clazz.getAnnotation(Interceptors.class).value()).map(c -> {
+            try {
+                return (Interceptor<I>) c.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(String.format(
+                        "Cannot create instance of interceptor %s. Please ensure it has a public constructor " +
+                                "with no arguments, or override the getInterceptors method instead of using the annotation", c.getSimpleName()), e);
+            }
+        }).collect(Collectors.toList())
+                : new ArrayList<>();
+    }
+
     /**
      * Represents an HTTP response from an api operation
      */
@@ -435,21 +454,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<{{operationIdCamelCase}}Input>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<{{operationIdCamelCase}}Input>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<{{operationIdCamelCase}}Input>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    "Cannot create instance of interceptor %s. Please ensure it has a public constructor " +
-                                            "with no arguments, or override the getInterceptors method instead of using the annotation", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<{{operationIdCamelCase}}Input>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<{{operationIdCamelCase}}Input>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<{{operationIdCamelCase}}Input>() {
@@ -497,4 +513,85 @@ public class Handlers {
 
 {{/operation}}
 {{/operations}}
+    public static abstract class HandlerRouter implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        {{#operations}}
+        {{#operation}}
+        private static final String {{nickname}}MethodAndPath = concatMethodAndPath("{{httpMethod}}", "{{path}}");
+        {{/operation}}
+        {{/operations}}
+
+        {{#operations}}
+        {{#operation}}
+        private final {{operationIdCamelCase}} constructed{{operationIdCamelCase}};
+        {{/operation}}
+        {{/operations}}
+
+        {{#operations}}
+        {{#operation}}
+        /**
+         * This method must return your implementation of the {{operationIdCamelCase}} operation
+         */
+        public abstract {{operationIdCamelCase}} {{nickname}}();
+        {{/operation}}
+        {{/operations}}
+
+        private static enum Route {
+            {{#operations}}
+            {{#operation}}
+            {{nickname}}Route,
+            {{/operation}}
+            {{/operations}}
+        }
+
+        /**
+         * Map of method and path to the route to map to
+         */
+        private final Map<String, Route> routes = new HashMap<>();
+
+        public HandlerRouter() {
+            {{#operations}}
+            {{#operation}}
+            this.routes.put({{nickname}}MethodAndPath, Route.{{nickname}}Route);
+            {{/operation}}
+            {{/operations}}
+            // Handlers are all constructed in the router's constructor such that lambda behaviour remains consistent;
+            // ie resources created in the constructor remain in memory between invocations.
+            // https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
+            {{#operations}}
+            {{#operation}}
+            this.constructed{{operationIdCamelCase}} = this.{{nickname}}();
+            {{/operation}}
+            {{/operations}}
+        }
+
+        /**
+         * For more complex interceptors that require instantiation with parameters, you may override this method to
+         * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+         * prefer the @Interceptors annotation.
+         */
+        public <T> List<Interceptor<T>> getInterceptors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            String method = event.getRequestContext().getHttpMethod();
+            String path = event.getRequestContext().getResourcePath();
+            String methodAndPath = concatMethodAndPath(method, path);
+            Route route = this.routes.get(methodAndPath);
+
+            switch (route) {
+                {{#operations}}
+                {{#operation}}
+                case {{nickname}}Route:
+                    List<Interceptor<{{operationIdCamelCase}}Input>> {{nickname}}Interceptors = getAnnotationInterceptors(this.getClass());
+                    {{nickname}}Interceptors.addAll(this.getInterceptors());
+                    return this.constructed{{operationIdCamelCase}}.handleRequestWithAdditionalInterceptors(event, context, {{nickname}}Interceptors);
+                {{/operation}}
+                {{/operations}}
+                default:
+                    throw new RuntimeException(String.format("No registered handler for method {} and path {}", method, path));
+            }
+        }
+    }
 }

--- a/packages/open-api-gateway/scripts/generators/java/templates/operations.mustache
+++ b/packages/open-api-gateway/scripts/generators/java/templates/operations.mustache
@@ -1,0 +1,19 @@
+package {{package}};
+
+{{>generatedAnnotation}}
+public class Operations {
+    /**
+     * Returns an OperationConfig Builder with all values populated with the given value.
+     * You can override specific values on the builder if you like.
+     * Make sure you call `.build()` at the end to construct the OperationConfig.
+     */
+    public static <T> OperationConfig.OperationConfigBuilder<T> all(final T value) {
+        return OperationConfig.<T>builder()
+                {{#operations}}
+                {{#operation}}
+                .{{nickname}}(value)
+                {{/operation}}
+                {{/operations}}
+                ;
+    }
+}

--- a/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-java-client-source-code.test.ts.snap
+++ b/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-java-client-source-code.test.ts.snap
@@ -157,6 +157,7 @@ src/main/java/test/test/client/api/DefaultApi.java
 src/main/java/test/test/client/api/DefaultApi/Handlers.java
 src/main/java/test/test/client/api/DefaultApi/OperationConfig.java
 src/main/java/test/test/client/api/DefaultApi/OperationLookup.java
+src/main/java/test/test/client/api/DefaultApi/Operations.java
 src/main/java/test/test/client/auth/ApiKeyAuth.java
 src/main/java/test/test/client/auth/Authentication.java
 src/main/java/test/test/client/auth/HttpBasicAuth.java
@@ -5304,6 +5305,25 @@ public class Handlers {
         }
     }
 
+    private static String concatMethodAndPath(final String method, final String path) {
+        return String.format(\\"%s||%s\\", method.toLowerCase(), path);
+    }
+
+    private static <T, I> List<Interceptor<I>> getAnnotationInterceptors(Class<T> clazz) {
+        // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
+        return clazz.isAnnotationPresent(Interceptors.class)
+                ? Arrays.stream(clazz.getAnnotation(Interceptors.class).value()).map(c -> {
+            try {
+                return (Interceptor<I>) c.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(String.format(
+                        \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
+                                \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", c.getSimpleName()), e);
+            }
+        }).collect(Collectors.toList())
+                : new ArrayList<>();
+    }
+
     /**
      * Represents an HTTP response from an api operation
      */
@@ -5656,21 +5676,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<SomeTestOperationInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<SomeTestOperationInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<SomeTestOperationInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<SomeTestOperationInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<SomeTestOperationInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<SomeTestOperationInput>() {
@@ -5716,6 +5733,59 @@ public class Handlers {
         }
     }
 
+    public static abstract class HandlerRouter implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        private static final String someTestOperationMethodAndPath = concatMethodAndPath(\\"POST\\", \\"/operation/{pathParam}\\");
+
+        private final SomeTestOperation constructedSomeTestOperation;
+
+        /**
+         * This method must return your implementation of the SomeTestOperation operation
+         */
+        public abstract SomeTestOperation someTestOperation();
+
+        private static enum Route {
+            someTestOperationRoute,
+        }
+
+        /**
+         * Map of method and path to the route to map to
+         */
+        private final Map<String, Route> routes = new HashMap<>();
+
+        public HandlerRouter() {
+            this.routes.put(someTestOperationMethodAndPath, Route.someTestOperationRoute);
+            // Handlers are all constructed in the router's constructor such that lambda behaviour remains consistent;
+            // ie resources created in the constructor remain in memory between invocations.
+            // https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
+            this.constructedSomeTestOperation = this.someTestOperation();
+        }
+
+        /**
+         * For more complex interceptors that require instantiation with parameters, you may override this method to
+         * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+         * prefer the @Interceptors annotation.
+         */
+        public <T> List<Interceptor<T>> getInterceptors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            String method = event.getRequestContext().getHttpMethod();
+            String path = event.getRequestContext().getResourcePath();
+            String methodAndPath = concatMethodAndPath(method, path);
+            Route route = this.routes.get(methodAndPath);
+
+            switch (route) {
+                case someTestOperationRoute:
+                    List<Interceptor<SomeTestOperationInput>> someTestOperationInterceptors = getAnnotationInterceptors(this.getClass());
+                    someTestOperationInterceptors.addAll(this.getInterceptors());
+                    return this.constructedSomeTestOperation.handleRequestWithAdditionalInterceptors(event, context, someTestOperationInterceptors);
+                default:
+                    throw new RuntimeException(String.format(\\"No registered handler for method {} and path {}\\", method, path));
+            }
+        }
+    }
 }",
   "src/main/java/test/test/client/api/DefaultApi/OperationConfig.java": "package test.test.client.api;
 
@@ -5765,6 +5835,22 @@ public class OperationLookup {
         config.put(\\"someTestOperation\\", new HashMap<String, String>() { { put(\\"path\\", \\"/operation/{pathParam}\\"); put(\\"method\\", \\"POST\\"); } });
 
         return config;
+    }
+}
+",
+  "src/main/java/test/test/client/api/DefaultApi/Operations.java": "package test.test.client.api;
+
+@javax.annotation.Generated(value = \\"org.openapitools.codegen.languages.JavaClientCodegen\\")
+public class Operations {
+    /**
+     * Returns an OperationConfig Builder with all values populated with the given value.
+     * You can override specific values on the builder if you like.
+     * Make sure you call \`.build()\` at the end to construct the OperationConfig.
+     */
+    public static <T> OperationConfig.OperationConfigBuilder<T> all(final T value) {
+        return OperationConfig.<T>builder()
+                .someTestOperation(value)
+                ;
     }
 }
 ",
@@ -7507,6 +7593,7 @@ src/main/java/test/test/client/api/DefaultApi.java
 src/main/java/test/test/client/api/DefaultApi/Handlers.java
 src/main/java/test/test/client/api/DefaultApi/OperationConfig.java
 src/main/java/test/test/client/api/DefaultApi/OperationLookup.java
+src/main/java/test/test/client/api/DefaultApi/Operations.java
 src/main/java/test/test/client/auth/ApiKeyAuth.java
 src/main/java/test/test/client/auth/Authentication.java
 src/main/java/test/test/client/auth/HttpBasicAuth.java
@@ -13646,6 +13733,25 @@ public class Handlers {
         }
     }
 
+    private static String concatMethodAndPath(final String method, final String path) {
+        return String.format(\\"%s||%s\\", method.toLowerCase(), path);
+    }
+
+    private static <T, I> List<Interceptor<I>> getAnnotationInterceptors(Class<T> clazz) {
+        // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
+        return clazz.isAnnotationPresent(Interceptors.class)
+                ? Arrays.stream(clazz.getAnnotation(Interceptors.class).value()).map(c -> {
+            try {
+                return (Interceptor<I>) c.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(String.format(
+                        \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
+                                \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", c.getSimpleName()), e);
+            }
+        }).collect(Collectors.toList())
+                : new ArrayList<>();
+    }
+
     /**
      * Represents an HTTP response from an api operation
      */
@@ -13947,21 +14053,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<AnyRequestResponseInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<AnyRequestResponseInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<AnyRequestResponseInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<AnyRequestResponseInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<AnyRequestResponseInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<AnyRequestResponseInput>() {
@@ -14170,21 +14273,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<EmptyInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<EmptyInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<EmptyInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<EmptyInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<EmptyInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<EmptyInput>() {
@@ -14398,21 +14498,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<MediaTypesInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<MediaTypesInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<MediaTypesInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<MediaTypesInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<MediaTypesInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<MediaTypesInput>() {
@@ -14697,21 +14794,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<OperationOneInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<OperationOneInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<OperationOneInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<OperationOneInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<OperationOneInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<OperationOneInput>() {
@@ -14920,21 +15014,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<WithoutOperationIdDeleteInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<WithoutOperationIdDeleteInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<WithoutOperationIdDeleteInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<WithoutOperationIdDeleteInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<WithoutOperationIdDeleteInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<WithoutOperationIdDeleteInput>() {
@@ -14980,6 +15071,111 @@ public class Handlers {
         }
     }
 
+    public static abstract class HandlerRouter implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        private static final String anyRequestResponseMethodAndPath = concatMethodAndPath(\\"PUT\\", \\"/any-request-response\\");
+        private static final String emptyMethodAndPath = concatMethodAndPath(\\"PUT\\", \\"/empty-response\\");
+        private static final String mediaTypesMethodAndPath = concatMethodAndPath(\\"POST\\", \\"/different-media-type\\");
+        private static final String operationOneMethodAndPath = concatMethodAndPath(\\"POST\\", \\"/path/{pathParam}\\");
+        private static final String withoutOperationIdDeleteMethodAndPath = concatMethodAndPath(\\"DELETE\\", \\"/without-operation-id\\");
+
+        private final AnyRequestResponse constructedAnyRequestResponse;
+        private final Empty constructedEmpty;
+        private final MediaTypes constructedMediaTypes;
+        private final OperationOne constructedOperationOne;
+        private final WithoutOperationIdDelete constructedWithoutOperationIdDelete;
+
+        /**
+         * This method must return your implementation of the AnyRequestResponse operation
+         */
+        public abstract AnyRequestResponse anyRequestResponse();
+        /**
+         * This method must return your implementation of the Empty operation
+         */
+        public abstract Empty empty();
+        /**
+         * This method must return your implementation of the MediaTypes operation
+         */
+        public abstract MediaTypes mediaTypes();
+        /**
+         * This method must return your implementation of the OperationOne operation
+         */
+        public abstract OperationOne operationOne();
+        /**
+         * This method must return your implementation of the WithoutOperationIdDelete operation
+         */
+        public abstract WithoutOperationIdDelete withoutOperationIdDelete();
+
+        private static enum Route {
+            anyRequestResponseRoute,
+            emptyRoute,
+            mediaTypesRoute,
+            operationOneRoute,
+            withoutOperationIdDeleteRoute,
+        }
+
+        /**
+         * Map of method and path to the route to map to
+         */
+        private final Map<String, Route> routes = new HashMap<>();
+
+        public HandlerRouter() {
+            this.routes.put(anyRequestResponseMethodAndPath, Route.anyRequestResponseRoute);
+            this.routes.put(emptyMethodAndPath, Route.emptyRoute);
+            this.routes.put(mediaTypesMethodAndPath, Route.mediaTypesRoute);
+            this.routes.put(operationOneMethodAndPath, Route.operationOneRoute);
+            this.routes.put(withoutOperationIdDeleteMethodAndPath, Route.withoutOperationIdDeleteRoute);
+            // Handlers are all constructed in the router's constructor such that lambda behaviour remains consistent;
+            // ie resources created in the constructor remain in memory between invocations.
+            // https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
+            this.constructedAnyRequestResponse = this.anyRequestResponse();
+            this.constructedEmpty = this.empty();
+            this.constructedMediaTypes = this.mediaTypes();
+            this.constructedOperationOne = this.operationOne();
+            this.constructedWithoutOperationIdDelete = this.withoutOperationIdDelete();
+        }
+
+        /**
+         * For more complex interceptors that require instantiation with parameters, you may override this method to
+         * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+         * prefer the @Interceptors annotation.
+         */
+        public <T> List<Interceptor<T>> getInterceptors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            String method = event.getRequestContext().getHttpMethod();
+            String path = event.getRequestContext().getResourcePath();
+            String methodAndPath = concatMethodAndPath(method, path);
+            Route route = this.routes.get(methodAndPath);
+
+            switch (route) {
+                case anyRequestResponseRoute:
+                    List<Interceptor<AnyRequestResponseInput>> anyRequestResponseInterceptors = getAnnotationInterceptors(this.getClass());
+                    anyRequestResponseInterceptors.addAll(this.getInterceptors());
+                    return this.constructedAnyRequestResponse.handleRequestWithAdditionalInterceptors(event, context, anyRequestResponseInterceptors);
+                case emptyRoute:
+                    List<Interceptor<EmptyInput>> emptyInterceptors = getAnnotationInterceptors(this.getClass());
+                    emptyInterceptors.addAll(this.getInterceptors());
+                    return this.constructedEmpty.handleRequestWithAdditionalInterceptors(event, context, emptyInterceptors);
+                case mediaTypesRoute:
+                    List<Interceptor<MediaTypesInput>> mediaTypesInterceptors = getAnnotationInterceptors(this.getClass());
+                    mediaTypesInterceptors.addAll(this.getInterceptors());
+                    return this.constructedMediaTypes.handleRequestWithAdditionalInterceptors(event, context, mediaTypesInterceptors);
+                case operationOneRoute:
+                    List<Interceptor<OperationOneInput>> operationOneInterceptors = getAnnotationInterceptors(this.getClass());
+                    operationOneInterceptors.addAll(this.getInterceptors());
+                    return this.constructedOperationOne.handleRequestWithAdditionalInterceptors(event, context, operationOneInterceptors);
+                case withoutOperationIdDeleteRoute:
+                    List<Interceptor<WithoutOperationIdDeleteInput>> withoutOperationIdDeleteInterceptors = getAnnotationInterceptors(this.getClass());
+                    withoutOperationIdDeleteInterceptors.addAll(this.getInterceptors());
+                    return this.constructedWithoutOperationIdDelete.handleRequestWithAdditionalInterceptors(event, context, withoutOperationIdDeleteInterceptors);
+                default:
+                    throw new RuntimeException(String.format(\\"No registered handler for method {} and path {}\\", method, path));
+            }
+        }
+    }
 }",
   "src/main/java/test/test/client/api/DefaultApi/OperationConfig.java": "package test.test.client.api;
 
@@ -15045,6 +15241,26 @@ public class OperationLookup {
         config.put(\\"withoutOperationIdDelete\\", new HashMap<String, String>() { { put(\\"path\\", \\"/without-operation-id\\"); put(\\"method\\", \\"DELETE\\"); } });
 
         return config;
+    }
+}
+",
+  "src/main/java/test/test/client/api/DefaultApi/Operations.java": "package test.test.client.api;
+
+@javax.annotation.Generated(value = \\"org.openapitools.codegen.languages.JavaClientCodegen\\")
+public class Operations {
+    /**
+     * Returns an OperationConfig Builder with all values populated with the given value.
+     * You can override specific values on the builder if you like.
+     * Make sure you call \`.build()\` at the end to construct the OperationConfig.
+     */
+    public static <T> OperationConfig.OperationConfigBuilder<T> all(final T value) {
+        return OperationConfig.<T>builder()
+                .anyRequestResponse(value)
+                .empty(value)
+                .mediaTypes(value)
+                .operationOne(value)
+                .withoutOperationIdDelete(value)
+                ;
     }
 }
 ",

--- a/packages/open-api-gateway/test/project/open-api-gateway-java-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-java-project/__snapshots__/monorepo.test.ts.snap
@@ -1357,6 +1357,7 @@ src/main/java/com/generated/api/myapijava/client/api/DefaultApi.java
 src/main/java/com/generated/api/myapijava/client/api/DefaultApi/Handlers.java
 src/main/java/com/generated/api/myapijava/client/api/DefaultApi/OperationConfig.java
 src/main/java/com/generated/api/myapijava/client/api/DefaultApi/OperationLookup.java
+src/main/java/com/generated/api/myapijava/client/api/DefaultApi/Operations.java
 src/main/java/com/generated/api/myapijava/client/auth/ApiKeyAuth.java
 src/main/java/com/generated/api/myapijava/client/auth/Authentication.java
 src/main/java/com/generated/api/myapijava/client/auth/HttpBasicAuth.java
@@ -6331,6 +6332,25 @@ public class Handlers {
         }
     }
 
+    private static String concatMethodAndPath(final String method, final String path) {
+        return String.format(\\"%s||%s\\", method.toLowerCase(), path);
+    }
+
+    private static <T, I> List<Interceptor<I>> getAnnotationInterceptors(Class<T> clazz) {
+        // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
+        return clazz.isAnnotationPresent(Interceptors.class)
+                ? Arrays.stream(clazz.getAnnotation(Interceptors.class).value()).map(c -> {
+            try {
+                return (Interceptor<I>) c.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(String.format(
+                        \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
+                                \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", c.getSimpleName()), e);
+            }
+        }).collect(Collectors.toList())
+                : new ArrayList<>();
+    }
+
     /**
      * Represents an HTTP response from an api operation
      */
@@ -6674,21 +6694,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<SayHelloInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<SayHelloInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<SayHelloInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<SayHelloInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<SayHelloInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<SayHelloInput>() {
@@ -6734,6 +6751,59 @@ public class Handlers {
         }
     }
 
+    public static abstract class HandlerRouter implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        private static final String sayHelloMethodAndPath = concatMethodAndPath(\\"GET\\", \\"/hello\\");
+
+        private final SayHello constructedSayHello;
+
+        /**
+         * This method must return your implementation of the SayHello operation
+         */
+        public abstract SayHello sayHello();
+
+        private static enum Route {
+            sayHelloRoute,
+        }
+
+        /**
+         * Map of method and path to the route to map to
+         */
+        private final Map<String, Route> routes = new HashMap<>();
+
+        public HandlerRouter() {
+            this.routes.put(sayHelloMethodAndPath, Route.sayHelloRoute);
+            // Handlers are all constructed in the router's constructor such that lambda behaviour remains consistent;
+            // ie resources created in the constructor remain in memory between invocations.
+            // https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
+            this.constructedSayHello = this.sayHello();
+        }
+
+        /**
+         * For more complex interceptors that require instantiation with parameters, you may override this method to
+         * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+         * prefer the @Interceptors annotation.
+         */
+        public <T> List<Interceptor<T>> getInterceptors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            String method = event.getRequestContext().getHttpMethod();
+            String path = event.getRequestContext().getResourcePath();
+            String methodAndPath = concatMethodAndPath(method, path);
+            Route route = this.routes.get(methodAndPath);
+
+            switch (route) {
+                case sayHelloRoute:
+                    List<Interceptor<SayHelloInput>> sayHelloInterceptors = getAnnotationInterceptors(this.getClass());
+                    sayHelloInterceptors.addAll(this.getInterceptors());
+                    return this.constructedSayHello.handleRequestWithAdditionalInterceptors(event, context, sayHelloInterceptors);
+                default:
+                    throw new RuntimeException(String.format(\\"No registered handler for method {} and path {}\\", method, path));
+            }
+        }
+    }
 }",
   "packages/my-api/generated/java/src/main/java/com/generated/api/myapijava/client/api/DefaultApi/OperationConfig.java": "package com.generated.api.myapijava.client.api;
 
@@ -6781,6 +6851,22 @@ public class OperationLookup {
         config.put(\\"sayHello\\", new HashMap<String, String>() { { put(\\"path\\", \\"/hello\\"); put(\\"method\\", \\"GET\\"); } });
 
         return config;
+    }
+}
+",
+  "packages/my-api/generated/java/src/main/java/com/generated/api/myapijava/client/api/DefaultApi/Operations.java": "package com.generated.api.myapijava.client.api;
+
+@javax.annotation.Generated(value = \\"org.openapitools.codegen.languages.JavaClientCodegen\\")
+public class Operations {
+    /**
+     * Returns an OperationConfig Builder with all values populated with the given value.
+     * You can override specific values on the builder if you like.
+     * Make sure you call \`.build()\` at the end to construct the OperationConfig.
+     */
+    public static <T> OperationConfig.OperationConfigBuilder<T> all(final T value) {
+        return OperationConfig.<T>builder()
+                .sayHello(value)
+                ;
     }
 }
 ",

--- a/packages/open-api-gateway/test/project/open-api-gateway-java-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-java-project/__snapshots__/standalone.test.ts.snap
@@ -482,6 +482,7 @@ src/main/java/com/generated/api/myapijava/client/api/DefaultApi.java
 src/main/java/com/generated/api/myapijava/client/api/DefaultApi/Handlers.java
 src/main/java/com/generated/api/myapijava/client/api/DefaultApi/OperationConfig.java
 src/main/java/com/generated/api/myapijava/client/api/DefaultApi/OperationLookup.java
+src/main/java/com/generated/api/myapijava/client/api/DefaultApi/Operations.java
 src/main/java/com/generated/api/myapijava/client/auth/ApiKeyAuth.java
 src/main/java/com/generated/api/myapijava/client/auth/Authentication.java
 src/main/java/com/generated/api/myapijava/client/auth/HttpBasicAuth.java
@@ -5456,6 +5457,25 @@ public class Handlers {
         }
     }
 
+    private static String concatMethodAndPath(final String method, final String path) {
+        return String.format(\\"%s||%s\\", method.toLowerCase(), path);
+    }
+
+    private static <T, I> List<Interceptor<I>> getAnnotationInterceptors(Class<T> clazz) {
+        // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
+        return clazz.isAnnotationPresent(Interceptors.class)
+                ? Arrays.stream(clazz.getAnnotation(Interceptors.class).value()).map(c -> {
+            try {
+                return (Interceptor<I>) c.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(String.format(
+                        \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
+                                \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", c.getSimpleName()), e);
+            }
+        }).collect(Collectors.toList())
+                : new ArrayList<>();
+    }
+
     /**
      * Represents an HTTP response from an api operation
      */
@@ -5799,21 +5819,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<SayHelloInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<SayHelloInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<SayHelloInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<SayHelloInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<SayHelloInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<SayHelloInput>() {
@@ -5859,6 +5876,59 @@ public class Handlers {
         }
     }
 
+    public static abstract class HandlerRouter implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        private static final String sayHelloMethodAndPath = concatMethodAndPath(\\"GET\\", \\"/hello\\");
+
+        private final SayHello constructedSayHello;
+
+        /**
+         * This method must return your implementation of the SayHello operation
+         */
+        public abstract SayHello sayHello();
+
+        private static enum Route {
+            sayHelloRoute,
+        }
+
+        /**
+         * Map of method and path to the route to map to
+         */
+        private final Map<String, Route> routes = new HashMap<>();
+
+        public HandlerRouter() {
+            this.routes.put(sayHelloMethodAndPath, Route.sayHelloRoute);
+            // Handlers are all constructed in the router's constructor such that lambda behaviour remains consistent;
+            // ie resources created in the constructor remain in memory between invocations.
+            // https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
+            this.constructedSayHello = this.sayHello();
+        }
+
+        /**
+         * For more complex interceptors that require instantiation with parameters, you may override this method to
+         * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+         * prefer the @Interceptors annotation.
+         */
+        public <T> List<Interceptor<T>> getInterceptors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            String method = event.getRequestContext().getHttpMethod();
+            String path = event.getRequestContext().getResourcePath();
+            String methodAndPath = concatMethodAndPath(method, path);
+            Route route = this.routes.get(methodAndPath);
+
+            switch (route) {
+                case sayHelloRoute:
+                    List<Interceptor<SayHelloInput>> sayHelloInterceptors = getAnnotationInterceptors(this.getClass());
+                    sayHelloInterceptors.addAll(this.getInterceptors());
+                    return this.constructedSayHello.handleRequestWithAdditionalInterceptors(event, context, sayHelloInterceptors);
+                default:
+                    throw new RuntimeException(String.format(\\"No registered handler for method {} and path {}\\", method, path));
+            }
+        }
+    }
 }",
   "generated/java/src/main/java/com/generated/api/myapijava/client/api/DefaultApi/OperationConfig.java": "package com.generated.api.myapijava.client.api;
 
@@ -5906,6 +5976,22 @@ public class OperationLookup {
         config.put(\\"sayHello\\", new HashMap<String, String>() { { put(\\"path\\", \\"/hello\\"); put(\\"method\\", \\"GET\\"); } });
 
         return config;
+    }
+}
+",
+  "generated/java/src/main/java/com/generated/api/myapijava/client/api/DefaultApi/Operations.java": "package com.generated.api.myapijava.client.api;
+
+@javax.annotation.Generated(value = \\"org.openapitools.codegen.languages.JavaClientCodegen\\")
+public class Operations {
+    /**
+     * Returns an OperationConfig Builder with all values populated with the given value.
+     * You can override specific values on the builder if you like.
+     * Make sure you call \`.build()\` at the end to construct the OperationConfig.
+     */
+    public static <T> OperationConfig.OperationConfigBuilder<T> all(final T value) {
+        return OperationConfig.<T>builder()
+                .sayHello(value)
+                ;
     }
 }
 ",

--- a/packages/open-api-gateway/test/project/open-api-gateway-java-project/__snapshots__/with-docs.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-java-project/__snapshots__/with-docs.test.ts.snap
@@ -3726,6 +3726,7 @@ src/main/java/com/generated/api/myapijava/client/api/DefaultApi.java
 src/main/java/com/generated/api/myapijava/client/api/DefaultApi/Handlers.java
 src/main/java/com/generated/api/myapijava/client/api/DefaultApi/OperationConfig.java
 src/main/java/com/generated/api/myapijava/client/api/DefaultApi/OperationLookup.java
+src/main/java/com/generated/api/myapijava/client/api/DefaultApi/Operations.java
 src/main/java/com/generated/api/myapijava/client/auth/ApiKeyAuth.java
 src/main/java/com/generated/api/myapijava/client/auth/Authentication.java
 src/main/java/com/generated/api/myapijava/client/auth/HttpBasicAuth.java
@@ -8700,6 +8701,25 @@ public class Handlers {
         }
     }
 
+    private static String concatMethodAndPath(final String method, final String path) {
+        return String.format(\\"%s||%s\\", method.toLowerCase(), path);
+    }
+
+    private static <T, I> List<Interceptor<I>> getAnnotationInterceptors(Class<T> clazz) {
+        // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
+        return clazz.isAnnotationPresent(Interceptors.class)
+                ? Arrays.stream(clazz.getAnnotation(Interceptors.class).value()).map(c -> {
+            try {
+                return (Interceptor<I>) c.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(String.format(
+                        \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
+                                \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", c.getSimpleName()), e);
+            }
+        }).collect(Collectors.toList())
+                : new ArrayList<>();
+    }
+
     /**
      * Represents an HTTP response from an api operation
      */
@@ -9043,21 +9063,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<SayHelloInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<SayHelloInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<SayHelloInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<SayHelloInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<SayHelloInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<SayHelloInput>() {
@@ -9103,6 +9120,59 @@ public class Handlers {
         }
     }
 
+    public static abstract class HandlerRouter implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        private static final String sayHelloMethodAndPath = concatMethodAndPath(\\"GET\\", \\"/hello\\");
+
+        private final SayHello constructedSayHello;
+
+        /**
+         * This method must return your implementation of the SayHello operation
+         */
+        public abstract SayHello sayHello();
+
+        private static enum Route {
+            sayHelloRoute,
+        }
+
+        /**
+         * Map of method and path to the route to map to
+         */
+        private final Map<String, Route> routes = new HashMap<>();
+
+        public HandlerRouter() {
+            this.routes.put(sayHelloMethodAndPath, Route.sayHelloRoute);
+            // Handlers are all constructed in the router's constructor such that lambda behaviour remains consistent;
+            // ie resources created in the constructor remain in memory between invocations.
+            // https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
+            this.constructedSayHello = this.sayHello();
+        }
+
+        /**
+         * For more complex interceptors that require instantiation with parameters, you may override this method to
+         * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+         * prefer the @Interceptors annotation.
+         */
+        public <T> List<Interceptor<T>> getInterceptors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            String method = event.getRequestContext().getHttpMethod();
+            String path = event.getRequestContext().getResourcePath();
+            String methodAndPath = concatMethodAndPath(method, path);
+            Route route = this.routes.get(methodAndPath);
+
+            switch (route) {
+                case sayHelloRoute:
+                    List<Interceptor<SayHelloInput>> sayHelloInterceptors = getAnnotationInterceptors(this.getClass());
+                    sayHelloInterceptors.addAll(this.getInterceptors());
+                    return this.constructedSayHello.handleRequestWithAdditionalInterceptors(event, context, sayHelloInterceptors);
+                default:
+                    throw new RuntimeException(String.format(\\"No registered handler for method {} and path {}\\", method, path));
+            }
+        }
+    }
 }",
   "generated/java/src/main/java/com/generated/api/myapijava/client/api/DefaultApi/OperationConfig.java": "package com.generated.api.myapijava.client.api;
 
@@ -9150,6 +9220,22 @@ public class OperationLookup {
         config.put(\\"sayHello\\", new HashMap<String, String>() { { put(\\"path\\", \\"/hello\\"); put(\\"method\\", \\"GET\\"); } });
 
         return config;
+    }
+}
+",
+  "generated/java/src/main/java/com/generated/api/myapijava/client/api/DefaultApi/Operations.java": "package com.generated.api.myapijava.client.api;
+
+@javax.annotation.Generated(value = \\"org.openapitools.codegen.languages.JavaClientCodegen\\")
+public class Operations {
+    /**
+     * Returns an OperationConfig Builder with all values populated with the given value.
+     * You can override specific values on the builder if you like.
+     * Make sure you call \`.build()\` at the end to construct the OperationConfig.
+     */
+    public static <T> OperationConfig.OperationConfigBuilder<T> all(final T value) {
+        return OperationConfig.<T>builder()
+                .sayHello(value)
+                ;
     }
 }
 ",

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
@@ -1328,6 +1328,7 @@ src/main/java/com/generated/api/myapijava/client/api/DefaultApi.java
 src/main/java/com/generated/api/myapijava/client/api/DefaultApi/Handlers.java
 src/main/java/com/generated/api/myapijava/client/api/DefaultApi/OperationConfig.java
 src/main/java/com/generated/api/myapijava/client/api/DefaultApi/OperationLookup.java
+src/main/java/com/generated/api/myapijava/client/api/DefaultApi/Operations.java
 src/main/java/com/generated/api/myapijava/client/auth/ApiKeyAuth.java
 src/main/java/com/generated/api/myapijava/client/auth/Authentication.java
 src/main/java/com/generated/api/myapijava/client/auth/HttpBasicAuth.java
@@ -6294,6 +6295,25 @@ public class Handlers {
         }
     }
 
+    private static String concatMethodAndPath(final String method, final String path) {
+        return String.format(\\"%s||%s\\", method.toLowerCase(), path);
+    }
+
+    private static <T, I> List<Interceptor<I>> getAnnotationInterceptors(Class<T> clazz) {
+        // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
+        return clazz.isAnnotationPresent(Interceptors.class)
+                ? Arrays.stream(clazz.getAnnotation(Interceptors.class).value()).map(c -> {
+            try {
+                return (Interceptor<I>) c.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(String.format(
+                        \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
+                                \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", c.getSimpleName()), e);
+            }
+        }).collect(Collectors.toList())
+                : new ArrayList<>();
+    }
+
     /**
      * Represents an HTTP response from an api operation
      */
@@ -6637,21 +6657,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<SayHelloInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<SayHelloInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<SayHelloInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<SayHelloInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<SayHelloInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<SayHelloInput>() {
@@ -6697,6 +6714,59 @@ public class Handlers {
         }
     }
 
+    public static abstract class HandlerRouter implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        private static final String sayHelloMethodAndPath = concatMethodAndPath(\\"GET\\", \\"/hello\\");
+
+        private final SayHello constructedSayHello;
+
+        /**
+         * This method must return your implementation of the SayHello operation
+         */
+        public abstract SayHello sayHello();
+
+        private static enum Route {
+            sayHelloRoute,
+        }
+
+        /**
+         * Map of method and path to the route to map to
+         */
+        private final Map<String, Route> routes = new HashMap<>();
+
+        public HandlerRouter() {
+            this.routes.put(sayHelloMethodAndPath, Route.sayHelloRoute);
+            // Handlers are all constructed in the router's constructor such that lambda behaviour remains consistent;
+            // ie resources created in the constructor remain in memory between invocations.
+            // https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
+            this.constructedSayHello = this.sayHello();
+        }
+
+        /**
+         * For more complex interceptors that require instantiation with parameters, you may override this method to
+         * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+         * prefer the @Interceptors annotation.
+         */
+        public <T> List<Interceptor<T>> getInterceptors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            String method = event.getRequestContext().getHttpMethod();
+            String path = event.getRequestContext().getResourcePath();
+            String methodAndPath = concatMethodAndPath(method, path);
+            Route route = this.routes.get(methodAndPath);
+
+            switch (route) {
+                case sayHelloRoute:
+                    List<Interceptor<SayHelloInput>> sayHelloInterceptors = getAnnotationInterceptors(this.getClass());
+                    sayHelloInterceptors.addAll(this.getInterceptors());
+                    return this.constructedSayHello.handleRequestWithAdditionalInterceptors(event, context, sayHelloInterceptors);
+                default:
+                    throw new RuntimeException(String.format(\\"No registered handler for method {} and path {}\\", method, path));
+            }
+        }
+    }
 }",
   "packages/my_api/generated/java/src/main/java/com/generated/api/myapijava/client/api/DefaultApi/OperationConfig.java": "package com.generated.api.myapijava.client.api;
 
@@ -6744,6 +6814,22 @@ public class OperationLookup {
         config.put(\\"sayHello\\", new HashMap<String, String>() { { put(\\"path\\", \\"/hello\\"); put(\\"method\\", \\"GET\\"); } });
 
         return config;
+    }
+}
+",
+  "packages/my_api/generated/java/src/main/java/com/generated/api/myapijava/client/api/DefaultApi/Operations.java": "package com.generated.api.myapijava.client.api;
+
+@javax.annotation.Generated(value = \\"org.openapitools.codegen.languages.JavaClientCodegen\\")
+public class Operations {
+    /**
+     * Returns an OperationConfig Builder with all values populated with the given value.
+     * You can override specific values on the builder if you like.
+     * Make sure you call \`.build()\` at the end to construct the OperationConfig.
+     */
+    public static <T> OperationConfig.OperationConfigBuilder<T> all(final T value) {
+        return OperationConfig.<T>builder()
+                .sayHello(value)
+                ;
     }
 }
 ",

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
@@ -447,6 +447,7 @@ src/main/java/com/generated/api/myapijava/client/api/DefaultApi.java
 src/main/java/com/generated/api/myapijava/client/api/DefaultApi/Handlers.java
 src/main/java/com/generated/api/myapijava/client/api/DefaultApi/OperationConfig.java
 src/main/java/com/generated/api/myapijava/client/api/DefaultApi/OperationLookup.java
+src/main/java/com/generated/api/myapijava/client/api/DefaultApi/Operations.java
 src/main/java/com/generated/api/myapijava/client/auth/ApiKeyAuth.java
 src/main/java/com/generated/api/myapijava/client/auth/Authentication.java
 src/main/java/com/generated/api/myapijava/client/auth/HttpBasicAuth.java
@@ -5421,6 +5422,25 @@ public class Handlers {
         }
     }
 
+    private static String concatMethodAndPath(final String method, final String path) {
+        return String.format(\\"%s||%s\\", method.toLowerCase(), path);
+    }
+
+    private static <T, I> List<Interceptor<I>> getAnnotationInterceptors(Class<T> clazz) {
+        // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
+        return clazz.isAnnotationPresent(Interceptors.class)
+                ? Arrays.stream(clazz.getAnnotation(Interceptors.class).value()).map(c -> {
+            try {
+                return (Interceptor<I>) c.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(String.format(
+                        \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
+                                \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", c.getSimpleName()), e);
+            }
+        }).collect(Collectors.toList())
+                : new ArrayList<>();
+    }
+
     /**
      * Represents an HTTP response from an api operation
      */
@@ -5764,21 +5784,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<SayHelloInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<SayHelloInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<SayHelloInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<SayHelloInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<SayHelloInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<SayHelloInput>() {
@@ -5824,6 +5841,59 @@ public class Handlers {
         }
     }
 
+    public static abstract class HandlerRouter implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        private static final String sayHelloMethodAndPath = concatMethodAndPath(\\"GET\\", \\"/hello\\");
+
+        private final SayHello constructedSayHello;
+
+        /**
+         * This method must return your implementation of the SayHello operation
+         */
+        public abstract SayHello sayHello();
+
+        private static enum Route {
+            sayHelloRoute,
+        }
+
+        /**
+         * Map of method and path to the route to map to
+         */
+        private final Map<String, Route> routes = new HashMap<>();
+
+        public HandlerRouter() {
+            this.routes.put(sayHelloMethodAndPath, Route.sayHelloRoute);
+            // Handlers are all constructed in the router's constructor such that lambda behaviour remains consistent;
+            // ie resources created in the constructor remain in memory between invocations.
+            // https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
+            this.constructedSayHello = this.sayHello();
+        }
+
+        /**
+         * For more complex interceptors that require instantiation with parameters, you may override this method to
+         * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+         * prefer the @Interceptors annotation.
+         */
+        public <T> List<Interceptor<T>> getInterceptors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            String method = event.getRequestContext().getHttpMethod();
+            String path = event.getRequestContext().getResourcePath();
+            String methodAndPath = concatMethodAndPath(method, path);
+            Route route = this.routes.get(methodAndPath);
+
+            switch (route) {
+                case sayHelloRoute:
+                    List<Interceptor<SayHelloInput>> sayHelloInterceptors = getAnnotationInterceptors(this.getClass());
+                    sayHelloInterceptors.addAll(this.getInterceptors());
+                    return this.constructedSayHello.handleRequestWithAdditionalInterceptors(event, context, sayHelloInterceptors);
+                default:
+                    throw new RuntimeException(String.format(\\"No registered handler for method {} and path {}\\", method, path));
+            }
+        }
+    }
 }",
   "generated/java/src/main/java/com/generated/api/myapijava/client/api/DefaultApi/OperationConfig.java": "package com.generated.api.myapijava.client.api;
 
@@ -5871,6 +5941,22 @@ public class OperationLookup {
         config.put(\\"sayHello\\", new HashMap<String, String>() { { put(\\"path\\", \\"/hello\\"); put(\\"method\\", \\"GET\\"); } });
 
         return config;
+    }
+}
+",
+  "generated/java/src/main/java/com/generated/api/myapijava/client/api/DefaultApi/Operations.java": "package com.generated.api.myapijava.client.api;
+
+@javax.annotation.Generated(value = \\"org.openapitools.codegen.languages.JavaClientCodegen\\")
+public class Operations {
+    /**
+     * Returns an OperationConfig Builder with all values populated with the given value.
+     * You can override specific values on the builder if you like.
+     * Make sure you call \`.build()\` at the end to construct the OperationConfig.
+     */
+    public static <T> OperationConfig.OperationConfigBuilder<T> all(final T value) {
+        return OperationConfig.<T>builder()
+                .sayHello(value)
+                ;
     }
 }
 ",

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
@@ -1835,6 +1835,7 @@ src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Handlers.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationLookup.java
+src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java
 src/main/java/com/generated/api/testmyapijava/client/auth/ApiKeyAuth.java
 src/main/java/com/generated/api/testmyapijava/client/auth/Authentication.java
 src/main/java/com/generated/api/testmyapijava/client/auth/HttpBasicAuth.java
@@ -6801,6 +6802,25 @@ public class Handlers {
         }
     }
 
+    private static String concatMethodAndPath(final String method, final String path) {
+        return String.format(\\"%s||%s\\", method.toLowerCase(), path);
+    }
+
+    private static <T, I> List<Interceptor<I>> getAnnotationInterceptors(Class<T> clazz) {
+        // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
+        return clazz.isAnnotationPresent(Interceptors.class)
+                ? Arrays.stream(clazz.getAnnotation(Interceptors.class).value()).map(c -> {
+            try {
+                return (Interceptor<I>) c.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(String.format(
+                        \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
+                                \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", c.getSimpleName()), e);
+            }
+        }).collect(Collectors.toList())
+                : new ArrayList<>();
+    }
+
     /**
      * Represents an HTTP response from an api operation
      */
@@ -7144,21 +7164,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<SayHelloInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<SayHelloInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<SayHelloInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<SayHelloInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<SayHelloInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<SayHelloInput>() {
@@ -7204,6 +7221,59 @@ public class Handlers {
         }
     }
 
+    public static abstract class HandlerRouter implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        private static final String sayHelloMethodAndPath = concatMethodAndPath(\\"GET\\", \\"/hello\\");
+
+        private final SayHello constructedSayHello;
+
+        /**
+         * This method must return your implementation of the SayHello operation
+         */
+        public abstract SayHello sayHello();
+
+        private static enum Route {
+            sayHelloRoute,
+        }
+
+        /**
+         * Map of method and path to the route to map to
+         */
+        private final Map<String, Route> routes = new HashMap<>();
+
+        public HandlerRouter() {
+            this.routes.put(sayHelloMethodAndPath, Route.sayHelloRoute);
+            // Handlers are all constructed in the router's constructor such that lambda behaviour remains consistent;
+            // ie resources created in the constructor remain in memory between invocations.
+            // https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
+            this.constructedSayHello = this.sayHello();
+        }
+
+        /**
+         * For more complex interceptors that require instantiation with parameters, you may override this method to
+         * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+         * prefer the @Interceptors annotation.
+         */
+        public <T> List<Interceptor<T>> getInterceptors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            String method = event.getRequestContext().getHttpMethod();
+            String path = event.getRequestContext().getResourcePath();
+            String methodAndPath = concatMethodAndPath(method, path);
+            Route route = this.routes.get(methodAndPath);
+
+            switch (route) {
+                case sayHelloRoute:
+                    List<Interceptor<SayHelloInput>> sayHelloInterceptors = getAnnotationInterceptors(this.getClass());
+                    sayHelloInterceptors.addAll(this.getInterceptors());
+                    return this.constructedSayHello.handleRequestWithAdditionalInterceptors(event, context, sayHelloInterceptors);
+                default:
+                    throw new RuntimeException(String.format(\\"No registered handler for method {} and path {}\\", method, path));
+            }
+        }
+    }
 }",
   "packages/api/generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java": "package com.generated.api.testmyapijava.client.api;
 
@@ -7251,6 +7321,22 @@ public class OperationLookup {
         config.put(\\"sayHello\\", new HashMap<String, String>() { { put(\\"path\\", \\"/hello\\"); put(\\"method\\", \\"GET\\"); } });
 
         return config;
+    }
+}
+",
+  "packages/api/generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java": "package com.generated.api.testmyapijava.client.api;
+
+@javax.annotation.Generated(value = \\"org.openapitools.codegen.languages.JavaClientCodegen\\")
+public class Operations {
+    /**
+     * Returns an OperationConfig Builder with all values populated with the given value.
+     * You can override specific values on the builder if you like.
+     * Make sure you call \`.build()\` at the end to construct the OperationConfig.
+     */
+    public static <T> OperationConfig.OperationConfigBuilder<T> all(final T value) {
+        return OperationConfig.<T>builder()
+                .sayHello(value)
+                ;
     }
 }
 ",
@@ -18642,6 +18728,7 @@ src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Handlers.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationLookup.java
+src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java
 src/main/java/com/generated/api/testmyapijava/client/auth/ApiKeyAuth.java
 src/main/java/com/generated/api/testmyapijava/client/auth/Authentication.java
 src/main/java/com/generated/api/testmyapijava/client/auth/HttpBasicAuth.java
@@ -23608,6 +23695,25 @@ public class Handlers {
         }
     }
 
+    private static String concatMethodAndPath(final String method, final String path) {
+        return String.format(\\"%s||%s\\", method.toLowerCase(), path);
+    }
+
+    private static <T, I> List<Interceptor<I>> getAnnotationInterceptors(Class<T> clazz) {
+        // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
+        return clazz.isAnnotationPresent(Interceptors.class)
+                ? Arrays.stream(clazz.getAnnotation(Interceptors.class).value()).map(c -> {
+            try {
+                return (Interceptor<I>) c.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(String.format(
+                        \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
+                                \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", c.getSimpleName()), e);
+            }
+        }).collect(Collectors.toList())
+                : new ArrayList<>();
+    }
+
     /**
      * Represents an HTTP response from an api operation
      */
@@ -23951,21 +24057,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<SayHelloInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<SayHelloInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<SayHelloInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<SayHelloInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<SayHelloInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<SayHelloInput>() {
@@ -24011,6 +24114,59 @@ public class Handlers {
         }
     }
 
+    public static abstract class HandlerRouter implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        private static final String sayHelloMethodAndPath = concatMethodAndPath(\\"GET\\", \\"/hello\\");
+
+        private final SayHello constructedSayHello;
+
+        /**
+         * This method must return your implementation of the SayHello operation
+         */
+        public abstract SayHello sayHello();
+
+        private static enum Route {
+            sayHelloRoute,
+        }
+
+        /**
+         * Map of method and path to the route to map to
+         */
+        private final Map<String, Route> routes = new HashMap<>();
+
+        public HandlerRouter() {
+            this.routes.put(sayHelloMethodAndPath, Route.sayHelloRoute);
+            // Handlers are all constructed in the router's constructor such that lambda behaviour remains consistent;
+            // ie resources created in the constructor remain in memory between invocations.
+            // https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
+            this.constructedSayHello = this.sayHello();
+        }
+
+        /**
+         * For more complex interceptors that require instantiation with parameters, you may override this method to
+         * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+         * prefer the @Interceptors annotation.
+         */
+        public <T> List<Interceptor<T>> getInterceptors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            String method = event.getRequestContext().getHttpMethod();
+            String path = event.getRequestContext().getResourcePath();
+            String methodAndPath = concatMethodAndPath(method, path);
+            Route route = this.routes.get(methodAndPath);
+
+            switch (route) {
+                case sayHelloRoute:
+                    List<Interceptor<SayHelloInput>> sayHelloInterceptors = getAnnotationInterceptors(this.getClass());
+                    sayHelloInterceptors.addAll(this.getInterceptors());
+                    return this.constructedSayHello.handleRequestWithAdditionalInterceptors(event, context, sayHelloInterceptors);
+                default:
+                    throw new RuntimeException(String.format(\\"No registered handler for method {} and path {}\\", method, path));
+            }
+        }
+    }
 }",
   "packages/api/generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java": "package com.generated.api.testmyapijava.client.api;
 
@@ -24058,6 +24214,22 @@ public class OperationLookup {
         config.put(\\"sayHello\\", new HashMap<String, String>() { { put(\\"path\\", \\"/hello\\"); put(\\"method\\", \\"GET\\"); } });
 
         return config;
+    }
+}
+",
+  "packages/api/generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java": "package com.generated.api.testmyapijava.client.api;
+
+@javax.annotation.Generated(value = \\"org.openapitools.codegen.languages.JavaClientCodegen\\")
+public class Operations {
+    /**
+     * Returns an OperationConfig Builder with all values populated with the given value.
+     * You can override specific values on the builder if you like.
+     * Make sure you call \`.build()\` at the end to construct the OperationConfig.
+     */
+    public static <T> OperationConfig.OperationConfigBuilder<T> all(final T value) {
+        return OperationConfig.<T>builder()
+                .sayHello(value)
+                ;
     }
 }
 ",
@@ -35463,6 +35635,7 @@ src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Handlers.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationLookup.java
+src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java
 src/main/java/com/generated/api/testmyapijava/client/auth/ApiKeyAuth.java
 src/main/java/com/generated/api/testmyapijava/client/auth/Authentication.java
 src/main/java/com/generated/api/testmyapijava/client/auth/HttpBasicAuth.java
@@ -40429,6 +40602,25 @@ public class Handlers {
         }
     }
 
+    private static String concatMethodAndPath(final String method, final String path) {
+        return String.format(\\"%s||%s\\", method.toLowerCase(), path);
+    }
+
+    private static <T, I> List<Interceptor<I>> getAnnotationInterceptors(Class<T> clazz) {
+        // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
+        return clazz.isAnnotationPresent(Interceptors.class)
+                ? Arrays.stream(clazz.getAnnotation(Interceptors.class).value()).map(c -> {
+            try {
+                return (Interceptor<I>) c.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(String.format(
+                        \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
+                                \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", c.getSimpleName()), e);
+            }
+        }).collect(Collectors.toList())
+                : new ArrayList<>();
+    }
+
     /**
      * Represents an HTTP response from an api operation
      */
@@ -40772,21 +40964,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<SayHelloInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<SayHelloInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<SayHelloInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<SayHelloInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<SayHelloInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<SayHelloInput>() {
@@ -40832,6 +41021,59 @@ public class Handlers {
         }
     }
 
+    public static abstract class HandlerRouter implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        private static final String sayHelloMethodAndPath = concatMethodAndPath(\\"GET\\", \\"/hello\\");
+
+        private final SayHello constructedSayHello;
+
+        /**
+         * This method must return your implementation of the SayHello operation
+         */
+        public abstract SayHello sayHello();
+
+        private static enum Route {
+            sayHelloRoute,
+        }
+
+        /**
+         * Map of method and path to the route to map to
+         */
+        private final Map<String, Route> routes = new HashMap<>();
+
+        public HandlerRouter() {
+            this.routes.put(sayHelloMethodAndPath, Route.sayHelloRoute);
+            // Handlers are all constructed in the router's constructor such that lambda behaviour remains consistent;
+            // ie resources created in the constructor remain in memory between invocations.
+            // https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
+            this.constructedSayHello = this.sayHello();
+        }
+
+        /**
+         * For more complex interceptors that require instantiation with parameters, you may override this method to
+         * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+         * prefer the @Interceptors annotation.
+         */
+        public <T> List<Interceptor<T>> getInterceptors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            String method = event.getRequestContext().getHttpMethod();
+            String path = event.getRequestContext().getResourcePath();
+            String methodAndPath = concatMethodAndPath(method, path);
+            Route route = this.routes.get(methodAndPath);
+
+            switch (route) {
+                case sayHelloRoute:
+                    List<Interceptor<SayHelloInput>> sayHelloInterceptors = getAnnotationInterceptors(this.getClass());
+                    sayHelloInterceptors.addAll(this.getInterceptors());
+                    return this.constructedSayHello.handleRequestWithAdditionalInterceptors(event, context, sayHelloInterceptors);
+                default:
+                    throw new RuntimeException(String.format(\\"No registered handler for method {} and path {}\\", method, path));
+            }
+        }
+    }
 }",
   "packages/api/generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java": "package com.generated.api.testmyapijava.client.api;
 
@@ -40879,6 +41121,22 @@ public class OperationLookup {
         config.put(\\"sayHello\\", new HashMap<String, String>() { { put(\\"path\\", \\"/hello\\"); put(\\"method\\", \\"GET\\"); } });
 
         return config;
+    }
+}
+",
+  "packages/api/generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java": "package com.generated.api.testmyapijava.client.api;
+
+@javax.annotation.Generated(value = \\"org.openapitools.codegen.languages.JavaClientCodegen\\")
+public class Operations {
+    /**
+     * Returns an OperationConfig Builder with all values populated with the given value.
+     * You can override specific values on the builder if you like.
+     * Make sure you call \`.build()\` at the end to construct the OperationConfig.
+     */
+    public static <T> OperationConfig.OperationConfigBuilder<T> all(final T value) {
+        return OperationConfig.<T>builder()
+                .sayHello(value)
+                ;
     }
 }
 ",

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
@@ -1308,6 +1308,7 @@ src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Handlers.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationLookup.java
+src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java
 src/main/java/com/generated/api/testmyapijava/client/auth/ApiKeyAuth.java
 src/main/java/com/generated/api/testmyapijava/client/auth/Authentication.java
 src/main/java/com/generated/api/testmyapijava/client/auth/HttpBasicAuth.java
@@ -6282,6 +6283,25 @@ public class Handlers {
         }
     }
 
+    private static String concatMethodAndPath(final String method, final String path) {
+        return String.format(\\"%s||%s\\", method.toLowerCase(), path);
+    }
+
+    private static <T, I> List<Interceptor<I>> getAnnotationInterceptors(Class<T> clazz) {
+        // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
+        return clazz.isAnnotationPresent(Interceptors.class)
+                ? Arrays.stream(clazz.getAnnotation(Interceptors.class).value()).map(c -> {
+            try {
+                return (Interceptor<I>) c.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(String.format(
+                        \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
+                                \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", c.getSimpleName()), e);
+            }
+        }).collect(Collectors.toList())
+                : new ArrayList<>();
+    }
+
     /**
      * Represents an HTTP response from an api operation
      */
@@ -6625,21 +6645,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<SayHelloInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<SayHelloInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<SayHelloInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<SayHelloInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<SayHelloInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<SayHelloInput>() {
@@ -6685,6 +6702,59 @@ public class Handlers {
         }
     }
 
+    public static abstract class HandlerRouter implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        private static final String sayHelloMethodAndPath = concatMethodAndPath(\\"GET\\", \\"/hello\\");
+
+        private final SayHello constructedSayHello;
+
+        /**
+         * This method must return your implementation of the SayHello operation
+         */
+        public abstract SayHello sayHello();
+
+        private static enum Route {
+            sayHelloRoute,
+        }
+
+        /**
+         * Map of method and path to the route to map to
+         */
+        private final Map<String, Route> routes = new HashMap<>();
+
+        public HandlerRouter() {
+            this.routes.put(sayHelloMethodAndPath, Route.sayHelloRoute);
+            // Handlers are all constructed in the router's constructor such that lambda behaviour remains consistent;
+            // ie resources created in the constructor remain in memory between invocations.
+            // https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
+            this.constructedSayHello = this.sayHello();
+        }
+
+        /**
+         * For more complex interceptors that require instantiation with parameters, you may override this method to
+         * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+         * prefer the @Interceptors annotation.
+         */
+        public <T> List<Interceptor<T>> getInterceptors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            String method = event.getRequestContext().getHttpMethod();
+            String path = event.getRequestContext().getResourcePath();
+            String methodAndPath = concatMethodAndPath(method, path);
+            Route route = this.routes.get(methodAndPath);
+
+            switch (route) {
+                case sayHelloRoute:
+                    List<Interceptor<SayHelloInput>> sayHelloInterceptors = getAnnotationInterceptors(this.getClass());
+                    sayHelloInterceptors.addAll(this.getInterceptors());
+                    return this.constructedSayHello.handleRequestWithAdditionalInterceptors(event, context, sayHelloInterceptors);
+                default:
+                    throw new RuntimeException(String.format(\\"No registered handler for method {} and path {}\\", method, path));
+            }
+        }
+    }
 }",
   "generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java": "package com.generated.api.testmyapijava.client.api;
 
@@ -6732,6 +6802,22 @@ public class OperationLookup {
         config.put(\\"sayHello\\", new HashMap<String, String>() { { put(\\"path\\", \\"/hello\\"); put(\\"method\\", \\"GET\\"); } });
 
         return config;
+    }
+}
+",
+  "generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java": "package com.generated.api.testmyapijava.client.api;
+
+@javax.annotation.Generated(value = \\"org.openapitools.codegen.languages.JavaClientCodegen\\")
+public class Operations {
+    /**
+     * Returns an OperationConfig Builder with all values populated with the given value.
+     * You can override specific values on the builder if you like.
+     * Make sure you call \`.build()\` at the end to construct the OperationConfig.
+     */
+    public static <T> OperationConfig.OperationConfigBuilder<T> all(final T value) {
+        return OperationConfig.<T>builder()
+                .sayHello(value)
+                ;
     }
 }
 ",
@@ -17534,6 +17620,7 @@ src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Handlers.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationLookup.java
+src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java
 src/main/java/com/generated/api/testmyapijava/client/auth/ApiKeyAuth.java
 src/main/java/com/generated/api/testmyapijava/client/auth/Authentication.java
 src/main/java/com/generated/api/testmyapijava/client/auth/HttpBasicAuth.java
@@ -22508,6 +22595,25 @@ public class Handlers {
         }
     }
 
+    private static String concatMethodAndPath(final String method, final String path) {
+        return String.format(\\"%s||%s\\", method.toLowerCase(), path);
+    }
+
+    private static <T, I> List<Interceptor<I>> getAnnotationInterceptors(Class<T> clazz) {
+        // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
+        return clazz.isAnnotationPresent(Interceptors.class)
+                ? Arrays.stream(clazz.getAnnotation(Interceptors.class).value()).map(c -> {
+            try {
+                return (Interceptor<I>) c.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(String.format(
+                        \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
+                                \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", c.getSimpleName()), e);
+            }
+        }).collect(Collectors.toList())
+                : new ArrayList<>();
+    }
+
     /**
      * Represents an HTTP response from an api operation
      */
@@ -22851,21 +22957,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<SayHelloInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<SayHelloInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<SayHelloInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<SayHelloInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<SayHelloInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<SayHelloInput>() {
@@ -22911,6 +23014,59 @@ public class Handlers {
         }
     }
 
+    public static abstract class HandlerRouter implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        private static final String sayHelloMethodAndPath = concatMethodAndPath(\\"GET\\", \\"/hello\\");
+
+        private final SayHello constructedSayHello;
+
+        /**
+         * This method must return your implementation of the SayHello operation
+         */
+        public abstract SayHello sayHello();
+
+        private static enum Route {
+            sayHelloRoute,
+        }
+
+        /**
+         * Map of method and path to the route to map to
+         */
+        private final Map<String, Route> routes = new HashMap<>();
+
+        public HandlerRouter() {
+            this.routes.put(sayHelloMethodAndPath, Route.sayHelloRoute);
+            // Handlers are all constructed in the router's constructor such that lambda behaviour remains consistent;
+            // ie resources created in the constructor remain in memory between invocations.
+            // https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
+            this.constructedSayHello = this.sayHello();
+        }
+
+        /**
+         * For more complex interceptors that require instantiation with parameters, you may override this method to
+         * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+         * prefer the @Interceptors annotation.
+         */
+        public <T> List<Interceptor<T>> getInterceptors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            String method = event.getRequestContext().getHttpMethod();
+            String path = event.getRequestContext().getResourcePath();
+            String methodAndPath = concatMethodAndPath(method, path);
+            Route route = this.routes.get(methodAndPath);
+
+            switch (route) {
+                case sayHelloRoute:
+                    List<Interceptor<SayHelloInput>> sayHelloInterceptors = getAnnotationInterceptors(this.getClass());
+                    sayHelloInterceptors.addAll(this.getInterceptors());
+                    return this.constructedSayHello.handleRequestWithAdditionalInterceptors(event, context, sayHelloInterceptors);
+                default:
+                    throw new RuntimeException(String.format(\\"No registered handler for method {} and path {}\\", method, path));
+            }
+        }
+    }
 }",
   "generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java": "package com.generated.api.testmyapijava.client.api;
 
@@ -22958,6 +23114,22 @@ public class OperationLookup {
         config.put(\\"sayHello\\", new HashMap<String, String>() { { put(\\"path\\", \\"/hello\\"); put(\\"method\\", \\"GET\\"); } });
 
         return config;
+    }
+}
+",
+  "generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java": "package com.generated.api.testmyapijava.client.api;
+
+@javax.annotation.Generated(value = \\"org.openapitools.codegen.languages.JavaClientCodegen\\")
+public class Operations {
+    /**
+     * Returns an OperationConfig Builder with all values populated with the given value.
+     * You can override specific values on the builder if you like.
+     * Make sure you call \`.build()\` at the end to construct the OperationConfig.
+     */
+    public static <T> OperationConfig.OperationConfigBuilder<T> all(final T value) {
+        return OperationConfig.<T>builder()
+                .sayHello(value)
+                ;
     }
 }
 ",
@@ -33753,6 +33925,7 @@ src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Handlers.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationLookup.java
+src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java
 src/main/java/com/generated/api/testmyapijava/client/auth/ApiKeyAuth.java
 src/main/java/com/generated/api/testmyapijava/client/auth/Authentication.java
 src/main/java/com/generated/api/testmyapijava/client/auth/HttpBasicAuth.java
@@ -38727,6 +38900,25 @@ public class Handlers {
         }
     }
 
+    private static String concatMethodAndPath(final String method, final String path) {
+        return String.format(\\"%s||%s\\", method.toLowerCase(), path);
+    }
+
+    private static <T, I> List<Interceptor<I>> getAnnotationInterceptors(Class<T> clazz) {
+        // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
+        return clazz.isAnnotationPresent(Interceptors.class)
+                ? Arrays.stream(clazz.getAnnotation(Interceptors.class).value()).map(c -> {
+            try {
+                return (Interceptor<I>) c.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(String.format(
+                        \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
+                                \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", c.getSimpleName()), e);
+            }
+        }).collect(Collectors.toList())
+                : new ArrayList<>();
+    }
+
     /**
      * Represents an HTTP response from an api operation
      */
@@ -39070,21 +39262,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<SayHelloInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<SayHelloInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<SayHelloInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<SayHelloInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<SayHelloInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<SayHelloInput>() {
@@ -39130,6 +39319,59 @@ public class Handlers {
         }
     }
 
+    public static abstract class HandlerRouter implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        private static final String sayHelloMethodAndPath = concatMethodAndPath(\\"GET\\", \\"/hello\\");
+
+        private final SayHello constructedSayHello;
+
+        /**
+         * This method must return your implementation of the SayHello operation
+         */
+        public abstract SayHello sayHello();
+
+        private static enum Route {
+            sayHelloRoute,
+        }
+
+        /**
+         * Map of method and path to the route to map to
+         */
+        private final Map<String, Route> routes = new HashMap<>();
+
+        public HandlerRouter() {
+            this.routes.put(sayHelloMethodAndPath, Route.sayHelloRoute);
+            // Handlers are all constructed in the router's constructor such that lambda behaviour remains consistent;
+            // ie resources created in the constructor remain in memory between invocations.
+            // https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
+            this.constructedSayHello = this.sayHello();
+        }
+
+        /**
+         * For more complex interceptors that require instantiation with parameters, you may override this method to
+         * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+         * prefer the @Interceptors annotation.
+         */
+        public <T> List<Interceptor<T>> getInterceptors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            String method = event.getRequestContext().getHttpMethod();
+            String path = event.getRequestContext().getResourcePath();
+            String methodAndPath = concatMethodAndPath(method, path);
+            Route route = this.routes.get(methodAndPath);
+
+            switch (route) {
+                case sayHelloRoute:
+                    List<Interceptor<SayHelloInput>> sayHelloInterceptors = getAnnotationInterceptors(this.getClass());
+                    sayHelloInterceptors.addAll(this.getInterceptors());
+                    return this.constructedSayHello.handleRequestWithAdditionalInterceptors(event, context, sayHelloInterceptors);
+                default:
+                    throw new RuntimeException(String.format(\\"No registered handler for method {} and path {}\\", method, path));
+            }
+        }
+    }
 }",
   "generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java": "package com.generated.api.testmyapijava.client.api;
 
@@ -39177,6 +39419,22 @@ public class OperationLookup {
         config.put(\\"sayHello\\", new HashMap<String, String>() { { put(\\"path\\", \\"/hello\\"); put(\\"method\\", \\"GET\\"); } });
 
         return config;
+    }
+}
+",
+  "generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java": "package com.generated.api.testmyapijava.client.api;
+
+@javax.annotation.Generated(value = \\"org.openapitools.codegen.languages.JavaClientCodegen\\")
+public class Operations {
+    /**
+     * Returns an OperationConfig Builder with all values populated with the given value.
+     * You can override specific values on the builder if you like.
+     * Make sure you call \`.build()\` at the end to construct the OperationConfig.
+     */
+    public static <T> OperationConfig.OperationConfigBuilder<T> all(final T value) {
+        return OperationConfig.<T>builder()
+                .sayHello(value)
+                ;
     }
 }
 ",

--- a/packages/open-api-gateway/test/project/smithy-api-gateway-java-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/smithy-api-gateway-java-project/__snapshots__/standalone.test.ts.snap
@@ -476,6 +476,7 @@ src/main/java/com/generated/api/testjava/client/api/DefaultApi.java
 src/main/java/com/generated/api/testjava/client/api/DefaultApi/Handlers.java
 src/main/java/com/generated/api/testjava/client/api/DefaultApi/OperationConfig.java
 src/main/java/com/generated/api/testjava/client/api/DefaultApi/OperationLookup.java
+src/main/java/com/generated/api/testjava/client/api/DefaultApi/Operations.java
 src/main/java/com/generated/api/testjava/client/auth/ApiKeyAuth.java
 src/main/java/com/generated/api/testjava/client/auth/Authentication.java
 src/main/java/com/generated/api/testjava/client/auth/HttpBasicAuth.java
@@ -5450,6 +5451,25 @@ public class Handlers {
         }
     }
 
+    private static String concatMethodAndPath(final String method, final String path) {
+        return String.format(\\"%s||%s\\", method.toLowerCase(), path);
+    }
+
+    private static <T, I> List<Interceptor<I>> getAnnotationInterceptors(Class<T> clazz) {
+        // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
+        return clazz.isAnnotationPresent(Interceptors.class)
+                ? Arrays.stream(clazz.getAnnotation(Interceptors.class).value()).map(c -> {
+            try {
+                return (Interceptor<I>) c.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(String.format(
+                        \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
+                                \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", c.getSimpleName()), e);
+            }
+        }).collect(Collectors.toList())
+                : new ArrayList<>();
+    }
+
     /**
      * Represents an HTTP response from an api operation
      */
@@ -5793,21 +5813,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<SayHelloInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<SayHelloInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<SayHelloInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<SayHelloInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<SayHelloInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<SayHelloInput>() {
@@ -5853,6 +5870,59 @@ public class Handlers {
         }
     }
 
+    public static abstract class HandlerRouter implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        private static final String sayHelloMethodAndPath = concatMethodAndPath(\\"GET\\", \\"/hello\\");
+
+        private final SayHello constructedSayHello;
+
+        /**
+         * This method must return your implementation of the SayHello operation
+         */
+        public abstract SayHello sayHello();
+
+        private static enum Route {
+            sayHelloRoute,
+        }
+
+        /**
+         * Map of method and path to the route to map to
+         */
+        private final Map<String, Route> routes = new HashMap<>();
+
+        public HandlerRouter() {
+            this.routes.put(sayHelloMethodAndPath, Route.sayHelloRoute);
+            // Handlers are all constructed in the router's constructor such that lambda behaviour remains consistent;
+            // ie resources created in the constructor remain in memory between invocations.
+            // https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
+            this.constructedSayHello = this.sayHello();
+        }
+
+        /**
+         * For more complex interceptors that require instantiation with parameters, you may override this method to
+         * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+         * prefer the @Interceptors annotation.
+         */
+        public <T> List<Interceptor<T>> getInterceptors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            String method = event.getRequestContext().getHttpMethod();
+            String path = event.getRequestContext().getResourcePath();
+            String methodAndPath = concatMethodAndPath(method, path);
+            Route route = this.routes.get(methodAndPath);
+
+            switch (route) {
+                case sayHelloRoute:
+                    List<Interceptor<SayHelloInput>> sayHelloInterceptors = getAnnotationInterceptors(this.getClass());
+                    sayHelloInterceptors.addAll(this.getInterceptors());
+                    return this.constructedSayHello.handleRequestWithAdditionalInterceptors(event, context, sayHelloInterceptors);
+                default:
+                    throw new RuntimeException(String.format(\\"No registered handler for method {} and path {}\\", method, path));
+            }
+        }
+    }
 }",
   "generated/java/src/main/java/com/generated/api/testjava/client/api/DefaultApi/OperationConfig.java": "package com.generated.api.testjava.client.api;
 
@@ -5900,6 +5970,22 @@ public class OperationLookup {
         config.put(\\"sayHello\\", new HashMap<String, String>() { { put(\\"path\\", \\"/hello\\"); put(\\"method\\", \\"GET\\"); } });
 
         return config;
+    }
+}
+",
+  "generated/java/src/main/java/com/generated/api/testjava/client/api/DefaultApi/Operations.java": "package com.generated.api.testjava.client.api;
+
+@javax.annotation.Generated(value = \\"org.openapitools.codegen.languages.JavaClientCodegen\\")
+public class Operations {
+    /**
+     * Returns an OperationConfig Builder with all values populated with the given value.
+     * You can override specific values on the builder if you like.
+     * Make sure you call \`.build()\` at the end to construct the OperationConfig.
+     */
+    public static <T> OperationConfig.OperationConfigBuilder<T> all(final T value) {
+        return OperationConfig.<T>builder()
+                .sayHello(value)
+                ;
     }
 }
 ",

--- a/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
@@ -1838,6 +1838,7 @@ src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Handlers.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationLookup.java
+src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java
 src/main/java/com/generated/api/testmyapijava/client/auth/ApiKeyAuth.java
 src/main/java/com/generated/api/testmyapijava/client/auth/Authentication.java
 src/main/java/com/generated/api/testmyapijava/client/auth/HttpBasicAuth.java
@@ -6804,6 +6805,25 @@ public class Handlers {
         }
     }
 
+    private static String concatMethodAndPath(final String method, final String path) {
+        return String.format(\\"%s||%s\\", method.toLowerCase(), path);
+    }
+
+    private static <T, I> List<Interceptor<I>> getAnnotationInterceptors(Class<T> clazz) {
+        // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
+        return clazz.isAnnotationPresent(Interceptors.class)
+                ? Arrays.stream(clazz.getAnnotation(Interceptors.class).value()).map(c -> {
+            try {
+                return (Interceptor<I>) c.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(String.format(
+                        \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
+                                \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", c.getSimpleName()), e);
+            }
+        }).collect(Collectors.toList())
+                : new ArrayList<>();
+    }
+
     /**
      * Represents an HTTP response from an api operation
      */
@@ -7147,21 +7167,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<SayHelloInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<SayHelloInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<SayHelloInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<SayHelloInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<SayHelloInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<SayHelloInput>() {
@@ -7207,6 +7224,59 @@ public class Handlers {
         }
     }
 
+    public static abstract class HandlerRouter implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        private static final String sayHelloMethodAndPath = concatMethodAndPath(\\"GET\\", \\"/hello\\");
+
+        private final SayHello constructedSayHello;
+
+        /**
+         * This method must return your implementation of the SayHello operation
+         */
+        public abstract SayHello sayHello();
+
+        private static enum Route {
+            sayHelloRoute,
+        }
+
+        /**
+         * Map of method and path to the route to map to
+         */
+        private final Map<String, Route> routes = new HashMap<>();
+
+        public HandlerRouter() {
+            this.routes.put(sayHelloMethodAndPath, Route.sayHelloRoute);
+            // Handlers are all constructed in the router's constructor such that lambda behaviour remains consistent;
+            // ie resources created in the constructor remain in memory between invocations.
+            // https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
+            this.constructedSayHello = this.sayHello();
+        }
+
+        /**
+         * For more complex interceptors that require instantiation with parameters, you may override this method to
+         * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+         * prefer the @Interceptors annotation.
+         */
+        public <T> List<Interceptor<T>> getInterceptors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            String method = event.getRequestContext().getHttpMethod();
+            String path = event.getRequestContext().getResourcePath();
+            String methodAndPath = concatMethodAndPath(method, path);
+            Route route = this.routes.get(methodAndPath);
+
+            switch (route) {
+                case sayHelloRoute:
+                    List<Interceptor<SayHelloInput>> sayHelloInterceptors = getAnnotationInterceptors(this.getClass());
+                    sayHelloInterceptors.addAll(this.getInterceptors());
+                    return this.constructedSayHello.handleRequestWithAdditionalInterceptors(event, context, sayHelloInterceptors);
+                default:
+                    throw new RuntimeException(String.format(\\"No registered handler for method {} and path {}\\", method, path));
+            }
+        }
+    }
 }",
   "packages/api/generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java": "package com.generated.api.testmyapijava.client.api;
 
@@ -7254,6 +7324,22 @@ public class OperationLookup {
         config.put(\\"sayHello\\", new HashMap<String, String>() { { put(\\"path\\", \\"/hello\\"); put(\\"method\\", \\"GET\\"); } });
 
         return config;
+    }
+}
+",
+  "packages/api/generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java": "package com.generated.api.testmyapijava.client.api;
+
+@javax.annotation.Generated(value = \\"org.openapitools.codegen.languages.JavaClientCodegen\\")
+public class Operations {
+    /**
+     * Returns an OperationConfig Builder with all values populated with the given value.
+     * You can override specific values on the builder if you like.
+     * Make sure you call \`.build()\` at the end to construct the OperationConfig.
+     */
+    public static <T> OperationConfig.OperationConfigBuilder<T> all(final T value) {
+        return OperationConfig.<T>builder()
+                .sayHello(value)
+                ;
     }
 }
 ",
@@ -21131,6 +21217,7 @@ src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Handlers.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationLookup.java
+src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java
 src/main/java/com/generated/api/testmyapijava/client/auth/ApiKeyAuth.java
 src/main/java/com/generated/api/testmyapijava/client/auth/Authentication.java
 src/main/java/com/generated/api/testmyapijava/client/auth/HttpBasicAuth.java
@@ -26097,6 +26184,25 @@ public class Handlers {
         }
     }
 
+    private static String concatMethodAndPath(final String method, final String path) {
+        return String.format(\\"%s||%s\\", method.toLowerCase(), path);
+    }
+
+    private static <T, I> List<Interceptor<I>> getAnnotationInterceptors(Class<T> clazz) {
+        // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
+        return clazz.isAnnotationPresent(Interceptors.class)
+                ? Arrays.stream(clazz.getAnnotation(Interceptors.class).value()).map(c -> {
+            try {
+                return (Interceptor<I>) c.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(String.format(
+                        \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
+                                \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", c.getSimpleName()), e);
+            }
+        }).collect(Collectors.toList())
+                : new ArrayList<>();
+    }
+
     /**
      * Represents an HTTP response from an api operation
      */
@@ -26440,21 +26546,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<SayHelloInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<SayHelloInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<SayHelloInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<SayHelloInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<SayHelloInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<SayHelloInput>() {
@@ -26500,6 +26603,59 @@ public class Handlers {
         }
     }
 
+    public static abstract class HandlerRouter implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        private static final String sayHelloMethodAndPath = concatMethodAndPath(\\"GET\\", \\"/hello\\");
+
+        private final SayHello constructedSayHello;
+
+        /**
+         * This method must return your implementation of the SayHello operation
+         */
+        public abstract SayHello sayHello();
+
+        private static enum Route {
+            sayHelloRoute,
+        }
+
+        /**
+         * Map of method and path to the route to map to
+         */
+        private final Map<String, Route> routes = new HashMap<>();
+
+        public HandlerRouter() {
+            this.routes.put(sayHelloMethodAndPath, Route.sayHelloRoute);
+            // Handlers are all constructed in the router's constructor such that lambda behaviour remains consistent;
+            // ie resources created in the constructor remain in memory between invocations.
+            // https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
+            this.constructedSayHello = this.sayHello();
+        }
+
+        /**
+         * For more complex interceptors that require instantiation with parameters, you may override this method to
+         * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+         * prefer the @Interceptors annotation.
+         */
+        public <T> List<Interceptor<T>> getInterceptors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            String method = event.getRequestContext().getHttpMethod();
+            String path = event.getRequestContext().getResourcePath();
+            String methodAndPath = concatMethodAndPath(method, path);
+            Route route = this.routes.get(methodAndPath);
+
+            switch (route) {
+                case sayHelloRoute:
+                    List<Interceptor<SayHelloInput>> sayHelloInterceptors = getAnnotationInterceptors(this.getClass());
+                    sayHelloInterceptors.addAll(this.getInterceptors());
+                    return this.constructedSayHello.handleRequestWithAdditionalInterceptors(event, context, sayHelloInterceptors);
+                default:
+                    throw new RuntimeException(String.format(\\"No registered handler for method {} and path {}\\", method, path));
+            }
+        }
+    }
 }",
   "packages/api/generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java": "package com.generated.api.testmyapijava.client.api;
 
@@ -26547,6 +26703,22 @@ public class OperationLookup {
         config.put(\\"sayHello\\", new HashMap<String, String>() { { put(\\"path\\", \\"/hello\\"); put(\\"method\\", \\"GET\\"); } });
 
         return config;
+    }
+}
+",
+  "packages/api/generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java": "package com.generated.api.testmyapijava.client.api;
+
+@javax.annotation.Generated(value = \\"org.openapitools.codegen.languages.JavaClientCodegen\\")
+public class Operations {
+    /**
+     * Returns an OperationConfig Builder with all values populated with the given value.
+     * You can override specific values on the builder if you like.
+     * Make sure you call \`.build()\` at the end to construct the OperationConfig.
+     */
+    public static <T> OperationConfig.OperationConfigBuilder<T> all(final T value) {
+        return OperationConfig.<T>builder()
+                .sayHello(value)
+                ;
     }
 }
 ",
@@ -40438,6 +40610,7 @@ src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Handlers.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationLookup.java
+src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java
 src/main/java/com/generated/api/testmyapijava/client/auth/ApiKeyAuth.java
 src/main/java/com/generated/api/testmyapijava/client/auth/Authentication.java
 src/main/java/com/generated/api/testmyapijava/client/auth/HttpBasicAuth.java
@@ -45404,6 +45577,25 @@ public class Handlers {
         }
     }
 
+    private static String concatMethodAndPath(final String method, final String path) {
+        return String.format(\\"%s||%s\\", method.toLowerCase(), path);
+    }
+
+    private static <T, I> List<Interceptor<I>> getAnnotationInterceptors(Class<T> clazz) {
+        // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
+        return clazz.isAnnotationPresent(Interceptors.class)
+                ? Arrays.stream(clazz.getAnnotation(Interceptors.class).value()).map(c -> {
+            try {
+                return (Interceptor<I>) c.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(String.format(
+                        \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
+                                \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", c.getSimpleName()), e);
+            }
+        }).collect(Collectors.toList())
+                : new ArrayList<>();
+    }
+
     /**
      * Represents an HTTP response from an api operation
      */
@@ -45747,21 +45939,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<SayHelloInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<SayHelloInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<SayHelloInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<SayHelloInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<SayHelloInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<SayHelloInput>() {
@@ -45807,6 +45996,59 @@ public class Handlers {
         }
     }
 
+    public static abstract class HandlerRouter implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        private static final String sayHelloMethodAndPath = concatMethodAndPath(\\"GET\\", \\"/hello\\");
+
+        private final SayHello constructedSayHello;
+
+        /**
+         * This method must return your implementation of the SayHello operation
+         */
+        public abstract SayHello sayHello();
+
+        private static enum Route {
+            sayHelloRoute,
+        }
+
+        /**
+         * Map of method and path to the route to map to
+         */
+        private final Map<String, Route> routes = new HashMap<>();
+
+        public HandlerRouter() {
+            this.routes.put(sayHelloMethodAndPath, Route.sayHelloRoute);
+            // Handlers are all constructed in the router's constructor such that lambda behaviour remains consistent;
+            // ie resources created in the constructor remain in memory between invocations.
+            // https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
+            this.constructedSayHello = this.sayHello();
+        }
+
+        /**
+         * For more complex interceptors that require instantiation with parameters, you may override this method to
+         * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+         * prefer the @Interceptors annotation.
+         */
+        public <T> List<Interceptor<T>> getInterceptors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            String method = event.getRequestContext().getHttpMethod();
+            String path = event.getRequestContext().getResourcePath();
+            String methodAndPath = concatMethodAndPath(method, path);
+            Route route = this.routes.get(methodAndPath);
+
+            switch (route) {
+                case sayHelloRoute:
+                    List<Interceptor<SayHelloInput>> sayHelloInterceptors = getAnnotationInterceptors(this.getClass());
+                    sayHelloInterceptors.addAll(this.getInterceptors());
+                    return this.constructedSayHello.handleRequestWithAdditionalInterceptors(event, context, sayHelloInterceptors);
+                default:
+                    throw new RuntimeException(String.format(\\"No registered handler for method {} and path {}\\", method, path));
+            }
+        }
+    }
 }",
   "packages/api/generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java": "package com.generated.api.testmyapijava.client.api;
 
@@ -45854,6 +46096,22 @@ public class OperationLookup {
         config.put(\\"sayHello\\", new HashMap<String, String>() { { put(\\"path\\", \\"/hello\\"); put(\\"method\\", \\"GET\\"); } });
 
         return config;
+    }
+}
+",
+  "packages/api/generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java": "package com.generated.api.testmyapijava.client.api;
+
+@javax.annotation.Generated(value = \\"org.openapitools.codegen.languages.JavaClientCodegen\\")
+public class Operations {
+    /**
+     * Returns an OperationConfig Builder with all values populated with the given value.
+     * You can override specific values on the builder if you like.
+     * Make sure you call \`.build()\` at the end to construct the OperationConfig.
+     */
+    public static <T> OperationConfig.OperationConfigBuilder<T> all(final T value) {
+        return OperationConfig.<T>builder()
+                .sayHello(value)
+                ;
     }
 }
 ",

--- a/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
@@ -1311,6 +1311,7 @@ src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Handlers.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationLookup.java
+src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java
 src/main/java/com/generated/api/testmyapijava/client/auth/ApiKeyAuth.java
 src/main/java/com/generated/api/testmyapijava/client/auth/Authentication.java
 src/main/java/com/generated/api/testmyapijava/client/auth/HttpBasicAuth.java
@@ -6285,6 +6286,25 @@ public class Handlers {
         }
     }
 
+    private static String concatMethodAndPath(final String method, final String path) {
+        return String.format(\\"%s||%s\\", method.toLowerCase(), path);
+    }
+
+    private static <T, I> List<Interceptor<I>> getAnnotationInterceptors(Class<T> clazz) {
+        // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
+        return clazz.isAnnotationPresent(Interceptors.class)
+                ? Arrays.stream(clazz.getAnnotation(Interceptors.class).value()).map(c -> {
+            try {
+                return (Interceptor<I>) c.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(String.format(
+                        \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
+                                \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", c.getSimpleName()), e);
+            }
+        }).collect(Collectors.toList())
+                : new ArrayList<>();
+    }
+
     /**
      * Represents an HTTP response from an api operation
      */
@@ -6628,21 +6648,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<SayHelloInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<SayHelloInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<SayHelloInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<SayHelloInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<SayHelloInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<SayHelloInput>() {
@@ -6688,6 +6705,59 @@ public class Handlers {
         }
     }
 
+    public static abstract class HandlerRouter implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        private static final String sayHelloMethodAndPath = concatMethodAndPath(\\"GET\\", \\"/hello\\");
+
+        private final SayHello constructedSayHello;
+
+        /**
+         * This method must return your implementation of the SayHello operation
+         */
+        public abstract SayHello sayHello();
+
+        private static enum Route {
+            sayHelloRoute,
+        }
+
+        /**
+         * Map of method and path to the route to map to
+         */
+        private final Map<String, Route> routes = new HashMap<>();
+
+        public HandlerRouter() {
+            this.routes.put(sayHelloMethodAndPath, Route.sayHelloRoute);
+            // Handlers are all constructed in the router's constructor such that lambda behaviour remains consistent;
+            // ie resources created in the constructor remain in memory between invocations.
+            // https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
+            this.constructedSayHello = this.sayHello();
+        }
+
+        /**
+         * For more complex interceptors that require instantiation with parameters, you may override this method to
+         * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+         * prefer the @Interceptors annotation.
+         */
+        public <T> List<Interceptor<T>> getInterceptors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            String method = event.getRequestContext().getHttpMethod();
+            String path = event.getRequestContext().getResourcePath();
+            String methodAndPath = concatMethodAndPath(method, path);
+            Route route = this.routes.get(methodAndPath);
+
+            switch (route) {
+                case sayHelloRoute:
+                    List<Interceptor<SayHelloInput>> sayHelloInterceptors = getAnnotationInterceptors(this.getClass());
+                    sayHelloInterceptors.addAll(this.getInterceptors());
+                    return this.constructedSayHello.handleRequestWithAdditionalInterceptors(event, context, sayHelloInterceptors);
+                default:
+                    throw new RuntimeException(String.format(\\"No registered handler for method {} and path {}\\", method, path));
+            }
+        }
+    }
 }",
   "generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java": "package com.generated.api.testmyapijava.client.api;
 
@@ -6735,6 +6805,22 @@ public class OperationLookup {
         config.put(\\"sayHello\\", new HashMap<String, String>() { { put(\\"path\\", \\"/hello\\"); put(\\"method\\", \\"GET\\"); } });
 
         return config;
+    }
+}
+",
+  "generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java": "package com.generated.api.testmyapijava.client.api;
+
+@javax.annotation.Generated(value = \\"org.openapitools.codegen.languages.JavaClientCodegen\\")
+public class Operations {
+    /**
+     * Returns an OperationConfig Builder with all values populated with the given value.
+     * You can override specific values on the builder if you like.
+     * Make sure you call \`.build()\` at the end to construct the OperationConfig.
+     */
+    public static <T> OperationConfig.OperationConfigBuilder<T> all(final T value) {
+        return OperationConfig.<T>builder()
+                .sayHello(value)
+                ;
     }
 }
 ",
@@ -20023,6 +20109,7 @@ src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Handlers.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationLookup.java
+src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java
 src/main/java/com/generated/api/testmyapijava/client/auth/ApiKeyAuth.java
 src/main/java/com/generated/api/testmyapijava/client/auth/Authentication.java
 src/main/java/com/generated/api/testmyapijava/client/auth/HttpBasicAuth.java
@@ -24997,6 +25084,25 @@ public class Handlers {
         }
     }
 
+    private static String concatMethodAndPath(final String method, final String path) {
+        return String.format(\\"%s||%s\\", method.toLowerCase(), path);
+    }
+
+    private static <T, I> List<Interceptor<I>> getAnnotationInterceptors(Class<T> clazz) {
+        // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
+        return clazz.isAnnotationPresent(Interceptors.class)
+                ? Arrays.stream(clazz.getAnnotation(Interceptors.class).value()).map(c -> {
+            try {
+                return (Interceptor<I>) c.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(String.format(
+                        \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
+                                \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", c.getSimpleName()), e);
+            }
+        }).collect(Collectors.toList())
+                : new ArrayList<>();
+    }
+
     /**
      * Represents an HTTP response from an api operation
      */
@@ -25340,21 +25446,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<SayHelloInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<SayHelloInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<SayHelloInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<SayHelloInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<SayHelloInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<SayHelloInput>() {
@@ -25400,6 +25503,59 @@ public class Handlers {
         }
     }
 
+    public static abstract class HandlerRouter implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        private static final String sayHelloMethodAndPath = concatMethodAndPath(\\"GET\\", \\"/hello\\");
+
+        private final SayHello constructedSayHello;
+
+        /**
+         * This method must return your implementation of the SayHello operation
+         */
+        public abstract SayHello sayHello();
+
+        private static enum Route {
+            sayHelloRoute,
+        }
+
+        /**
+         * Map of method and path to the route to map to
+         */
+        private final Map<String, Route> routes = new HashMap<>();
+
+        public HandlerRouter() {
+            this.routes.put(sayHelloMethodAndPath, Route.sayHelloRoute);
+            // Handlers are all constructed in the router's constructor such that lambda behaviour remains consistent;
+            // ie resources created in the constructor remain in memory between invocations.
+            // https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
+            this.constructedSayHello = this.sayHello();
+        }
+
+        /**
+         * For more complex interceptors that require instantiation with parameters, you may override this method to
+         * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+         * prefer the @Interceptors annotation.
+         */
+        public <T> List<Interceptor<T>> getInterceptors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            String method = event.getRequestContext().getHttpMethod();
+            String path = event.getRequestContext().getResourcePath();
+            String methodAndPath = concatMethodAndPath(method, path);
+            Route route = this.routes.get(methodAndPath);
+
+            switch (route) {
+                case sayHelloRoute:
+                    List<Interceptor<SayHelloInput>> sayHelloInterceptors = getAnnotationInterceptors(this.getClass());
+                    sayHelloInterceptors.addAll(this.getInterceptors());
+                    return this.constructedSayHello.handleRequestWithAdditionalInterceptors(event, context, sayHelloInterceptors);
+                default:
+                    throw new RuntimeException(String.format(\\"No registered handler for method {} and path {}\\", method, path));
+            }
+        }
+    }
 }",
   "generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java": "package com.generated.api.testmyapijava.client.api;
 
@@ -25447,6 +25603,22 @@ public class OperationLookup {
         config.put(\\"sayHello\\", new HashMap<String, String>() { { put(\\"path\\", \\"/hello\\"); put(\\"method\\", \\"GET\\"); } });
 
         return config;
+    }
+}
+",
+  "generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java": "package com.generated.api.testmyapijava.client.api;
+
+@javax.annotation.Generated(value = \\"org.openapitools.codegen.languages.JavaClientCodegen\\")
+public class Operations {
+    /**
+     * Returns an OperationConfig Builder with all values populated with the given value.
+     * You can override specific values on the builder if you like.
+     * Make sure you call \`.build()\` at the end to construct the OperationConfig.
+     */
+    public static <T> OperationConfig.OperationConfigBuilder<T> all(final T value) {
+        return OperationConfig.<T>builder()
+                .sayHello(value)
+                ;
     }
 }
 ",
@@ -38728,6 +38900,7 @@ src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Handlers.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java
 src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationLookup.java
+src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java
 src/main/java/com/generated/api/testmyapijava/client/auth/ApiKeyAuth.java
 src/main/java/com/generated/api/testmyapijava/client/auth/Authentication.java
 src/main/java/com/generated/api/testmyapijava/client/auth/HttpBasicAuth.java
@@ -43702,6 +43875,25 @@ public class Handlers {
         }
     }
 
+    private static String concatMethodAndPath(final String method, final String path) {
+        return String.format(\\"%s||%s\\", method.toLowerCase(), path);
+    }
+
+    private static <T, I> List<Interceptor<I>> getAnnotationInterceptors(Class<T> clazz) {
+        // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
+        return clazz.isAnnotationPresent(Interceptors.class)
+                ? Arrays.stream(clazz.getAnnotation(Interceptors.class).value()).map(c -> {
+            try {
+                return (Interceptor<I>) c.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                throw new RuntimeException(String.format(
+                        \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
+                                \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", c.getSimpleName()), e);
+            }
+        }).collect(Collectors.toList())
+                : new ArrayList<>();
+    }
+
     /**
      * Represents an HTTP response from an api operation
      */
@@ -44045,21 +44237,18 @@ public class Handlers {
 
         @Override
         public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+        }
+
+        public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<SayHelloInput>> additionalInterceptors) {
             final Map<String, Object> interceptorContext = new HashMap<>();
 
-            // Support specifying simple interceptors via the @Interceptors({ MyInterceptor.class, MyOtherInterceptor.class }) format
-            List<Interceptor<SayHelloInput>> interceptors = this.getClass().isAnnotationPresent(Interceptors.class)
-                    ? Arrays.stream(this.getClass().getAnnotation(Interceptors.class).value()).map(clazz -> {
-                        try {
-                            return (Interceptor<SayHelloInput>) clazz.getDeclaredConstructor().newInstance();
-                        } catch (Exception e) {
-                            throw new RuntimeException(String.format(
-                                    \\"Cannot create instance of interceptor %s. Please ensure it has a public constructor \\" +
-                                            \\"with no arguments, or override the getInterceptors method instead of using the annotation\\", clazz.getSimpleName()), e);
-                        }
-                     }).collect(Collectors.toList())
-                    : new ArrayList<>();
+            List<Interceptor<SayHelloInput>> interceptors = new ArrayList<>();
+            interceptors.addAll(additionalInterceptors);
 
+            List<Interceptor<SayHelloInput>> annotationInterceptors = getAnnotationInterceptors(this.getClass());
+
+            interceptors.addAll(annotationInterceptors);
             interceptors.addAll(this.getInterceptors());
 
             final HandlerChain chain = buildHandlerChain(interceptors, new HandlerChain<SayHelloInput>() {
@@ -44105,6 +44294,59 @@ public class Handlers {
         }
     }
 
+    public static abstract class HandlerRouter implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+        private static final String sayHelloMethodAndPath = concatMethodAndPath(\\"GET\\", \\"/hello\\");
+
+        private final SayHello constructedSayHello;
+
+        /**
+         * This method must return your implementation of the SayHello operation
+         */
+        public abstract SayHello sayHello();
+
+        private static enum Route {
+            sayHelloRoute,
+        }
+
+        /**
+         * Map of method and path to the route to map to
+         */
+        private final Map<String, Route> routes = new HashMap<>();
+
+        public HandlerRouter() {
+            this.routes.put(sayHelloMethodAndPath, Route.sayHelloRoute);
+            // Handlers are all constructed in the router's constructor such that lambda behaviour remains consistent;
+            // ie resources created in the constructor remain in memory between invocations.
+            // https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
+            this.constructedSayHello = this.sayHello();
+        }
+
+        /**
+         * For more complex interceptors that require instantiation with parameters, you may override this method to
+         * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+         * prefer the @Interceptors annotation.
+         */
+        public <T> List<Interceptor<T>> getInterceptors() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+            String method = event.getRequestContext().getHttpMethod();
+            String path = event.getRequestContext().getResourcePath();
+            String methodAndPath = concatMethodAndPath(method, path);
+            Route route = this.routes.get(methodAndPath);
+
+            switch (route) {
+                case sayHelloRoute:
+                    List<Interceptor<SayHelloInput>> sayHelloInterceptors = getAnnotationInterceptors(this.getClass());
+                    sayHelloInterceptors.addAll(this.getInterceptors());
+                    return this.constructedSayHello.handleRequestWithAdditionalInterceptors(event, context, sayHelloInterceptors);
+                default:
+                    throw new RuntimeException(String.format(\\"No registered handler for method {} and path {}\\", method, path));
+            }
+        }
+    }
 }",
   "generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/OperationConfig.java": "package com.generated.api.testmyapijava.client.api;
 
@@ -44152,6 +44394,22 @@ public class OperationLookup {
         config.put(\\"sayHello\\", new HashMap<String, String>() { { put(\\"path\\", \\"/hello\\"); put(\\"method\\", \\"GET\\"); } });
 
         return config;
+    }
+}
+",
+  "generated/java/src/main/java/com/generated/api/testmyapijava/client/api/DefaultApi/Operations.java": "package com.generated.api.testmyapijava.client.api;
+
+@javax.annotation.Generated(value = \\"org.openapitools.codegen.languages.JavaClientCodegen\\")
+public class Operations {
+    /**
+     * Returns an OperationConfig Builder with all values populated with the given value.
+     * You can override specific values on the builder if you like.
+     * Make sure you call \`.build()\` at the end to construct the OperationConfig.
+     */
+    public static <T> OperationConfig.OperationConfigBuilder<T> all(final T value) {
+        return OperationConfig.<T>builder()
+                .sayHello(value)
+                ;
     }
 }
 ",


### PR DESCRIPTION
Adds a `HandlerRouter` class to the generated Java client which can be extended and used as the lambda entrypoint for all operations.

The router requires you to define a method for every operation, which returns a handler for that operation. Like with TypeScript and Python, these handlers are the same handlers can be used in a standalone fashion, so the router is another layer that can be easily added/removed should users decide to consolidate/split their lambdas.

The router can also be decorated with interceptors to apply to all operations (and/or override the `getInterceptors` method to return interceptors which need parameters for construction).

fix #238