### PR TITLE
fix: packageManager isn't configured properly

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn commitlint --edit
+pnpm commitlint --edit

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "license": "Apache-2.0",
   "version": "0.0.0",
   "types": "lib/index.d.ts",
-  "packageManager": "pnpm@8",
+  "packageManager": "pnpm@8.0.0",
   "private": true,
   "config": {
     "commitizen": {

--- a/packages/nx-monorepo/src/nx-monorepo.ts
+++ b/packages/nx-monorepo/src/nx-monorepo.ts
@@ -220,17 +220,17 @@ export class NxMonorepoProject extends TypeScriptProject {
         this.package.addEngine("pnpm", ">=8");
         // https://nodejs.org/api/corepack.html
         // https://nodejs.org/api/packages.html#packagemanager
-        this.package.addField("packageManager", "pnpm@8");
+        this.package.addField("packageManager", "pnpm@8.0.0");
         break;
       }
       case NodePackageManager.YARN: {
         this.package.addEngine("yarn", ">=1 <2");
-        this.package.addField("packageManager", "yarn@1");
+        this.package.addField("packageManager", "yarn@1.0.0");
         break;
       }
       case NodePackageManager.YARN2: {
         this.package.addEngine("yarn", ">=2 <3");
-        this.package.addField("packageManager", "yarn@2");
+        this.package.addField("packageManager", "yarn@2.0.0");
         break;
       }
     }


### PR DESCRIPTION
The recent node.js returns "Usage error" if `packageManager` isn't
semver. This commit fixes the versions to semver complient.

Also, `commit-msg` hook is still using `yarn`. Since the package manager
for this repository is `pnpm`, this commit also updates the hook.

----

## Usage Error
```
❯ node -v
v18.15.0
❯ pnpm -v
8.2.0

# On the repository root
❯ pnpm -v
Usage Error: Invalid package manager specification in package.json; expected a semver version

$ pnpm ...
```