### PR TITLE
fix(open-api-gateway): pkg manager support in scripts and debug option

### DIFF
--- a/packages/open-api-gateway/scripts/common/common.sh
+++ b/packages/open-api-gateway/scripts/common/common.sh
@@ -2,43 +2,46 @@
 
 set -e
 
-# Determine which package manager we're using
-# Preference: pnpm > yarn > npm
-# Use if available, otherwise fall back to npm so as not to require it as a system-wide dependency
-pkg_manager=pnpm
-pkg_install_cmd=install
-if ! $pkg_manager -v &> /dev/null; then
-  pkg_manager=yarn
-  pkg_install_cmd=add
-  if ! $pkg_manager -v &> /dev/null; then
-    pkg_manager=npm
-    pkg_install_cmd=install
-  fi
-fi
-
-# yarn classic vs v2+ have different behavior
-# check if it's the classic or later
-if [ "$pkg_manager" == "yarn" ]; then
-  yarn_version=$(yarn --version)
-  yarn_major_version=${yarn_version:0:1}
-fi
-
 ##
-# workaround yarn v2+ needs yarn.lock present for the "add" command
-__prepare_tmpdir() {
-  if [ "$pkg_manager" == "yarn" ]; then
-    if [ "$yarn_major_version" != "1" ]; then
-      touch yarn.lock
-    fi
+# log debug messages if OPEN_API_GATEWAY_DEBUG env var set to 1
+# this is a helper function for debugging our scripts
+log() {
+  if [ "$OPEN_API_GATEWAY_DEBUG" == 1 ]; then
+    echo "$@"
   fi
 }
+
+# Determine which package manager we're using
+# Use pnpm if available, otherwise fall back to npm (it's present if you have node)
+
+# NOTES: removed `yarn` option: yarn v2+ has no backwards compatibility and will
+# fail to run some of the commands because peer dependencies not found;
+# yarn v1 has no significant performance difference from npm/npx
+pkg_manager=pnpm
+if ! $pkg_manager -v &> /dev/null; then
+  pkg_manager=npm
+fi
+
+log "package manager :: $pkg_manager"
 
 ##
 # installs the passed packages with the package manager in use
 install_packages() {
-  __prepare_tmpdir
-  # yarn2's --silent switch doesn't work, hence >/dev/null
-  $pkg_manager $pkg_install_cmd --silent "$@" >/dev/null 2>&1
+  log "installing packages :: $@"
+
+  if [ "$pkg_manager" == "pnpm" ]; then
+    reporter=silent
+    if [ "$OPEN_API_GATEWAY_DEBUG" == 1 ]; then
+      reporter=default
+    fi
+    $pkg_manager install --reporter=$reporter "$@"
+  else
+    silent_switch="--silent"
+    if [ "$OPEN_API_GATEWAY_DEBUG" == 1 ]; then
+      silent_switch=""
+    fi
+    $pkg_manager install $silent_switch "$@"
+  fi
 }
 
 ##
@@ -46,17 +49,14 @@ install_packages() {
 run_command() {
   cmd="$@"
 
-  if [ "$pkg_manager" == "yarn" ]; then
-    if [ "$yarn_major_version" == "1" ]; then
-      runner="yarn run"
-    else
-      runner="yarn dlx"
-    fi
-  elif [ "$pkg_manager" == "pnpm" ]; then
-    runner="pnpx"
+  if [ "$pkg_manager" == "pnpm" ]; then
+    # pnpx cli was deprecated in v6 --> use pnpm dlx
+    runner="pnpm dlx"
   else
     runner="npx"
   fi
+
+  log "running command $runner $cmd"
 
   $runner $cmd >/dev/null 2>&1
 }

--- a/packages/open-api-gateway/scripts/custom/docs/html-redoc
+++ b/packages/open-api-gateway/scripts/custom/docs/html-redoc
@@ -21,6 +21,8 @@ working_dir=$(pwd)
 tmp_dir=$(mktemp -d "${TMPDIR:-/tmp/}generate-docs-html-redoc.XXXXXXXXX")
 cd $tmp_dir
 
+log "html-redoc :: tmp_dir :: $tmp_dir"
+
 # Install dependencies
 install_packages redoc-cli@0.13.20
 

--- a/packages/open-api-gateway/scripts/generators/generate
+++ b/packages/open-api-gateway/scripts/generators/generate
@@ -31,6 +31,8 @@ script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && 
 tmp_dir=$(mktemp -d "${TMPDIR:-/tmp/}generate-client-$generator_dir.XXXXXXXXX")
 cd $tmp_dir
 
+log "generate :: tmp_dir :: $tmp_dir"
+
 # Copy the specific generator directory into the temp directory
 cp -r $script_dir/$generator_dir/* .
 
@@ -41,7 +43,7 @@ install_packages @openapitools/openapi-generator-cli@2.5.1
 sed 's|{{src}}|'"$src_dir"'|g' config.yaml > config.final.yaml
 
 # Generate the client
-run_command openapi-generator-cli generate \
+run_command @openapitools/openapi-generator-cli generate \
   --log-to-stderr \
   --generator-name $generator \
   --skip-operation-example \

--- a/packages/open-api-gateway/scripts/parser/parse-openapi-spec
+++ b/packages/open-api-gateway/scripts/parser/parse-openapi-spec
@@ -12,6 +12,8 @@ script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && 
 tmp_dir=$(mktemp -d "${TMPDIR:-/tmp/}parse-openapi-spec.XXXXXXXXX")
 cd $tmp_dir
 
+log "parse-openapi-spec :: tmp_dir :: $tmp_dir"
+
 # Copy the parse script into the temp directory
 cp -r $script_dir/* .
 


### PR DESCRIPTION
Fixes #

* added debugging options for parser/generator scripts: use `OPEN_API_GATEWAY_DEBUG=1 npx projen` to see script logs
* removed `yarn` pkg_manager - use `npm` or `pnpm`
* fixed `openapi-generator-cli` command (use namespace)