### PR TITLE
chore: merge queue support in workflows

### DIFF
--- a/.github/workflows/aws-arch-pricing.yml
+++ b/.github/workflows/aws-arch-pricing.yml
@@ -11,8 +11,6 @@ jobs:
       contents: read
     outputs:
       patch_created: ${{ steps.create_patch.outputs.patch_created }}
-    env:
-      CI: "false"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,11 +2,30 @@ name: build
 on:
   pull_request: {}
   workflow_dispatch: {}
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group
+  merge_group:
+    types: [checks_requested]
 env:
   NX_BRANCH: ${{ github.event.number }}
   NX_RUN_GROUP: ${{ github.run_id }}
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+# Minimum permissions required by skip-duplicate-actions
+permissions:
+  actions: write
+  contents: read
 jobs:
+  # https://github.com/marketplace/actions/skip-duplicate-actions
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          concurrent_skipping: 'never'
+          skip_after_successful_duplicate: 'true'
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
   build:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -8,6 +8,9 @@ on:
       - reopened
       - ready_for_review
       - edited
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group
+  merge_group:
+    types: [checks_requested]
 jobs:
   validate:
     name: Validate PR title


### PR DESCRIPTION
https://github.com/community/community/discussions/39933

Merge Queue required actions block the queue - this PR should enable them to work in the merge queue and enable us to mark build/pr-lint as required actions again.

Also, resolving aws-arch-pricing workflow that was run as CI when it was marked as CI=false.