### PR TITLE
fix(open-api-gateway): scripts support various package managers

### DIFF
--- a/packages/open-api-gateway/scripts/common/common.sh
+++ b/packages/open-api-gateway/scripts/common/common.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -e
+
+# Determine which package manager we're using
+# Preference: pnpm > yarn > npm
+# Use if available, otherwise fall back to npm so as not to require it as a system-wide dependency
+pkg_manager=pnpm
+pkg_install_cmd=install
+if ! $pkg_manager -v &> /dev/null; then
+  pkg_manager=yarn
+  pkg_install_cmd=add
+  if ! $pkg_manager -v &> /dev/null; then
+    pkg_manager=npm
+    pkg_install_cmd=install
+  fi
+fi
+
+# yarn classic vs v2+ have different behavior
+# check if it's the classic or later
+if [ "$pkg_manager" == "yarn" ]; then
+  yarn_version=$(yarn --version)
+  yarn_major_version=${yarn_version:0:1}
+fi
+
+##
+# workaround yarn v2+ needs yarn.lock present for the "add" command
+__prepare_tmpdir() {
+  if [ "$pkg_manager" == "yarn" ]; then
+    if [ "$yarn_major_version" != "1" ]; then
+      touch yarn.lock
+    fi
+  fi
+}
+
+##
+# installs the passed packages with the package manager in use
+install_packages() {
+  __prepare_tmpdir
+  # yarn2's --silent switch doesn't work, hence >/dev/null
+  $pkg_manager $pkg_install_cmd --silent "$@" >/dev/null 2>&1
+}
+
+##
+# runs the passed command with the package manager's proper syntax
+run_command() {
+  cmd="$@"
+
+  if [ "$pkg_manager" == "yarn" ]; then
+    if [ "$yarn_major_version" == "1" ]; then
+      runner="yarn run"
+    else
+      runner="yarn dlx"
+    fi
+  elif [ "$pkg_manager" == "pnpm" ]; then
+    runner="pnpx"
+  else
+    runner="npx"
+  fi
+
+  $runner $cmd >/dev/null 2>&1
+}

--- a/packages/open-api-gateway/scripts/custom/docs/html-redoc
+++ b/packages/open-api-gateway/scripts/custom/docs/html-redoc
@@ -14,27 +14,18 @@ echo "Generating HTML Redoc documentation..."
 
 working_dir=$(pwd)
 
+# load common package manager helper functions
+. "$working_dir/../../common/common.sh"
+
 # Create a temporary directory
 tmp_dir=$(mktemp -d "${TMPDIR:-/tmp/}generate-docs-html-redoc.XXXXXXXXX")
 cd $tmp_dir
 
-# Preference: pnpm > yarn > npm. Use if available, otherwise fall back to npm so as not to require it as a system-wide dependency
-pkg_manager=pnpm
-pkg_install_cmd=install
-if ! $pkg_manager -v &> /dev/null; then
-  pkg_manager=yarn
-  pkg_install_cmd=add
-  if ! $pkg_manager -v &> /dev/null; then
-    pkg_manager=npm
-    pkg_install_cmd=install
-  fi
-fi
-
 # Install dependencies
-$pkg_manager $pkg_install_cmd --silent redoc-cli@0.13.20
+install_packages redoc-cli@0.13.20
 
 # Generate
-npx redoc-cli build $spec_path --output $output_path
+run_command redoc-cli build $spec_path --output $output_path
 
 echo "HTML Redoc documentation generation done!"
 

--- a/packages/open-api-gateway/scripts/generators/generate
+++ b/packages/open-api-gateway/scripts/generators/generate
@@ -24,6 +24,9 @@ working_dir=$(pwd)
 # Get the directory this script is executing in (scripts/generators)
 script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
 
+# load common package manager helper functions
+. "$script_dir/../common/common.sh"
+
 # Create a temporary directory
 tmp_dir=$(mktemp -d "${TMPDIR:-/tmp/}generate-client-$generator_dir.XXXXXXXXX")
 cd $tmp_dir
@@ -31,26 +34,14 @@ cd $tmp_dir
 # Copy the specific generator directory into the temp directory
 cp -r $script_dir/$generator_dir/* .
 
-# Preference: pnpm > yarn > npm. Use if available, otherwise fall back to npm so as not to require it as a system-wide dependency
-pkg_manager=pnpm
-pkg_install_cmd=install
-if ! $pkg_manager -v &> /dev/null; then
-  pkg_manager=yarn
-  pkg_install_cmd=add
-  if ! $pkg_manager -v &> /dev/null; then
-    pkg_manager=npm
-    pkg_install_cmd=install
-  fi
-fi
-
 # Install dependencies
-$pkg_manager $pkg_install_cmd --silent @openapitools/openapi-generator-cli@2.5.1
+install_packages @openapitools/openapi-generator-cli@2.5.1
 
 # Support a special placeholder of {{src}} in config.yaml to ensure our custom templates get written to the correct folder
 sed 's|{{src}}|'"$src_dir"'|g' config.yaml > config.final.yaml
 
 # Generate the client
-npx openapi-generator-cli generate \
+run_command openapi-generator-cli generate \
   --log-to-stderr \
   --generator-name $generator \
   --skip-operation-example \

--- a/packages/open-api-gateway/scripts/parser/parse-openapi-spec
+++ b/packages/open-api-gateway/scripts/parser/parse-openapi-spec
@@ -5,6 +5,9 @@ set -e
 working_dir=$(pwd)
 script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
 
+# load common package manager helper functions
+. "$script_dir/../common/common.sh"
+
 # Create a temporary directory
 tmp_dir=$(mktemp -d "${TMPDIR:-/tmp/}parse-openapi-spec.XXXXXXXXX")
 cd $tmp_dir
@@ -12,21 +15,9 @@ cd $tmp_dir
 # Copy the parse script into the temp directory
 cp -r $script_dir/* .
 
-# Preference: pnpm > yarn > npm. Use if available, otherwise fall back to npm so as not to require it as a system-wide dependency
-pkg_manager=pnpm
-pkg_install_cmd=install
-if ! $pkg_manager -v &> /dev/null; then
-  pkg_manager=yarn
-  pkg_install_cmd=add
-  if ! $pkg_manager -v &> /dev/null; then
-    pkg_manager=npm
-    pkg_install_cmd=install
-  fi
-fi
-
 # Install dependencies. Note that projen version does not need to be kept in sync with project projen version since
 # this runs in isolation.
-$pkg_manager $pkg_install_cmd --silent \
+install_packages \
   typescript@4.7.2 \
   @types/node@14.14.20 \
   ts-node@10.8.1 \
@@ -36,7 +27,8 @@ $pkg_manager $pkg_install_cmd --silent \
   projen@0.67.46
 
 # Run the parse script
-npx ts-node parse-openapi-spec.ts "$@"
+run_command "ts-node parse-openapi-spec.ts $@"
+echo "openapi-spec parsed"
 
 # Clean up
 cd $working_dir


### PR DESCRIPTION
Fixes #

* created a common helper to determine available package managers and handle operations with them (install packages, run commands) with the proper syntax (due to the lack of`yarn berry`'s backwards compatibility)
* now all scripts support `pnpm`, `yarn classic`, `yarn berry`, `npm`, as well as `pnpx`, `yarn run` (v1), `yarn dlx` (v2+), `npx` commands
