### PR TITLE
build: upgrade node version when release to package manager

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,9 +81,10 @@ jobs:
       contents: read
     if: needs.release.outputs.latest_commit == github.sha
     steps:
-      - uses: actions/setup-node@v2
+      - name: Install Node.js
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 18
       - name: Install pnpm
         run: npm install -g pnpm
       - name: Download build artifacts
@@ -110,9 +111,10 @@ jobs:
         with:
           distribution: temurin
           java-version: 11.x
-      - uses: actions/setup-node@v2
+      - name: Install Node.js
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 18
       - name: Install pnpm
         run: npm install -g pnpm
       - name: Download build artifacts
@@ -138,9 +140,10 @@ jobs:
       contents: read
     if: needs.release.outputs.latest_commit == github.sha
     steps:
-      - uses: actions/setup-node@v2
+      - name: Install Node.js
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 18
       - name: Install pnpm
         run: npm install -g pnpm
       - uses: actions/setup-python@v2


### PR DESCRIPTION
Release to package managers is currently failing as pnpm requires NODE >16.