### PR TITLE
feat(identity): support updated MFA props and UserPoolWithMFA construct

### DIFF
--- a/packages/aws-arch/package.json
+++ b/packages/aws-arch/package.json
@@ -162,13 +162,6 @@
       "rootDir": "src"
     }
   },
-  "files": [
-    "assets",
-    "lib",
-    "LICENSE_THIRD_PARTY",
-    "NOTICE",
-    "jsii"
-  ],
   "nx": {
     "targets": {
       "build": {
@@ -181,6 +174,7 @@
           "{projectRoot}/target",
           "{projectRoot}/LICENSE_THIRD_PARTY",
           "{projectRoot}/.jsii",
+          "{projectRoot}/docs/api",
           "{projectRoot}/assets",
           "{projectRoot}/src/generated"
         ],
@@ -205,6 +199,13 @@
       }
     }
   },
+  "files": [
+    "assets",
+    "lib",
+    "LICENSE_THIRD_PARTY",
+    "NOTICE",
+    "jsii"
+  ],
   "pnpm": {
     "overrides": {
       "@types/prettier": "2.6.0",

--- a/packages/aws-prototyping-sdk/package.json
+++ b/packages/aws-prototyping-sdk/package.json
@@ -159,9 +159,6 @@
       "**/samples/**"
     ]
   },
-  "bundle": {
-    "exclude": true
-  },
   "nx": {
     "targets": {
       "build": {
@@ -174,6 +171,7 @@
           "{projectRoot}/target",
           "{projectRoot}/LICENSE_THIRD_PARTY",
           "{projectRoot}/.jsii",
+          "{projectRoot}/docs/api",
           "{projectRoot}/nx-monorepo",
           "{projectRoot}/pdk-nag",
           "{projectRoot}/pipeline"
@@ -191,6 +189,9 @@
       "@aws-prototyping-sdk/pipeline",
       "@aws-prototyping-sdk/nx-monorepo"
     ]
+  },
+  "bundle": {
+    "exclude": true
   },
   "exports": {
     ".": "./index.js",

--- a/packages/cdk-graph-plugin-diagram/package.json
+++ b/packages/cdk-graph-plugin-diagram/package.json
@@ -212,6 +212,7 @@
           "{projectRoot}/target",
           "{projectRoot}/LICENSE_THIRD_PARTY",
           "{projectRoot}/.jsii",
+          "{projectRoot}/docs/api",
           "{projectRoot}/node_modules/sharp/build",
           "{projectRoot}/node_modules/sharp/vendor"
         ],

--- a/packages/cdk-graph/package.json
+++ b/packages/cdk-graph/package.json
@@ -173,6 +173,29 @@
       "rootDir": "src"
     }
   },
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": [
+          "{projectRoot}/dist",
+          "{projectRoot}/lib",
+          "{projectRoot}/build",
+          "{projectRoot}/coverage",
+          "{projectRoot}/test-reports",
+          "{projectRoot}/target",
+          "{projectRoot}/LICENSE_THIRD_PARTY",
+          "{projectRoot}/.jsii",
+          "{projectRoot}/docs/api"
+        ],
+        "dependsOn": [
+          {
+            "target": "build",
+            "projects": "dependencies"
+          }
+        ]
+      }
+    }
+  },
   "pnpm": {
     "overrides": {
       "@types/prettier": "2.6.0",

--- a/packages/cloudscape-react-ts-website/package.json
+++ b/packages/cloudscape-react-ts-website/package.json
@@ -134,6 +134,29 @@
       "rootDir": "src"
     }
   },
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": [
+          "{projectRoot}/dist",
+          "{projectRoot}/lib",
+          "{projectRoot}/build",
+          "{projectRoot}/coverage",
+          "{projectRoot}/test-reports",
+          "{projectRoot}/target",
+          "{projectRoot}/LICENSE_THIRD_PARTY",
+          "{projectRoot}/.jsii",
+          "{projectRoot}/docs/api"
+        ],
+        "dependsOn": [
+          {
+            "target": "build",
+            "projects": "dependencies"
+          }
+        ]
+      }
+    }
+  },
   "pnpm": {
     "overrides": {
       "@types/prettier": "2.6.0",

--- a/packages/identity/README.md
+++ b/packages/identity/README.md
@@ -1,3 +1,13 @@
+> **BREAKING CHANGES** (pre-release)
+> - `> v0.15.5`: updated defaults for UserPoolWithMfa will break deployments for already created userPools. If migrating to a newer version of this package, be sure to set the following in your `cdk.context.json`:
+>
+>  
+>   ```
+>     {
+>       "@aws-prototyping-sdk/identity:useLegacyMFAProps":true
+>     }
+>   ```
+
 This module by default deploys a configurable Identity Provider with a default Cognito User Pool. These resources can be used by your website to restrict access to only authenticated users if needed. All settings are configurable and the creation of these AuthN resources can be disabled if needed or configured to use custom AuthN providers i.e. Facebook, Google, etc.
 
 Below is a conceptual view of the default architecture this module creates:

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -145,6 +145,29 @@
       "rootDir": "src"
     }
   },
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": [
+          "{projectRoot}/dist",
+          "{projectRoot}/lib",
+          "{projectRoot}/build",
+          "{projectRoot}/coverage",
+          "{projectRoot}/test-reports",
+          "{projectRoot}/target",
+          "{projectRoot}/LICENSE_THIRD_PARTY",
+          "{projectRoot}/.jsii",
+          "{projectRoot}/docs/api"
+        ],
+        "dependsOn": [
+          {
+            "target": "build",
+            "projects": "dependencies"
+          }
+        ]
+      }
+    }
+  },
   "pnpm": {
     "overrides": {
       "@types/prettier": "2.6.0",

--- a/packages/identity/src/index.ts
+++ b/packages/identity/src/index.ts
@@ -1,3 +1,4 @@
 /*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0 */
 export * from "./user-identity";
+export * from "./userpool-with-mfa";

--- a/packages/identity/src/userpool-with-mfa.ts
+++ b/packages/identity/src/userpool-with-mfa.ts
@@ -1,0 +1,119 @@
+/*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0 */
+import { PDKNag } from "@aws-prototyping-sdk/pdk-nag";
+import { Duration, Stack } from "aws-cdk-lib";
+import {
+  AccountRecovery,
+  AdvancedSecurityMode,
+  Mfa,
+  UserPool,
+  UserPoolProps,
+} from "aws-cdk-lib/aws-cognito";
+import { Construct } from "constructs";
+
+/**
+ * Boolean context to indicate whether legacy MFA props should be used.
+ */
+export const USE_LEGACY_MFA_PROPS_CONTEXT_KEY =
+  "@aws-prototyping-sdk/identity:useLegacyMFAProps";
+
+/**
+ * Legacy Userpool Props which configures MFA for SMS only.
+ */
+const LEGACY_DEFAULT_PROPS: UserPoolProps = {
+  deletionProtection: true,
+  passwordPolicy: {
+    minLength: 8,
+    requireLowercase: true,
+    requireUppercase: true,
+    requireDigits: true,
+    requireSymbols: true,
+    tempPasswordValidity: Duration.days(3),
+  },
+  advancedSecurityMode: AdvancedSecurityMode.ENFORCED,
+  mfa: Mfa.REQUIRED,
+  accountRecovery: AccountRecovery.EMAIL_ONLY,
+  autoVerify: {
+    email: true,
+  },
+};
+
+/**
+ * Userpool default props which configure MFA across SMS/TOTP.
+ */
+const DEFAULT_PROPS: UserPoolProps = {
+  deletionProtection: true,
+  passwordPolicy: {
+    minLength: 8,
+    requireLowercase: true,
+    requireUppercase: true,
+    requireDigits: true,
+    requireSymbols: true,
+    tempPasswordValidity: Duration.days(3),
+  },
+  mfa: Mfa.REQUIRED,
+  mfaSecondFactor: { sms: true, otp: true },
+  signInCaseSensitive: false,
+  advancedSecurityMode: AdvancedSecurityMode.ENFORCED,
+  signInAliases: { username: true },
+  accountRecovery: AccountRecovery.EMAIL_ONLY,
+  selfSignUpEnabled: false,
+  standardAttributes: {
+    phoneNumber: { required: false },
+    email: { required: true },
+    givenName: { required: true },
+    familyName: { required: true },
+  },
+  autoVerify: {
+    email: true,
+    phone: true,
+  },
+  keepOriginal: {
+    email: true,
+    phone: true,
+  },
+};
+
+/**
+ * UserPoolWithMfa props.
+ */
+export interface UserPoolWithMfaProps extends UserPoolProps {}
+
+/**
+ * Configures a UserPool with MFA across SMS/TOTP using sane defaults.
+ */
+export class UserPoolWithMfa extends UserPool {
+  constructor(scope: Construct, id: string, props?: UserPoolWithMfaProps) {
+    super(scope, id, {
+      ...(shouldUseLegacyProps(scope) ? LEGACY_DEFAULT_PROPS : DEFAULT_PROPS),
+      ...props,
+    });
+
+    const stack = Stack.of(this);
+
+    ["AwsSolutions-IAM5", "AwsPrototyping-IAMNoWildcardPermissions"].forEach(
+      (RuleId) => {
+        PDKNag.addResourceSuppressionsByPathNoThrow(
+          stack,
+          `${PDKNag.getStackPrefix(stack)}${id}/UserPool/smsRole/Resource`,
+          [
+            {
+              id: RuleId,
+              reason:
+                "MFA requires sending a text to a users phone number which cannot be known at deployment time.",
+              appliesTo: ["Resource::*"],
+            },
+          ]
+        );
+      }
+    );
+  }
+}
+
+/**
+ * Determines if legacy props should be used by looking at the control flag in cdk context.
+ *
+ * @param scope construct scope.
+ */
+const shouldUseLegacyProps = (scope: Construct) =>
+  scope.node.tryGetContext(USE_LEGACY_MFA_PROPS_CONTEXT_KEY);

--- a/packages/identity/test/__snapshots__/user-identity.test.ts.snap
+++ b/packages/identity/test/__snapshots__/user-identity.test.ts.snap
@@ -176,12 +176,14 @@ Object {
         },
         "AutoVerifiedAttributes": Array [
           "email",
+          "phone_number",
         ],
         "DeletionProtection": "ACTIVE",
         "EmailVerificationMessage": "The verification code to your new account is {####}",
         "EmailVerificationSubject": "Verify your new account",
         "EnabledMfas": Array [
           "SMS_MFA",
+          "SOFTWARE_TOKEN_MFA",
         ],
         "MfaConfiguration": "ON",
         "Policies": Object {
@@ -194,6 +196,28 @@ Object {
             "TemporaryPasswordValidityDays": 3,
           },
         },
+        "Schema": Array [
+          Object {
+            "Mutable": true,
+            "Name": "phone_number",
+            "Required": false,
+          },
+          Object {
+            "Mutable": true,
+            "Name": "email",
+            "Required": true,
+          },
+          Object {
+            "Mutable": true,
+            "Name": "given_name",
+            "Required": true,
+          },
+          Object {
+            "Mutable": true,
+            "Name": "family_name",
+            "Required": true,
+          },
+        ],
         "SmsConfiguration": Object {
           "ExternalId": "NestedStackDefaultsNestedUserPoolF08F152B",
           "SnsCallerArn": Object {
@@ -204,8 +228,17 @@ Object {
           },
         },
         "SmsVerificationMessage": "The verification code to your new account is {####}",
+        "UserAttributeUpdateSettings": Object {
+          "AttributesRequireVerificationBeforeUpdate": Array [
+            "email",
+            "phone_number",
+          ],
+        },
         "UserPoolAddOns": Object {
           "AdvancedSecurityMode": "ENFORCED",
+        },
+        "UsernameConfiguration": Object {
+          "CaseSensitive": false,
         },
         "VerificationMessageTemplate": Object {
           "DefaultEmailOption": "CONFIRM_WITH_CODE",
@@ -249,26 +282,6 @@ Object {
       "Type": "AWS::Cognito::UserPoolClient",
     },
     "DefaultsNestedUserPoolsmsRole9E53925E": Object {
-      "Metadata": Object {
-        "cdk_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "applies_to": Array [
-                "Resource::*",
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "MFA requires sending a text to a users phone number which cannot be known at deployment time.",
-            },
-            Object {
-              "applies_to": Array [
-                "Resource::*",
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "MFA requires sending a text to a users phone number which cannot be known at deployment time.",
-            },
-          ],
-        },
-      },
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -304,6 +317,329 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+  },
+}
+`;
+
+exports[`User Identity Unit Tests Defaults - using legacy props 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "DefaultsLegacyPropsIdentityPool99521833": Object {
+      "DependsOn": Array [
+        "DefaultsLegacyPropsUserPoolEF40D398",
+        "DefaultsLegacyPropsUserPoolsmsRole885B2281",
+        "DefaultsLegacyPropsUserPoolWebClient084DDFA3",
+      ],
+      "Properties": Object {
+        "AllowUnauthenticatedIdentities": false,
+        "CognitoIdentityProviders": Array [
+          Object {
+            "ClientId": Object {
+              "Ref": "DefaultsLegacyPropsUserPoolWebClient084DDFA3",
+            },
+            "ProviderName": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "cognito-idp.",
+                  Object {
+                    "Ref": "AWS::Region",
+                  },
+                  ".",
+                  Object {
+                    "Ref": "AWS::URLSuffix",
+                  },
+                  "/",
+                  Object {
+                    "Ref": "DefaultsLegacyPropsUserPoolEF40D398",
+                  },
+                ],
+              ],
+            },
+            "ServerSideTokenCheck": true,
+          },
+        ],
+      },
+      "Type": "AWS::Cognito::IdentityPool",
+    },
+    "DefaultsLegacyPropsIdentityPoolAuthenticatedRole13B826B9": Object {
+      "DependsOn": Array [
+        "DefaultsLegacyPropsUserPoolEF40D398",
+        "DefaultsLegacyPropsUserPoolsmsRole885B2281",
+        "DefaultsLegacyPropsUserPoolWebClient084DDFA3",
+      ],
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Condition": Object {
+                "ForAnyValue:StringLike": Object {
+                  "cognito-identity.amazonaws.com:amr": "authenticated",
+                },
+                "StringEquals": Object {
+                  "cognito-identity.amazonaws.com:aud": Object {
+                    "Ref": "DefaultsLegacyPropsIdentityPool99521833",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Federated": "cognito-identity.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Description": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "Default Authenticated Role for Identity Pool ",
+              Object {
+                "Fn::GetAtt": Array [
+                  "DefaultsLegacyPropsIdentityPool99521833",
+                  "Name",
+                ],
+              },
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsLegacyPropsIdentityPoolDefaultRoleAttachmentC29D2D43": Object {
+      "DependsOn": Array [
+        "DefaultsLegacyPropsUserPoolEF40D398",
+        "DefaultsLegacyPropsUserPoolsmsRole885B2281",
+        "DefaultsLegacyPropsUserPoolWebClient084DDFA3",
+      ],
+      "Properties": Object {
+        "IdentityPoolId": Object {
+          "Ref": "DefaultsLegacyPropsIdentityPool99521833",
+        },
+        "Roles": Object {
+          "authenticated": Object {
+            "Fn::GetAtt": Array [
+              "DefaultsLegacyPropsIdentityPoolAuthenticatedRole13B826B9",
+              "Arn",
+            ],
+          },
+          "unauthenticated": Object {
+            "Fn::GetAtt": Array [
+              "DefaultsLegacyPropsIdentityPoolUnauthenticatedRole933ECEDF",
+              "Arn",
+            ],
+          },
+        },
+      },
+      "Type": "AWS::Cognito::IdentityPoolRoleAttachment",
+    },
+    "DefaultsLegacyPropsIdentityPoolUnauthenticatedRole933ECEDF": Object {
+      "DependsOn": Array [
+        "DefaultsLegacyPropsUserPoolEF40D398",
+        "DefaultsLegacyPropsUserPoolsmsRole885B2281",
+        "DefaultsLegacyPropsUserPoolWebClient084DDFA3",
+      ],
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Condition": Object {
+                "ForAnyValue:StringLike": Object {
+                  "cognito-identity.amazonaws.com:amr": "unauthenticated",
+                },
+                "StringEquals": Object {
+                  "cognito-identity.amazonaws.com:aud": Object {
+                    "Ref": "DefaultsLegacyPropsIdentityPool99521833",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Federated": "cognito-identity.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Description": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "Default Unauthenticated Role for Identity Pool ",
+              Object {
+                "Fn::GetAtt": Array [
+                  "DefaultsLegacyPropsIdentityPool99521833",
+                  "Name",
+                ],
+              },
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsLegacyPropsUserPoolEF40D398": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "AccountRecoverySetting": Object {
+          "RecoveryMechanisms": Array [
+            Object {
+              "Name": "verified_email",
+              "Priority": 1,
+            },
+          ],
+        },
+        "AdminCreateUserConfig": Object {
+          "AllowAdminCreateUserOnly": true,
+        },
+        "AutoVerifiedAttributes": Array [
+          "email",
+        ],
+        "DeletionProtection": "ACTIVE",
+        "EmailVerificationMessage": "The verification code to your new account is {####}",
+        "EmailVerificationSubject": "Verify your new account",
+        "EnabledMfas": Array [
+          "SMS_MFA",
+        ],
+        "MfaConfiguration": "ON",
+        "Policies": Object {
+          "PasswordPolicy": Object {
+            "MinimumLength": 8,
+            "RequireLowercase": true,
+            "RequireNumbers": true,
+            "RequireSymbols": true,
+            "RequireUppercase": true,
+            "TemporaryPasswordValidityDays": 3,
+          },
+        },
+        "SmsConfiguration": Object {
+          "ExternalId": "DefaultsLegacyPropsUserPoolF2A9E2AD",
+          "SnsCallerArn": Object {
+            "Fn::GetAtt": Array [
+              "DefaultsLegacyPropsUserPoolsmsRole885B2281",
+              "Arn",
+            ],
+          },
+        },
+        "SmsVerificationMessage": "The verification code to your new account is {####}",
+        "UserPoolAddOns": Object {
+          "AdvancedSecurityMode": "ENFORCED",
+        },
+        "VerificationMessageTemplate": Object {
+          "DefaultEmailOption": "CONFIRM_WITH_CODE",
+          "EmailMessage": "The verification code to your new account is {####}",
+          "EmailSubject": "Verify your new account",
+          "SmsMessage": "The verification code to your new account is {####}",
+        },
+      },
+      "Type": "AWS::Cognito::UserPool",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "DefaultsLegacyPropsUserPoolWebClient084DDFA3": Object {
+      "Properties": Object {
+        "AllowedOAuthFlows": Array [
+          "implicit",
+          "code",
+        ],
+        "AllowedOAuthFlowsUserPoolClient": true,
+        "AllowedOAuthScopes": Array [
+          "profile",
+          "phone",
+          "email",
+          "openid",
+          "aws.cognito.signin.user.admin",
+        ],
+        "CallbackURLs": Array [
+          "https://example.com",
+        ],
+        "ExplicitAuthFlows": Array [
+          "ALLOW_USER_PASSWORD_AUTH",
+          "ALLOW_USER_SRP_AUTH",
+          "ALLOW_REFRESH_TOKEN_AUTH",
+        ],
+        "SupportedIdentityProviders": Array [
+          "COGNITO",
+        ],
+        "UserPoolId": Object {
+          "Ref": "DefaultsLegacyPropsUserPoolEF40D398",
+        },
+      },
+      "Type": "AWS::Cognito::UserPoolClient",
+    },
+    "DefaultsLegacyPropsUserPoolsmsRole885B2281": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Condition": Object {
+                "StringEquals": Object {
+                  "sts:ExternalId": "DefaultsLegacyPropsUserPoolF2A9E2AD",
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "cognito-idp.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Policies": Array [
+          Object {
+            "PolicyDocument": Object {
+              "Statement": Array [
+                Object {
+                  "Action": "sns:Publish",
+                  "Effect": "Allow",
+                  "Resource": "*",
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "sns-publish",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
     },
   },
 }
@@ -492,12 +828,14 @@ Object {
         },
         "AutoVerifiedAttributes": Array [
           "email",
+          "phone_number",
         ],
         "DeletionProtection": "ACTIVE",
         "EmailVerificationMessage": "The verification code to your new account is {####}",
         "EmailVerificationSubject": "Verify your new account",
         "EnabledMfas": Array [
           "SMS_MFA",
+          "SOFTWARE_TOKEN_MFA",
         ],
         "MfaConfiguration": "ON",
         "Policies": Object {
@@ -510,6 +848,28 @@ Object {
             "TemporaryPasswordValidityDays": 3,
           },
         },
+        "Schema": Array [
+          Object {
+            "Mutable": true,
+            "Name": "phone_number",
+            "Required": false,
+          },
+          Object {
+            "Mutable": true,
+            "Name": "email",
+            "Required": true,
+          },
+          Object {
+            "Mutable": true,
+            "Name": "given_name",
+            "Required": true,
+          },
+          Object {
+            "Mutable": true,
+            "Name": "family_name",
+            "Required": true,
+          },
+        ],
         "SmsConfiguration": Object {
           "ExternalId": "DefaultsUserPool4C3A90C6",
           "SnsCallerArn": Object {
@@ -520,8 +880,17 @@ Object {
           },
         },
         "SmsVerificationMessage": "The verification code to your new account is {####}",
+        "UserAttributeUpdateSettings": Object {
+          "AttributesRequireVerificationBeforeUpdate": Array [
+            "email",
+            "phone_number",
+          ],
+        },
         "UserPoolAddOns": Object {
           "AdvancedSecurityMode": "ENFORCED",
+        },
+        "UsernameConfiguration": Object {
+          "CaseSensitive": false,
         },
         "VerificationMessageTemplate": Object {
           "DefaultEmailOption": "CONFIRM_WITH_CODE",
@@ -565,26 +934,6 @@ Object {
       "Type": "AWS::Cognito::UserPoolClient",
     },
     "DefaultsUserPoolsmsRoleE0CA6B10": Object {
-      "Metadata": Object {
-        "cdk_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "applies_to": Array [
-                "Resource::*",
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "MFA requires sending a text to a users phone number which cannot be known at deployment time.",
-            },
-            Object {
-              "applies_to": Array [
-                "Resource::*",
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "MFA requires sending a text to a users phone number which cannot be known at deployment time.",
-            },
-          ],
-        },
-      },
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -663,6 +1012,10 @@ Object {
   },
   "Resources": Object {
     "DefaultsIdentityPoolAuthenticatedRole69EA113E": Object {
+      "DependsOn": Array [
+        "UserPool6BA7E5F2",
+        "UserPoolWebClient4C9370B0",
+      ],
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -704,13 +1057,47 @@ Object {
       "Type": "AWS::IAM::Role",
     },
     "DefaultsIdentityPoolBA85B5EA": Object {
+      "DependsOn": Array [
+        "UserPool6BA7E5F2",
+        "UserPoolWebClient4C9370B0",
+      ],
       "Properties": Object {
         "AllowUnauthenticatedIdentities": false,
-        "CognitoIdentityProviders": Array [],
+        "CognitoIdentityProviders": Array [
+          Object {
+            "ClientId": Object {
+              "Ref": "UserPoolWebClient4C9370B0",
+            },
+            "ProviderName": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "cognito-idp.",
+                  Object {
+                    "Ref": "AWS::Region",
+                  },
+                  ".",
+                  Object {
+                    "Ref": "AWS::URLSuffix",
+                  },
+                  "/",
+                  Object {
+                    "Ref": "UserPool6BA7E5F2",
+                  },
+                ],
+              ],
+            },
+            "ServerSideTokenCheck": true,
+          },
+        ],
       },
       "Type": "AWS::Cognito::IdentityPool",
     },
     "DefaultsIdentityPoolDefaultRoleAttachment961DF578": Object {
+      "DependsOn": Array [
+        "UserPool6BA7E5F2",
+        "UserPoolWebClient4C9370B0",
+      ],
       "Properties": Object {
         "IdentityPoolId": Object {
           "Ref": "DefaultsIdentityPoolBA85B5EA",
@@ -733,6 +1120,10 @@ Object {
       "Type": "AWS::Cognito::IdentityPoolRoleAttachment",
     },
     "DefaultsIdentityPoolUnauthenticatedRole863CFE8C": Object {
+      "DependsOn": Array [
+        "UserPool6BA7E5F2",
+        "UserPoolWebClient4C9370B0",
+      ],
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -803,6 +1194,37 @@ Object {
       },
       "Type": "AWS::Cognito::UserPool",
       "UpdateReplacePolicy": "Retain",
+    },
+    "UserPoolWebClient4C9370B0": Object {
+      "Properties": Object {
+        "AllowedOAuthFlows": Array [
+          "implicit",
+          "code",
+        ],
+        "AllowedOAuthFlowsUserPoolClient": true,
+        "AllowedOAuthScopes": Array [
+          "profile",
+          "phone",
+          "email",
+          "openid",
+          "aws.cognito.signin.user.admin",
+        ],
+        "CallbackURLs": Array [
+          "https://example.com",
+        ],
+        "ExplicitAuthFlows": Array [
+          "ALLOW_USER_PASSWORD_AUTH",
+          "ALLOW_USER_SRP_AUTH",
+          "ALLOW_REFRESH_TOKEN_AUTH",
+        ],
+        "SupportedIdentityProviders": Array [
+          "COGNITO",
+        ],
+        "UserPoolId": Object {
+          "Ref": "UserPool6BA7E5F2",
+        },
+      },
+      "Type": "AWS::Cognito::UserPoolClient",
     },
   },
   "Rules": Object {

--- a/packages/identity/test/user-identity.test.ts
+++ b/packages/identity/test/user-identity.test.ts
@@ -4,12 +4,19 @@ import { PDKNag } from "@aws-prototyping-sdk/pdk-nag";
 import { App, NestedStack, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 import { UserPool } from "aws-cdk-lib/aws-cognito";
-import { UserIdentity } from "../src";
+import { USE_LEGACY_MFA_PROPS_CONTEXT_KEY, UserIdentity } from "../src";
 
 describe("User Identity Unit Tests", () => {
   it("Defaults", () => {
     const stack = new Stack(PDKNag.app());
     new UserIdentity(stack, "Defaults");
+    expect(Template.fromStack(stack)).toMatchSnapshot();
+  });
+
+  it("Defaults - using legacy props", () => {
+    const stack = new Stack(PDKNag.app());
+    stack.node.setContext(USE_LEGACY_MFA_PROPS_CONTEXT_KEY, true);
+    new UserIdentity(stack, "Defaults Legacy Props");
     expect(Template.fromStack(stack)).toMatchSnapshot();
   });
 

--- a/packages/nx-monorepo/package.json
+++ b/packages/nx-monorepo/package.json
@@ -153,6 +153,29 @@
       "rootDir": "src"
     }
   },
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": [
+          "{projectRoot}/dist",
+          "{projectRoot}/lib",
+          "{projectRoot}/build",
+          "{projectRoot}/coverage",
+          "{projectRoot}/test-reports",
+          "{projectRoot}/target",
+          "{projectRoot}/LICENSE_THIRD_PARTY",
+          "{projectRoot}/.jsii",
+          "{projectRoot}/docs/api"
+        ],
+        "dependsOn": [
+          {
+            "target": "build",
+            "projects": "dependencies"
+          }
+        ]
+      }
+    }
+  },
   "pnpm": {
     "overrides": {
       "@types/prettier": "2.6.0",

--- a/packages/open-api-gateway/package.json
+++ b/packages/open-api-gateway/package.json
@@ -164,6 +164,29 @@
       "rootDir": "src"
     }
   },
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": [
+          "{projectRoot}/dist",
+          "{projectRoot}/lib",
+          "{projectRoot}/build",
+          "{projectRoot}/coverage",
+          "{projectRoot}/test-reports",
+          "{projectRoot}/target",
+          "{projectRoot}/LICENSE_THIRD_PARTY",
+          "{projectRoot}/.jsii",
+          "{projectRoot}/docs/api"
+        ],
+        "dependsOn": [
+          {
+            "target": "build",
+            "projects": "dependencies"
+          }
+        ]
+      }
+    }
+  },
   "pnpm": {
     "overrides": {
       "@types/prettier": "2.6.0",

--- a/packages/pdk-nag/package.json
+++ b/packages/pdk-nag/package.json
@@ -138,6 +138,29 @@
       "rootDir": "src"
     }
   },
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": [
+          "{projectRoot}/dist",
+          "{projectRoot}/lib",
+          "{projectRoot}/build",
+          "{projectRoot}/coverage",
+          "{projectRoot}/test-reports",
+          "{projectRoot}/target",
+          "{projectRoot}/LICENSE_THIRD_PARTY",
+          "{projectRoot}/.jsii",
+          "{projectRoot}/docs/api"
+        ],
+        "dependsOn": [
+          {
+            "target": "build",
+            "projects": "dependencies"
+          }
+        ]
+      }
+    }
+  },
   "pnpm": {
     "overrides": {
       "@types/prettier": "2.6.0",

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -143,6 +143,29 @@
       "rootDir": "src"
     }
   },
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": [
+          "{projectRoot}/dist",
+          "{projectRoot}/lib",
+          "{projectRoot}/build",
+          "{projectRoot}/coverage",
+          "{projectRoot}/test-reports",
+          "{projectRoot}/target",
+          "{projectRoot}/LICENSE_THIRD_PARTY",
+          "{projectRoot}/.jsii",
+          "{projectRoot}/docs/api"
+        ],
+        "dependsOn": [
+          {
+            "target": "build",
+            "projects": "dependencies"
+          }
+        ]
+      }
+    }
+  },
   "pnpm": {
     "overrides": {
       "@types/prettier": "2.6.0",

--- a/packages/static-website/package.json
+++ b/packages/static-website/package.json
@@ -144,6 +144,29 @@
       "rootDir": "src"
     }
   },
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": [
+          "{projectRoot}/dist",
+          "{projectRoot}/lib",
+          "{projectRoot}/build",
+          "{projectRoot}/coverage",
+          "{projectRoot}/test-reports",
+          "{projectRoot}/target",
+          "{projectRoot}/LICENSE_THIRD_PARTY",
+          "{projectRoot}/.jsii",
+          "{projectRoot}/docs/api"
+        ],
+        "dependsOn": [
+          {
+            "target": "build",
+            "projects": "dependencies"
+          }
+        ]
+      }
+    }
+  },
   "pnpm": {
     "overrides": {
       "@types/prettier": "2.6.0",

--- a/packages/type-safe-api/package.json
+++ b/packages/type-safe-api/package.json
@@ -171,6 +171,29 @@
       "rootDir": "src"
     }
   },
+  "nx": {
+    "targets": {
+      "build": {
+        "outputs": [
+          "{projectRoot}/dist",
+          "{projectRoot}/lib",
+          "{projectRoot}/build",
+          "{projectRoot}/coverage",
+          "{projectRoot}/test-reports",
+          "{projectRoot}/target",
+          "{projectRoot}/LICENSE_THIRD_PARTY",
+          "{projectRoot}/.jsii",
+          "{projectRoot}/docs/api"
+        ],
+        "dependsOn": [
+          {
+            "target": "build",
+            "projects": "dependencies"
+          }
+        ]
+      }
+    }
+  },
   "pnpm": {
     "overrides": {
       "@types/prettier": "2.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13137,7 +13137,7 @@ packages:
     dependencies:
       semver: 7.3.8
       shelljs: 0.8.5
-      typescript: 5.1.0-dev.20230417
+      typescript: 5.1.0-dev.20230418
     dev: true
 
   /duplexer2@0.0.2:
@@ -24436,8 +24436,8 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
-  /typescript@5.1.0-dev.20230417:
-    resolution: {integrity: sha512-bEjKfPjxAgvrUViweybCkB++3y9qyF4hCBeXOf998QQDJpLAcaQWmub4IoPZ5yTvrkuGuNzFpy46tytA4p1fbA==}
+  /typescript@5.1.0-dev.20230418:
+    resolution: {integrity: sha512-BfA/KV0xddF8ZCAQZxZ0FoS8p+nWKXVaa5fctXW6WNGfcYF04cXlLB6F6uf3uCVbd0iad4YdHchz3KR0722QLg==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true

--- a/private/pdk-project.ts
+++ b/private/pdk-project.ts
@@ -287,6 +287,12 @@ class PDKDocgen {
         `mkdir -p ${docsBasePath}/java && jsii-docgen -l java -r -o ${docsBasePath}/java/index.md`
       );
 
+    project.nxOverride(
+      "targets.build.outputs",
+      [`{projectRoot}/${docsBasePath}`],
+      true
+    );
+
     // spawn docgen after compilation (requires the .jsii manifest).
     project.postCompileTask.spawn(docgen);
     project.gitignore.exclude(`/${docsBasePath}`);


### PR DESCRIPTION
- Refactor out UserPool into re-usable UserPoolWithMFA construct
- Support updated MFA props
- Fix caching issue with docs
- Support backwards compatibility with a `@aws-prototyping-sdk/identity:useLegacyMFAProps` feature flag

BREAKING CHANGE: UserPoolWithMfa construct has recently been added which provides a more well rounded set of default configurations for the UserPool. It introduces a breaking change in that existing customers of the UserIdentity construct prior to v0.15.5 will by default be upgraded to use the new defaults which will cause deployments to fail. To workaround this, a new cdk context property ‘@aws-prototyping-sdk/identity:useLegacyMFAProps’ was added to revert back to legacy defaults.
