### PR TITLE
ci(release): ignore non-target package language publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
           path: dist
       - name: Release
         working-directory: dist/packages
-        run: for d in *; do cd $d && npx -p publib@latest publib-npm && cd ..; done;
+        run: for d in *; do cd $d && ( [ -d "dist/js" ] && npx -p publib@latest publib-npm || echo "Ignore `basename $PWD` - no dist/js" ) && cd ..; done;
         env:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
@@ -119,7 +119,7 @@ jobs:
           path: dist
       - name: Release
         working-directory: dist/packages
-        run: for d in *; do cd $d && npx -p publib@latest publib-maven && cd ..; done;
+        run: for d in *; do cd $d && ( [ -d "dist/java" ] && npx -p publib@latest publib-maven || echo "Ignore `basename $PWD` - no dist/java" ) && cd ..; done;
         env:
           MAVEN_ENDPOINT: https://aws.oss.sonatype.org
           MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
@@ -148,7 +148,7 @@ jobs:
           path: dist
       - name: Release
         working-directory: dist/packages
-        run: for d in *; do cd $d && npx -p publib@latest publib-pypi && cd ..; done;
+        run: for d in *; do cd $d && ( [ -d "dist/python" ] && npx -p publib@latest publib-pypi || echo "Ignore `basename $PWD` - no dist/python" ) && cd ..; done;
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}


### PR DESCRIPTION
Now that packages can disable pypi+maven publishing, we need to detect this in release workflow and
skip publishing for targets that pacakge does not generate dist artifacts for.