### PR TITLE
fix: explicitly list executableFiles

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -197,6 +197,10 @@
       "type": "override"
     },
     {
+      "name": "@pnpm/types",
+      "type": "runtime"
+    },
+    {
       "name": "aws-cdk-lib",
       "type": "runtime"
     },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,13 +81,13 @@ export class MyPackageProject extends PDKProject {
 
 Please refer to existing projects for examples on full configuration.
 
-Once your class is created, simply instantiate it within `.projenrc.ts` and run `npx projen` from the root in order for it to be synthesized.
+Once your class is created, simply instantiate it within `.projenrc.ts` and run `pnpm projen` from the root in order for it to be synthesized.
 
 Any new project created **MUST** set the stability to `experimental`. This is to ensure the `aws-prototyping-sdk` package maintains only stable code. Once a sufficient enough period of time, tests, documentation and usage of this project has occured, it can be promoted to `stable`.
 
 #### Note regarding dependencies
 
-The jsii runtimes in non-javascript languages do not use `npm install`, and as a consequence cannot rely on `npm install` bringing in a packages dependencies. As a consequence, dependencies that are not themselves jsii modules, must also be referenced in the `bundledDependencies` section, so that they are bundled within the NPM package.
+The jsii runtimes in non-javascript languages do not use `pnpm i`, and as a consequence cannot rely on `pnpm i` bringing in a packages dependencies. As a consequence, dependencies that are not themselves jsii modules, must also be referenced in the `bundledDependencies` section, so that they are bundled within the NPM package.
 
 ### Write your code and tests
 
@@ -155,8 +155,8 @@ To send us a pull request, please:
 
 1. Fork the repository.
 2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
-3. Run `yarn build` to ensure everything builds and tests correctly.
-  > This will execute `npx nx run-many --target=build --output-style=stream --nx-bail` to build all sub-projects in the workspace.
+3. Run `pnpm build` to ensure everything builds and tests correctly.
+  > This will execute `pnpm nx run-many --target=build --output-style=stream --nx-bail` to build all sub-projects in the workspace.
 4. Commit to your fork on a new branch using [conventional commit messages](CONTRIBUTING.md#commits).
 5. Send us a pull request, answering any default questions in the pull request template.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
@@ -173,7 +173,7 @@ for committing changes. To commit your changes run the following commands:
 
 ```bash
 git add -A # stage your changes
-npx cz # launch commitizen
+pnpm cz # launch commitizen
 ```
 
 An interactive UI will be displayed which you can follow to get your change committed.

--- a/README.md
+++ b/README.md
@@ -21,17 +21,17 @@ pnpm i
 This package is built using [projen](https://github.com/projen/projen) and [nx](https://nx.dev/getting-started/intro) as such all tasks should be invoked
 via either:
 
-- `pnpx nx run-many --target=<task> --all` - executes the `<task>` on every package, in dependency order.
-- `pnpx nx run <package_name>:<task>` - executes the `<task>` on the specified `<package_name>`.
+- `pnpm nx run-many --target=<task> --all` - executes the `<task>` on every package, in dependency order.
+- `pnpm nx run <package_name>:<task>` - executes the `<task>` on the specified `<package_name>`.
 
-To build the full project, run `pnpx nx run-many --target=build --all`
+To build the full project, run `pnpm nx run-many --target=build --all`
 
-Any change to `projects/*` or `.projenrc.ts` requires a synth to be executed. To do this, run: `pnpx projen` from the root directory.
+Any change to `projects/*` or `.projenrc.ts` requires a synth to be executed. To do this, run: `pnpm projen` from the root directory.
 
 ## Nx workspace script alias
-In addition to the above `pnpx nx <command>` format to execute commands, the workspace package contains useful alias for common tasks.
+In addition to the above `pnpm nx <command>` format to execute commands, the workspace package contains useful alias for common tasks.
 
-Executing `pnpm <task>` for common tasks will execute `pnpx nx run-many --target=<task> --output-style=stream --nx-bail`, such as `pnpm build` will execute `pnpx nx run-many --target=build --output-style=stream --nx-bail` across all packages.
+Executing `pnpm <task>` for common tasks will execute `pnpm nx run-many --target=<task> --output-style=stream --nx-bail`, such as `pnpm build` will execute `pnpx nx run-many --target=build --output-style=stream --nx-bail` across all packages.
 
 All nx run-many alias scripts access additional arguments, such as to only run on specific projects you can use `pnpm build --projects=proj1,proj2`.
 > See [Nx Run-Many options](https://nx.dev/packages/nx/documents/run-many#options) for details.

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
+    "@pnpm/types": "*",
     "aws-cdk-lib": "^2.60.0",
     "cdk-nag": "^2.21.65",
     "constructs": "^10.1.222",

--- a/packages/open-api-gateway/package.json
+++ b/packages/open-api-gateway/package.json
@@ -92,7 +92,13 @@
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "executableFiles": [
+      "scripts/common/common.sh",
+      "scripts/custom/docs/html-redoc",
+      "scripts/generators/generate",
+      "scripts/parser/parse-openapi-spec"
+    ]
   },
   "version": "0.0.0",
   "jest": {

--- a/packages/open-api-gateway/src/project/spec/components/parsed-spec.ts
+++ b/packages/open-api-gateway/src/project/spec/components/parsed-spec.ts
@@ -29,7 +29,7 @@ export class ParsedSpec extends Component {
   static parse(specPath: string, outputPath: string) {
     // Parse the spec and write to the target output path
     exec(
-      `chmod +x ./parse-openapi-spec && ./parse-openapi-spec --specPath=${specPath} --outputPath=${outputPath}`,
+      `./parse-openapi-spec --specPath=${specPath} --outputPath=${outputPath}`,
       {
         cwd: path.resolve(
           __dirname,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,7 @@ importers:
       '@nrwl/devkit': ^15.5.1
       '@nrwl/nx-cloud': ^15.0.2
       '@nrwl/workspace': ^15.5.1
+      '@pnpm/types': '*'
       '@types/node': ^14
       '@typescript-eslint/eslint-plugin': ^5
       '@typescript-eslint/parser': ^5
@@ -63,6 +64,7 @@ importers:
       ts-node: ^10.9.1
       typescript: ^4.9.4
     dependencies:
+      '@pnpm/types': 9.0.0
       aws-cdk-lib: 2.69.0_constructs@10.1.283
       cdk-nag: 2.23.4_ccev454wgxtwnjk4ihgqzj7w7y
       constructs: 10.1.283
@@ -7441,6 +7443,11 @@ packages:
       config-chain: 1.1.13
     dev: true
 
+  /@pnpm/types/9.0.0:
+    resolution: {integrity: sha512-+nNqpNvqb1u3WW/cHDo7tGjqJBWWe4GAHEdELrz4QMQwGAtG/1GF6NMc0cewdwgU2k67CI3JHGu4quZJnMEUJg==}
+    engines: {node: '>=16.14'}
+    dev: false
+
   /@radix-ui/number/1.0.0:
     resolution: {integrity: sha512-Ofwh/1HX69ZfJRiRBMTy7rgjAzHmwe4kW9C9Y99HTRUcYLUuVT0KESFj15rPjRgKJs20GPq8Bm5aEDJ8DuA3vA==}
     dependencies:
@@ -11744,7 +11751,7 @@ packages:
     dependencies:
       semver: 7.3.8
       shelljs: 0.8.5
-      typescript: 5.1.0-dev.20230323
+      typescript: 5.1.0-dev.20230326
     dev: true
 
   /duplexer/0.1.2:
@@ -21409,7 +21416,7 @@ packages:
       '@types/jest': 27.5.2
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 27.5.1_ts-node@10.9.1
+      jest: 27.5.1
       jest-util: 27.5.1
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -21611,8 +21618,8 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
-  /typescript/5.1.0-dev.20230323:
-    resolution: {integrity: sha512-C/U2MNu/RkpNWJLPqo0q6ZimJLwBaQkd9ktJOjLDyV6/d/HgVfvVI15ga0UH4yj4bKRY0B8Yoth8pyn6jP+IUg==}
+  /typescript/5.1.0-dev.20230326:
+    resolution: {integrity: sha512-qyVhH6ncazjP48EMUqy8i9K85BTSbGKdXVFab0+7Srvu9UXjn2Qq3X/eHAV6vVVAXNYHR94OXdqtkD8DhkzEcw==}
     engines: {node: '>=12.20'}
     hasBin: true
     dev: true

--- a/private/pdk-project.ts
+++ b/private/pdk-project.ts
@@ -1,5 +1,6 @@
 /*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0 */
+import { PublishConfig as _PublishConfig } from "@pnpm/types/lib/package";
 import { SampleDir } from "projen";
 import {
   JsiiJavaTarget,
@@ -16,6 +17,10 @@ import {
 } from "./projects/pdk-monorepo-project";
 import { buildExecutableCommand } from "../packages/nx-monorepo/src";
 import type { Nx } from "../packages/nx-monorepo/src/nx-types";
+
+export type PublishConfig = _PublishConfig & {
+  access?: undefined | "restricted" | "public";
+};
 
 /**
  * Configuration options for the PDK Project.
@@ -41,6 +46,13 @@ export interface PDKProjectOptions extends JsiiProjectOptions {
    * @see https://nx.dev/reference/project-configuration
    */
   readonly nx?: Nx.ProjectConfig;
+
+  /**
+   * PublishConfig.
+   *
+   * @see https://pnpm.io/package_json#publishconfig
+   */
+  readonly publishConfig?: PublishConfig;
 }
 
 /**
@@ -160,7 +172,7 @@ export abstract class PDKProject extends JsiiProject {
       ],
     });
 
-    this.pdkRelease = new PDKRelease(this);
+    this.pdkRelease = new PDKRelease(this, options.publishConfig);
 
     if (options.nx) {
       this.nx = options.nx;
@@ -228,7 +240,7 @@ export abstract class PDKProject extends JsiiProject {
  * bumps package versions using semantic versioning.
  */
 class PDKRelease extends Release {
-  constructor(project: PDKProject) {
+  constructor(project: PDKProject, publishConfig?: PublishConfig) {
     super(project, {
       versionFile: "package.json",
       task: project.buildTask,
@@ -268,6 +280,7 @@ class PDKRelease extends Release {
 
     project.package.addField("publishConfig", {
       access: "public",
+      ...publishConfig,
     });
   }
 }

--- a/private/projects/open-api-gateway-project.ts
+++ b/private/projects/open-api-gateway-project.ts
@@ -41,6 +41,14 @@ export class OpenApiGatewayProject extends PDKProject {
           globalSetup: "<rootDir>/jest.setup.ts",
         },
       },
+      publishConfig: {
+        executableFiles: [
+          "scripts/common/common.sh",
+          "scripts/custom/docs/html-redoc",
+          "scripts/generators/generate",
+          "scripts/parser/parse-openapi-spec",
+        ],
+      },
     });
 
     this.eslint?.addRules({ "import/no-unresolved": ["off"] });

--- a/private/projects/pdk-monorepo-project.ts
+++ b/private/projects/pdk-monorepo-project.ts
@@ -94,7 +94,7 @@ export class PDKMonorepoProject extends NxMonorepoProject {
       monorepoUpgradeDepsOptions: {
         syncpackConfig: { ...DEFAULT_CONFIG, workspace: false },
       },
-      deps: ["fast-xml-parser", "projen"],
+      deps: ["fast-xml-parser", "projen", "@pnpm/types"],
       nxConfig: {
         // This is OK to be stored given its read only and the repository is public
         nxCloudReadOnlyAccessToken:


### PR DESCRIPTION
PNPM does not transfer file permissions when packing the tarball, only bins or files explicitly listed in publishConfig.executableFiles are granted executable perms.

In addition - I have also updates some old references to yarn/npx from the docs.

Fixes #322