### PR TITLE
fix(type-safe-api): ensure gradle wrapper is executable and remove link for monorepo

### DIFF
--- a/packages/type-safe-api/package.json
+++ b/packages/type-safe-api/package.json
@@ -102,7 +102,9 @@
       "scripts/generators/generate",
       "scripts/parser/parse-openapi-spec",
       "scripts/custom/infrastructure/cdk/generate-type-safe-cdk-construct",
-      "scripts/custom/clean-openapi-generated-code/clean-openapi-generated-code"
+      "scripts/custom/clean-openapi-generated-code/clean-openapi-generated-code",
+      "samples/smithy/gradlew",
+      "samples/smithy/gradelw.bat"
     ]
   },
   "version": "0.0.0",

--- a/packages/type-safe-api/src/project/type-safe-api-project.ts
+++ b/packages/type-safe-api/src/project/type-safe-api-project.ts
@@ -155,6 +155,7 @@ export class TypeSafeApiProject extends Project {
       parent: parentMonorepo ?? this,
       parentPackageName: this.name,
       generatedCodeDir: runtimeDirRelativeToParent,
+      isWithinMonorepo: !!parentMonorepo,
       // Spec path relative to each generated client dir
       parsedSpecPath: path.join(
         "..",
@@ -235,6 +236,7 @@ export class TypeSafeApiProject extends Project {
       parent: parentMonorepo ?? this,
       parentPackageName: this.name,
       generatedCodeDir: infraDirRelativeToParent,
+      isWithinMonorepo: !!parentMonorepo,
       // Spec path relative to each generated infra package dir
       parsedSpecPath: path.join(
         "..",

--- a/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
@@ -5959,9 +5959,6 @@ tsconfig.esm.json
           Object {
             "exec": "yarn install --check-files",
           },
-          Object {
-            "exec": "yarn link",
-          },
         ],
       },
       "install:ci": Object {
@@ -12157,9 +12154,6 @@ tsconfig.esm.json
           Object {
             "exec": "yarn install --check-files",
           },
-          Object {
-            "exec": "yarn link",
-          },
         ],
       },
       "install:ci": Object {
@@ -17129,7 +17123,6 @@ tsconfig.tsbuildinfo
       Object {
         "name": "openapi-typescript-typescript-runtime",
         "type": "runtime",
-        "version": "file:../../runtime/typescript",
       },
     ],
   },
@@ -17201,9 +17194,6 @@ tsconfig.tsbuildinfo
         "name": "install",
         "steps": Array [
           Object {
-            "exec": "yarn link openapi-typescript-typescript-runtime",
-          },
-          Object {
             "exec": "yarn install --check-files",
           },
         ],
@@ -17261,19 +17251,19 @@ tsconfig.tsbuildinfo
             "exec": "yarn upgrade npm-check-updates",
           },
           Object {
-            "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='openapi-typescript-typescript-runtime'",
+            "exec": "npm-check-updates --dep dev --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='openapi-typescript-typescript-runtime'",
+            "exec": "npm-check-updates --dep optional --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='openapi-typescript-typescript-runtime'",
+            "exec": "npm-check-updates --dep peer --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='openapi-typescript-typescript-runtime'",
+            "exec": "npm-check-updates --dep prod --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='openapi-typescript-typescript-runtime'",
+            "exec": "npm-check-updates --dep bundle --upgrade --target=minor",
           },
           Object {
             "exec": "yarn install --check-files",
@@ -17511,7 +17501,7 @@ tsconfig.tsbuildinfo
       "aws-cdk-lib": "*",
       "cdk-nag": "*",
       "constructs": "*",
-      "openapi-typescript-typescript-runtime": "file:../../runtime/typescript",
+      "openapi-typescript-typescript-runtime": "*",
     },
     "devDependencies": Object {
       "@types/node": "^16",
@@ -18959,9 +18949,6 @@ tsconfig.esm.json
         "steps": Array [
           Object {
             "exec": "yarn install --check-files",
-          },
-          Object {
-            "exec": "yarn link",
           },
         ],
       },
@@ -25505,9 +25492,6 @@ tsconfig.esm.json
           Object {
             "exec": "yarn install --check-files",
           },
-          Object {
-            "exec": "yarn link",
-          },
         ],
       },
       "install:ci": Object {
@@ -29686,7 +29670,6 @@ tsconfig.tsbuildinfo
       Object {
         "name": "smithy-npm-typescript-runtime",
         "type": "runtime",
-        "version": "file:../../runtime/typescript",
       },
     ],
   },
@@ -29758,9 +29741,6 @@ tsconfig.tsbuildinfo
         "name": "install",
         "steps": Array [
           Object {
-            "exec": "npm link smithy-npm-typescript-runtime",
-          },
-          Object {
             "exec": "npm install",
           },
         ],
@@ -29818,19 +29798,19 @@ tsconfig.tsbuildinfo
             "exec": "npm update npm-check-updates",
           },
           Object {
-            "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='smithy-npm-typescript-runtime'",
+            "exec": "npm-check-updates --dep dev --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='smithy-npm-typescript-runtime'",
+            "exec": "npm-check-updates --dep optional --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='smithy-npm-typescript-runtime'",
+            "exec": "npm-check-updates --dep peer --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='smithy-npm-typescript-runtime'",
+            "exec": "npm-check-updates --dep prod --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='smithy-npm-typescript-runtime'",
+            "exec": "npm-check-updates --dep bundle --upgrade --target=minor",
           },
           Object {
             "exec": "npm install",
@@ -30068,7 +30048,7 @@ tsconfig.tsbuildinfo
       "aws-cdk-lib": "*",
       "cdk-nag": "*",
       "constructs": "*",
-      "smithy-npm-typescript-runtime": "file:../../runtime/typescript",
+      "smithy-npm-typescript-runtime": "*",
     },
     "devDependencies": Object {
       "@types/node": "^16",
@@ -30718,9 +30698,6 @@ tsconfig.esm.json
         "steps": Array [
           Object {
             "exec": "npm install",
-          },
-          Object {
-            "exec": "npm link",
           },
         ],
       },
@@ -34893,7 +34870,6 @@ tsconfig.tsbuildinfo
       Object {
         "name": "smithy-pnpm-typescript-runtime",
         "type": "runtime",
-        "version": "file:../../runtime/typescript",
       },
     ],
   },
@@ -34965,9 +34941,6 @@ tsconfig.tsbuildinfo
         "name": "install",
         "steps": Array [
           Object {
-            "exec": "pnpm link /../../runtime/typescript",
-          },
-          Object {
             "exec": "pnpm i --no-frozen-lockfile",
           },
         ],
@@ -35025,19 +34998,19 @@ tsconfig.tsbuildinfo
             "exec": "pnpm update npm-check-updates",
           },
           Object {
-            "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='smithy-pnpm-typescript-runtime'",
+            "exec": "npm-check-updates --dep dev --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='smithy-pnpm-typescript-runtime'",
+            "exec": "npm-check-updates --dep optional --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='smithy-pnpm-typescript-runtime'",
+            "exec": "npm-check-updates --dep peer --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='smithy-pnpm-typescript-runtime'",
+            "exec": "npm-check-updates --dep prod --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='smithy-pnpm-typescript-runtime'",
+            "exec": "npm-check-updates --dep bundle --upgrade --target=minor",
           },
           Object {
             "exec": "pnpm i --no-frozen-lockfile",
@@ -35275,7 +35248,7 @@ tsconfig.tsbuildinfo
       "aws-cdk-lib": "*",
       "cdk-nag": "*",
       "constructs": "*",
-      "smithy-pnpm-typescript-runtime": "file:../../runtime/typescript",
+      "smithy-pnpm-typescript-runtime": "*",
     },
     "devDependencies": Object {
       "@types/node": "^16",
@@ -42248,9 +42221,6 @@ tsconfig.esm.json
           Object {
             "exec": "yarn install --check-files",
           },
-          Object {
-            "exec": "yarn link",
-          },
         ],
       },
       "install:ci": Object {
@@ -47274,7 +47244,6 @@ tsconfig.tsbuildinfo
       Object {
         "name": "smithy-typescript-typescript-runtime",
         "type": "runtime",
-        "version": "file:../../runtime/typescript",
       },
     ],
   },
@@ -47346,9 +47315,6 @@ tsconfig.tsbuildinfo
         "name": "install",
         "steps": Array [
           Object {
-            "exec": "yarn link smithy-typescript-typescript-runtime",
-          },
-          Object {
             "exec": "yarn install --check-files",
           },
         ],
@@ -47406,19 +47372,19 @@ tsconfig.tsbuildinfo
             "exec": "yarn upgrade npm-check-updates",
           },
           Object {
-            "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='smithy-typescript-typescript-runtime'",
+            "exec": "npm-check-updates --dep dev --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='smithy-typescript-typescript-runtime'",
+            "exec": "npm-check-updates --dep optional --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='smithy-typescript-typescript-runtime'",
+            "exec": "npm-check-updates --dep peer --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='smithy-typescript-typescript-runtime'",
+            "exec": "npm-check-updates --dep prod --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='smithy-typescript-typescript-runtime'",
+            "exec": "npm-check-updates --dep bundle --upgrade --target=minor",
           },
           Object {
             "exec": "yarn install --check-files",
@@ -47656,7 +47622,7 @@ tsconfig.tsbuildinfo
       "aws-cdk-lib": "*",
       "cdk-nag": "*",
       "constructs": "*",
-      "smithy-typescript-typescript-runtime": "file:../../runtime/typescript",
+      "smithy-typescript-typescript-runtime": "*",
     },
     "devDependencies": Object {
       "@types/node": "^16",
@@ -49158,9 +49124,6 @@ tsconfig.esm.json
         "steps": Array [
           Object {
             "exec": "yarn install --check-files",
-          },
-          Object {
-            "exec": "yarn link",
           },
         ],
       },
@@ -53340,7 +53303,6 @@ tsconfig.tsbuildinfo
       Object {
         "name": "smithy-yarn-typescript-runtime",
         "type": "runtime",
-        "version": "file:../../runtime/typescript",
       },
     ],
   },
@@ -53412,9 +53374,6 @@ tsconfig.tsbuildinfo
         "name": "install",
         "steps": Array [
           Object {
-            "exec": "yarn link smithy-yarn-typescript-runtime",
-          },
-          Object {
             "exec": "yarn install --check-files",
           },
         ],
@@ -53472,19 +53431,19 @@ tsconfig.tsbuildinfo
             "exec": "yarn upgrade npm-check-updates",
           },
           Object {
-            "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='smithy-yarn-typescript-runtime'",
+            "exec": "npm-check-updates --dep dev --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='smithy-yarn-typescript-runtime'",
+            "exec": "npm-check-updates --dep optional --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='smithy-yarn-typescript-runtime'",
+            "exec": "npm-check-updates --dep peer --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='smithy-yarn-typescript-runtime'",
+            "exec": "npm-check-updates --dep prod --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='smithy-yarn-typescript-runtime'",
+            "exec": "npm-check-updates --dep bundle --upgrade --target=minor",
           },
           Object {
             "exec": "yarn install --check-files",
@@ -53722,7 +53681,7 @@ tsconfig.tsbuildinfo
       "aws-cdk-lib": "*",
       "cdk-nag": "*",
       "constructs": "*",
-      "smithy-yarn-typescript-runtime": "file:../../runtime/typescript",
+      "smithy-yarn-typescript-runtime": "*",
     },
     "devDependencies": Object {
       "@types/node": "^16",
@@ -54372,9 +54331,6 @@ tsconfig.esm.json
         "steps": Array [
           Object {
             "exec": "yarn install --check-files",
-          },
-          Object {
-            "exec": "yarn link",
           },
         ],
       },
@@ -58554,7 +58510,6 @@ tsconfig.tsbuildinfo
       Object {
         "name": "smithy-yarn2-typescript-runtime",
         "type": "runtime",
-        "version": "file:../../runtime/typescript",
       },
     ],
   },
@@ -58626,9 +58581,6 @@ tsconfig.tsbuildinfo
         "name": "install",
         "steps": Array [
           Object {
-            "exec": "yarn2 link smithy-yarn2-typescript-runtime",
-          },
-          Object {
             "exec": "yarn install",
           },
         ],
@@ -58686,19 +58638,19 @@ tsconfig.tsbuildinfo
             "exec": "yarn upgrade npm-check-updates",
           },
           Object {
-            "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='smithy-yarn2-typescript-runtime'",
+            "exec": "npm-check-updates --dep dev --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='smithy-yarn2-typescript-runtime'",
+            "exec": "npm-check-updates --dep optional --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='smithy-yarn2-typescript-runtime'",
+            "exec": "npm-check-updates --dep peer --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='smithy-yarn2-typescript-runtime'",
+            "exec": "npm-check-updates --dep prod --upgrade --target=minor",
           },
           Object {
-            "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='smithy-yarn2-typescript-runtime'",
+            "exec": "npm-check-updates --dep bundle --upgrade --target=minor",
           },
           Object {
             "exec": "yarn install",
@@ -58936,7 +58888,7 @@ tsconfig.tsbuildinfo
       "aws-cdk-lib": "*",
       "cdk-nag": "*",
       "constructs": "*",
-      "smithy-yarn2-typescript-runtime": "file:../../runtime/typescript",
+      "smithy-yarn2-typescript-runtime": "*",
     },
     "devDependencies": Object {
       "@types/node": "^16",
@@ -59586,9 +59538,6 @@ tsconfig.esm.json
         "steps": Array [
           Object {
             "exec": "yarn install",
-          },
-          Object {
-            "exec": "yarn2 link",
           },
         ],
       },

--- a/private/projects/type-safe-api-project.ts
+++ b/private/projects/type-safe-api-project.ts
@@ -57,6 +57,8 @@ export class TypeSafeApiProject extends PDKProject {
           "scripts/parser/parse-openapi-spec",
           "scripts/custom/infrastructure/cdk/generate-type-safe-cdk-construct",
           "scripts/custom/clean-openapi-generated-code/clean-openapi-generated-code",
+          "samples/smithy/gradlew",
+          "samples/smithy/gradelw.bat",
         ],
       },
     });


### PR DESCRIPTION
Make sure `gradlew` and `gradlew.bat` are executable if they're copied in at build time.

Also, add missing `isWithinMonorepo` param which indicated to the generated TS projects whether to run `yarn link` etc in the non-monorepo case.
