### PR TITLE
fix: ensure py deps are installed

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -66,6 +66,9 @@
       "steps": [
         {
           "exec": "ts-node --project tsconfig.dev.json .projenrc.ts"
+        },
+        {
+          "spawn": "install"
         }
       ]
     },

--- a/packages/nx-monorepo/src/nx-monorepo.ts
+++ b/packages/nx-monorepo/src/nx-monorepo.ts
@@ -458,6 +458,7 @@ export class NxMonorepoProject extends TypeScriptProject {
         .map((project) => project.name)
         .join(",")} --parallel=1`
     );
+    this.defaultTask?.spawn(monorepoInstallTask);
 
     // Update the nx.json to ensure that install-py follows dependency order
     this.nxJson.addOverride("targetDependencies.install-py", [

--- a/packages/nx-monorepo/test/__snapshots__/nx-monorepo.test.ts.snap
+++ b/packages/nx-monorepo/test/__snapshots__/nx-monorepo.test.ts.snap
@@ -7180,6 +7180,9 @@ target
           Object {
             "exec": "ts-node --project tsconfig.dev.json .projenrc.ts",
           },
+          Object {
+            "spawn": "install",
+          },
         ],
       },
       "eject": Object {

--- a/packages/open-api-gateway/test/project/open-api-gateway-java-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-java-project/__snapshots__/monorepo.test.ts.snap
@@ -471,6 +471,9 @@ target
           Object {
             "exec": "ts-node --project tsconfig.dev.json .projenrc.ts",
           },
+          Object {
+            "spawn": "install",
+          },
         ],
       },
       "eject": Object {

--- a/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-python-project/__snapshots__/monorepo.test.ts.snap
@@ -473,6 +473,9 @@ target
           Object {
             "exec": "ts-node --project tsconfig.dev.json .projenrc.ts",
           },
+          Object {
+            "spawn": "install",
+          },
         ],
       },
       "eject": Object {

--- a/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/open-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
@@ -472,6 +472,9 @@ target
           Object {
             "exec": "ts-node --project tsconfig.dev.json .projenrc.ts",
           },
+          Object {
+            "spawn": "install",
+          },
         ],
       },
       "eject": Object {
@@ -17953,6 +17956,9 @@ target
         "steps": Array [
           Object {
             "exec": "ts-node --project tsconfig.dev.json .projenrc.ts",
+          },
+          Object {
+            "spawn": "install",
           },
         ],
       },
@@ -35442,6 +35448,9 @@ target
           Object {
             "exec": "ts-node --project tsconfig.dev.json .projenrc.ts",
           },
+          Object {
+            "spawn": "install",
+          },
         ],
       },
       "eject": Object {
@@ -52919,6 +52928,9 @@ target
         "steps": Array [
           Object {
             "exec": "ts-node --project tsconfig.dev.json .projenrc.ts",
+          },
+          Object {
+            "spawn": "install",
           },
         ],
       },

--- a/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
+++ b/packages/open-api-gateway/test/project/smithy-api-gateway-ts-project/__snapshots__/monorepo.test.ts.snap
@@ -474,6 +474,9 @@ target
           Object {
             "exec": "ts-node --project tsconfig.dev.json .projenrc.ts",
           },
+          Object {
+            "spawn": "install",
+          },
         ],
       },
       "eject": Object {
@@ -19382,6 +19385,9 @@ target
         "steps": Array [
           Object {
             "exec": "ts-node --project tsconfig.dev.json .projenrc.ts",
+          },
+          Object {
+            "spawn": "install",
           },
         ],
       },
@@ -38298,6 +38304,9 @@ target
           Object {
             "exec": "ts-node --project tsconfig.dev.json .projenrc.ts",
           },
+          Object {
+            "spawn": "install",
+          },
         ],
       },
       "eject": Object {
@@ -57202,6 +57211,9 @@ target
         "steps": Array [
           Object {
             "exec": "ts-node --project tsconfig.dev.json .projenrc.ts",
+          },
+          Object {
+            "spawn": "install",
           },
         ],
       },


### PR DESCRIPTION
Python deps are not currently installed automatically when running `npx projen`. This ensure the install task is executed as part of default synth.