### PR TITLE
feat(pipeline): compile ts pipeline as part of build by default

### DIFF
--- a/packages/pipeline/src/pdk-pipeline-ts-project.ts
+++ b/packages/pipeline/src/pdk-pipeline-ts-project.ts
@@ -33,6 +33,10 @@ export class PDKPipelineTsProject extends AwsCdkTypeScriptApp {
 
     this.addDeps("aws-prototyping-sdk", "cdk-nag");
 
+    // AwsCdkTypeScriptApp removes ts compilation - add back to err on the side of caution should infrastructure
+    // include NodejsFunctions that won't be type-checked during CDK synthesis
+    this.compileTask.reset("tsc --build");
+
     new SampleDir(this, this.srcdir, {
       sourceDir: path.join(__dirname, "..", "samples", "typescript", "src"),
     });

--- a/packages/pipeline/test/__snapshots__/pdk-pipeline-ts-project.test.ts.snap
+++ b/packages/pipeline/test/__snapshots__/pdk-pipeline-ts-project.test.ts.snap
@@ -446,6 +446,11 @@ cdk.out/
       "compile": Object {
         "description": "Only compile",
         "name": "compile",
+        "steps": Array [
+          Object {
+            "exec": "tsc --build",
+          },
+        ],
       },
       "default": Object {
         "description": "Synthesize project files",
@@ -3378,6 +3383,11 @@ cdk.out/
       "compile": Object {
         "description": "Only compile",
         "name": "compile",
+        "steps": Array [
+          Object {
+            "exec": "tsc --build",
+          },
+        ],
       },
       "default": Object {
         "description": "Synthesize project files",
@@ -6310,6 +6320,11 @@ cdk.out/
       "compile": Object {
         "description": "Only compile",
         "name": "compile",
+        "steps": Array [
+          Object {
+            "exec": "tsc --build",
+          },
+        ],
       },
       "default": Object {
         "description": "Synthesize project files",


### PR DESCRIPTION
The `AwsCdkTypeScriptApp` which the `PDKPipelineTsProject` inherits from disables compilation due to synth executing via TypeScript anyway. (See https://github.com/projen/projen/issues/1958)

However, any `NodejsFunction`s that are referenced won't be type checked at build time which can lead to mistakes. We err on the side of caution by adding TypeScript compilation to the build by default, given `NodejsFunction` is used quite frequently.