### PR TITLE
fix(open-api-gateway): fix typescript standalone handler wrappers

### DIFF
--- a/packages/open-api-gateway/scripts/generators/typescript/templates/operationConfig.mustache
+++ b/packages/open-api-gateway/scripts/generators/typescript/templates/operationConfig.mustache
@@ -199,7 +199,7 @@ export type {{operationIdCamelCase}}ChainedHandlerFunction = ChainedLambdaHandle
 export const {{nickname}}Handler = (
     firstHandler: {{operationIdCamelCase}}ChainedHandlerFunction,
     ...remainingHandlers: {{operationIdCamelCase}}ChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'{{nickname}}'> => async (event: any, context: any, additionalInterceptors: {{operationIdCamelCase}}ChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'{{nickname}}'> => async (event: any, context: any, _callback?: any, additionalInterceptors: {{operationIdCamelCase}}ChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -313,5 +313,5 @@ export const handlerRouter = (props: HandlerRouterProps<
 >): OperationApiGatewayLambdaHandler<OperationIds> => async (event, context) => {
   const operationId = OperationIdByMethodAndPath[concatMethodAndPath(event.requestContext.httpMethod, event.requestContext.resourcePath)];
   const handler = props.handlers[operationId];
-  return handler(event, context, props.interceptors);
+  return handler(event, context, undefined, props.interceptors);
 };

--- a/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-typescript-client-source-code.test.ts.snap
+++ b/packages/open-api-gateway/test/project/codegen/components/__snapshots__/generated-typescript-client-source-code.test.ts.snap
@@ -1466,7 +1466,7 @@ export type SomeTestOperationChainedHandlerFunction = ChainedLambdaHandlerFuncti
 export const someTestOperationHandler = (
     firstHandler: SomeTestOperationChainedHandlerFunction,
     ...remainingHandlers: SomeTestOperationChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'someTestOperation'> => async (event: any, context: any, additionalInterceptors: SomeTestOperationChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'someTestOperation'> => async (event: any, context: any, _callback?: any, additionalInterceptors: SomeTestOperationChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -1563,7 +1563,7 @@ export const handlerRouter = (props: HandlerRouterProps<
 >): OperationApiGatewayLambdaHandler<OperationIds> => async (event, context) => {
   const operationId = OperationIdByMethodAndPath[concatMethodAndPath(event.requestContext.httpMethod, event.requestContext.resourcePath)];
   const handler = props.handlers[operationId];
-  return handler(event, context, props.interceptors);
+  return handler(event, context, undefined, props.interceptors);
 };
 ",
   "src/apis/index.ts": "/* tslint:disable */
@@ -3900,7 +3900,7 @@ export type AnyRequestResponseChainedHandlerFunction = ChainedLambdaHandlerFunct
 export const anyRequestResponseHandler = (
     firstHandler: AnyRequestResponseChainedHandlerFunction,
     ...remainingHandlers: AnyRequestResponseChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'anyRequestResponse'> => async (event: any, context: any, additionalInterceptors: AnyRequestResponseChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'anyRequestResponse'> => async (event: any, context: any, _callback?: any, additionalInterceptors: AnyRequestResponseChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -3974,7 +3974,7 @@ export type EmptyChainedHandlerFunction = ChainedLambdaHandlerFunction<EmptyRequ
 export const emptyHandler = (
     firstHandler: EmptyChainedHandlerFunction,
     ...remainingHandlers: EmptyChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'empty'> => async (event: any, context: any, additionalInterceptors: EmptyChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'empty'> => async (event: any, context: any, _callback?: any, additionalInterceptors: EmptyChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -4048,7 +4048,7 @@ export type MediaTypesChainedHandlerFunction = ChainedLambdaHandlerFunction<Medi
 export const mediaTypesHandler = (
     firstHandler: MediaTypesChainedHandlerFunction,
     ...remainingHandlers: MediaTypesChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'mediaTypes'> => async (event: any, context: any, additionalInterceptors: MediaTypesChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'mediaTypes'> => async (event: any, context: any, _callback?: any, additionalInterceptors: MediaTypesChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -4128,7 +4128,7 @@ export type OperationOneChainedHandlerFunction = ChainedLambdaHandlerFunction<Op
 export const operationOneHandler = (
     firstHandler: OperationOneChainedHandlerFunction,
     ...remainingHandlers: OperationOneChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'operationOne'> => async (event: any, context: any, additionalInterceptors: OperationOneChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'operationOne'> => async (event: any, context: any, _callback?: any, additionalInterceptors: OperationOneChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -4206,7 +4206,7 @@ export type WithoutOperationIdDeleteChainedHandlerFunction = ChainedLambdaHandle
 export const withoutOperationIdDeleteHandler = (
     firstHandler: WithoutOperationIdDeleteChainedHandlerFunction,
     ...remainingHandlers: WithoutOperationIdDeleteChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'withoutOperationIdDelete'> => async (event: any, context: any, additionalInterceptors: WithoutOperationIdDeleteChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'withoutOperationIdDelete'> => async (event: any, context: any, _callback?: any, additionalInterceptors: WithoutOperationIdDeleteChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -4304,7 +4304,7 @@ export const handlerRouter = (props: HandlerRouterProps<
 >): OperationApiGatewayLambdaHandler<OperationIds> => async (event, context) => {
   const operationId = OperationIdByMethodAndPath[concatMethodAndPath(event.requestContext.httpMethod, event.requestContext.resourcePath)];
   const handler = props.handlers[operationId];
-  return handler(event, context, props.interceptors);
+  return handler(event, context, undefined, props.interceptors);
 };
 ",
   "src/apis/index.ts": "/* tslint:disable */

--- a/packages/open-api-gateway/test/project/open-api-gateway-java-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-java-project/__snapshots__/monorepo.test.ts.snap
@@ -15281,7 +15281,7 @@ export type SayHelloChainedHandlerFunction = ChainedLambdaHandlerFunction<SayHel
 export const sayHelloHandler = (
     firstHandler: SayHelloChainedHandlerFunction,
     ...remainingHandlers: SayHelloChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, _callback?: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -15378,7 +15378,7 @@ export const handlerRouter = (props: HandlerRouterProps<
 >): OperationApiGatewayLambdaHandler<OperationIds> => async (event, context) => {
   const operationId = OperationIdByMethodAndPath[concatMethodAndPath(event.requestContext.httpMethod, event.requestContext.resourcePath)];
   const handler = props.handlers[operationId];
-  return handler(event, context, props.interceptors);
+  return handler(event, context, undefined, props.interceptors);
 };
 ",
   "packages/my-api/generated/typescript/src/apis/index.ts": "/* tslint:disable */

--- a/packages/open-api-gateway/test/project/open-api-gateway-java-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-java-project/__snapshots__/standalone.test.ts.snap
@@ -14412,7 +14412,7 @@ export type SayHelloChainedHandlerFunction = ChainedLambdaHandlerFunction<SayHel
 export const sayHelloHandler = (
     firstHandler: SayHelloChainedHandlerFunction,
     ...remainingHandlers: SayHelloChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, _callback?: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -14509,7 +14509,7 @@ export const handlerRouter = (props: HandlerRouterProps<
 >): OperationApiGatewayLambdaHandler<OperationIds> => async (event, context) => {
   const operationId = OperationIdByMethodAndPath[concatMethodAndPath(event.requestContext.httpMethod, event.requestContext.resourcePath)];
   const handler = props.handlers[operationId];
-  return handler(event, context, props.interceptors);
+  return handler(event, context, undefined, props.interceptors);
 };
 ",
   "generated/typescript/src/apis/index.ts": "/* tslint:disable */

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
@@ -15255,7 +15255,7 @@ export type SayHelloChainedHandlerFunction = ChainedLambdaHandlerFunction<SayHel
 export const sayHelloHandler = (
     firstHandler: SayHelloChainedHandlerFunction,
     ...remainingHandlers: SayHelloChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, _callback?: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -15352,7 +15352,7 @@ export const handlerRouter = (props: HandlerRouterProps<
 >): OperationApiGatewayLambdaHandler<OperationIds> => async (event, context) => {
   const operationId = OperationIdByMethodAndPath[concatMethodAndPath(event.requestContext.httpMethod, event.requestContext.resourcePath)];
   const handler = props.handlers[operationId];
-  return handler(event, context, props.interceptors);
+  return handler(event, context, undefined, props.interceptors);
 };
 ",
   "packages/my_api/generated/typescript/src/apis/index.ts": "/* tslint:disable */

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/standalone.test.ts.snap
@@ -14383,7 +14383,7 @@ export type SayHelloChainedHandlerFunction = ChainedLambdaHandlerFunction<SayHel
 export const sayHelloHandler = (
     firstHandler: SayHelloChainedHandlerFunction,
     ...remainingHandlers: SayHelloChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, _callback?: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -14480,7 +14480,7 @@ export const handlerRouter = (props: HandlerRouterProps<
 >): OperationApiGatewayLambdaHandler<OperationIds> => async (event, context) => {
   const operationId = OperationIdByMethodAndPath[concatMethodAndPath(event.requestContext.httpMethod, event.requestContext.resourcePath)];
   const handler = props.handlers[operationId];
-  return handler(event, context, props.interceptors);
+  return handler(event, context, undefined, props.interceptors);
 };
 ",
   "generated/typescript/src/apis/index.ts": "/* tslint:disable */

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/custom-directories.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/custom-directories.test.ts.snap
@@ -2092,7 +2092,7 @@ export type SayHelloChainedHandlerFunction = ChainedLambdaHandlerFunction<SayHel
 export const sayHelloHandler = (
     firstHandler: SayHelloChainedHandlerFunction,
     ...remainingHandlers: SayHelloChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, _callback?: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -2189,7 +2189,7 @@ export const handlerRouter = (props: HandlerRouterProps<
 >): OperationApiGatewayLambdaHandler<OperationIds> => async (event, context) => {
   const operationId = OperationIdByMethodAndPath[concatMethodAndPath(event.requestContext.httpMethod, event.requestContext.resourcePath)];
   const handler = props.handlers[operationId];
-  return handler(event, context, props.interceptors);
+  return handler(event, context, undefined, props.interceptors);
 };
 ",
   "gen/typescript/src/apis/index.ts": "/* tslint:disable */

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
@@ -15756,7 +15756,7 @@ export type SayHelloChainedHandlerFunction = ChainedLambdaHandlerFunction<SayHel
 export const sayHelloHandler = (
     firstHandler: SayHelloChainedHandlerFunction,
     ...remainingHandlers: SayHelloChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, _callback?: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -15853,7 +15853,7 @@ export const handlerRouter = (props: HandlerRouterProps<
 >): OperationApiGatewayLambdaHandler<OperationIds> => async (event, context) => {
   const operationId = OperationIdByMethodAndPath[concatMethodAndPath(event.requestContext.httpMethod, event.requestContext.resourcePath)];
   const handler = props.handlers[operationId];
-  return handler(event, context, props.interceptors);
+  return handler(event, context, undefined, props.interceptors);
 };
 ",
   "packages/api/generated/typescript/src/apis/index.ts": "/* tslint:disable */
@@ -32655,7 +32655,7 @@ export type SayHelloChainedHandlerFunction = ChainedLambdaHandlerFunction<SayHel
 export const sayHelloHandler = (
     firstHandler: SayHelloChainedHandlerFunction,
     ...remainingHandlers: SayHelloChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, _callback?: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -32752,7 +32752,7 @@ export const handlerRouter = (props: HandlerRouterProps<
 >): OperationApiGatewayLambdaHandler<OperationIds> => async (event, context) => {
   const operationId = OperationIdByMethodAndPath[concatMethodAndPath(event.requestContext.httpMethod, event.requestContext.resourcePath)];
   const handler = props.handlers[operationId];
-  return handler(event, context, props.interceptors);
+  return handler(event, context, undefined, props.interceptors);
 };
 ",
   "packages/api/generated/typescript/src/apis/index.ts": "/* tslint:disable */
@@ -49556,7 +49556,7 @@ export type SayHelloChainedHandlerFunction = ChainedLambdaHandlerFunction<SayHel
 export const sayHelloHandler = (
     firstHandler: SayHelloChainedHandlerFunction,
     ...remainingHandlers: SayHelloChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, _callback?: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -49653,7 +49653,7 @@ export const handlerRouter = (props: HandlerRouterProps<
 >): OperationApiGatewayLambdaHandler<OperationIds> => async (event, context) => {
   const operationId = OperationIdByMethodAndPath[concatMethodAndPath(event.requestContext.httpMethod, event.requestContext.resourcePath)];
   const handler = props.handlers[operationId];
-  return handler(event, context, props.interceptors);
+  return handler(event, context, undefined, props.interceptors);
 };
 ",
   "packages/api/generated/typescript/src/apis/index.ts": "/* tslint:disable */

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
@@ -15238,7 +15238,7 @@ export type SayHelloChainedHandlerFunction = ChainedLambdaHandlerFunction<SayHel
 export const sayHelloHandler = (
     firstHandler: SayHelloChainedHandlerFunction,
     ...remainingHandlers: SayHelloChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, _callback?: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -15335,7 +15335,7 @@ export const handlerRouter = (props: HandlerRouterProps<
 >): OperationApiGatewayLambdaHandler<OperationIds> => async (event, context) => {
   const operationId = OperationIdByMethodAndPath[concatMethodAndPath(event.requestContext.httpMethod, event.requestContext.resourcePath)];
   const handler = props.handlers[operationId];
-  return handler(event, context, props.interceptors);
+  return handler(event, context, undefined, props.interceptors);
 };
 ",
   "generated/typescript/src/apis/index.ts": "/* tslint:disable */
@@ -31556,7 +31556,7 @@ export type SayHelloChainedHandlerFunction = ChainedLambdaHandlerFunction<SayHel
 export const sayHelloHandler = (
     firstHandler: SayHelloChainedHandlerFunction,
     ...remainingHandlers: SayHelloChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, _callback?: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -31653,7 +31653,7 @@ export const handlerRouter = (props: HandlerRouterProps<
 >): OperationApiGatewayLambdaHandler<OperationIds> => async (event, context) => {
   const operationId = OperationIdByMethodAndPath[concatMethodAndPath(event.requestContext.httpMethod, event.requestContext.resourcePath)];
   const handler = props.handlers[operationId];
-  return handler(event, context, props.interceptors);
+  return handler(event, context, undefined, props.interceptors);
 };
 ",
   "generated/typescript/src/apis/index.ts": "/* tslint:disable */
@@ -47855,7 +47855,7 @@ export type SayHelloChainedHandlerFunction = ChainedLambdaHandlerFunction<SayHel
 export const sayHelloHandler = (
     firstHandler: SayHelloChainedHandlerFunction,
     ...remainingHandlers: SayHelloChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, _callback?: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -47952,7 +47952,7 @@ export const handlerRouter = (props: HandlerRouterProps<
 >): OperationApiGatewayLambdaHandler<OperationIds> => async (event, context) => {
   const operationId = OperationIdByMethodAndPath[concatMethodAndPath(event.requestContext.httpMethod, event.requestContext.resourcePath)];
   const handler = props.handlers[operationId];
-  return handler(event, context, props.interceptors);
+  return handler(event, context, undefined, props.interceptors);
 };
 ",
   "generated/typescript/src/apis/index.ts": "/* tslint:disable */

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/with-docs.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/with-docs.test.ts.snap
@@ -5345,7 +5345,7 @@ export type SayHelloChainedHandlerFunction = ChainedLambdaHandlerFunction<SayHel
 export const sayHelloHandler = (
     firstHandler: SayHelloChainedHandlerFunction,
     ...remainingHandlers: SayHelloChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, _callback?: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -5442,7 +5442,7 @@ export const handlerRouter = (props: HandlerRouterProps<
 >): OperationApiGatewayLambdaHandler<OperationIds> => async (event, context) => {
   const operationId = OperationIdByMethodAndPath[concatMethodAndPath(event.requestContext.httpMethod, event.requestContext.resourcePath)];
   const handler = props.handlers[operationId];
-  return handler(event, context, props.interceptors);
+  return handler(event, context, undefined, props.interceptors);
 };
 ",
   "generated/typescript/src/apis/index.ts": "/* tslint:disable */

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/without-sample-code.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/without-sample-code.test.ts.snap
@@ -2092,7 +2092,7 @@ export type SayHelloChainedHandlerFunction = ChainedLambdaHandlerFunction<SayHel
 export const sayHelloHandler = (
     firstHandler: SayHelloChainedHandlerFunction,
     ...remainingHandlers: SayHelloChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, _callback?: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -2189,7 +2189,7 @@ export const handlerRouter = (props: HandlerRouterProps<
 >): OperationApiGatewayLambdaHandler<OperationIds> => async (event, context) => {
   const operationId = OperationIdByMethodAndPath[concatMethodAndPath(event.requestContext.httpMethod, event.requestContext.resourcePath)];
   const handler = props.handlers[operationId];
-  return handler(event, context, props.interceptors);
+  return handler(event, context, undefined, props.interceptors);
 };
 ",
   "generated/typescript/src/apis/index.ts": "/* tslint:disable */

--- a/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
@@ -15759,7 +15759,7 @@ export type SayHelloChainedHandlerFunction = ChainedLambdaHandlerFunction<SayHel
 export const sayHelloHandler = (
     firstHandler: SayHelloChainedHandlerFunction,
     ...remainingHandlers: SayHelloChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, _callback?: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -15856,7 +15856,7 @@ export const handlerRouter = (props: HandlerRouterProps<
 >): OperationApiGatewayLambdaHandler<OperationIds> => async (event, context) => {
   const operationId = OperationIdByMethodAndPath[concatMethodAndPath(event.requestContext.httpMethod, event.requestContext.resourcePath)];
   const handler = props.handlers[operationId];
-  return handler(event, context, props.interceptors);
+  return handler(event, context, undefined, props.interceptors);
 };
 ",
   "packages/api/generated/typescript/src/apis/index.ts": "/* tslint:disable */
@@ -35144,7 +35144,7 @@ export type SayHelloChainedHandlerFunction = ChainedLambdaHandlerFunction<SayHel
 export const sayHelloHandler = (
     firstHandler: SayHelloChainedHandlerFunction,
     ...remainingHandlers: SayHelloChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, _callback?: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -35241,7 +35241,7 @@ export const handlerRouter = (props: HandlerRouterProps<
 >): OperationApiGatewayLambdaHandler<OperationIds> => async (event, context) => {
   const operationId = OperationIdByMethodAndPath[concatMethodAndPath(event.requestContext.httpMethod, event.requestContext.resourcePath)];
   const handler = props.handlers[operationId];
-  return handler(event, context, props.interceptors);
+  return handler(event, context, undefined, props.interceptors);
 };
 ",
   "packages/api/generated/typescript/src/apis/index.ts": "/* tslint:disable */
@@ -54531,7 +54531,7 @@ export type SayHelloChainedHandlerFunction = ChainedLambdaHandlerFunction<SayHel
 export const sayHelloHandler = (
     firstHandler: SayHelloChainedHandlerFunction,
     ...remainingHandlers: SayHelloChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, _callback?: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -54628,7 +54628,7 @@ export const handlerRouter = (props: HandlerRouterProps<
 >): OperationApiGatewayLambdaHandler<OperationIds> => async (event, context) => {
   const operationId = OperationIdByMethodAndPath[concatMethodAndPath(event.requestContext.httpMethod, event.requestContext.resourcePath)];
   const handler = props.handlers[operationId];
-  return handler(event, context, props.interceptors);
+  return handler(event, context, undefined, props.interceptors);
 };
 ",
   "packages/api/generated/typescript/src/apis/index.ts": "/* tslint:disable */

--- a/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
+++ b/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/standalone.test.ts.snap
@@ -15241,7 +15241,7 @@ export type SayHelloChainedHandlerFunction = ChainedLambdaHandlerFunction<SayHel
 export const sayHelloHandler = (
     firstHandler: SayHelloChainedHandlerFunction,
     ...remainingHandlers: SayHelloChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, _callback?: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -15338,7 +15338,7 @@ export const handlerRouter = (props: HandlerRouterProps<
 >): OperationApiGatewayLambdaHandler<OperationIds> => async (event, context) => {
   const operationId = OperationIdByMethodAndPath[concatMethodAndPath(event.requestContext.httpMethod, event.requestContext.resourcePath)];
   const handler = props.handlers[operationId];
-  return handler(event, context, props.interceptors);
+  return handler(event, context, undefined, props.interceptors);
 };
 ",
   "generated/typescript/src/apis/index.ts": "/* tslint:disable */
@@ -34045,7 +34045,7 @@ export type SayHelloChainedHandlerFunction = ChainedLambdaHandlerFunction<SayHel
 export const sayHelloHandler = (
     firstHandler: SayHelloChainedHandlerFunction,
     ...remainingHandlers: SayHelloChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, _callback?: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -34142,7 +34142,7 @@ export const handlerRouter = (props: HandlerRouterProps<
 >): OperationApiGatewayLambdaHandler<OperationIds> => async (event, context) => {
   const operationId = OperationIdByMethodAndPath[concatMethodAndPath(event.requestContext.httpMethod, event.requestContext.resourcePath)];
   const handler = props.handlers[operationId];
-  return handler(event, context, props.interceptors);
+  return handler(event, context, undefined, props.interceptors);
 };
 ",
   "generated/typescript/src/apis/index.ts": "/* tslint:disable */
@@ -52830,7 +52830,7 @@ export type SayHelloChainedHandlerFunction = ChainedLambdaHandlerFunction<SayHel
 export const sayHelloHandler = (
     firstHandler: SayHelloChainedHandlerFunction,
     ...remainingHandlers: SayHelloChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, _callback?: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -52927,7 +52927,7 @@ export const handlerRouter = (props: HandlerRouterProps<
 >): OperationApiGatewayLambdaHandler<OperationIds> => async (event, context) => {
   const operationId = OperationIdByMethodAndPath[concatMethodAndPath(event.requestContext.httpMethod, event.requestContext.resourcePath)];
   const handler = props.handlers[operationId];
-  return handler(event, context, props.interceptors);
+  return handler(event, context, undefined, props.interceptors);
 };
 ",
   "generated/typescript/src/apis/index.ts": "/* tslint:disable */

--- a/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/with-smithy-build-options.test.ts.snap
+++ b/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/with-smithy-build-options.test.ts.snap
@@ -2605,7 +2605,7 @@ export type SayHelloChainedHandlerFunction = ChainedLambdaHandlerFunction<SayHel
 export const sayHelloHandler = (
     firstHandler: SayHelloChainedHandlerFunction,
     ...remainingHandlers: SayHelloChainedHandlerFunction[]
-): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
+): OperationApiGatewayLambdaHandler<'sayHello'> => async (event: any, context: any, _callback?: any, additionalInterceptors: SayHelloChainedHandlerFunction[] = []): Promise<any> => {
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
@@ -2702,7 +2702,7 @@ export const handlerRouter = (props: HandlerRouterProps<
 >): OperationApiGatewayLambdaHandler<OperationIds> => async (event, context) => {
   const operationId = OperationIdByMethodAndPath[concatMethodAndPath(event.requestContext.httpMethod, event.requestContext.resourcePath)];
   const handler = props.handlers[operationId];
-  return handler(event, context, props.interceptors);
+  return handler(event, context, undefined, props.interceptors);
 };
 ",
   "packages/api/generated/typescript/src/apis/index.ts": "/* tslint:disable */


### PR DESCRIPTION
Since the introduction of `handlerRouter` in `0.12.25`, using the TypeScript handler wrappers in a standalone fashion has been broken.

This is due to the lambda handler being invoked with three arguments `(event, context, callback)`, where `callback` overrides the expected `additionalInterceptors` parameter.

Address this by accepting `additionalInterceptors` as a fourth parameter rather than third.

Fixes #258
