### PR TITLE
chore(workflow): aws-arch-pricing build with update snapshots

### DIFF
--- a/.github/workflows/aws-arch-pricing.yml
+++ b/.github/workflows/aws-arch-pricing.yml
@@ -25,7 +25,13 @@ jobs:
         run: pnpm projen fetch-pricing-manifest
       - name: Build
         working-directory: packages/aws-arch
-        run: pnpm build
+        # Need to run each build step manually to allow updating snapshots in test
+        run: -|
+          pnpm projen pre-compile
+          pnpm projen compile
+          pnpm projen post-compile
+          pnpm jest --updateSnapshot
+          pnpm projen package
       - id: create_patch
         name: Find mutations
         run: |-


### PR DESCRIPTION
CI is always set to true in github actions, so we need to manually
call the build steps to force updating snapshots in this workflow.

https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables