### PR TITLE
chore: remove merge_group from pull-request-lint

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -8,9 +8,6 @@ on:
       - reopened
       - ready_for_review
       - edited
-  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group
-  merge_group:
-    types: [checks_requested]
 jobs:
   validate:
     name: Validate PR title


### PR DESCRIPTION
This workflow did not actually need to support the merge_group trigger.
