### PR TITLE
fix(open-api-gateway): fix yarn and pnpm commands used during spec parsing and code generation

### DIFF
--- a/packages/open-api-gateway/scripts/common/common.sh
+++ b/packages/open-api-gateway/scripts/common/common.sh
@@ -50,10 +50,10 @@ run_command() {
     if [ "$yarn_major_version" == "1" ]; then
       runner="yarn run"
     else
-      runner="yarn dlx"
+      runner="yarn exec"
     fi
   elif [ "$pkg_manager" == "pnpm" ]; then
-    runner="pnpx"
+    runner="pnpm exec"
   else
     runner="npx"
   fi


### PR DESCRIPTION
`pnpx` is deprecated in favour of `pnpm dlx` and `pnpm exec`.  See: https://pnpm.io/6.x/pnpx-cli

`pnpm exec` is the right choice here as the executable name is different to the package name for `openapi-generator-cli` , and we already include an install step for the executable anyway. Same for `yarn`.
