### PR TITLE
fix: make ACL's private

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -50,6 +50,10 @@
       "type": "build"
     },
     {
+      "name": "commitizen",
+      "type": "build"
+    },
+    {
       "name": "cz-conventional-changelog",
       "type": "build"
     },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/node": "^16",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
+    "commitizen": "^4.3.0",
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^8",
     "eslint-config-prettier": "^8.6.0",

--- a/packages/nx-monorepo/test/nx-monorepo.test.ts
+++ b/packages/nx-monorepo/test/nx-monorepo.test.ts
@@ -215,7 +215,7 @@ describe("NX Monorepo Unit Tests", () => {
     addProject("nine");
     addProject("ten");
 
-    project.synth();
+    synthSnapshot(project);
 
     // @ts-ignore accessing private subprojects which projen uses for synth order
     const subProjects: TypeScriptProject[] = project.subprojects;

--- a/packages/pipeline/README.md
+++ b/packages/pipeline/README.md
@@ -1,3 +1,7 @@
+> **BREAKING CHANGES** (pre-release)
+> - `> v0.16.1`: Refactored PDKPipeline to now be a construct so accessing CodePipeline methods now requires accessing a public codePipeline property i.e: `pdkPipeline.codePipeline.XXX`
+>
+
 The pipeline module vends an extension to CDK's CodePipeline construct, named PDKPipeline. It additionally creates a CodeCommit repository and by default is configured to build the project assumming nx-monorepo is being used (although this can be changed). A Sonarqube Scanner can also be configured to trigger a scan whenever the synth build job completes successfully. This Scanner is non-blocking and as such is not instrumented as part of the pipeline.
 
 The architecture for the PDKPipeline is as follows:

--- a/packages/pipeline/samples/typescript/test/__snapshots__/pipeline.test.ts.snap
+++ b/packages/pipeline/samples/typescript/test/__snapshots__/pipeline.test.ts.snap
@@ -2,30 +2,8 @@
 
 exports[`Snapshot 1`] = `
 Object {
-  "Metadata": Object {
-    "cdk_nag": Object {
-      "rules_to_suppress": Array [
-        Object {
-          "id": "AwsSolutions-CB4",
-          "reason": "Encryption of Codebuild is not required.",
-        },
-        Object {
-          "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
-          "reason": "Encryption of Codebuild is not required.",
-        },
-        Object {
-          "id": "AwsSolutions-S1",
-          "reason": "Access Log buckets should not have s3 bucket logging",
-        },
-        Object {
-          "id": "AwsPrototyping-S3BucketLoggingEnabled",
-          "reason": "Access Log buckets should not have s3 bucket logging",
-        },
-      ],
-    },
-  },
   "Outputs": Object {
-    "CodeRepositoryGRCUrl": Object {
+    "ApplicationPipelineCodeRepositoryGRCUrl52F51C17": Object {
       "Value": Object {
         "Fn::Join": Array [
           "",
@@ -37,7 +15,7 @@ Object {
             "://",
             Object {
               "Fn::GetAtt": Array [
-                "CodeRepositoryBA42F94A",
+                "ApplicationPipelineCodeRepositoryA734F3FA",
                 "Name",
               ],
             },
@@ -54,16 +32,22 @@ Object {
     },
   },
   "Resources": Object {
-    "AccessLogsBucket83982689": Object {
+    "ApplicationPipelineAccessLogsBucketAFC4E2E4": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
-        "AccessControl": "LogDeliveryWrite",
         "BucketEncryption": Object {
           "ServerSideEncryptionConfiguration": Array [
             Object {
               "ServerSideEncryptionByDefault": Object {
                 "SSEAlgorithm": "AES256",
               },
+            },
+          ],
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
             },
           ],
         },
@@ -83,14 +67,14 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Delete",
     },
-    "AccessLogsBucketAutoDeleteObjectsCustomResource93F9213A": Object {
+    "ApplicationPipelineAccessLogsBucketAutoDeleteObjectsCustomResource86C84D8B": Object {
       "DeletionPolicy": "Delete",
       "DependsOn": Array [
-        "AccessLogsBucketPolicy7F77476F",
+        "ApplicationPipelineAccessLogsBucketPolicy9D7CCAB8",
       ],
       "Properties": Object {
         "BucketName": Object {
-          "Ref": "AccessLogsBucket83982689",
+          "Ref": "ApplicationPipelineAccessLogsBucketAFC4E2E4",
         },
         "ServiceToken": Object {
           "Fn::GetAtt": Array [
@@ -102,10 +86,10 @@ Object {
       "Type": "Custom::S3AutoDeleteObjects",
       "UpdateReplacePolicy": "Delete",
     },
-    "AccessLogsBucketPolicy7F77476F": Object {
+    "ApplicationPipelineAccessLogsBucketPolicy9D7CCAB8": Object {
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "AccessLogsBucket83982689",
+          "Ref": "ApplicationPipelineAccessLogsBucketAFC4E2E4",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -123,7 +107,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "AccessLogsBucket83982689",
+                    "ApplicationPipelineAccessLogsBucketAFC4E2E4",
                     "Arn",
                   ],
                 },
@@ -133,7 +117,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "AccessLogsBucket83982689",
+                          "ApplicationPipelineAccessLogsBucketAFC4E2E4",
                           "Arn",
                         ],
                       },
@@ -161,7 +145,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "AccessLogsBucket83982689",
+                    "ApplicationPipelineAccessLogsBucketAFC4E2E4",
                     "Arn",
                   ],
                 },
@@ -171,7 +155,230 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "AccessLogsBucket83982689",
+                          "ApplicationPipelineAccessLogsBucketAFC4E2E4",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": "s3:PutObject",
+              "Condition": Object {
+                "ArnLike": Object {
+                  "aws:SourceArn": Object {
+                    "Fn::GetAtt": Array [
+                      "ApplicationPipelineArtifactsBucketD6B45A16",
+                      "Arn",
+                    ],
+                  },
+                },
+                "StringEquals": Object {
+                  "aws:SourceAccount": Object {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "logging.s3.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "ApplicationPipelineAccessLogsBucketAFC4E2E4",
+                        "Arn",
+                      ],
+                    },
+                    "/access-logs*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "ApplicationPipelineArtifactKey284E3A3C": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "EnableKeyRotation": true,
+        "KeyPolicy": Object {
+          "Statement": Array [
+            Object {
+              "Action": "kms:*",
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::KMS::Key",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ApplicationPipelineArtifactsBucketAutoDeleteObjectsCustomResource349BB700": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "ApplicationPipelineArtifactsBucketPolicy0F22EB48",
+      ],
+      "Properties": Object {
+        "BucketName": Object {
+          "Ref": "ApplicationPipelineArtifactsBucketD6B45A16",
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ApplicationPipelineArtifactsBucketD6B45A16": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "BucketEncryption": Object {
+          "ServerSideEncryptionConfiguration": Array [
+            Object {
+              "ServerSideEncryptionByDefault": Object {
+                "KMSMasterKeyID": Object {
+                  "Fn::GetAtt": Array [
+                    "ApplicationPipelineArtifactKey284E3A3C",
+                    "Arn",
+                  ],
+                },
+                "SSEAlgorithm": "aws:kms",
+              },
+            },
+          ],
+        },
+        "LoggingConfiguration": Object {
+          "DestinationBucketName": Object {
+            "Ref": "ApplicationPipelineAccessLogsBucketAFC4E2E4",
+          },
+          "LogFilePrefix": "access-logs",
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
+            },
+          ],
+        },
+        "PublicAccessBlockConfiguration": Object {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": Array [
+          Object {
+            "Key": "aws-cdk:auto-delete-objects",
+            "Value": "true",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ApplicationPipelineArtifactsBucketPolicy0F22EB48": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "ApplicationPipelineArtifactsBucketD6B45A16",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ApplicationPipelineArtifactsBucketD6B45A16",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ApplicationPipelineArtifactsBucketD6B45A16",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::GetAtt": Array [
+                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+                    "Arn",
+                  ],
+                },
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ApplicationPipelineArtifactsBucketD6B45A16",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ApplicationPipelineArtifactsBucketD6B45A16",
                           "Arn",
                         ],
                       },
@@ -187,7 +394,7 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "ApplicationPipelineCodeBuildActionRole155C9984": Object {
+    "ApplicationPipelineCodeBuildActionRole98AD1444": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -224,7 +431,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApplicationPipelineCodeBuildActionRoleDefaultPolicyC8190973": Object {
+    "ApplicationPipelineCodeBuildActionRoleDefaultPolicyFE7AFEF3": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -237,7 +444,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                  "ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A",
                   "Arn",
                 ],
               },
@@ -251,7 +458,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "ApplicationPipelineUpdatePipelineSelfMutation36D37AA8",
+                  "ApplicationPipelineUpdatePipelineSelfMutation66D95DA8",
                   "Arn",
                 ],
               },
@@ -259,16 +466,162 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "ApplicationPipelineCodeBuildActionRoleDefaultPolicyC8190973",
+        "PolicyName": "ApplicationPipelineCodeBuildActionRoleDefaultPolicyFE7AFEF3",
         "Roles": Array [
           Object {
-            "Ref": "ApplicationPipelineCodeBuildActionRole155C9984",
+            "Ref": "ApplicationPipelineCodeBuildActionRole98AD1444",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "ApplicationPipelineUpdatePipelineSelfMutation36D37AA8": Object {
+    "ApplicationPipelineCodePipeline92ED701F": Object {
+      "DependsOn": Array [
+        "ApplicationPipelineCodePipelineRoleDefaultPolicy02E04067",
+        "ApplicationPipelineCodePipelineRole53E5791D",
+      ],
+      "Properties": Object {
+        "ArtifactStore": Object {
+          "EncryptionKey": Object {
+            "Id": Object {
+              "Fn::GetAtt": Array [
+                "ApplicationPipelineArtifactKey284E3A3C",
+                "Arn",
+              ],
+            },
+            "Type": "KMS",
+          },
+          "Location": Object {
+            "Ref": "ApplicationPipelineArtifactsBucketD6B45A16",
+          },
+          "Type": "S3",
+        },
+        "RestartExecutionOnUpdate": true,
+        "RoleArn": Object {
+          "Fn::GetAtt": Array [
+            "ApplicationPipelineCodePipelineRole53E5791D",
+            "Arn",
+          ],
+        },
+        "Stages": Array [
+          Object {
+            "Actions": Array [
+              Object {
+                "ActionTypeId": Object {
+                  "Category": "Source",
+                  "Owner": "AWS",
+                  "Provider": "CodeCommit",
+                  "Version": "1",
+                },
+                "Configuration": Object {
+                  "BranchName": "mainline",
+                  "PollForSourceChanges": false,
+                  "RepositoryName": Object {
+                    "Fn::GetAtt": Array [
+                      "ApplicationPipelineCodeRepositoryA734F3FA",
+                      "Name",
+                    ],
+                  },
+                },
+                "Name": Object {
+                  "Fn::GetAtt": Array [
+                    "ApplicationPipelineCodeRepositoryA734F3FA",
+                    "Name",
+                  ],
+                },
+                "OutputArtifacts": Array [
+                  Object {
+                    "Name": "c8dccfc7b4b06e6314cb1dc9e5680d002e559b8933_Source",
+                  },
+                ],
+                "RoleArn": Object {
+                  "Fn::GetAtt": Array [
+                    "ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRole0900531A",
+                    "Arn",
+                  ],
+                },
+                "RunOrder": 1,
+              },
+            ],
+            "Name": "Source",
+          },
+          Object {
+            "Actions": Array [
+              Object {
+                "ActionTypeId": Object {
+                  "Category": "Build",
+                  "Owner": "AWS",
+                  "Provider": "CodeBuild",
+                  "Version": "1",
+                },
+                "Configuration": Object {
+                  "EnvironmentVariables": "[{\\"name\\":\\"_PROJECT_CONFIG_HASH\\",\\"type\\":\\"PLAINTEXT\\",\\"value\\":\\"13fb1f6f3f0a665500d00a30e46cf5c67342362be94a9d79d179c2ea7436a504\\"}]",
+                  "ProjectName": Object {
+                    "Ref": "ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A",
+                  },
+                },
+                "InputArtifacts": Array [
+                  Object {
+                    "Name": "c8dccfc7b4b06e6314cb1dc9e5680d002e559b8933_Source",
+                  },
+                ],
+                "Name": "Synth",
+                "OutputArtifacts": Array [
+                  Object {
+                    "Name": "Synth_Output",
+                  },
+                  Object {
+                    "Name": "Synth__",
+                  },
+                ],
+                "RoleArn": Object {
+                  "Fn::GetAtt": Array [
+                    "ApplicationPipelineCodeBuildActionRole98AD1444",
+                    "Arn",
+                  ],
+                },
+                "RunOrder": 1,
+              },
+            ],
+            "Name": "Build",
+          },
+          Object {
+            "Actions": Array [
+              Object {
+                "ActionTypeId": Object {
+                  "Category": "Build",
+                  "Owner": "AWS",
+                  "Provider": "CodeBuild",
+                  "Version": "1",
+                },
+                "Configuration": Object {
+                  "EnvironmentVariables": "[{\\"name\\":\\"_PROJECT_CONFIG_HASH\\",\\"type\\":\\"PLAINTEXT\\",\\"value\\":\\"2e13b99bcda0cb81fc6053cd8a65f303945d49fe774f18ad2c20d178423d9be6\\"}]",
+                  "ProjectName": Object {
+                    "Ref": "ApplicationPipelineUpdatePipelineSelfMutation66D95DA8",
+                  },
+                },
+                "InputArtifacts": Array [
+                  Object {
+                    "Name": "Synth_Output",
+                  },
+                ],
+                "Name": "SelfMutate",
+                "RoleArn": Object {
+                  "Fn::GetAtt": Array [
+                    "ApplicationPipelineCodeBuildActionRole98AD1444",
+                    "Arn",
+                  ],
+                },
+                "RunOrder": 1,
+              },
+            ],
+            "Name": "UpdatePipeline",
+          },
+        ],
+      },
+      "Type": "AWS::CodePipeline::Pipeline",
+    },
+    "ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A": Object {
       "Properties": Object {
         "Artifacts": Object {
           "Type": "CODEPIPELINE",
@@ -276,10 +629,10 @@ Object {
         "Cache": Object {
           "Type": "NO_CACHE",
         },
-        "Description": "Pipeline step pipeline-test/CodePipeline/UpdatePipeline/SelfMutate",
+        "Description": "Pipeline step pipeline-test/CodePipeline/Build/Synth",
         "EncryptionKey": Object {
           "Fn::GetAtt": Array [
-            "ArtifactKey8D84C5F0",
+            "ApplicationPipelineArtifactKey284E3A3C",
             "Arn",
           ],
         },
@@ -292,7 +645,7 @@ Object {
         },
         "ServiceRole": Object {
           "Fn::GetAtt": Array [
-            "ApplicationPipelineUpdatePipelineSelfMutationRole59A20D82",
+            "ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectRole75D1C6E6",
             "Arn",
           ],
         },
@@ -302,13 +655,26 @@ Object {
   \\"phases\\": {
     \\"install\\": {
       \\"commands\\": [
-        \\"npm install -g aws-cdk@2\\"
+        \\"npm install -g aws-cdk\\",
+        \\"yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile\\"
       ]
     },
     \\"build\\": {
       \\"commands\\": [
-        \\"cdk -a . deploy pipeline-test --require-approval=never --verbose\\"
+        \\"npx nx run-many --target=build --all\\"
       ]
+    }
+  },
+  \\"artifacts\\": {
+    \\"secondary-artifacts\\": {
+      \\"Synth_Output\\": {
+        \\"base-directory\\": \\"packages/infra/cdk.out\\",
+        \\"files\\": \\"**/*\\"
+      },
+      \\"Synth__\\": {
+        \\"base-directory\\": \\".\\",
+        \\"files\\": \\"**/*\\"
+      }
     }
   }
 }",
@@ -317,7 +683,7 @@ Object {
       },
       "Type": "AWS::CodeBuild::Project",
     },
-    "ApplicationPipelineUpdatePipelineSelfMutationRole59A20D82": Object {
+    "ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectRole75D1C6E6": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -334,191 +700,7 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApplicationPipelineUpdatePipelineSelfMutationRoleDefaultPolicy88A56583": Object {
-      "Metadata": Object {
-        "cdk_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<ApplicationPipelineUpdatePipelineSelfMutation.*>-\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:\\\\*:iam::<AWS::AccountId>:role/\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to assume a role from within the current account in order to deploy.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to list all buckets and stacks.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": Object {
-                    "Fn::Join": Array [
-                      "",
-                      Array [
-                        "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|",
-                        Object {
-                          "Ref": "AWS::AccountId",
-                        },
-                        "):log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\*$/g",
-                      ],
-                    ],
-                  },
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<ApplicationPipelineUpdatePipelineSelfMutation.*>-\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:\\\\*:iam::<AWS::AccountId>:role/\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to assume a role from within the current account in order to deploy.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to list all buckets and stacks.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": Object {
-                    "Fn::Join": Array [
-                      "",
-                      Array [
-                        "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|",
-                        Object {
-                          "Ref": "AWS::AccountId",
-                        },
-                        "):log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\*$/g",
-                      ],
-                    ],
-                  },
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-          ],
-        },
-      },
+    "ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicy4B9195CC": Object {
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -548,7 +730,7 @@ Object {
                       },
                       ":log-group:/aws/codebuild/",
                       Object {
-                        "Ref": "ApplicationPipelineUpdatePipelineSelfMutation36D37AA8",
+                        "Ref": "ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A",
                       },
                     ],
                   ],
@@ -571,7 +753,7 @@ Object {
                       },
                       ":log-group:/aws/codebuild/",
                       Object {
-                        "Ref": "ApplicationPipelineUpdatePipelineSelfMutation36D37AA8",
+                        "Ref": "ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A",
                       },
                       ":*",
                     ],
@@ -606,7 +788,604 @@ Object {
                     },
                     ":report-group/",
                     Object {
-                      "Ref": "ApplicationPipelineUpdatePipelineSelfMutation36D37AA8",
+                      "Ref": "ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A",
+                    },
+                    "-*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ApplicationPipelineArtifactsBucketD6B45A16",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ApplicationPipelineArtifactsBucketD6B45A16",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "kms:Decrypt",
+                "kms:DescribeKey",
+                "kms:Encrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ApplicationPipelineArtifactKey284E3A3C",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "kms:Decrypt",
+                "kms:Encrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ApplicationPipelineArtifactKey284E3A3C",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicy4B9195CC",
+        "Roles": Array [
+          Object {
+            "Ref": "ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectRole75D1C6E6",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApplicationPipelineCodePipelineEventsRoleCF718FC7": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApplicationPipelineCodePipelineEventsRoleDefaultPolicy4A96451E": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "codepipeline:StartPipelineExecution",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":codepipeline:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "ApplicationPipelineCodePipeline92ED701F",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApplicationPipelineCodePipelineEventsRoleDefaultPolicy4A96451E",
+        "Roles": Array [
+          Object {
+            "Ref": "ApplicationPipelineCodePipelineEventsRoleCF718FC7",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApplicationPipelineCodePipelineRole53E5791D": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "codepipeline.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApplicationPipelineCodePipelineRoleDefaultPolicy02E04067": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ApplicationPipelineArtifactsBucketD6B45A16",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ApplicationPipelineArtifactsBucketD6B45A16",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "kms:Decrypt",
+                "kms:DescribeKey",
+                "kms:Encrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ApplicationPipelineArtifactKey284E3A3C",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRole0900531A",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ApplicationPipelineCodeBuildActionRole98AD1444",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApplicationPipelineCodePipelineRoleDefaultPolicy02E04067",
+        "Roles": Array [
+          Object {
+            "Ref": "ApplicationPipelineCodePipelineRole53E5791D",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRole0900531A": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyE92AF83A": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ApplicationPipelineArtifactsBucketD6B45A16",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ApplicationPipelineArtifactsBucketD6B45A16",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "kms:Decrypt",
+                "kms:DescribeKey",
+                "kms:Encrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ApplicationPipelineArtifactKey284E3A3C",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codecommit:GetBranch",
+                "codecommit:GetCommit",
+                "codecommit:UploadArchive",
+                "codecommit:GetUploadArchiveStatus",
+                "codecommit:CancelUploadArchive",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "ApplicationPipelineCodeRepositoryA734F3FA",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyE92AF83A",
+        "Roles": Array [
+          Object {
+            "Ref": "ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRole0900531A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApplicationPipelineCodeRepositoryA734F3FA": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "RepositoryName": "monorepo",
+      },
+      "Type": "AWS::CodeCommit::Repository",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "ApplicationPipelineCodeRepositorypipelinetestApplicationPipelineCodePipeline31AB4045mainlineEventRule30640423": Object {
+      "Properties": Object {
+        "EventPattern": Object {
+          "detail": Object {
+            "event": Array [
+              "referenceCreated",
+              "referenceUpdated",
+            ],
+            "referenceName": Array [
+              "mainline",
+            ],
+          },
+          "detail-type": Array [
+            "CodeCommit Repository State Change",
+          ],
+          "resources": Array [
+            Object {
+              "Fn::GetAtt": Array [
+                "ApplicationPipelineCodeRepositoryA734F3FA",
+                "Arn",
+              ],
+            },
+          ],
+          "source": Array [
+            "aws.codecommit",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": Array [
+          Object {
+            "Arn": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "arn:",
+                  Object {
+                    "Ref": "AWS::Partition",
+                  },
+                  ":codepipeline:",
+                  Object {
+                    "Ref": "AWS::Region",
+                  },
+                  ":",
+                  Object {
+                    "Ref": "AWS::AccountId",
+                  },
+                  ":",
+                  Object {
+                    "Ref": "ApplicationPipelineCodePipeline92ED701F",
+                  },
+                ],
+              ],
+            },
+            "Id": "Target0",
+            "RoleArn": Object {
+              "Fn::GetAtt": Array [
+                "ApplicationPipelineCodePipelineEventsRoleCF718FC7",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "ApplicationPipelineUpdatePipelineSelfMutation66D95DA8": Object {
+      "Properties": Object {
+        "Artifacts": Object {
+          "Type": "CODEPIPELINE",
+        },
+        "Cache": Object {
+          "Type": "NO_CACHE",
+        },
+        "Description": "Pipeline step pipeline-test/CodePipeline/UpdatePipeline/SelfMutate",
+        "EncryptionKey": Object {
+          "Fn::GetAtt": Array [
+            "ApplicationPipelineArtifactKey284E3A3C",
+            "Arn",
+          ],
+        },
+        "Environment": Object {
+          "ComputeType": "BUILD_GENERAL1_SMALL",
+          "Image": "aws/codebuild/standard:6.0",
+          "ImagePullCredentialsType": "CODEBUILD",
+          "PrivilegedMode": false,
+          "Type": "LINUX_CONTAINER",
+        },
+        "ServiceRole": Object {
+          "Fn::GetAtt": Array [
+            "ApplicationPipelineUpdatePipelineSelfMutationRoleD476D3E4",
+            "Arn",
+          ],
+        },
+        "Source": Object {
+          "BuildSpec": "{
+  \\"version\\": \\"0.2\\",
+  \\"phases\\": {
+    \\"install\\": {
+      \\"commands\\": [
+        \\"npm install -g aws-cdk@2\\"
+      ]
+    },
+    \\"build\\": {
+      \\"commands\\": [
+        \\"cdk -a . deploy pipeline-test --require-approval=never --verbose\\"
+      ]
+    }
+  }
+}",
+          "Type": "CODEPIPELINE",
+        },
+      },
+      "Type": "AWS::CodeBuild::Project",
+    },
+    "ApplicationPipelineUpdatePipelineSelfMutationRoleD476D3E4": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "codebuild.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApplicationPipelineUpdatePipelineSelfMutationRoleDefaultPolicyE74ACD15": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":logs:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":log-group:/aws/codebuild/",
+                      Object {
+                        "Ref": "ApplicationPipelineUpdatePipelineSelfMutation66D95DA8",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":logs:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":log-group:/aws/codebuild/",
+                      Object {
+                        "Ref": "ApplicationPipelineUpdatePipelineSelfMutation66D95DA8",
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "codebuild:CreateReportGroup",
+                "codebuild:CreateReport",
+                "codebuild:UpdateReport",
+                "codebuild:BatchPutTestCases",
+                "codebuild:BatchPutCodeCoverages",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":codebuild:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":report-group/",
+                    Object {
+                      "Ref": "ApplicationPipelineUpdatePipelineSelfMutation66D95DA8",
                     },
                     "-*",
                   ],
@@ -658,7 +1437,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "ApplicationPipelineArtifactsBucketD6B45A16",
                     "Arn",
                   ],
                 },
@@ -668,7 +1447,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "ApplicationPipelineArtifactsBucketD6B45A16",
                           "Arn",
                         ],
                       },
@@ -686,7 +1465,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "ArtifactKey8D84C5F0",
+                  "ApplicationPipelineArtifactKey284E3A3C",
                   "Arn",
                 ],
               },
@@ -701,7 +1480,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "ArtifactKey8D84C5F0",
+                  "ApplicationPipelineArtifactKey284E3A3C",
                   "Arn",
                 ],
               },
@@ -709,1166 +1488,14 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "ApplicationPipelineUpdatePipelineSelfMutationRoleDefaultPolicy88A56583",
+        "PolicyName": "ApplicationPipelineUpdatePipelineSelfMutationRoleDefaultPolicyE74ACD15",
         "Roles": Array [
           Object {
-            "Ref": "ApplicationPipelineUpdatePipelineSelfMutationRole59A20D82",
+            "Ref": "ApplicationPipelineUpdatePipelineSelfMutationRoleD476D3E4",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "ArtifactKey8D84C5F0": Object {
-      "DeletionPolicy": "Delete",
-      "Properties": Object {
-        "EnableKeyRotation": true,
-        "KeyPolicy": Object {
-          "Statement": Array [
-            Object {
-              "Action": "kms:*",
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":iam::",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":root",
-                    ],
-                  ],
-                },
-              },
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::KMS::Key",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ArtifactsBucket2AAC5544": Object {
-      "DeletionPolicy": "Delete",
-      "Properties": Object {
-        "BucketEncryption": Object {
-          "ServerSideEncryptionConfiguration": Array [
-            Object {
-              "ServerSideEncryptionByDefault": Object {
-                "KMSMasterKeyID": Object {
-                  "Fn::GetAtt": Array [
-                    "ArtifactKey8D84C5F0",
-                    "Arn",
-                  ],
-                },
-                "SSEAlgorithm": "aws:kms",
-              },
-            },
-          ],
-        },
-        "LoggingConfiguration": Object {
-          "DestinationBucketName": Object {
-            "Ref": "AccessLogsBucket83982689",
-          },
-          "LogFilePrefix": "access-logs",
-        },
-        "PublicAccessBlockConfiguration": Object {
-          "BlockPublicAcls": true,
-          "BlockPublicPolicy": true,
-          "IgnorePublicAcls": true,
-          "RestrictPublicBuckets": true,
-        },
-        "Tags": Array [
-          Object {
-            "Key": "aws-cdk:auto-delete-objects",
-            "Value": "true",
-          },
-        ],
-      },
-      "Type": "AWS::S3::Bucket",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ArtifactsBucketAutoDeleteObjectsCustomResource0E3B4320": Object {
-      "DeletionPolicy": "Delete",
-      "DependsOn": Array [
-        "ArtifactsBucketPolicy852CB646",
-      ],
-      "Properties": Object {
-        "BucketName": Object {
-          "Ref": "ArtifactsBucket2AAC5544",
-        },
-        "ServiceToken": Object {
-          "Fn::GetAtt": Array [
-            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "Custom::S3AutoDeleteObjects",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ArtifactsBucketPolicy852CB646": Object {
-      "Properties": Object {
-        "Bucket": Object {
-          "Ref": "ArtifactsBucket2AAC5544",
-        },
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "s3:*",
-              "Condition": Object {
-                "Bool": Object {
-                  "aws:SecureTransport": "false",
-                },
-              },
-              "Effect": "Deny",
-              "Principal": Object {
-                "AWS": "*",
-              },
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "s3:GetBucket*",
-                "s3:List*",
-                "s3:DeleteObject*",
-              ],
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": Object {
-                  "Fn::GetAtt": Array [
-                    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
-                    "Arn",
-                  ],
-                },
-              },
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::S3::BucketPolicy",
-    },
-    "CodePipelineB74E5936": Object {
-      "DependsOn": Array [
-        "CodePipelineRoleDefaultPolicy8D520A8D",
-        "CodePipelineRoleB3A660B4",
-      ],
-      "Properties": Object {
-        "ArtifactStore": Object {
-          "EncryptionKey": Object {
-            "Id": Object {
-              "Fn::GetAtt": Array [
-                "ArtifactKey8D84C5F0",
-                "Arn",
-              ],
-            },
-            "Type": "KMS",
-          },
-          "Location": Object {
-            "Ref": "ArtifactsBucket2AAC5544",
-          },
-          "Type": "S3",
-        },
-        "RestartExecutionOnUpdate": true,
-        "RoleArn": Object {
-          "Fn::GetAtt": Array [
-            "CodePipelineRoleB3A660B4",
-            "Arn",
-          ],
-        },
-        "Stages": Array [
-          Object {
-            "Actions": Array [
-              Object {
-                "ActionTypeId": Object {
-                  "Category": "Source",
-                  "Owner": "AWS",
-                  "Provider": "CodeCommit",
-                  "Version": "1",
-                },
-                "Configuration": Object {
-                  "BranchName": "mainline",
-                  "PollForSourceChanges": false,
-                  "RepositoryName": Object {
-                    "Fn::GetAtt": Array [
-                      "CodeRepositoryBA42F94A",
-                      "Name",
-                    ],
-                  },
-                },
-                "Name": Object {
-                  "Fn::GetAtt": Array [
-                    "CodeRepositoryBA42F94A",
-                    "Name",
-                  ],
-                },
-                "OutputArtifacts": Array [
-                  Object {
-                    "Name": "c825c34765dfb5e99261fa6cab9fea074f8881c7c4_Source",
-                  },
-                ],
-                "RoleArn": Object {
-                  "Fn::GetAtt": Array [
-                    "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70",
-                    "Arn",
-                  ],
-                },
-                "RunOrder": 1,
-              },
-            ],
-            "Name": "Source",
-          },
-          Object {
-            "Actions": Array [
-              Object {
-                "ActionTypeId": Object {
-                  "Category": "Build",
-                  "Owner": "AWS",
-                  "Provider": "CodeBuild",
-                  "Version": "1",
-                },
-                "Configuration": Object {
-                  "EnvironmentVariables": "[{\\"name\\":\\"_PROJECT_CONFIG_HASH\\",\\"type\\":\\"PLAINTEXT\\",\\"value\\":\\"13fb1f6f3f0a665500d00a30e46cf5c67342362be94a9d79d179c2ea7436a504\\"}]",
-                  "ProjectName": Object {
-                    "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
-                  },
-                },
-                "InputArtifacts": Array [
-                  Object {
-                    "Name": "c825c34765dfb5e99261fa6cab9fea074f8881c7c4_Source",
-                  },
-                ],
-                "Name": "Synth",
-                "OutputArtifacts": Array [
-                  Object {
-                    "Name": "Synth_Output",
-                  },
-                  Object {
-                    "Name": "Synth__",
-                  },
-                ],
-                "RoleArn": Object {
-                  "Fn::GetAtt": Array [
-                    "ApplicationPipelineCodeBuildActionRole155C9984",
-                    "Arn",
-                  ],
-                },
-                "RunOrder": 1,
-              },
-            ],
-            "Name": "Build",
-          },
-          Object {
-            "Actions": Array [
-              Object {
-                "ActionTypeId": Object {
-                  "Category": "Build",
-                  "Owner": "AWS",
-                  "Provider": "CodeBuild",
-                  "Version": "1",
-                },
-                "Configuration": Object {
-                  "EnvironmentVariables": "[{\\"name\\":\\"_PROJECT_CONFIG_HASH\\",\\"type\\":\\"PLAINTEXT\\",\\"value\\":\\"2e13b99bcda0cb81fc6053cd8a65f303945d49fe774f18ad2c20d178423d9be6\\"}]",
-                  "ProjectName": Object {
-                    "Ref": "ApplicationPipelineUpdatePipelineSelfMutation36D37AA8",
-                  },
-                },
-                "InputArtifacts": Array [
-                  Object {
-                    "Name": "Synth_Output",
-                  },
-                ],
-                "Name": "SelfMutate",
-                "RoleArn": Object {
-                  "Fn::GetAtt": Array [
-                    "ApplicationPipelineCodeBuildActionRole155C9984",
-                    "Arn",
-                  ],
-                },
-                "RunOrder": 1,
-              },
-            ],
-            "Name": "UpdatePipeline",
-          },
-        ],
-      },
-      "Type": "AWS::CodePipeline::Pipeline",
-    },
-    "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6": Object {
-      "Properties": Object {
-        "Artifacts": Object {
-          "Type": "CODEPIPELINE",
-        },
-        "Cache": Object {
-          "Type": "NO_CACHE",
-        },
-        "Description": "Pipeline step pipeline-test/CodePipeline/Build/Synth",
-        "EncryptionKey": Object {
-          "Fn::GetAtt": Array [
-            "ArtifactKey8D84C5F0",
-            "Arn",
-          ],
-        },
-        "Environment": Object {
-          "ComputeType": "BUILD_GENERAL1_SMALL",
-          "Image": "aws/codebuild/standard:6.0",
-          "ImagePullCredentialsType": "CODEBUILD",
-          "PrivilegedMode": false,
-          "Type": "LINUX_CONTAINER",
-        },
-        "ServiceRole": Object {
-          "Fn::GetAtt": Array [
-            "CodePipelineBuildSynthCdkBuildProjectRoleB73287D4",
-            "Arn",
-          ],
-        },
-        "Source": Object {
-          "BuildSpec": "{
-  \\"version\\": \\"0.2\\",
-  \\"phases\\": {
-    \\"install\\": {
-      \\"commands\\": [
-        \\"npm install -g aws-cdk\\",
-        \\"yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile\\"
-      ]
-    },
-    \\"build\\": {
-      \\"commands\\": [
-        \\"npx nx run-many --target=build --all\\"
-      ]
-    }
-  },
-  \\"artifacts\\": {
-    \\"secondary-artifacts\\": {
-      \\"Synth_Output\\": {
-        \\"base-directory\\": \\"packages/infra/cdk.out\\",
-        \\"files\\": \\"**/*\\"
-      },
-      \\"Synth__\\": {
-        \\"base-directory\\": \\".\\",
-        \\"files\\": \\"**/*\\"
-      }
-    }
-  }
-}",
-          "Type": "CODEPIPELINE",
-        },
-      },
-      "Type": "AWS::CodeBuild::Project",
-    },
-    "CodePipelineBuildSynthCdkBuildProjectRoleB73287D4": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "codebuild.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyB7EDB705": Object {
-      "Metadata": Object {
-        "cdk_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
-            },
-          ],
-        },
-      },
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "logs:CreateLogGroup",
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":logs:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":log-group:/aws/codebuild/",
-                      Object {
-                        "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
-                      },
-                    ],
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":logs:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":log-group:/aws/codebuild/",
-                      Object {
-                        "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
-                      },
-                      ":*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "codebuild:CreateReportGroup",
-                "codebuild:CreateReport",
-                "codebuild:UpdateReport",
-                "codebuild:BatchPutTestCases",
-                "codebuild:BatchPutCodeCoverages",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:",
-                    Object {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":codebuild:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":report-group/",
-                    Object {
-                      "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
-                    },
-                    "-*",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-                "s3:DeleteObject*",
-                "s3:PutObject",
-                "s3:PutObjectLegalHold",
-                "s3:PutObjectRetention",
-                "s3:PutObjectTagging",
-                "s3:PutObjectVersionTagging",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "kms:Decrypt",
-                "kms:DescribeKey",
-                "kms:Encrypt",
-                "kms:ReEncrypt*",
-                "kms:GenerateDataKey*",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "ArtifactKey8D84C5F0",
-                  "Arn",
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "kms:Decrypt",
-                "kms:Encrypt",
-                "kms:ReEncrypt*",
-                "kms:GenerateDataKey*",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "ArtifactKey8D84C5F0",
-                  "Arn",
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "CodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyB7EDB705",
-        "Roles": Array [
-          Object {
-            "Ref": "CodePipelineBuildSynthCdkBuildProjectRoleB73287D4",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "CodePipelineEventsRole4196480D": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "events.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CodePipelineEventsRoleDefaultPolicy13DBD2D2": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "codepipeline:StartPipelineExecution",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:",
-                    Object {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":codepipeline:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "CodePipelineB74E5936",
-                    },
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "CodePipelineEventsRoleDefaultPolicy13DBD2D2",
-        "Roles": Array [
-          Object {
-            "Ref": "CodePipelineEventsRole4196480D",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "CodePipelineRoleB3A660B4": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "codepipeline.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CodePipelineRoleDefaultPolicy8D520A8D": Object {
-      "Metadata": Object {
-        "cdk_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-          ],
-        },
-      },
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-                "s3:DeleteObject*",
-                "s3:PutObject",
-                "s3:PutObjectLegalHold",
-                "s3:PutObjectRetention",
-                "s3:PutObjectTagging",
-                "s3:PutObjectVersionTagging",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "kms:Decrypt",
-                "kms:DescribeKey",
-                "kms:Encrypt",
-                "kms:ReEncrypt*",
-                "kms:GenerateDataKey*",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "ArtifactKey8D84C5F0",
-                  "Arn",
-                ],
-              },
-            },
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70",
-                  "Arn",
-                ],
-              },
-            },
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "ApplicationPipelineCodeBuildActionRole155C9984",
-                  "Arn",
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "CodePipelineRoleDefaultPolicy8D520A8D",
-        "Roles": Array [
-          Object {
-            "Ref": "CodePipelineRoleB3A660B4",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":iam::",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":root",
-                    ],
-                  ],
-                },
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyAFBD34E4": Object {
-      "Metadata": Object {
-        "cdk_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-          ],
-        },
-      },
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-                "s3:DeleteObject*",
-                "s3:PutObject",
-                "s3:PutObjectLegalHold",
-                "s3:PutObjectRetention",
-                "s3:PutObjectTagging",
-                "s3:PutObjectVersionTagging",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "kms:Decrypt",
-                "kms:DescribeKey",
-                "kms:Encrypt",
-                "kms:ReEncrypt*",
-                "kms:GenerateDataKey*",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "ArtifactKey8D84C5F0",
-                  "Arn",
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "codecommit:GetBranch",
-                "codecommit:GetCommit",
-                "codecommit:UploadArchive",
-                "codecommit:GetUploadArchiveStatus",
-                "codecommit:CancelUploadArchive",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "CodeRepositoryBA42F94A",
-                  "Arn",
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "CodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyAFBD34E4",
-        "Roles": Array [
-          Object {
-            "Ref": "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "CodeRepositoryBA42F94A": Object {
-      "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "RepositoryName": "monorepo",
-      },
-      "Type": "AWS::CodeCommit::Repository",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "CodeRepositorypipelinetestCodePipelineC82F8C25mainlineEventRule152901D1": Object {
-      "Properties": Object {
-        "EventPattern": Object {
-          "detail": Object {
-            "event": Array [
-              "referenceCreated",
-              "referenceUpdated",
-            ],
-            "referenceName": Array [
-              "mainline",
-            ],
-          },
-          "detail-type": Array [
-            "CodeCommit Repository State Change",
-          ],
-          "resources": Array [
-            Object {
-              "Fn::GetAtt": Array [
-                "CodeRepositoryBA42F94A",
-                "Arn",
-              ],
-            },
-          ],
-          "source": Array [
-            "aws.codecommit",
-          ],
-        },
-        "State": "ENABLED",
-        "Targets": Array [
-          Object {
-            "Arn": Object {
-              "Fn::Join": Array [
-                "",
-                Array [
-                  "arn:",
-                  Object {
-                    "Ref": "AWS::Partition",
-                  },
-                  ":codepipeline:",
-                  Object {
-                    "Ref": "AWS::Region",
-                  },
-                  ":",
-                  Object {
-                    "Ref": "AWS::AccountId",
-                  },
-                  ":",
-                  Object {
-                    "Ref": "CodePipelineB74E5936",
-                  },
-                ],
-              ],
-            },
-            "Id": "Target0",
-            "RoleArn": Object {
-              "Fn::GetAtt": Array [
-                "CodePipelineEventsRole4196480D",
-                "Arn",
-              ],
-            },
-          },
-        ],
-      },
-      "Type": "AWS::Events::Rule",
     },
     "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F": Object {
       "DependsOn": Array [
@@ -1887,7 +1514,7 @@ Object {
             Array [
               "Lambda function for auto-deleting objects in ",
               Object {
-                "Ref": "AccessLogsBucket83982689",
+                "Ref": "ApplicationPipelineAccessLogsBucketAFC4E2E4",
               },
               " S3 bucket.",
             ],

--- a/packages/pipeline/test/__snapshots__/pdk-pipeline-ts-project.test.ts.snap
+++ b/packages/pipeline/test/__snapshots__/pdk-pipeline-ts-project.test.ts.snap
@@ -1040,30 +1040,8 @@ app.synth();
 
 exports[\`Snapshot 1\`] = \`
 Object {
-  \\"Metadata\\": Object {
-    \\"cdk_nag\\": Object {
-      \\"rules_to_suppress\\": Array [
-        Object {
-          \\"id\\": \\"AwsSolutions-CB4\\",
-          \\"reason\\": \\"Encryption of Codebuild is not required.\\",
-        },
-        Object {
-          \\"id\\": \\"AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts\\",
-          \\"reason\\": \\"Encryption of Codebuild is not required.\\",
-        },
-        Object {
-          \\"id\\": \\"AwsSolutions-S1\\",
-          \\"reason\\": \\"Access Log buckets should not have s3 bucket logging\\",
-        },
-        Object {
-          \\"id\\": \\"AwsPrototyping-S3BucketLoggingEnabled\\",
-          \\"reason\\": \\"Access Log buckets should not have s3 bucket logging\\",
-        },
-      ],
-    },
-  },
   \\"Outputs\\": Object {
-    \\"CodeRepositoryGRCUrl\\": Object {
+    \\"ApplicationPipelineCodeRepositoryGRCUrl52F51C17\\": Object {
       \\"Value\\": Object {
         \\"Fn::Join\\": Array [
           \\"\\",
@@ -1075,7 +1053,7 @@ Object {
             \\"://\\",
             Object {
               \\"Fn::GetAtt\\": Array [
-                \\"CodeRepositoryBA42F94A\\",
+                \\"ApplicationPipelineCodeRepositoryA734F3FA\\",
                 \\"Name\\",
               ],
             },
@@ -1092,16 +1070,22 @@ Object {
     },
   },
   \\"Resources\\": Object {
-    \\"AccessLogsBucket83982689\\": Object {
+    \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\": Object {
       \\"DeletionPolicy\\": \\"Delete\\",
       \\"Properties\\": Object {
-        \\"AccessControl\\": \\"LogDeliveryWrite\\",
         \\"BucketEncryption\\": Object {
           \\"ServerSideEncryptionConfiguration\\": Array [
             Object {
               \\"ServerSideEncryptionByDefault\\": Object {
                 \\"SSEAlgorithm\\": \\"AES256\\",
               },
+            },
+          ],
+        },
+        \\"OwnershipControls\\": Object {
+          \\"Rules\\": Array [
+            Object {
+              \\"ObjectOwnership\\": \\"BucketOwnerEnforced\\",
             },
           ],
         },
@@ -1121,14 +1105,14 @@ Object {
       \\"Type\\": \\"AWS::S3::Bucket\\",
       \\"UpdateReplacePolicy\\": \\"Delete\\",
     },
-    \\"AccessLogsBucketAutoDeleteObjectsCustomResource93F9213A\\": Object {
+    \\"ApplicationPipelineAccessLogsBucketAutoDeleteObjectsCustomResource86C84D8B\\": Object {
       \\"DeletionPolicy\\": \\"Delete\\",
       \\"DependsOn\\": Array [
-        \\"AccessLogsBucketPolicy7F77476F\\",
+        \\"ApplicationPipelineAccessLogsBucketPolicy9D7CCAB8\\",
       ],
       \\"Properties\\": Object {
         \\"BucketName\\": Object {
-          \\"Ref\\": \\"AccessLogsBucket83982689\\",
+          \\"Ref\\": \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
         },
         \\"ServiceToken\\": Object {
           \\"Fn::GetAtt\\": Array [
@@ -1140,10 +1124,10 @@ Object {
       \\"Type\\": \\"Custom::S3AutoDeleteObjects\\",
       \\"UpdateReplacePolicy\\": \\"Delete\\",
     },
-    \\"AccessLogsBucketPolicy7F77476F\\": Object {
+    \\"ApplicationPipelineAccessLogsBucketPolicy9D7CCAB8\\": Object {
       \\"Properties\\": Object {
         \\"Bucket\\": Object {
-          \\"Ref\\": \\"AccessLogsBucket83982689\\",
+          \\"Ref\\": \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
         },
         \\"PolicyDocument\\": Object {
           \\"Statement\\": Array [
@@ -1161,7 +1145,7 @@ Object {
               \\"Resource\\": Array [
                 Object {
                   \\"Fn::GetAtt\\": Array [
-                    \\"AccessLogsBucket83982689\\",
+                    \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
                     \\"Arn\\",
                   ],
                 },
@@ -1171,7 +1155,7 @@ Object {
                     Array [
                       Object {
                         \\"Fn::GetAtt\\": Array [
-                          \\"AccessLogsBucket83982689\\",
+                          \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
                           \\"Arn\\",
                         ],
                       },
@@ -1199,7 +1183,7 @@ Object {
               \\"Resource\\": Array [
                 Object {
                   \\"Fn::GetAtt\\": Array [
-                    \\"AccessLogsBucket83982689\\",
+                    \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
                     \\"Arn\\",
                   ],
                 },
@@ -1209,7 +1193,230 @@ Object {
                     Array [
                       Object {
                         \\"Fn::GetAtt\\": Array [
-                          \\"AccessLogsBucket83982689\\",
+                          \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
+                          \\"Arn\\",
+                        ],
+                      },
+                      \\"/*\\",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              \\"Action\\": \\"s3:PutObject\\",
+              \\"Condition\\": Object {
+                \\"ArnLike\\": Object {
+                  \\"aws:SourceArn\\": Object {
+                    \\"Fn::GetAtt\\": Array [
+                      \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                      \\"Arn\\",
+                    ],
+                  },
+                },
+                \\"StringEquals\\": Object {
+                  \\"aws:SourceAccount\\": Object {
+                    \\"Ref\\": \\"AWS::AccountId\\",
+                  },
+                },
+              },
+              \\"Effect\\": \\"Allow\\",
+              \\"Principal\\": Object {
+                \\"Service\\": \\"logging.s3.amazonaws.com\\",
+              },
+              \\"Resource\\": Object {
+                \\"Fn::Join\\": Array [
+                  \\"\\",
+                  Array [
+                    Object {
+                      \\"Fn::GetAtt\\": Array [
+                        \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
+                        \\"Arn\\",
+                      ],
+                    },
+                    \\"/access-logs*\\",
+                  ],
+                ],
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+      },
+      \\"Type\\": \\"AWS::S3::BucketPolicy\\",
+    },
+    \\"ApplicationPipelineArtifactKey284E3A3C\\": Object {
+      \\"DeletionPolicy\\": \\"Delete\\",
+      \\"Properties\\": Object {
+        \\"EnableKeyRotation\\": true,
+        \\"KeyPolicy\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": \\"kms:*\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Principal\\": Object {
+                \\"AWS\\": Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      \\"arn:\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::Partition\\",
+                      },
+                      \\":iam::\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::AccountId\\",
+                      },
+                      \\":root\\",
+                    ],
+                  ],
+                },
+              },
+              \\"Resource\\": \\"*\\",
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+      },
+      \\"Type\\": \\"AWS::KMS::Key\\",
+      \\"UpdateReplacePolicy\\": \\"Delete\\",
+    },
+    \\"ApplicationPipelineArtifactsBucketAutoDeleteObjectsCustomResource349BB700\\": Object {
+      \\"DeletionPolicy\\": \\"Delete\\",
+      \\"DependsOn\\": Array [
+        \\"ApplicationPipelineArtifactsBucketPolicy0F22EB48\\",
+      ],
+      \\"Properties\\": Object {
+        \\"BucketName\\": Object {
+          \\"Ref\\": \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+        },
+        \\"ServiceToken\\": Object {
+          \\"Fn::GetAtt\\": Array [
+            \\"CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F\\",
+            \\"Arn\\",
+          ],
+        },
+      },
+      \\"Type\\": \\"Custom::S3AutoDeleteObjects\\",
+      \\"UpdateReplacePolicy\\": \\"Delete\\",
+    },
+    \\"ApplicationPipelineArtifactsBucketD6B45A16\\": Object {
+      \\"DeletionPolicy\\": \\"Delete\\",
+      \\"Properties\\": Object {
+        \\"BucketEncryption\\": Object {
+          \\"ServerSideEncryptionConfiguration\\": Array [
+            Object {
+              \\"ServerSideEncryptionByDefault\\": Object {
+                \\"KMSMasterKeyID\\": Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineArtifactKey284E3A3C\\",
+                    \\"Arn\\",
+                  ],
+                },
+                \\"SSEAlgorithm\\": \\"aws:kms\\",
+              },
+            },
+          ],
+        },
+        \\"LoggingConfiguration\\": Object {
+          \\"DestinationBucketName\\": Object {
+            \\"Ref\\": \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
+          },
+          \\"LogFilePrefix\\": \\"access-logs\\",
+        },
+        \\"OwnershipControls\\": Object {
+          \\"Rules\\": Array [
+            Object {
+              \\"ObjectOwnership\\": \\"BucketOwnerEnforced\\",
+            },
+          ],
+        },
+        \\"PublicAccessBlockConfiguration\\": Object {
+          \\"BlockPublicAcls\\": true,
+          \\"BlockPublicPolicy\\": true,
+          \\"IgnorePublicAcls\\": true,
+          \\"RestrictPublicBuckets\\": true,
+        },
+        \\"Tags\\": Array [
+          Object {
+            \\"Key\\": \\"aws-cdk:auto-delete-objects\\",
+            \\"Value\\": \\"true\\",
+          },
+        ],
+      },
+      \\"Type\\": \\"AWS::S3::Bucket\\",
+      \\"UpdateReplacePolicy\\": \\"Delete\\",
+    },
+    \\"ApplicationPipelineArtifactsBucketPolicy0F22EB48\\": Object {
+      \\"Properties\\": Object {
+        \\"Bucket\\": Object {
+          \\"Ref\\": \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+        },
+        \\"PolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": \\"s3:*\\",
+              \\"Condition\\": Object {
+                \\"Bool\\": Object {
+                  \\"aws:SecureTransport\\": \\"false\\",
+                },
+              },
+              \\"Effect\\": \\"Deny\\",
+              \\"Principal\\": Object {
+                \\"AWS\\": \\"*\\",
+              },
+              \\"Resource\\": Array [
+                Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                    \\"Arn\\",
+                  ],
+                },
+                Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      Object {
+                        \\"Fn::GetAtt\\": Array [
+                          \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                          \\"Arn\\",
+                        ],
+                      },
+                      \\"/*\\",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"s3:GetBucket*\\",
+                \\"s3:List*\\",
+                \\"s3:DeleteObject*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Principal\\": Object {
+                \\"AWS\\": Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092\\",
+                    \\"Arn\\",
+                  ],
+                },
+              },
+              \\"Resource\\": Array [
+                Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                    \\"Arn\\",
+                  ],
+                },
+                Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      Object {
+                        \\"Fn::GetAtt\\": Array [
+                          \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
                           \\"Arn\\",
                         ],
                       },
@@ -1225,7 +1432,7 @@ Object {
       },
       \\"Type\\": \\"AWS::S3::BucketPolicy\\",
     },
-    \\"ApplicationPipelineCodeBuildActionRole155C9984\\": Object {
+    \\"ApplicationPipelineCodeBuildActionRole98AD1444\\": Object {
       \\"Properties\\": Object {
         \\"AssumeRolePolicyDocument\\": Object {
           \\"Statement\\": Array [
@@ -1262,7 +1469,7 @@ Object {
       },
       \\"Type\\": \\"AWS::IAM::Role\\",
     },
-    \\"ApplicationPipelineCodeBuildActionRoleDefaultPolicyC8190973\\": Object {
+    \\"ApplicationPipelineCodeBuildActionRoleDefaultPolicyFE7AFEF3\\": Object {
       \\"Properties\\": Object {
         \\"PolicyDocument\\": Object {
           \\"Statement\\": Array [
@@ -1275,7 +1482,7 @@ Object {
               \\"Effect\\": \\"Allow\\",
               \\"Resource\\": Object {
                 \\"Fn::GetAtt\\": Array [
-                  \\"CodePipelineBuildSynthCdkBuildProjectEDF0E7B6\\",
+                  \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A\\",
                   \\"Arn\\",
                 ],
               },
@@ -1289,7 +1496,7 @@ Object {
               \\"Effect\\": \\"Allow\\",
               \\"Resource\\": Object {
                 \\"Fn::GetAtt\\": Array [
-                  \\"ApplicationPipelineUpdatePipelineSelfMutation36D37AA8\\",
+                  \\"ApplicationPipelineUpdatePipelineSelfMutation66D95DA8\\",
                   \\"Arn\\",
                 ],
               },
@@ -1297,16 +1504,162 @@ Object {
           ],
           \\"Version\\": \\"2012-10-17\\",
         },
-        \\"PolicyName\\": \\"ApplicationPipelineCodeBuildActionRoleDefaultPolicyC8190973\\",
+        \\"PolicyName\\": \\"ApplicationPipelineCodeBuildActionRoleDefaultPolicyFE7AFEF3\\",
         \\"Roles\\": Array [
           Object {
-            \\"Ref\\": \\"ApplicationPipelineCodeBuildActionRole155C9984\\",
+            \\"Ref\\": \\"ApplicationPipelineCodeBuildActionRole98AD1444\\",
           },
         ],
       },
       \\"Type\\": \\"AWS::IAM::Policy\\",
     },
-    \\"ApplicationPipelineUpdatePipelineSelfMutation36D37AA8\\": Object {
+    \\"ApplicationPipelineCodePipeline92ED701F\\": Object {
+      \\"DependsOn\\": Array [
+        \\"ApplicationPipelineCodePipelineRoleDefaultPolicy02E04067\\",
+        \\"ApplicationPipelineCodePipelineRole53E5791D\\",
+      ],
+      \\"Properties\\": Object {
+        \\"ArtifactStore\\": Object {
+          \\"EncryptionKey\\": Object {
+            \\"Id\\": Object {
+              \\"Fn::GetAtt\\": Array [
+                \\"ApplicationPipelineArtifactKey284E3A3C\\",
+                \\"Arn\\",
+              ],
+            },
+            \\"Type\\": \\"KMS\\",
+          },
+          \\"Location\\": Object {
+            \\"Ref\\": \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+          },
+          \\"Type\\": \\"S3\\",
+        },
+        \\"RestartExecutionOnUpdate\\": true,
+        \\"RoleArn\\": Object {
+          \\"Fn::GetAtt\\": Array [
+            \\"ApplicationPipelineCodePipelineRole53E5791D\\",
+            \\"Arn\\",
+          ],
+        },
+        \\"Stages\\": Array [
+          Object {
+            \\"Actions\\": Array [
+              Object {
+                \\"ActionTypeId\\": Object {
+                  \\"Category\\": \\"Source\\",
+                  \\"Owner\\": \\"AWS\\",
+                  \\"Provider\\": \\"CodeCommit\\",
+                  \\"Version\\": \\"1\\",
+                },
+                \\"Configuration\\": Object {
+                  \\"BranchName\\": \\"mainline\\",
+                  \\"PollForSourceChanges\\": false,
+                  \\"RepositoryName\\": Object {
+                    \\"Fn::GetAtt\\": Array [
+                      \\"ApplicationPipelineCodeRepositoryA734F3FA\\",
+                      \\"Name\\",
+                    ],
+                  },
+                },
+                \\"Name\\": Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineCodeRepositoryA734F3FA\\",
+                    \\"Name\\",
+                  ],
+                },
+                \\"OutputArtifacts\\": Array [
+                  Object {
+                    \\"Name\\": \\"c8dccfc7b4b06e6314cb1dc9e5680d002e559b8933_Source\\",
+                  },
+                ],
+                \\"RoleArn\\": Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRole0900531A\\",
+                    \\"Arn\\",
+                  ],
+                },
+                \\"RunOrder\\": 1,
+              },
+            ],
+            \\"Name\\": \\"Source\\",
+          },
+          Object {
+            \\"Actions\\": Array [
+              Object {
+                \\"ActionTypeId\\": Object {
+                  \\"Category\\": \\"Build\\",
+                  \\"Owner\\": \\"AWS\\",
+                  \\"Provider\\": \\"CodeBuild\\",
+                  \\"Version\\": \\"1\\",
+                },
+                \\"Configuration\\": Object {
+                  \\"EnvironmentVariables\\": \\"[{\\\\\\\\\\"name\\\\\\\\\\":\\\\\\\\\\"_PROJECT_CONFIG_HASH\\\\\\\\\\",\\\\\\\\\\"type\\\\\\\\\\":\\\\\\\\\\"PLAINTEXT\\\\\\\\\\",\\\\\\\\\\"value\\\\\\\\\\":\\\\\\\\\\"13fb1f6f3f0a665500d00a30e46cf5c67342362be94a9d79d179c2ea7436a504\\\\\\\\\\"}]\\",
+                  \\"ProjectName\\": Object {
+                    \\"Ref\\": \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A\\",
+                  },
+                },
+                \\"InputArtifacts\\": Array [
+                  Object {
+                    \\"Name\\": \\"c8dccfc7b4b06e6314cb1dc9e5680d002e559b8933_Source\\",
+                  },
+                ],
+                \\"Name\\": \\"Synth\\",
+                \\"OutputArtifacts\\": Array [
+                  Object {
+                    \\"Name\\": \\"Synth_Output\\",
+                  },
+                  Object {
+                    \\"Name\\": \\"Synth__\\",
+                  },
+                ],
+                \\"RoleArn\\": Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineCodeBuildActionRole98AD1444\\",
+                    \\"Arn\\",
+                  ],
+                },
+                \\"RunOrder\\": 1,
+              },
+            ],
+            \\"Name\\": \\"Build\\",
+          },
+          Object {
+            \\"Actions\\": Array [
+              Object {
+                \\"ActionTypeId\\": Object {
+                  \\"Category\\": \\"Build\\",
+                  \\"Owner\\": \\"AWS\\",
+                  \\"Provider\\": \\"CodeBuild\\",
+                  \\"Version\\": \\"1\\",
+                },
+                \\"Configuration\\": Object {
+                  \\"EnvironmentVariables\\": \\"[{\\\\\\\\\\"name\\\\\\\\\\":\\\\\\\\\\"_PROJECT_CONFIG_HASH\\\\\\\\\\",\\\\\\\\\\"type\\\\\\\\\\":\\\\\\\\\\"PLAINTEXT\\\\\\\\\\",\\\\\\\\\\"value\\\\\\\\\\":\\\\\\\\\\"2e13b99bcda0cb81fc6053cd8a65f303945d49fe774f18ad2c20d178423d9be6\\\\\\\\\\"}]\\",
+                  \\"ProjectName\\": Object {
+                    \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation66D95DA8\\",
+                  },
+                },
+                \\"InputArtifacts\\": Array [
+                  Object {
+                    \\"Name\\": \\"Synth_Output\\",
+                  },
+                ],
+                \\"Name\\": \\"SelfMutate\\",
+                \\"RoleArn\\": Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineCodeBuildActionRole98AD1444\\",
+                    \\"Arn\\",
+                  ],
+                },
+                \\"RunOrder\\": 1,
+              },
+            ],
+            \\"Name\\": \\"UpdatePipeline\\",
+          },
+        ],
+      },
+      \\"Type\\": \\"AWS::CodePipeline::Pipeline\\",
+    },
+    \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A\\": Object {
       \\"Properties\\": Object {
         \\"Artifacts\\": Object {
           \\"Type\\": \\"CODEPIPELINE\\",
@@ -1314,10 +1667,10 @@ Object {
         \\"Cache\\": Object {
           \\"Type\\": \\"NO_CACHE\\",
         },
-        \\"Description\\": \\"Pipeline step pipeline-test/CodePipeline/UpdatePipeline/SelfMutate\\",
+        \\"Description\\": \\"Pipeline step pipeline-test/CodePipeline/Build/Synth\\",
         \\"EncryptionKey\\": Object {
           \\"Fn::GetAtt\\": Array [
-            \\"ArtifactKey8D84C5F0\\",
+            \\"ApplicationPipelineArtifactKey284E3A3C\\",
             \\"Arn\\",
           ],
         },
@@ -1330,7 +1683,7 @@ Object {
         },
         \\"ServiceRole\\": Object {
           \\"Fn::GetAtt\\": Array [
-            \\"ApplicationPipelineUpdatePipelineSelfMutationRole59A20D82\\",
+            \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectRole75D1C6E6\\",
             \\"Arn\\",
           ],
         },
@@ -1340,13 +1693,26 @@ Object {
   \\\\\\\\\\"phases\\\\\\\\\\": {
     \\\\\\\\\\"install\\\\\\\\\\": {
       \\\\\\\\\\"commands\\\\\\\\\\": [
-        \\\\\\\\\\"npm install -g aws-cdk@2\\\\\\\\\\"
+        \\\\\\\\\\"npm install -g aws-cdk\\\\\\\\\\",
+        \\\\\\\\\\"yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile\\\\\\\\\\"
       ]
     },
     \\\\\\\\\\"build\\\\\\\\\\": {
       \\\\\\\\\\"commands\\\\\\\\\\": [
-        \\\\\\\\\\"cdk -a . deploy pipeline-test --require-approval=never --verbose\\\\\\\\\\"
+        \\\\\\\\\\"npx nx run-many --target=build --all\\\\\\\\\\"
       ]
+    }
+  },
+  \\\\\\\\\\"artifacts\\\\\\\\\\": {
+    \\\\\\\\\\"secondary-artifacts\\\\\\\\\\": {
+      \\\\\\\\\\"Synth_Output\\\\\\\\\\": {
+        \\\\\\\\\\"base-directory\\\\\\\\\\": \\\\\\\\\\"packages/infra/cdk.out\\\\\\\\\\",
+        \\\\\\\\\\"files\\\\\\\\\\": \\\\\\\\\\"**/*\\\\\\\\\\"
+      },
+      \\\\\\\\\\"Synth__\\\\\\\\\\": {
+        \\\\\\\\\\"base-directory\\\\\\\\\\": \\\\\\\\\\".\\\\\\\\\\",
+        \\\\\\\\\\"files\\\\\\\\\\": \\\\\\\\\\"**/*\\\\\\\\\\"
+      }
     }
   }
 }\\",
@@ -1355,7 +1721,7 @@ Object {
       },
       \\"Type\\": \\"AWS::CodeBuild::Project\\",
     },
-    \\"ApplicationPipelineUpdatePipelineSelfMutationRole59A20D82\\": Object {
+    \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectRole75D1C6E6\\": Object {
       \\"Properties\\": Object {
         \\"AssumeRolePolicyDocument\\": Object {
           \\"Statement\\": Array [
@@ -1372,191 +1738,7 @@ Object {
       },
       \\"Type\\": \\"AWS::IAM::Role\\",
     },
-    \\"ApplicationPipelineUpdatePipelineSelfMutationRoleDefaultPolicy88A56583\\": Object {
-      \\"Metadata\\": Object {
-        \\"cdk_nag\\": Object {
-          \\"rules_to_suppress\\": Array [
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<ApplicationPipelineUpdatePipelineSelfMutation.*>-\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to create report groups that are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:\\\\\\\\\\\\\\\\*:iam::<AWS::AccountId>:role/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to assume a role from within the current account in order to deploy.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to list all buckets and stacks.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": Object {
-                    \\"Fn::Join\\": Array [
-                      \\"\\",
-                      Array [
-                        \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|\\",
-                        Object {
-                          \\"Ref\\": \\"AWS::AccountId\\",
-                        },
-                        \\"):log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\\\\\\\\\\\\\*$/g\\",
-                      ],
-                    ],
-                  },
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<ApplicationPipelineUpdatePipelineSelfMutation.*>-\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to create report groups that are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:\\\\\\\\\\\\\\\\*:iam::<AWS::AccountId>:role/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to assume a role from within the current account in order to deploy.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to list all buckets and stacks.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": Object {
-                    \\"Fn::Join\\": Array [
-                      \\"\\",
-                      Array [
-                        \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|\\",
-                        Object {
-                          \\"Ref\\": \\"AWS::AccountId\\",
-                        },
-                        \\"):log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\\\\\\\\\\\\\*$/g\\",
-                      ],
-                    ],
-                  },
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-          ],
-        },
-      },
+    \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicy4B9195CC\\": Object {
       \\"Properties\\": Object {
         \\"PolicyDocument\\": Object {
           \\"Statement\\": Array [
@@ -1586,7 +1768,7 @@ Object {
                       },
                       \\":log-group:/aws/codebuild/\\",
                       Object {
-                        \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation36D37AA8\\",
+                        \\"Ref\\": \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A\\",
                       },
                     ],
                   ],
@@ -1609,7 +1791,7 @@ Object {
                       },
                       \\":log-group:/aws/codebuild/\\",
                       Object {
-                        \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation36D37AA8\\",
+                        \\"Ref\\": \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A\\",
                       },
                       \\":*\\",
                     ],
@@ -1644,7 +1826,604 @@ Object {
                     },
                     \\":report-group/\\",
                     Object {
-                      \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation36D37AA8\\",
+                      \\"Ref\\": \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A\\",
+                    },
+                    \\"-*\\",
+                  ],
+                ],
+              },
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"s3:GetObject*\\",
+                \\"s3:GetBucket*\\",
+                \\"s3:List*\\",
+                \\"s3:DeleteObject*\\",
+                \\"s3:PutObject\\",
+                \\"s3:PutObjectLegalHold\\",
+                \\"s3:PutObjectRetention\\",
+                \\"s3:PutObjectTagging\\",
+                \\"s3:PutObjectVersionTagging\\",
+                \\"s3:Abort*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Array [
+                Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                    \\"Arn\\",
+                  ],
+                },
+                Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      Object {
+                        \\"Fn::GetAtt\\": Array [
+                          \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                          \\"Arn\\",
+                        ],
+                      },
+                      \\"/*\\",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"kms:Decrypt\\",
+                \\"kms:DescribeKey\\",
+                \\"kms:Encrypt\\",
+                \\"kms:ReEncrypt*\\",
+                \\"kms:GenerateDataKey*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::GetAtt\\": Array [
+                  \\"ApplicationPipelineArtifactKey284E3A3C\\",
+                  \\"Arn\\",
+                ],
+              },
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"kms:Decrypt\\",
+                \\"kms:Encrypt\\",
+                \\"kms:ReEncrypt*\\",
+                \\"kms:GenerateDataKey*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::GetAtt\\": Array [
+                  \\"ApplicationPipelineArtifactKey284E3A3C\\",
+                  \\"Arn\\",
+                ],
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+        \\"PolicyName\\": \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicy4B9195CC\\",
+        \\"Roles\\": Array [
+          Object {
+            \\"Ref\\": \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectRole75D1C6E6\\",
+          },
+        ],
+      },
+      \\"Type\\": \\"AWS::IAM::Policy\\",
+    },
+    \\"ApplicationPipelineCodePipelineEventsRoleCF718FC7\\": Object {
+      \\"Properties\\": Object {
+        \\"AssumeRolePolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": \\"sts:AssumeRole\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Principal\\": Object {
+                \\"Service\\": \\"events.amazonaws.com\\",
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+      },
+      \\"Type\\": \\"AWS::IAM::Role\\",
+    },
+    \\"ApplicationPipelineCodePipelineEventsRoleDefaultPolicy4A96451E\\": Object {
+      \\"Properties\\": Object {
+        \\"PolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": \\"codepipeline:StartPipelineExecution\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::Join\\": Array [
+                  \\"\\",
+                  Array [
+                    \\"arn:\\",
+                    Object {
+                      \\"Ref\\": \\"AWS::Partition\\",
+                    },
+                    \\":codepipeline:\\",
+                    Object {
+                      \\"Ref\\": \\"AWS::Region\\",
+                    },
+                    \\":\\",
+                    Object {
+                      \\"Ref\\": \\"AWS::AccountId\\",
+                    },
+                    \\":\\",
+                    Object {
+                      \\"Ref\\": \\"ApplicationPipelineCodePipeline92ED701F\\",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+        \\"PolicyName\\": \\"ApplicationPipelineCodePipelineEventsRoleDefaultPolicy4A96451E\\",
+        \\"Roles\\": Array [
+          Object {
+            \\"Ref\\": \\"ApplicationPipelineCodePipelineEventsRoleCF718FC7\\",
+          },
+        ],
+      },
+      \\"Type\\": \\"AWS::IAM::Policy\\",
+    },
+    \\"ApplicationPipelineCodePipelineRole53E5791D\\": Object {
+      \\"Properties\\": Object {
+        \\"AssumeRolePolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": \\"sts:AssumeRole\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Principal\\": Object {
+                \\"Service\\": \\"codepipeline.amazonaws.com\\",
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+      },
+      \\"Type\\": \\"AWS::IAM::Role\\",
+    },
+    \\"ApplicationPipelineCodePipelineRoleDefaultPolicy02E04067\\": Object {
+      \\"Properties\\": Object {
+        \\"PolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": Array [
+                \\"s3:GetObject*\\",
+                \\"s3:GetBucket*\\",
+                \\"s3:List*\\",
+                \\"s3:DeleteObject*\\",
+                \\"s3:PutObject\\",
+                \\"s3:PutObjectLegalHold\\",
+                \\"s3:PutObjectRetention\\",
+                \\"s3:PutObjectTagging\\",
+                \\"s3:PutObjectVersionTagging\\",
+                \\"s3:Abort*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Array [
+                Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                    \\"Arn\\",
+                  ],
+                },
+                Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      Object {
+                        \\"Fn::GetAtt\\": Array [
+                          \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                          \\"Arn\\",
+                        ],
+                      },
+                      \\"/*\\",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"kms:Decrypt\\",
+                \\"kms:DescribeKey\\",
+                \\"kms:Encrypt\\",
+                \\"kms:ReEncrypt*\\",
+                \\"kms:GenerateDataKey*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::GetAtt\\": Array [
+                  \\"ApplicationPipelineArtifactKey284E3A3C\\",
+                  \\"Arn\\",
+                ],
+              },
+            },
+            Object {
+              \\"Action\\": \\"sts:AssumeRole\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::GetAtt\\": Array [
+                  \\"ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRole0900531A\\",
+                  \\"Arn\\",
+                ],
+              },
+            },
+            Object {
+              \\"Action\\": \\"sts:AssumeRole\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::GetAtt\\": Array [
+                  \\"ApplicationPipelineCodeBuildActionRole98AD1444\\",
+                  \\"Arn\\",
+                ],
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+        \\"PolicyName\\": \\"ApplicationPipelineCodePipelineRoleDefaultPolicy02E04067\\",
+        \\"Roles\\": Array [
+          Object {
+            \\"Ref\\": \\"ApplicationPipelineCodePipelineRole53E5791D\\",
+          },
+        ],
+      },
+      \\"Type\\": \\"AWS::IAM::Policy\\",
+    },
+    \\"ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRole0900531A\\": Object {
+      \\"Properties\\": Object {
+        \\"AssumeRolePolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": \\"sts:AssumeRole\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Principal\\": Object {
+                \\"AWS\\": Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      \\"arn:\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::Partition\\",
+                      },
+                      \\":iam::\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::AccountId\\",
+                      },
+                      \\":root\\",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+      },
+      \\"Type\\": \\"AWS::IAM::Role\\",
+    },
+    \\"ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyE92AF83A\\": Object {
+      \\"Properties\\": Object {
+        \\"PolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": Array [
+                \\"s3:GetObject*\\",
+                \\"s3:GetBucket*\\",
+                \\"s3:List*\\",
+                \\"s3:DeleteObject*\\",
+                \\"s3:PutObject\\",
+                \\"s3:PutObjectLegalHold\\",
+                \\"s3:PutObjectRetention\\",
+                \\"s3:PutObjectTagging\\",
+                \\"s3:PutObjectVersionTagging\\",
+                \\"s3:Abort*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Array [
+                Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                    \\"Arn\\",
+                  ],
+                },
+                Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      Object {
+                        \\"Fn::GetAtt\\": Array [
+                          \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                          \\"Arn\\",
+                        ],
+                      },
+                      \\"/*\\",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"kms:Decrypt\\",
+                \\"kms:DescribeKey\\",
+                \\"kms:Encrypt\\",
+                \\"kms:ReEncrypt*\\",
+                \\"kms:GenerateDataKey*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::GetAtt\\": Array [
+                  \\"ApplicationPipelineArtifactKey284E3A3C\\",
+                  \\"Arn\\",
+                ],
+              },
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"codecommit:GetBranch\\",
+                \\"codecommit:GetCommit\\",
+                \\"codecommit:UploadArchive\\",
+                \\"codecommit:GetUploadArchiveStatus\\",
+                \\"codecommit:CancelUploadArchive\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::GetAtt\\": Array [
+                  \\"ApplicationPipelineCodeRepositoryA734F3FA\\",
+                  \\"Arn\\",
+                ],
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+        \\"PolicyName\\": \\"ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyE92AF83A\\",
+        \\"Roles\\": Array [
+          Object {
+            \\"Ref\\": \\"ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRole0900531A\\",
+          },
+        ],
+      },
+      \\"Type\\": \\"AWS::IAM::Policy\\",
+    },
+    \\"ApplicationPipelineCodeRepositoryA734F3FA\\": Object {
+      \\"DeletionPolicy\\": \\"Retain\\",
+      \\"Properties\\": Object {
+        \\"RepositoryName\\": \\"monorepo\\",
+      },
+      \\"Type\\": \\"AWS::CodeCommit::Repository\\",
+      \\"UpdateReplacePolicy\\": \\"Retain\\",
+    },
+    \\"ApplicationPipelineCodeRepositorypipelinetestApplicationPipelineCodePipeline31AB4045mainlineEventRule30640423\\": Object {
+      \\"Properties\\": Object {
+        \\"EventPattern\\": Object {
+          \\"detail\\": Object {
+            \\"event\\": Array [
+              \\"referenceCreated\\",
+              \\"referenceUpdated\\",
+            ],
+            \\"referenceName\\": Array [
+              \\"mainline\\",
+            ],
+          },
+          \\"detail-type\\": Array [
+            \\"CodeCommit Repository State Change\\",
+          ],
+          \\"resources\\": Array [
+            Object {
+              \\"Fn::GetAtt\\": Array [
+                \\"ApplicationPipelineCodeRepositoryA734F3FA\\",
+                \\"Arn\\",
+              ],
+            },
+          ],
+          \\"source\\": Array [
+            \\"aws.codecommit\\",
+          ],
+        },
+        \\"State\\": \\"ENABLED\\",
+        \\"Targets\\": Array [
+          Object {
+            \\"Arn\\": Object {
+              \\"Fn::Join\\": Array [
+                \\"\\",
+                Array [
+                  \\"arn:\\",
+                  Object {
+                    \\"Ref\\": \\"AWS::Partition\\",
+                  },
+                  \\":codepipeline:\\",
+                  Object {
+                    \\"Ref\\": \\"AWS::Region\\",
+                  },
+                  \\":\\",
+                  Object {
+                    \\"Ref\\": \\"AWS::AccountId\\",
+                  },
+                  \\":\\",
+                  Object {
+                    \\"Ref\\": \\"ApplicationPipelineCodePipeline92ED701F\\",
+                  },
+                ],
+              ],
+            },
+            \\"Id\\": \\"Target0\\",
+            \\"RoleArn\\": Object {
+              \\"Fn::GetAtt\\": Array [
+                \\"ApplicationPipelineCodePipelineEventsRoleCF718FC7\\",
+                \\"Arn\\",
+              ],
+            },
+          },
+        ],
+      },
+      \\"Type\\": \\"AWS::Events::Rule\\",
+    },
+    \\"ApplicationPipelineUpdatePipelineSelfMutation66D95DA8\\": Object {
+      \\"Properties\\": Object {
+        \\"Artifacts\\": Object {
+          \\"Type\\": \\"CODEPIPELINE\\",
+        },
+        \\"Cache\\": Object {
+          \\"Type\\": \\"NO_CACHE\\",
+        },
+        \\"Description\\": \\"Pipeline step pipeline-test/CodePipeline/UpdatePipeline/SelfMutate\\",
+        \\"EncryptionKey\\": Object {
+          \\"Fn::GetAtt\\": Array [
+            \\"ApplicationPipelineArtifactKey284E3A3C\\",
+            \\"Arn\\",
+          ],
+        },
+        \\"Environment\\": Object {
+          \\"ComputeType\\": \\"BUILD_GENERAL1_SMALL\\",
+          \\"Image\\": \\"aws/codebuild/standard:6.0\\",
+          \\"ImagePullCredentialsType\\": \\"CODEBUILD\\",
+          \\"PrivilegedMode\\": false,
+          \\"Type\\": \\"LINUX_CONTAINER\\",
+        },
+        \\"ServiceRole\\": Object {
+          \\"Fn::GetAtt\\": Array [
+            \\"ApplicationPipelineUpdatePipelineSelfMutationRoleD476D3E4\\",
+            \\"Arn\\",
+          ],
+        },
+        \\"Source\\": Object {
+          \\"BuildSpec\\": \\"{
+  \\\\\\\\\\"version\\\\\\\\\\": \\\\\\\\\\"0.2\\\\\\\\\\",
+  \\\\\\\\\\"phases\\\\\\\\\\": {
+    \\\\\\\\\\"install\\\\\\\\\\": {
+      \\\\\\\\\\"commands\\\\\\\\\\": [
+        \\\\\\\\\\"npm install -g aws-cdk@2\\\\\\\\\\"
+      ]
+    },
+    \\\\\\\\\\"build\\\\\\\\\\": {
+      \\\\\\\\\\"commands\\\\\\\\\\": [
+        \\\\\\\\\\"cdk -a . deploy pipeline-test --require-approval=never --verbose\\\\\\\\\\"
+      ]
+    }
+  }
+}\\",
+          \\"Type\\": \\"CODEPIPELINE\\",
+        },
+      },
+      \\"Type\\": \\"AWS::CodeBuild::Project\\",
+    },
+    \\"ApplicationPipelineUpdatePipelineSelfMutationRoleD476D3E4\\": Object {
+      \\"Properties\\": Object {
+        \\"AssumeRolePolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": \\"sts:AssumeRole\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Principal\\": Object {
+                \\"Service\\": \\"codebuild.amazonaws.com\\",
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+      },
+      \\"Type\\": \\"AWS::IAM::Role\\",
+    },
+    \\"ApplicationPipelineUpdatePipelineSelfMutationRoleDefaultPolicyE74ACD15\\": Object {
+      \\"Properties\\": Object {
+        \\"PolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": Array [
+                \\"logs:CreateLogGroup\\",
+                \\"logs:CreateLogStream\\",
+                \\"logs:PutLogEvents\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Array [
+                Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      \\"arn:\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::Partition\\",
+                      },
+                      \\":logs:\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::Region\\",
+                      },
+                      \\":\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::AccountId\\",
+                      },
+                      \\":log-group:/aws/codebuild/\\",
+                      Object {
+                        \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation66D95DA8\\",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      \\"arn:\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::Partition\\",
+                      },
+                      \\":logs:\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::Region\\",
+                      },
+                      \\":\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::AccountId\\",
+                      },
+                      \\":log-group:/aws/codebuild/\\",
+                      Object {
+                        \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation66D95DA8\\",
+                      },
+                      \\":*\\",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"codebuild:CreateReportGroup\\",
+                \\"codebuild:CreateReport\\",
+                \\"codebuild:UpdateReport\\",
+                \\"codebuild:BatchPutTestCases\\",
+                \\"codebuild:BatchPutCodeCoverages\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::Join\\": Array [
+                  \\"\\",
+                  Array [
+                    \\"arn:\\",
+                    Object {
+                      \\"Ref\\": \\"AWS::Partition\\",
+                    },
+                    \\":codebuild:\\",
+                    Object {
+                      \\"Ref\\": \\"AWS::Region\\",
+                    },
+                    \\":\\",
+                    Object {
+                      \\"Ref\\": \\"AWS::AccountId\\",
+                    },
+                    \\":report-group/\\",
+                    Object {
+                      \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation66D95DA8\\",
                     },
                     \\"-*\\",
                   ],
@@ -1696,7 +2475,7 @@ Object {
               \\"Resource\\": Array [
                 Object {
                   \\"Fn::GetAtt\\": Array [
-                    \\"ArtifactsBucket2AAC5544\\",
+                    \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
                     \\"Arn\\",
                   ],
                 },
@@ -1706,7 +2485,7 @@ Object {
                     Array [
                       Object {
                         \\"Fn::GetAtt\\": Array [
-                          \\"ArtifactsBucket2AAC5544\\",
+                          \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
                           \\"Arn\\",
                         ],
                       },
@@ -1724,7 +2503,7 @@ Object {
               \\"Effect\\": \\"Allow\\",
               \\"Resource\\": Object {
                 \\"Fn::GetAtt\\": Array [
-                  \\"ArtifactKey8D84C5F0\\",
+                  \\"ApplicationPipelineArtifactKey284E3A3C\\",
                   \\"Arn\\",
                 ],
               },
@@ -1739,7 +2518,7 @@ Object {
               \\"Effect\\": \\"Allow\\",
               \\"Resource\\": Object {
                 \\"Fn::GetAtt\\": Array [
-                  \\"ArtifactKey8D84C5F0\\",
+                  \\"ApplicationPipelineArtifactKey284E3A3C\\",
                   \\"Arn\\",
                 ],
               },
@@ -1747,1166 +2526,14 @@ Object {
           ],
           \\"Version\\": \\"2012-10-17\\",
         },
-        \\"PolicyName\\": \\"ApplicationPipelineUpdatePipelineSelfMutationRoleDefaultPolicy88A56583\\",
+        \\"PolicyName\\": \\"ApplicationPipelineUpdatePipelineSelfMutationRoleDefaultPolicyE74ACD15\\",
         \\"Roles\\": Array [
           Object {
-            \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutationRole59A20D82\\",
+            \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutationRoleD476D3E4\\",
           },
         ],
       },
       \\"Type\\": \\"AWS::IAM::Policy\\",
-    },
-    \\"ArtifactKey8D84C5F0\\": Object {
-      \\"DeletionPolicy\\": \\"Delete\\",
-      \\"Properties\\": Object {
-        \\"EnableKeyRotation\\": true,
-        \\"KeyPolicy\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": \\"kms:*\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Principal\\": Object {
-                \\"AWS\\": Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      \\"arn:\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::Partition\\",
-                      },
-                      \\":iam::\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::AccountId\\",
-                      },
-                      \\":root\\",
-                    ],
-                  ],
-                },
-              },
-              \\"Resource\\": \\"*\\",
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-      },
-      \\"Type\\": \\"AWS::KMS::Key\\",
-      \\"UpdateReplacePolicy\\": \\"Delete\\",
-    },
-    \\"ArtifactsBucket2AAC5544\\": Object {
-      \\"DeletionPolicy\\": \\"Delete\\",
-      \\"Properties\\": Object {
-        \\"BucketEncryption\\": Object {
-          \\"ServerSideEncryptionConfiguration\\": Array [
-            Object {
-              \\"ServerSideEncryptionByDefault\\": Object {
-                \\"KMSMasterKeyID\\": Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ArtifactKey8D84C5F0\\",
-                    \\"Arn\\",
-                  ],
-                },
-                \\"SSEAlgorithm\\": \\"aws:kms\\",
-              },
-            },
-          ],
-        },
-        \\"LoggingConfiguration\\": Object {
-          \\"DestinationBucketName\\": Object {
-            \\"Ref\\": \\"AccessLogsBucket83982689\\",
-          },
-          \\"LogFilePrefix\\": \\"access-logs\\",
-        },
-        \\"PublicAccessBlockConfiguration\\": Object {
-          \\"BlockPublicAcls\\": true,
-          \\"BlockPublicPolicy\\": true,
-          \\"IgnorePublicAcls\\": true,
-          \\"RestrictPublicBuckets\\": true,
-        },
-        \\"Tags\\": Array [
-          Object {
-            \\"Key\\": \\"aws-cdk:auto-delete-objects\\",
-            \\"Value\\": \\"true\\",
-          },
-        ],
-      },
-      \\"Type\\": \\"AWS::S3::Bucket\\",
-      \\"UpdateReplacePolicy\\": \\"Delete\\",
-    },
-    \\"ArtifactsBucketAutoDeleteObjectsCustomResource0E3B4320\\": Object {
-      \\"DeletionPolicy\\": \\"Delete\\",
-      \\"DependsOn\\": Array [
-        \\"ArtifactsBucketPolicy852CB646\\",
-      ],
-      \\"Properties\\": Object {
-        \\"BucketName\\": Object {
-          \\"Ref\\": \\"ArtifactsBucket2AAC5544\\",
-        },
-        \\"ServiceToken\\": Object {
-          \\"Fn::GetAtt\\": Array [
-            \\"CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F\\",
-            \\"Arn\\",
-          ],
-        },
-      },
-      \\"Type\\": \\"Custom::S3AutoDeleteObjects\\",
-      \\"UpdateReplacePolicy\\": \\"Delete\\",
-    },
-    \\"ArtifactsBucketPolicy852CB646\\": Object {
-      \\"Properties\\": Object {
-        \\"Bucket\\": Object {
-          \\"Ref\\": \\"ArtifactsBucket2AAC5544\\",
-        },
-        \\"PolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": \\"s3:*\\",
-              \\"Condition\\": Object {
-                \\"Bool\\": Object {
-                  \\"aws:SecureTransport\\": \\"false\\",
-                },
-              },
-              \\"Effect\\": \\"Deny\\",
-              \\"Principal\\": Object {
-                \\"AWS\\": \\"*\\",
-              },
-              \\"Resource\\": Array [
-                Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ArtifactsBucket2AAC5544\\",
-                    \\"Arn\\",
-                  ],
-                },
-                Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      Object {
-                        \\"Fn::GetAtt\\": Array [
-                          \\"ArtifactsBucket2AAC5544\\",
-                          \\"Arn\\",
-                        ],
-                      },
-                      \\"/*\\",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"s3:GetBucket*\\",
-                \\"s3:List*\\",
-                \\"s3:DeleteObject*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Principal\\": Object {
-                \\"AWS\\": Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092\\",
-                    \\"Arn\\",
-                  ],
-                },
-              },
-              \\"Resource\\": Array [
-                Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ArtifactsBucket2AAC5544\\",
-                    \\"Arn\\",
-                  ],
-                },
-                Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      Object {
-                        \\"Fn::GetAtt\\": Array [
-                          \\"ArtifactsBucket2AAC5544\\",
-                          \\"Arn\\",
-                        ],
-                      },
-                      \\"/*\\",
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-      },
-      \\"Type\\": \\"AWS::S3::BucketPolicy\\",
-    },
-    \\"CodePipelineB74E5936\\": Object {
-      \\"DependsOn\\": Array [
-        \\"CodePipelineRoleDefaultPolicy8D520A8D\\",
-        \\"CodePipelineRoleB3A660B4\\",
-      ],
-      \\"Properties\\": Object {
-        \\"ArtifactStore\\": Object {
-          \\"EncryptionKey\\": Object {
-            \\"Id\\": Object {
-              \\"Fn::GetAtt\\": Array [
-                \\"ArtifactKey8D84C5F0\\",
-                \\"Arn\\",
-              ],
-            },
-            \\"Type\\": \\"KMS\\",
-          },
-          \\"Location\\": Object {
-            \\"Ref\\": \\"ArtifactsBucket2AAC5544\\",
-          },
-          \\"Type\\": \\"S3\\",
-        },
-        \\"RestartExecutionOnUpdate\\": true,
-        \\"RoleArn\\": Object {
-          \\"Fn::GetAtt\\": Array [
-            \\"CodePipelineRoleB3A660B4\\",
-            \\"Arn\\",
-          ],
-        },
-        \\"Stages\\": Array [
-          Object {
-            \\"Actions\\": Array [
-              Object {
-                \\"ActionTypeId\\": Object {
-                  \\"Category\\": \\"Source\\",
-                  \\"Owner\\": \\"AWS\\",
-                  \\"Provider\\": \\"CodeCommit\\",
-                  \\"Version\\": \\"1\\",
-                },
-                \\"Configuration\\": Object {
-                  \\"BranchName\\": \\"mainline\\",
-                  \\"PollForSourceChanges\\": false,
-                  \\"RepositoryName\\": Object {
-                    \\"Fn::GetAtt\\": Array [
-                      \\"CodeRepositoryBA42F94A\\",
-                      \\"Name\\",
-                    ],
-                  },
-                },
-                \\"Name\\": Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"CodeRepositoryBA42F94A\\",
-                    \\"Name\\",
-                  ],
-                },
-                \\"OutputArtifacts\\": Array [
-                  Object {
-                    \\"Name\\": \\"c825c34765dfb5e99261fa6cab9fea074f8881c7c4_Source\\",
-                  },
-                ],
-                \\"RoleArn\\": Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70\\",
-                    \\"Arn\\",
-                  ],
-                },
-                \\"RunOrder\\": 1,
-              },
-            ],
-            \\"Name\\": \\"Source\\",
-          },
-          Object {
-            \\"Actions\\": Array [
-              Object {
-                \\"ActionTypeId\\": Object {
-                  \\"Category\\": \\"Build\\",
-                  \\"Owner\\": \\"AWS\\",
-                  \\"Provider\\": \\"CodeBuild\\",
-                  \\"Version\\": \\"1\\",
-                },
-                \\"Configuration\\": Object {
-                  \\"EnvironmentVariables\\": \\"[{\\\\\\\\\\"name\\\\\\\\\\":\\\\\\\\\\"_PROJECT_CONFIG_HASH\\\\\\\\\\",\\\\\\\\\\"type\\\\\\\\\\":\\\\\\\\\\"PLAINTEXT\\\\\\\\\\",\\\\\\\\\\"value\\\\\\\\\\":\\\\\\\\\\"13fb1f6f3f0a665500d00a30e46cf5c67342362be94a9d79d179c2ea7436a504\\\\\\\\\\"}]\\",
-                  \\"ProjectName\\": Object {
-                    \\"Ref\\": \\"CodePipelineBuildSynthCdkBuildProjectEDF0E7B6\\",
-                  },
-                },
-                \\"InputArtifacts\\": Array [
-                  Object {
-                    \\"Name\\": \\"c825c34765dfb5e99261fa6cab9fea074f8881c7c4_Source\\",
-                  },
-                ],
-                \\"Name\\": \\"Synth\\",
-                \\"OutputArtifacts\\": Array [
-                  Object {
-                    \\"Name\\": \\"Synth_Output\\",
-                  },
-                  Object {
-                    \\"Name\\": \\"Synth__\\",
-                  },
-                ],
-                \\"RoleArn\\": Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ApplicationPipelineCodeBuildActionRole155C9984\\",
-                    \\"Arn\\",
-                  ],
-                },
-                \\"RunOrder\\": 1,
-              },
-            ],
-            \\"Name\\": \\"Build\\",
-          },
-          Object {
-            \\"Actions\\": Array [
-              Object {
-                \\"ActionTypeId\\": Object {
-                  \\"Category\\": \\"Build\\",
-                  \\"Owner\\": \\"AWS\\",
-                  \\"Provider\\": \\"CodeBuild\\",
-                  \\"Version\\": \\"1\\",
-                },
-                \\"Configuration\\": Object {
-                  \\"EnvironmentVariables\\": \\"[{\\\\\\\\\\"name\\\\\\\\\\":\\\\\\\\\\"_PROJECT_CONFIG_HASH\\\\\\\\\\",\\\\\\\\\\"type\\\\\\\\\\":\\\\\\\\\\"PLAINTEXT\\\\\\\\\\",\\\\\\\\\\"value\\\\\\\\\\":\\\\\\\\\\"2e13b99bcda0cb81fc6053cd8a65f303945d49fe774f18ad2c20d178423d9be6\\\\\\\\\\"}]\\",
-                  \\"ProjectName\\": Object {
-                    \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation36D37AA8\\",
-                  },
-                },
-                \\"InputArtifacts\\": Array [
-                  Object {
-                    \\"Name\\": \\"Synth_Output\\",
-                  },
-                ],
-                \\"Name\\": \\"SelfMutate\\",
-                \\"RoleArn\\": Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ApplicationPipelineCodeBuildActionRole155C9984\\",
-                    \\"Arn\\",
-                  ],
-                },
-                \\"RunOrder\\": 1,
-              },
-            ],
-            \\"Name\\": \\"UpdatePipeline\\",
-          },
-        ],
-      },
-      \\"Type\\": \\"AWS::CodePipeline::Pipeline\\",
-    },
-    \\"CodePipelineBuildSynthCdkBuildProjectEDF0E7B6\\": Object {
-      \\"Properties\\": Object {
-        \\"Artifacts\\": Object {
-          \\"Type\\": \\"CODEPIPELINE\\",
-        },
-        \\"Cache\\": Object {
-          \\"Type\\": \\"NO_CACHE\\",
-        },
-        \\"Description\\": \\"Pipeline step pipeline-test/CodePipeline/Build/Synth\\",
-        \\"EncryptionKey\\": Object {
-          \\"Fn::GetAtt\\": Array [
-            \\"ArtifactKey8D84C5F0\\",
-            \\"Arn\\",
-          ],
-        },
-        \\"Environment\\": Object {
-          \\"ComputeType\\": \\"BUILD_GENERAL1_SMALL\\",
-          \\"Image\\": \\"aws/codebuild/standard:6.0\\",
-          \\"ImagePullCredentialsType\\": \\"CODEBUILD\\",
-          \\"PrivilegedMode\\": false,
-          \\"Type\\": \\"LINUX_CONTAINER\\",
-        },
-        \\"ServiceRole\\": Object {
-          \\"Fn::GetAtt\\": Array [
-            \\"CodePipelineBuildSynthCdkBuildProjectRoleB73287D4\\",
-            \\"Arn\\",
-          ],
-        },
-        \\"Source\\": Object {
-          \\"BuildSpec\\": \\"{
-  \\\\\\\\\\"version\\\\\\\\\\": \\\\\\\\\\"0.2\\\\\\\\\\",
-  \\\\\\\\\\"phases\\\\\\\\\\": {
-    \\\\\\\\\\"install\\\\\\\\\\": {
-      \\\\\\\\\\"commands\\\\\\\\\\": [
-        \\\\\\\\\\"npm install -g aws-cdk\\\\\\\\\\",
-        \\\\\\\\\\"yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile\\\\\\\\\\"
-      ]
-    },
-    \\\\\\\\\\"build\\\\\\\\\\": {
-      \\\\\\\\\\"commands\\\\\\\\\\": [
-        \\\\\\\\\\"npx nx run-many --target=build --all\\\\\\\\\\"
-      ]
-    }
-  },
-  \\\\\\\\\\"artifacts\\\\\\\\\\": {
-    \\\\\\\\\\"secondary-artifacts\\\\\\\\\\": {
-      \\\\\\\\\\"Synth_Output\\\\\\\\\\": {
-        \\\\\\\\\\"base-directory\\\\\\\\\\": \\\\\\\\\\"packages/infra/cdk.out\\\\\\\\\\",
-        \\\\\\\\\\"files\\\\\\\\\\": \\\\\\\\\\"**/*\\\\\\\\\\"
-      },
-      \\\\\\\\\\"Synth__\\\\\\\\\\": {
-        \\\\\\\\\\"base-directory\\\\\\\\\\": \\\\\\\\\\".\\\\\\\\\\",
-        \\\\\\\\\\"files\\\\\\\\\\": \\\\\\\\\\"**/*\\\\\\\\\\"
-      }
-    }
-  }
-}\\",
-          \\"Type\\": \\"CODEPIPELINE\\",
-        },
-      },
-      \\"Type\\": \\"AWS::CodeBuild::Project\\",
-    },
-    \\"CodePipelineBuildSynthCdkBuildProjectRoleB73287D4\\": Object {
-      \\"Properties\\": Object {
-        \\"AssumeRolePolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": \\"sts:AssumeRole\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Principal\\": Object {
-                \\"Service\\": \\"codebuild.amazonaws.com\\",
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-      },
-      \\"Type\\": \\"AWS::IAM::Role\\",
-    },
-    \\"CodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyB7EDB705\\": Object {
-      \\"Metadata\\": Object {
-        \\"cdk_nag\\": Object {
-          \\"rules_to_suppress\\": Array [
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to create report groups that are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to create report groups that are dynamically determined.\\",
-            },
-          ],
-        },
-      },
-      \\"Properties\\": Object {
-        \\"PolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": Array [
-                \\"logs:CreateLogGroup\\",
-                \\"logs:CreateLogStream\\",
-                \\"logs:PutLogEvents\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Array [
-                Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      \\"arn:\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::Partition\\",
-                      },
-                      \\":logs:\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::Region\\",
-                      },
-                      \\":\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::AccountId\\",
-                      },
-                      \\":log-group:/aws/codebuild/\\",
-                      Object {
-                        \\"Ref\\": \\"CodePipelineBuildSynthCdkBuildProjectEDF0E7B6\\",
-                      },
-                    ],
-                  ],
-                },
-                Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      \\"arn:\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::Partition\\",
-                      },
-                      \\":logs:\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::Region\\",
-                      },
-                      \\":\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::AccountId\\",
-                      },
-                      \\":log-group:/aws/codebuild/\\",
-                      Object {
-                        \\"Ref\\": \\"CodePipelineBuildSynthCdkBuildProjectEDF0E7B6\\",
-                      },
-                      \\":*\\",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"codebuild:CreateReportGroup\\",
-                \\"codebuild:CreateReport\\",
-                \\"codebuild:UpdateReport\\",
-                \\"codebuild:BatchPutTestCases\\",
-                \\"codebuild:BatchPutCodeCoverages\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::Join\\": Array [
-                  \\"\\",
-                  Array [
-                    \\"arn:\\",
-                    Object {
-                      \\"Ref\\": \\"AWS::Partition\\",
-                    },
-                    \\":codebuild:\\",
-                    Object {
-                      \\"Ref\\": \\"AWS::Region\\",
-                    },
-                    \\":\\",
-                    Object {
-                      \\"Ref\\": \\"AWS::AccountId\\",
-                    },
-                    \\":report-group/\\",
-                    Object {
-                      \\"Ref\\": \\"CodePipelineBuildSynthCdkBuildProjectEDF0E7B6\\",
-                    },
-                    \\"-*\\",
-                  ],
-                ],
-              },
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"s3:GetObject*\\",
-                \\"s3:GetBucket*\\",
-                \\"s3:List*\\",
-                \\"s3:DeleteObject*\\",
-                \\"s3:PutObject\\",
-                \\"s3:PutObjectLegalHold\\",
-                \\"s3:PutObjectRetention\\",
-                \\"s3:PutObjectTagging\\",
-                \\"s3:PutObjectVersionTagging\\",
-                \\"s3:Abort*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Array [
-                Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ArtifactsBucket2AAC5544\\",
-                    \\"Arn\\",
-                  ],
-                },
-                Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      Object {
-                        \\"Fn::GetAtt\\": Array [
-                          \\"ArtifactsBucket2AAC5544\\",
-                          \\"Arn\\",
-                        ],
-                      },
-                      \\"/*\\",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"kms:Decrypt\\",
-                \\"kms:DescribeKey\\",
-                \\"kms:Encrypt\\",
-                \\"kms:ReEncrypt*\\",
-                \\"kms:GenerateDataKey*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::GetAtt\\": Array [
-                  \\"ArtifactKey8D84C5F0\\",
-                  \\"Arn\\",
-                ],
-              },
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"kms:Decrypt\\",
-                \\"kms:Encrypt\\",
-                \\"kms:ReEncrypt*\\",
-                \\"kms:GenerateDataKey*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::GetAtt\\": Array [
-                  \\"ArtifactKey8D84C5F0\\",
-                  \\"Arn\\",
-                ],
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-        \\"PolicyName\\": \\"CodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyB7EDB705\\",
-        \\"Roles\\": Array [
-          Object {
-            \\"Ref\\": \\"CodePipelineBuildSynthCdkBuildProjectRoleB73287D4\\",
-          },
-        ],
-      },
-      \\"Type\\": \\"AWS::IAM::Policy\\",
-    },
-    \\"CodePipelineEventsRole4196480D\\": Object {
-      \\"Properties\\": Object {
-        \\"AssumeRolePolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": \\"sts:AssumeRole\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Principal\\": Object {
-                \\"Service\\": \\"events.amazonaws.com\\",
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-      },
-      \\"Type\\": \\"AWS::IAM::Role\\",
-    },
-    \\"CodePipelineEventsRoleDefaultPolicy13DBD2D2\\": Object {
-      \\"Properties\\": Object {
-        \\"PolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": \\"codepipeline:StartPipelineExecution\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::Join\\": Array [
-                  \\"\\",
-                  Array [
-                    \\"arn:\\",
-                    Object {
-                      \\"Ref\\": \\"AWS::Partition\\",
-                    },
-                    \\":codepipeline:\\",
-                    Object {
-                      \\"Ref\\": \\"AWS::Region\\",
-                    },
-                    \\":\\",
-                    Object {
-                      \\"Ref\\": \\"AWS::AccountId\\",
-                    },
-                    \\":\\",
-                    Object {
-                      \\"Ref\\": \\"CodePipelineB74E5936\\",
-                    },
-                  ],
-                ],
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-        \\"PolicyName\\": \\"CodePipelineEventsRoleDefaultPolicy13DBD2D2\\",
-        \\"Roles\\": Array [
-          Object {
-            \\"Ref\\": \\"CodePipelineEventsRole4196480D\\",
-          },
-        ],
-      },
-      \\"Type\\": \\"AWS::IAM::Policy\\",
-    },
-    \\"CodePipelineRoleB3A660B4\\": Object {
-      \\"Properties\\": Object {
-        \\"AssumeRolePolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": \\"sts:AssumeRole\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Principal\\": Object {
-                \\"Service\\": \\"codepipeline.amazonaws.com\\",
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-      },
-      \\"Type\\": \\"AWS::IAM::Role\\",
-    },
-    \\"CodePipelineRoleDefaultPolicy8D520A8D\\": Object {
-      \\"Metadata\\": Object {
-        \\"cdk_nag\\": Object {
-          \\"rules_to_suppress\\": Array [
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-          ],
-        },
-      },
-      \\"Properties\\": Object {
-        \\"PolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": Array [
-                \\"s3:GetObject*\\",
-                \\"s3:GetBucket*\\",
-                \\"s3:List*\\",
-                \\"s3:DeleteObject*\\",
-                \\"s3:PutObject\\",
-                \\"s3:PutObjectLegalHold\\",
-                \\"s3:PutObjectRetention\\",
-                \\"s3:PutObjectTagging\\",
-                \\"s3:PutObjectVersionTagging\\",
-                \\"s3:Abort*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Array [
-                Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ArtifactsBucket2AAC5544\\",
-                    \\"Arn\\",
-                  ],
-                },
-                Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      Object {
-                        \\"Fn::GetAtt\\": Array [
-                          \\"ArtifactsBucket2AAC5544\\",
-                          \\"Arn\\",
-                        ],
-                      },
-                      \\"/*\\",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"kms:Decrypt\\",
-                \\"kms:DescribeKey\\",
-                \\"kms:Encrypt\\",
-                \\"kms:ReEncrypt*\\",
-                \\"kms:GenerateDataKey*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::GetAtt\\": Array [
-                  \\"ArtifactKey8D84C5F0\\",
-                  \\"Arn\\",
-                ],
-              },
-            },
-            Object {
-              \\"Action\\": \\"sts:AssumeRole\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::GetAtt\\": Array [
-                  \\"CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70\\",
-                  \\"Arn\\",
-                ],
-              },
-            },
-            Object {
-              \\"Action\\": \\"sts:AssumeRole\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::GetAtt\\": Array [
-                  \\"ApplicationPipelineCodeBuildActionRole155C9984\\",
-                  \\"Arn\\",
-                ],
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-        \\"PolicyName\\": \\"CodePipelineRoleDefaultPolicy8D520A8D\\",
-        \\"Roles\\": Array [
-          Object {
-            \\"Ref\\": \\"CodePipelineRoleB3A660B4\\",
-          },
-        ],
-      },
-      \\"Type\\": \\"AWS::IAM::Policy\\",
-    },
-    \\"CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70\\": Object {
-      \\"Properties\\": Object {
-        \\"AssumeRolePolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": \\"sts:AssumeRole\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Principal\\": Object {
-                \\"AWS\\": Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      \\"arn:\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::Partition\\",
-                      },
-                      \\":iam::\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::AccountId\\",
-                      },
-                      \\":root\\",
-                    ],
-                  ],
-                },
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-      },
-      \\"Type\\": \\"AWS::IAM::Role\\",
-    },
-    \\"CodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyAFBD34E4\\": Object {
-      \\"Metadata\\": Object {
-        \\"cdk_nag\\": Object {
-          \\"rules_to_suppress\\": Array [
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-          ],
-        },
-      },
-      \\"Properties\\": Object {
-        \\"PolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": Array [
-                \\"s3:GetObject*\\",
-                \\"s3:GetBucket*\\",
-                \\"s3:List*\\",
-                \\"s3:DeleteObject*\\",
-                \\"s3:PutObject\\",
-                \\"s3:PutObjectLegalHold\\",
-                \\"s3:PutObjectRetention\\",
-                \\"s3:PutObjectTagging\\",
-                \\"s3:PutObjectVersionTagging\\",
-                \\"s3:Abort*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Array [
-                Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ArtifactsBucket2AAC5544\\",
-                    \\"Arn\\",
-                  ],
-                },
-                Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      Object {
-                        \\"Fn::GetAtt\\": Array [
-                          \\"ArtifactsBucket2AAC5544\\",
-                          \\"Arn\\",
-                        ],
-                      },
-                      \\"/*\\",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"kms:Decrypt\\",
-                \\"kms:DescribeKey\\",
-                \\"kms:Encrypt\\",
-                \\"kms:ReEncrypt*\\",
-                \\"kms:GenerateDataKey*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::GetAtt\\": Array [
-                  \\"ArtifactKey8D84C5F0\\",
-                  \\"Arn\\",
-                ],
-              },
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"codecommit:GetBranch\\",
-                \\"codecommit:GetCommit\\",
-                \\"codecommit:UploadArchive\\",
-                \\"codecommit:GetUploadArchiveStatus\\",
-                \\"codecommit:CancelUploadArchive\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::GetAtt\\": Array [
-                  \\"CodeRepositoryBA42F94A\\",
-                  \\"Arn\\",
-                ],
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-        \\"PolicyName\\": \\"CodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyAFBD34E4\\",
-        \\"Roles\\": Array [
-          Object {
-            \\"Ref\\": \\"CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70\\",
-          },
-        ],
-      },
-      \\"Type\\": \\"AWS::IAM::Policy\\",
-    },
-    \\"CodeRepositoryBA42F94A\\": Object {
-      \\"DeletionPolicy\\": \\"Retain\\",
-      \\"Properties\\": Object {
-        \\"RepositoryName\\": \\"monorepo\\",
-      },
-      \\"Type\\": \\"AWS::CodeCommit::Repository\\",
-      \\"UpdateReplacePolicy\\": \\"Retain\\",
-    },
-    \\"CodeRepositorypipelinetestCodePipelineC82F8C25mainlineEventRule152901D1\\": Object {
-      \\"Properties\\": Object {
-        \\"EventPattern\\": Object {
-          \\"detail\\": Object {
-            \\"event\\": Array [
-              \\"referenceCreated\\",
-              \\"referenceUpdated\\",
-            ],
-            \\"referenceName\\": Array [
-              \\"mainline\\",
-            ],
-          },
-          \\"detail-type\\": Array [
-            \\"CodeCommit Repository State Change\\",
-          ],
-          \\"resources\\": Array [
-            Object {
-              \\"Fn::GetAtt\\": Array [
-                \\"CodeRepositoryBA42F94A\\",
-                \\"Arn\\",
-              ],
-            },
-          ],
-          \\"source\\": Array [
-            \\"aws.codecommit\\",
-          ],
-        },
-        \\"State\\": \\"ENABLED\\",
-        \\"Targets\\": Array [
-          Object {
-            \\"Arn\\": Object {
-              \\"Fn::Join\\": Array [
-                \\"\\",
-                Array [
-                  \\"arn:\\",
-                  Object {
-                    \\"Ref\\": \\"AWS::Partition\\",
-                  },
-                  \\":codepipeline:\\",
-                  Object {
-                    \\"Ref\\": \\"AWS::Region\\",
-                  },
-                  \\":\\",
-                  Object {
-                    \\"Ref\\": \\"AWS::AccountId\\",
-                  },
-                  \\":\\",
-                  Object {
-                    \\"Ref\\": \\"CodePipelineB74E5936\\",
-                  },
-                ],
-              ],
-            },
-            \\"Id\\": \\"Target0\\",
-            \\"RoleArn\\": Object {
-              \\"Fn::GetAtt\\": Array [
-                \\"CodePipelineEventsRole4196480D\\",
-                \\"Arn\\",
-              ],
-            },
-          },
-        ],
-      },
-      \\"Type\\": \\"AWS::Events::Rule\\",
     },
     \\"CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F\\": Object {
       \\"DependsOn\\": Array [
@@ -2925,7 +2552,7 @@ Object {
             Array [
               \\"Lambda function for auto-deleting objects in \\",
               Object {
-                \\"Ref\\": \\"AccessLogsBucket83982689\\",
+                \\"Ref\\": \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
               },
               \\" S3 bucket.\\",
             ],
@@ -4130,30 +3757,8 @@ app.synth();
 
 exports[\`Snapshot 1\`] = \`
 Object {
-  \\"Metadata\\": Object {
-    \\"cdk_nag\\": Object {
-      \\"rules_to_suppress\\": Array [
-        Object {
-          \\"id\\": \\"AwsSolutions-CB4\\",
-          \\"reason\\": \\"Encryption of Codebuild is not required.\\",
-        },
-        Object {
-          \\"id\\": \\"AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts\\",
-          \\"reason\\": \\"Encryption of Codebuild is not required.\\",
-        },
-        Object {
-          \\"id\\": \\"AwsSolutions-S1\\",
-          \\"reason\\": \\"Access Log buckets should not have s3 bucket logging\\",
-        },
-        Object {
-          \\"id\\": \\"AwsPrototyping-S3BucketLoggingEnabled\\",
-          \\"reason\\": \\"Access Log buckets should not have s3 bucket logging\\",
-        },
-      ],
-    },
-  },
   \\"Outputs\\": Object {
-    \\"CodeRepositoryGRCUrl\\": Object {
+    \\"ApplicationPipelineCodeRepositoryGRCUrl52F51C17\\": Object {
       \\"Value\\": Object {
         \\"Fn::Join\\": Array [
           \\"\\",
@@ -4165,7 +3770,7 @@ Object {
             \\"://\\",
             Object {
               \\"Fn::GetAtt\\": Array [
-                \\"CodeRepositoryBA42F94A\\",
+                \\"ApplicationPipelineCodeRepositoryA734F3FA\\",
                 \\"Name\\",
               ],
             },
@@ -4182,16 +3787,22 @@ Object {
     },
   },
   \\"Resources\\": Object {
-    \\"AccessLogsBucket83982689\\": Object {
+    \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\": Object {
       \\"DeletionPolicy\\": \\"Delete\\",
       \\"Properties\\": Object {
-        \\"AccessControl\\": \\"LogDeliveryWrite\\",
         \\"BucketEncryption\\": Object {
           \\"ServerSideEncryptionConfiguration\\": Array [
             Object {
               \\"ServerSideEncryptionByDefault\\": Object {
                 \\"SSEAlgorithm\\": \\"AES256\\",
               },
+            },
+          ],
+        },
+        \\"OwnershipControls\\": Object {
+          \\"Rules\\": Array [
+            Object {
+              \\"ObjectOwnership\\": \\"BucketOwnerEnforced\\",
             },
           ],
         },
@@ -4211,14 +3822,14 @@ Object {
       \\"Type\\": \\"AWS::S3::Bucket\\",
       \\"UpdateReplacePolicy\\": \\"Delete\\",
     },
-    \\"AccessLogsBucketAutoDeleteObjectsCustomResource93F9213A\\": Object {
+    \\"ApplicationPipelineAccessLogsBucketAutoDeleteObjectsCustomResource86C84D8B\\": Object {
       \\"DeletionPolicy\\": \\"Delete\\",
       \\"DependsOn\\": Array [
-        \\"AccessLogsBucketPolicy7F77476F\\",
+        \\"ApplicationPipelineAccessLogsBucketPolicy9D7CCAB8\\",
       ],
       \\"Properties\\": Object {
         \\"BucketName\\": Object {
-          \\"Ref\\": \\"AccessLogsBucket83982689\\",
+          \\"Ref\\": \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
         },
         \\"ServiceToken\\": Object {
           \\"Fn::GetAtt\\": Array [
@@ -4230,10 +3841,10 @@ Object {
       \\"Type\\": \\"Custom::S3AutoDeleteObjects\\",
       \\"UpdateReplacePolicy\\": \\"Delete\\",
     },
-    \\"AccessLogsBucketPolicy7F77476F\\": Object {
+    \\"ApplicationPipelineAccessLogsBucketPolicy9D7CCAB8\\": Object {
       \\"Properties\\": Object {
         \\"Bucket\\": Object {
-          \\"Ref\\": \\"AccessLogsBucket83982689\\",
+          \\"Ref\\": \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
         },
         \\"PolicyDocument\\": Object {
           \\"Statement\\": Array [
@@ -4251,7 +3862,7 @@ Object {
               \\"Resource\\": Array [
                 Object {
                   \\"Fn::GetAtt\\": Array [
-                    \\"AccessLogsBucket83982689\\",
+                    \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
                     \\"Arn\\",
                   ],
                 },
@@ -4261,7 +3872,7 @@ Object {
                     Array [
                       Object {
                         \\"Fn::GetAtt\\": Array [
-                          \\"AccessLogsBucket83982689\\",
+                          \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
                           \\"Arn\\",
                         ],
                       },
@@ -4289,7 +3900,7 @@ Object {
               \\"Resource\\": Array [
                 Object {
                   \\"Fn::GetAtt\\": Array [
-                    \\"AccessLogsBucket83982689\\",
+                    \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
                     \\"Arn\\",
                   ],
                 },
@@ -4299,7 +3910,230 @@ Object {
                     Array [
                       Object {
                         \\"Fn::GetAtt\\": Array [
-                          \\"AccessLogsBucket83982689\\",
+                          \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
+                          \\"Arn\\",
+                        ],
+                      },
+                      \\"/*\\",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              \\"Action\\": \\"s3:PutObject\\",
+              \\"Condition\\": Object {
+                \\"ArnLike\\": Object {
+                  \\"aws:SourceArn\\": Object {
+                    \\"Fn::GetAtt\\": Array [
+                      \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                      \\"Arn\\",
+                    ],
+                  },
+                },
+                \\"StringEquals\\": Object {
+                  \\"aws:SourceAccount\\": Object {
+                    \\"Ref\\": \\"AWS::AccountId\\",
+                  },
+                },
+              },
+              \\"Effect\\": \\"Allow\\",
+              \\"Principal\\": Object {
+                \\"Service\\": \\"logging.s3.amazonaws.com\\",
+              },
+              \\"Resource\\": Object {
+                \\"Fn::Join\\": Array [
+                  \\"\\",
+                  Array [
+                    Object {
+                      \\"Fn::GetAtt\\": Array [
+                        \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
+                        \\"Arn\\",
+                      ],
+                    },
+                    \\"/access-logs*\\",
+                  ],
+                ],
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+      },
+      \\"Type\\": \\"AWS::S3::BucketPolicy\\",
+    },
+    \\"ApplicationPipelineArtifactKey284E3A3C\\": Object {
+      \\"DeletionPolicy\\": \\"Delete\\",
+      \\"Properties\\": Object {
+        \\"EnableKeyRotation\\": true,
+        \\"KeyPolicy\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": \\"kms:*\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Principal\\": Object {
+                \\"AWS\\": Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      \\"arn:\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::Partition\\",
+                      },
+                      \\":iam::\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::AccountId\\",
+                      },
+                      \\":root\\",
+                    ],
+                  ],
+                },
+              },
+              \\"Resource\\": \\"*\\",
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+      },
+      \\"Type\\": \\"AWS::KMS::Key\\",
+      \\"UpdateReplacePolicy\\": \\"Delete\\",
+    },
+    \\"ApplicationPipelineArtifactsBucketAutoDeleteObjectsCustomResource349BB700\\": Object {
+      \\"DeletionPolicy\\": \\"Delete\\",
+      \\"DependsOn\\": Array [
+        \\"ApplicationPipelineArtifactsBucketPolicy0F22EB48\\",
+      ],
+      \\"Properties\\": Object {
+        \\"BucketName\\": Object {
+          \\"Ref\\": \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+        },
+        \\"ServiceToken\\": Object {
+          \\"Fn::GetAtt\\": Array [
+            \\"CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F\\",
+            \\"Arn\\",
+          ],
+        },
+      },
+      \\"Type\\": \\"Custom::S3AutoDeleteObjects\\",
+      \\"UpdateReplacePolicy\\": \\"Delete\\",
+    },
+    \\"ApplicationPipelineArtifactsBucketD6B45A16\\": Object {
+      \\"DeletionPolicy\\": \\"Delete\\",
+      \\"Properties\\": Object {
+        \\"BucketEncryption\\": Object {
+          \\"ServerSideEncryptionConfiguration\\": Array [
+            Object {
+              \\"ServerSideEncryptionByDefault\\": Object {
+                \\"KMSMasterKeyID\\": Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineArtifactKey284E3A3C\\",
+                    \\"Arn\\",
+                  ],
+                },
+                \\"SSEAlgorithm\\": \\"aws:kms\\",
+              },
+            },
+          ],
+        },
+        \\"LoggingConfiguration\\": Object {
+          \\"DestinationBucketName\\": Object {
+            \\"Ref\\": \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
+          },
+          \\"LogFilePrefix\\": \\"access-logs\\",
+        },
+        \\"OwnershipControls\\": Object {
+          \\"Rules\\": Array [
+            Object {
+              \\"ObjectOwnership\\": \\"BucketOwnerEnforced\\",
+            },
+          ],
+        },
+        \\"PublicAccessBlockConfiguration\\": Object {
+          \\"BlockPublicAcls\\": true,
+          \\"BlockPublicPolicy\\": true,
+          \\"IgnorePublicAcls\\": true,
+          \\"RestrictPublicBuckets\\": true,
+        },
+        \\"Tags\\": Array [
+          Object {
+            \\"Key\\": \\"aws-cdk:auto-delete-objects\\",
+            \\"Value\\": \\"true\\",
+          },
+        ],
+      },
+      \\"Type\\": \\"AWS::S3::Bucket\\",
+      \\"UpdateReplacePolicy\\": \\"Delete\\",
+    },
+    \\"ApplicationPipelineArtifactsBucketPolicy0F22EB48\\": Object {
+      \\"Properties\\": Object {
+        \\"Bucket\\": Object {
+          \\"Ref\\": \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+        },
+        \\"PolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": \\"s3:*\\",
+              \\"Condition\\": Object {
+                \\"Bool\\": Object {
+                  \\"aws:SecureTransport\\": \\"false\\",
+                },
+              },
+              \\"Effect\\": \\"Deny\\",
+              \\"Principal\\": Object {
+                \\"AWS\\": \\"*\\",
+              },
+              \\"Resource\\": Array [
+                Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                    \\"Arn\\",
+                  ],
+                },
+                Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      Object {
+                        \\"Fn::GetAtt\\": Array [
+                          \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                          \\"Arn\\",
+                        ],
+                      },
+                      \\"/*\\",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"s3:GetBucket*\\",
+                \\"s3:List*\\",
+                \\"s3:DeleteObject*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Principal\\": Object {
+                \\"AWS\\": Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092\\",
+                    \\"Arn\\",
+                  ],
+                },
+              },
+              \\"Resource\\": Array [
+                Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                    \\"Arn\\",
+                  ],
+                },
+                Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      Object {
+                        \\"Fn::GetAtt\\": Array [
+                          \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
                           \\"Arn\\",
                         ],
                       },
@@ -4315,7 +4149,7 @@ Object {
       },
       \\"Type\\": \\"AWS::S3::BucketPolicy\\",
     },
-    \\"ApplicationPipelineCodeBuildActionRole155C9984\\": Object {
+    \\"ApplicationPipelineCodeBuildActionRole98AD1444\\": Object {
       \\"Properties\\": Object {
         \\"AssumeRolePolicyDocument\\": Object {
           \\"Statement\\": Array [
@@ -4352,7 +4186,7 @@ Object {
       },
       \\"Type\\": \\"AWS::IAM::Role\\",
     },
-    \\"ApplicationPipelineCodeBuildActionRoleDefaultPolicyC8190973\\": Object {
+    \\"ApplicationPipelineCodeBuildActionRoleDefaultPolicyFE7AFEF3\\": Object {
       \\"Properties\\": Object {
         \\"PolicyDocument\\": Object {
           \\"Statement\\": Array [
@@ -4365,7 +4199,7 @@ Object {
               \\"Effect\\": \\"Allow\\",
               \\"Resource\\": Object {
                 \\"Fn::GetAtt\\": Array [
-                  \\"CodePipelineBuildSynthCdkBuildProjectEDF0E7B6\\",
+                  \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A\\",
                   \\"Arn\\",
                 ],
               },
@@ -4379,7 +4213,7 @@ Object {
               \\"Effect\\": \\"Allow\\",
               \\"Resource\\": Object {
                 \\"Fn::GetAtt\\": Array [
-                  \\"ApplicationPipelineUpdatePipelineSelfMutation36D37AA8\\",
+                  \\"ApplicationPipelineUpdatePipelineSelfMutation66D95DA8\\",
                   \\"Arn\\",
                 ],
               },
@@ -4387,16 +4221,162 @@ Object {
           ],
           \\"Version\\": \\"2012-10-17\\",
         },
-        \\"PolicyName\\": \\"ApplicationPipelineCodeBuildActionRoleDefaultPolicyC8190973\\",
+        \\"PolicyName\\": \\"ApplicationPipelineCodeBuildActionRoleDefaultPolicyFE7AFEF3\\",
         \\"Roles\\": Array [
           Object {
-            \\"Ref\\": \\"ApplicationPipelineCodeBuildActionRole155C9984\\",
+            \\"Ref\\": \\"ApplicationPipelineCodeBuildActionRole98AD1444\\",
           },
         ],
       },
       \\"Type\\": \\"AWS::IAM::Policy\\",
     },
-    \\"ApplicationPipelineUpdatePipelineSelfMutation36D37AA8\\": Object {
+    \\"ApplicationPipelineCodePipeline92ED701F\\": Object {
+      \\"DependsOn\\": Array [
+        \\"ApplicationPipelineCodePipelineRoleDefaultPolicy02E04067\\",
+        \\"ApplicationPipelineCodePipelineRole53E5791D\\",
+      ],
+      \\"Properties\\": Object {
+        \\"ArtifactStore\\": Object {
+          \\"EncryptionKey\\": Object {
+            \\"Id\\": Object {
+              \\"Fn::GetAtt\\": Array [
+                \\"ApplicationPipelineArtifactKey284E3A3C\\",
+                \\"Arn\\",
+              ],
+            },
+            \\"Type\\": \\"KMS\\",
+          },
+          \\"Location\\": Object {
+            \\"Ref\\": \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+          },
+          \\"Type\\": \\"S3\\",
+        },
+        \\"RestartExecutionOnUpdate\\": true,
+        \\"RoleArn\\": Object {
+          \\"Fn::GetAtt\\": Array [
+            \\"ApplicationPipelineCodePipelineRole53E5791D\\",
+            \\"Arn\\",
+          ],
+        },
+        \\"Stages\\": Array [
+          Object {
+            \\"Actions\\": Array [
+              Object {
+                \\"ActionTypeId\\": Object {
+                  \\"Category\\": \\"Source\\",
+                  \\"Owner\\": \\"AWS\\",
+                  \\"Provider\\": \\"CodeCommit\\",
+                  \\"Version\\": \\"1\\",
+                },
+                \\"Configuration\\": Object {
+                  \\"BranchName\\": \\"mainline\\",
+                  \\"PollForSourceChanges\\": false,
+                  \\"RepositoryName\\": Object {
+                    \\"Fn::GetAtt\\": Array [
+                      \\"ApplicationPipelineCodeRepositoryA734F3FA\\",
+                      \\"Name\\",
+                    ],
+                  },
+                },
+                \\"Name\\": Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineCodeRepositoryA734F3FA\\",
+                    \\"Name\\",
+                  ],
+                },
+                \\"OutputArtifacts\\": Array [
+                  Object {
+                    \\"Name\\": \\"c8dccfc7b4b06e6314cb1dc9e5680d002e559b8933_Source\\",
+                  },
+                ],
+                \\"RoleArn\\": Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRole0900531A\\",
+                    \\"Arn\\",
+                  ],
+                },
+                \\"RunOrder\\": 1,
+              },
+            ],
+            \\"Name\\": \\"Source\\",
+          },
+          Object {
+            \\"Actions\\": Array [
+              Object {
+                \\"ActionTypeId\\": Object {
+                  \\"Category\\": \\"Build\\",
+                  \\"Owner\\": \\"AWS\\",
+                  \\"Provider\\": \\"CodeBuild\\",
+                  \\"Version\\": \\"1\\",
+                },
+                \\"Configuration\\": Object {
+                  \\"EnvironmentVariables\\": \\"[{\\\\\\\\\\"name\\\\\\\\\\":\\\\\\\\\\"_PROJECT_CONFIG_HASH\\\\\\\\\\",\\\\\\\\\\"type\\\\\\\\\\":\\\\\\\\\\"PLAINTEXT\\\\\\\\\\",\\\\\\\\\\"value\\\\\\\\\\":\\\\\\\\\\"13fb1f6f3f0a665500d00a30e46cf5c67342362be94a9d79d179c2ea7436a504\\\\\\\\\\"}]\\",
+                  \\"ProjectName\\": Object {
+                    \\"Ref\\": \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A\\",
+                  },
+                },
+                \\"InputArtifacts\\": Array [
+                  Object {
+                    \\"Name\\": \\"c8dccfc7b4b06e6314cb1dc9e5680d002e559b8933_Source\\",
+                  },
+                ],
+                \\"Name\\": \\"Synth\\",
+                \\"OutputArtifacts\\": Array [
+                  Object {
+                    \\"Name\\": \\"Synth_Output\\",
+                  },
+                  Object {
+                    \\"Name\\": \\"Synth__\\",
+                  },
+                ],
+                \\"RoleArn\\": Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineCodeBuildActionRole98AD1444\\",
+                    \\"Arn\\",
+                  ],
+                },
+                \\"RunOrder\\": 1,
+              },
+            ],
+            \\"Name\\": \\"Build\\",
+          },
+          Object {
+            \\"Actions\\": Array [
+              Object {
+                \\"ActionTypeId\\": Object {
+                  \\"Category\\": \\"Build\\",
+                  \\"Owner\\": \\"AWS\\",
+                  \\"Provider\\": \\"CodeBuild\\",
+                  \\"Version\\": \\"1\\",
+                },
+                \\"Configuration\\": Object {
+                  \\"EnvironmentVariables\\": \\"[{\\\\\\\\\\"name\\\\\\\\\\":\\\\\\\\\\"_PROJECT_CONFIG_HASH\\\\\\\\\\",\\\\\\\\\\"type\\\\\\\\\\":\\\\\\\\\\"PLAINTEXT\\\\\\\\\\",\\\\\\\\\\"value\\\\\\\\\\":\\\\\\\\\\"2e13b99bcda0cb81fc6053cd8a65f303945d49fe774f18ad2c20d178423d9be6\\\\\\\\\\"}]\\",
+                  \\"ProjectName\\": Object {
+                    \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation66D95DA8\\",
+                  },
+                },
+                \\"InputArtifacts\\": Array [
+                  Object {
+                    \\"Name\\": \\"Synth_Output\\",
+                  },
+                ],
+                \\"Name\\": \\"SelfMutate\\",
+                \\"RoleArn\\": Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineCodeBuildActionRole98AD1444\\",
+                    \\"Arn\\",
+                  ],
+                },
+                \\"RunOrder\\": 1,
+              },
+            ],
+            \\"Name\\": \\"UpdatePipeline\\",
+          },
+        ],
+      },
+      \\"Type\\": \\"AWS::CodePipeline::Pipeline\\",
+    },
+    \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A\\": Object {
       \\"Properties\\": Object {
         \\"Artifacts\\": Object {
           \\"Type\\": \\"CODEPIPELINE\\",
@@ -4404,10 +4384,10 @@ Object {
         \\"Cache\\": Object {
           \\"Type\\": \\"NO_CACHE\\",
         },
-        \\"Description\\": \\"Pipeline step pipeline-test/CodePipeline/UpdatePipeline/SelfMutate\\",
+        \\"Description\\": \\"Pipeline step pipeline-test/CodePipeline/Build/Synth\\",
         \\"EncryptionKey\\": Object {
           \\"Fn::GetAtt\\": Array [
-            \\"ArtifactKey8D84C5F0\\",
+            \\"ApplicationPipelineArtifactKey284E3A3C\\",
             \\"Arn\\",
           ],
         },
@@ -4420,7 +4400,7 @@ Object {
         },
         \\"ServiceRole\\": Object {
           \\"Fn::GetAtt\\": Array [
-            \\"ApplicationPipelineUpdatePipelineSelfMutationRole59A20D82\\",
+            \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectRole75D1C6E6\\",
             \\"Arn\\",
           ],
         },
@@ -4430,13 +4410,26 @@ Object {
   \\\\\\\\\\"phases\\\\\\\\\\": {
     \\\\\\\\\\"install\\\\\\\\\\": {
       \\\\\\\\\\"commands\\\\\\\\\\": [
-        \\\\\\\\\\"npm install -g aws-cdk@2\\\\\\\\\\"
+        \\\\\\\\\\"npm install -g aws-cdk\\\\\\\\\\",
+        \\\\\\\\\\"yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile\\\\\\\\\\"
       ]
     },
     \\\\\\\\\\"build\\\\\\\\\\": {
       \\\\\\\\\\"commands\\\\\\\\\\": [
-        \\\\\\\\\\"cdk -a . deploy pipeline-test --require-approval=never --verbose\\\\\\\\\\"
+        \\\\\\\\\\"npx nx run-many --target=build --all\\\\\\\\\\"
       ]
+    }
+  },
+  \\\\\\\\\\"artifacts\\\\\\\\\\": {
+    \\\\\\\\\\"secondary-artifacts\\\\\\\\\\": {
+      \\\\\\\\\\"Synth_Output\\\\\\\\\\": {
+        \\\\\\\\\\"base-directory\\\\\\\\\\": \\\\\\\\\\"packages/infra/cdk.out\\\\\\\\\\",
+        \\\\\\\\\\"files\\\\\\\\\\": \\\\\\\\\\"**/*\\\\\\\\\\"
+      },
+      \\\\\\\\\\"Synth__\\\\\\\\\\": {
+        \\\\\\\\\\"base-directory\\\\\\\\\\": \\\\\\\\\\".\\\\\\\\\\",
+        \\\\\\\\\\"files\\\\\\\\\\": \\\\\\\\\\"**/*\\\\\\\\\\"
+      }
     }
   }
 }\\",
@@ -4445,7 +4438,7 @@ Object {
       },
       \\"Type\\": \\"AWS::CodeBuild::Project\\",
     },
-    \\"ApplicationPipelineUpdatePipelineSelfMutationRole59A20D82\\": Object {
+    \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectRole75D1C6E6\\": Object {
       \\"Properties\\": Object {
         \\"AssumeRolePolicyDocument\\": Object {
           \\"Statement\\": Array [
@@ -4462,191 +4455,7 @@ Object {
       },
       \\"Type\\": \\"AWS::IAM::Role\\",
     },
-    \\"ApplicationPipelineUpdatePipelineSelfMutationRoleDefaultPolicy88A56583\\": Object {
-      \\"Metadata\\": Object {
-        \\"cdk_nag\\": Object {
-          \\"rules_to_suppress\\": Array [
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<ApplicationPipelineUpdatePipelineSelfMutation.*>-\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to create report groups that are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:\\\\\\\\\\\\\\\\*:iam::<AWS::AccountId>:role/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to assume a role from within the current account in order to deploy.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to list all buckets and stacks.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": Object {
-                    \\"Fn::Join\\": Array [
-                      \\"\\",
-                      Array [
-                        \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|\\",
-                        Object {
-                          \\"Ref\\": \\"AWS::AccountId\\",
-                        },
-                        \\"):log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\\\\\\\\\\\\\*$/g\\",
-                      ],
-                    ],
-                  },
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<ApplicationPipelineUpdatePipelineSelfMutation.*>-\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to create report groups that are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:\\\\\\\\\\\\\\\\*:iam::<AWS::AccountId>:role/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to assume a role from within the current account in order to deploy.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to list all buckets and stacks.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": Object {
-                    \\"Fn::Join\\": Array [
-                      \\"\\",
-                      Array [
-                        \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|\\",
-                        Object {
-                          \\"Ref\\": \\"AWS::AccountId\\",
-                        },
-                        \\"):log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\\\\\\\\\\\\\*$/g\\",
-                      ],
-                    ],
-                  },
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-          ],
-        },
-      },
+    \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicy4B9195CC\\": Object {
       \\"Properties\\": Object {
         \\"PolicyDocument\\": Object {
           \\"Statement\\": Array [
@@ -4676,7 +4485,7 @@ Object {
                       },
                       \\":log-group:/aws/codebuild/\\",
                       Object {
-                        \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation36D37AA8\\",
+                        \\"Ref\\": \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A\\",
                       },
                     ],
                   ],
@@ -4699,7 +4508,7 @@ Object {
                       },
                       \\":log-group:/aws/codebuild/\\",
                       Object {
-                        \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation36D37AA8\\",
+                        \\"Ref\\": \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A\\",
                       },
                       \\":*\\",
                     ],
@@ -4734,7 +4543,604 @@ Object {
                     },
                     \\":report-group/\\",
                     Object {
-                      \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation36D37AA8\\",
+                      \\"Ref\\": \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A\\",
+                    },
+                    \\"-*\\",
+                  ],
+                ],
+              },
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"s3:GetObject*\\",
+                \\"s3:GetBucket*\\",
+                \\"s3:List*\\",
+                \\"s3:DeleteObject*\\",
+                \\"s3:PutObject\\",
+                \\"s3:PutObjectLegalHold\\",
+                \\"s3:PutObjectRetention\\",
+                \\"s3:PutObjectTagging\\",
+                \\"s3:PutObjectVersionTagging\\",
+                \\"s3:Abort*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Array [
+                Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                    \\"Arn\\",
+                  ],
+                },
+                Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      Object {
+                        \\"Fn::GetAtt\\": Array [
+                          \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                          \\"Arn\\",
+                        ],
+                      },
+                      \\"/*\\",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"kms:Decrypt\\",
+                \\"kms:DescribeKey\\",
+                \\"kms:Encrypt\\",
+                \\"kms:ReEncrypt*\\",
+                \\"kms:GenerateDataKey*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::GetAtt\\": Array [
+                  \\"ApplicationPipelineArtifactKey284E3A3C\\",
+                  \\"Arn\\",
+                ],
+              },
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"kms:Decrypt\\",
+                \\"kms:Encrypt\\",
+                \\"kms:ReEncrypt*\\",
+                \\"kms:GenerateDataKey*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::GetAtt\\": Array [
+                  \\"ApplicationPipelineArtifactKey284E3A3C\\",
+                  \\"Arn\\",
+                ],
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+        \\"PolicyName\\": \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicy4B9195CC\\",
+        \\"Roles\\": Array [
+          Object {
+            \\"Ref\\": \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectRole75D1C6E6\\",
+          },
+        ],
+      },
+      \\"Type\\": \\"AWS::IAM::Policy\\",
+    },
+    \\"ApplicationPipelineCodePipelineEventsRoleCF718FC7\\": Object {
+      \\"Properties\\": Object {
+        \\"AssumeRolePolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": \\"sts:AssumeRole\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Principal\\": Object {
+                \\"Service\\": \\"events.amazonaws.com\\",
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+      },
+      \\"Type\\": \\"AWS::IAM::Role\\",
+    },
+    \\"ApplicationPipelineCodePipelineEventsRoleDefaultPolicy4A96451E\\": Object {
+      \\"Properties\\": Object {
+        \\"PolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": \\"codepipeline:StartPipelineExecution\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::Join\\": Array [
+                  \\"\\",
+                  Array [
+                    \\"arn:\\",
+                    Object {
+                      \\"Ref\\": \\"AWS::Partition\\",
+                    },
+                    \\":codepipeline:\\",
+                    Object {
+                      \\"Ref\\": \\"AWS::Region\\",
+                    },
+                    \\":\\",
+                    Object {
+                      \\"Ref\\": \\"AWS::AccountId\\",
+                    },
+                    \\":\\",
+                    Object {
+                      \\"Ref\\": \\"ApplicationPipelineCodePipeline92ED701F\\",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+        \\"PolicyName\\": \\"ApplicationPipelineCodePipelineEventsRoleDefaultPolicy4A96451E\\",
+        \\"Roles\\": Array [
+          Object {
+            \\"Ref\\": \\"ApplicationPipelineCodePipelineEventsRoleCF718FC7\\",
+          },
+        ],
+      },
+      \\"Type\\": \\"AWS::IAM::Policy\\",
+    },
+    \\"ApplicationPipelineCodePipelineRole53E5791D\\": Object {
+      \\"Properties\\": Object {
+        \\"AssumeRolePolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": \\"sts:AssumeRole\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Principal\\": Object {
+                \\"Service\\": \\"codepipeline.amazonaws.com\\",
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+      },
+      \\"Type\\": \\"AWS::IAM::Role\\",
+    },
+    \\"ApplicationPipelineCodePipelineRoleDefaultPolicy02E04067\\": Object {
+      \\"Properties\\": Object {
+        \\"PolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": Array [
+                \\"s3:GetObject*\\",
+                \\"s3:GetBucket*\\",
+                \\"s3:List*\\",
+                \\"s3:DeleteObject*\\",
+                \\"s3:PutObject\\",
+                \\"s3:PutObjectLegalHold\\",
+                \\"s3:PutObjectRetention\\",
+                \\"s3:PutObjectTagging\\",
+                \\"s3:PutObjectVersionTagging\\",
+                \\"s3:Abort*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Array [
+                Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                    \\"Arn\\",
+                  ],
+                },
+                Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      Object {
+                        \\"Fn::GetAtt\\": Array [
+                          \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                          \\"Arn\\",
+                        ],
+                      },
+                      \\"/*\\",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"kms:Decrypt\\",
+                \\"kms:DescribeKey\\",
+                \\"kms:Encrypt\\",
+                \\"kms:ReEncrypt*\\",
+                \\"kms:GenerateDataKey*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::GetAtt\\": Array [
+                  \\"ApplicationPipelineArtifactKey284E3A3C\\",
+                  \\"Arn\\",
+                ],
+              },
+            },
+            Object {
+              \\"Action\\": \\"sts:AssumeRole\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::GetAtt\\": Array [
+                  \\"ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRole0900531A\\",
+                  \\"Arn\\",
+                ],
+              },
+            },
+            Object {
+              \\"Action\\": \\"sts:AssumeRole\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::GetAtt\\": Array [
+                  \\"ApplicationPipelineCodeBuildActionRole98AD1444\\",
+                  \\"Arn\\",
+                ],
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+        \\"PolicyName\\": \\"ApplicationPipelineCodePipelineRoleDefaultPolicy02E04067\\",
+        \\"Roles\\": Array [
+          Object {
+            \\"Ref\\": \\"ApplicationPipelineCodePipelineRole53E5791D\\",
+          },
+        ],
+      },
+      \\"Type\\": \\"AWS::IAM::Policy\\",
+    },
+    \\"ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRole0900531A\\": Object {
+      \\"Properties\\": Object {
+        \\"AssumeRolePolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": \\"sts:AssumeRole\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Principal\\": Object {
+                \\"AWS\\": Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      \\"arn:\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::Partition\\",
+                      },
+                      \\":iam::\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::AccountId\\",
+                      },
+                      \\":root\\",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+      },
+      \\"Type\\": \\"AWS::IAM::Role\\",
+    },
+    \\"ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyE92AF83A\\": Object {
+      \\"Properties\\": Object {
+        \\"PolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": Array [
+                \\"s3:GetObject*\\",
+                \\"s3:GetBucket*\\",
+                \\"s3:List*\\",
+                \\"s3:DeleteObject*\\",
+                \\"s3:PutObject\\",
+                \\"s3:PutObjectLegalHold\\",
+                \\"s3:PutObjectRetention\\",
+                \\"s3:PutObjectTagging\\",
+                \\"s3:PutObjectVersionTagging\\",
+                \\"s3:Abort*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Array [
+                Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                    \\"Arn\\",
+                  ],
+                },
+                Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      Object {
+                        \\"Fn::GetAtt\\": Array [
+                          \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                          \\"Arn\\",
+                        ],
+                      },
+                      \\"/*\\",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"kms:Decrypt\\",
+                \\"kms:DescribeKey\\",
+                \\"kms:Encrypt\\",
+                \\"kms:ReEncrypt*\\",
+                \\"kms:GenerateDataKey*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::GetAtt\\": Array [
+                  \\"ApplicationPipelineArtifactKey284E3A3C\\",
+                  \\"Arn\\",
+                ],
+              },
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"codecommit:GetBranch\\",
+                \\"codecommit:GetCommit\\",
+                \\"codecommit:UploadArchive\\",
+                \\"codecommit:GetUploadArchiveStatus\\",
+                \\"codecommit:CancelUploadArchive\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::GetAtt\\": Array [
+                  \\"ApplicationPipelineCodeRepositoryA734F3FA\\",
+                  \\"Arn\\",
+                ],
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+        \\"PolicyName\\": \\"ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyE92AF83A\\",
+        \\"Roles\\": Array [
+          Object {
+            \\"Ref\\": \\"ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRole0900531A\\",
+          },
+        ],
+      },
+      \\"Type\\": \\"AWS::IAM::Policy\\",
+    },
+    \\"ApplicationPipelineCodeRepositoryA734F3FA\\": Object {
+      \\"DeletionPolicy\\": \\"Retain\\",
+      \\"Properties\\": Object {
+        \\"RepositoryName\\": \\"monorepo\\",
+      },
+      \\"Type\\": \\"AWS::CodeCommit::Repository\\",
+      \\"UpdateReplacePolicy\\": \\"Retain\\",
+    },
+    \\"ApplicationPipelineCodeRepositorypipelinetestApplicationPipelineCodePipeline31AB4045mainlineEventRule30640423\\": Object {
+      \\"Properties\\": Object {
+        \\"EventPattern\\": Object {
+          \\"detail\\": Object {
+            \\"event\\": Array [
+              \\"referenceCreated\\",
+              \\"referenceUpdated\\",
+            ],
+            \\"referenceName\\": Array [
+              \\"mainline\\",
+            ],
+          },
+          \\"detail-type\\": Array [
+            \\"CodeCommit Repository State Change\\",
+          ],
+          \\"resources\\": Array [
+            Object {
+              \\"Fn::GetAtt\\": Array [
+                \\"ApplicationPipelineCodeRepositoryA734F3FA\\",
+                \\"Arn\\",
+              ],
+            },
+          ],
+          \\"source\\": Array [
+            \\"aws.codecommit\\",
+          ],
+        },
+        \\"State\\": \\"ENABLED\\",
+        \\"Targets\\": Array [
+          Object {
+            \\"Arn\\": Object {
+              \\"Fn::Join\\": Array [
+                \\"\\",
+                Array [
+                  \\"arn:\\",
+                  Object {
+                    \\"Ref\\": \\"AWS::Partition\\",
+                  },
+                  \\":codepipeline:\\",
+                  Object {
+                    \\"Ref\\": \\"AWS::Region\\",
+                  },
+                  \\":\\",
+                  Object {
+                    \\"Ref\\": \\"AWS::AccountId\\",
+                  },
+                  \\":\\",
+                  Object {
+                    \\"Ref\\": \\"ApplicationPipelineCodePipeline92ED701F\\",
+                  },
+                ],
+              ],
+            },
+            \\"Id\\": \\"Target0\\",
+            \\"RoleArn\\": Object {
+              \\"Fn::GetAtt\\": Array [
+                \\"ApplicationPipelineCodePipelineEventsRoleCF718FC7\\",
+                \\"Arn\\",
+              ],
+            },
+          },
+        ],
+      },
+      \\"Type\\": \\"AWS::Events::Rule\\",
+    },
+    \\"ApplicationPipelineUpdatePipelineSelfMutation66D95DA8\\": Object {
+      \\"Properties\\": Object {
+        \\"Artifacts\\": Object {
+          \\"Type\\": \\"CODEPIPELINE\\",
+        },
+        \\"Cache\\": Object {
+          \\"Type\\": \\"NO_CACHE\\",
+        },
+        \\"Description\\": \\"Pipeline step pipeline-test/CodePipeline/UpdatePipeline/SelfMutate\\",
+        \\"EncryptionKey\\": Object {
+          \\"Fn::GetAtt\\": Array [
+            \\"ApplicationPipelineArtifactKey284E3A3C\\",
+            \\"Arn\\",
+          ],
+        },
+        \\"Environment\\": Object {
+          \\"ComputeType\\": \\"BUILD_GENERAL1_SMALL\\",
+          \\"Image\\": \\"aws/codebuild/standard:6.0\\",
+          \\"ImagePullCredentialsType\\": \\"CODEBUILD\\",
+          \\"PrivilegedMode\\": false,
+          \\"Type\\": \\"LINUX_CONTAINER\\",
+        },
+        \\"ServiceRole\\": Object {
+          \\"Fn::GetAtt\\": Array [
+            \\"ApplicationPipelineUpdatePipelineSelfMutationRoleD476D3E4\\",
+            \\"Arn\\",
+          ],
+        },
+        \\"Source\\": Object {
+          \\"BuildSpec\\": \\"{
+  \\\\\\\\\\"version\\\\\\\\\\": \\\\\\\\\\"0.2\\\\\\\\\\",
+  \\\\\\\\\\"phases\\\\\\\\\\": {
+    \\\\\\\\\\"install\\\\\\\\\\": {
+      \\\\\\\\\\"commands\\\\\\\\\\": [
+        \\\\\\\\\\"npm install -g aws-cdk@2\\\\\\\\\\"
+      ]
+    },
+    \\\\\\\\\\"build\\\\\\\\\\": {
+      \\\\\\\\\\"commands\\\\\\\\\\": [
+        \\\\\\\\\\"cdk -a . deploy pipeline-test --require-approval=never --verbose\\\\\\\\\\"
+      ]
+    }
+  }
+}\\",
+          \\"Type\\": \\"CODEPIPELINE\\",
+        },
+      },
+      \\"Type\\": \\"AWS::CodeBuild::Project\\",
+    },
+    \\"ApplicationPipelineUpdatePipelineSelfMutationRoleD476D3E4\\": Object {
+      \\"Properties\\": Object {
+        \\"AssumeRolePolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": \\"sts:AssumeRole\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Principal\\": Object {
+                \\"Service\\": \\"codebuild.amazonaws.com\\",
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+      },
+      \\"Type\\": \\"AWS::IAM::Role\\",
+    },
+    \\"ApplicationPipelineUpdatePipelineSelfMutationRoleDefaultPolicyE74ACD15\\": Object {
+      \\"Properties\\": Object {
+        \\"PolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": Array [
+                \\"logs:CreateLogGroup\\",
+                \\"logs:CreateLogStream\\",
+                \\"logs:PutLogEvents\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Array [
+                Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      \\"arn:\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::Partition\\",
+                      },
+                      \\":logs:\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::Region\\",
+                      },
+                      \\":\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::AccountId\\",
+                      },
+                      \\":log-group:/aws/codebuild/\\",
+                      Object {
+                        \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation66D95DA8\\",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      \\"arn:\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::Partition\\",
+                      },
+                      \\":logs:\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::Region\\",
+                      },
+                      \\":\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::AccountId\\",
+                      },
+                      \\":log-group:/aws/codebuild/\\",
+                      Object {
+                        \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation66D95DA8\\",
+                      },
+                      \\":*\\",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"codebuild:CreateReportGroup\\",
+                \\"codebuild:CreateReport\\",
+                \\"codebuild:UpdateReport\\",
+                \\"codebuild:BatchPutTestCases\\",
+                \\"codebuild:BatchPutCodeCoverages\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::Join\\": Array [
+                  \\"\\",
+                  Array [
+                    \\"arn:\\",
+                    Object {
+                      \\"Ref\\": \\"AWS::Partition\\",
+                    },
+                    \\":codebuild:\\",
+                    Object {
+                      \\"Ref\\": \\"AWS::Region\\",
+                    },
+                    \\":\\",
+                    Object {
+                      \\"Ref\\": \\"AWS::AccountId\\",
+                    },
+                    \\":report-group/\\",
+                    Object {
+                      \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation66D95DA8\\",
                     },
                     \\"-*\\",
                   ],
@@ -4786,7 +5192,7 @@ Object {
               \\"Resource\\": Array [
                 Object {
                   \\"Fn::GetAtt\\": Array [
-                    \\"ArtifactsBucket2AAC5544\\",
+                    \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
                     \\"Arn\\",
                   ],
                 },
@@ -4796,7 +5202,7 @@ Object {
                     Array [
                       Object {
                         \\"Fn::GetAtt\\": Array [
-                          \\"ArtifactsBucket2AAC5544\\",
+                          \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
                           \\"Arn\\",
                         ],
                       },
@@ -4814,7 +5220,7 @@ Object {
               \\"Effect\\": \\"Allow\\",
               \\"Resource\\": Object {
                 \\"Fn::GetAtt\\": Array [
-                  \\"ArtifactKey8D84C5F0\\",
+                  \\"ApplicationPipelineArtifactKey284E3A3C\\",
                   \\"Arn\\",
                 ],
               },
@@ -4829,7 +5235,7 @@ Object {
               \\"Effect\\": \\"Allow\\",
               \\"Resource\\": Object {
                 \\"Fn::GetAtt\\": Array [
-                  \\"ArtifactKey8D84C5F0\\",
+                  \\"ApplicationPipelineArtifactKey284E3A3C\\",
                   \\"Arn\\",
                 ],
               },
@@ -4837,1166 +5243,14 @@ Object {
           ],
           \\"Version\\": \\"2012-10-17\\",
         },
-        \\"PolicyName\\": \\"ApplicationPipelineUpdatePipelineSelfMutationRoleDefaultPolicy88A56583\\",
+        \\"PolicyName\\": \\"ApplicationPipelineUpdatePipelineSelfMutationRoleDefaultPolicyE74ACD15\\",
         \\"Roles\\": Array [
           Object {
-            \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutationRole59A20D82\\",
+            \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutationRoleD476D3E4\\",
           },
         ],
       },
       \\"Type\\": \\"AWS::IAM::Policy\\",
-    },
-    \\"ArtifactKey8D84C5F0\\": Object {
-      \\"DeletionPolicy\\": \\"Delete\\",
-      \\"Properties\\": Object {
-        \\"EnableKeyRotation\\": true,
-        \\"KeyPolicy\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": \\"kms:*\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Principal\\": Object {
-                \\"AWS\\": Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      \\"arn:\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::Partition\\",
-                      },
-                      \\":iam::\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::AccountId\\",
-                      },
-                      \\":root\\",
-                    ],
-                  ],
-                },
-              },
-              \\"Resource\\": \\"*\\",
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-      },
-      \\"Type\\": \\"AWS::KMS::Key\\",
-      \\"UpdateReplacePolicy\\": \\"Delete\\",
-    },
-    \\"ArtifactsBucket2AAC5544\\": Object {
-      \\"DeletionPolicy\\": \\"Delete\\",
-      \\"Properties\\": Object {
-        \\"BucketEncryption\\": Object {
-          \\"ServerSideEncryptionConfiguration\\": Array [
-            Object {
-              \\"ServerSideEncryptionByDefault\\": Object {
-                \\"KMSMasterKeyID\\": Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ArtifactKey8D84C5F0\\",
-                    \\"Arn\\",
-                  ],
-                },
-                \\"SSEAlgorithm\\": \\"aws:kms\\",
-              },
-            },
-          ],
-        },
-        \\"LoggingConfiguration\\": Object {
-          \\"DestinationBucketName\\": Object {
-            \\"Ref\\": \\"AccessLogsBucket83982689\\",
-          },
-          \\"LogFilePrefix\\": \\"access-logs\\",
-        },
-        \\"PublicAccessBlockConfiguration\\": Object {
-          \\"BlockPublicAcls\\": true,
-          \\"BlockPublicPolicy\\": true,
-          \\"IgnorePublicAcls\\": true,
-          \\"RestrictPublicBuckets\\": true,
-        },
-        \\"Tags\\": Array [
-          Object {
-            \\"Key\\": \\"aws-cdk:auto-delete-objects\\",
-            \\"Value\\": \\"true\\",
-          },
-        ],
-      },
-      \\"Type\\": \\"AWS::S3::Bucket\\",
-      \\"UpdateReplacePolicy\\": \\"Delete\\",
-    },
-    \\"ArtifactsBucketAutoDeleteObjectsCustomResource0E3B4320\\": Object {
-      \\"DeletionPolicy\\": \\"Delete\\",
-      \\"DependsOn\\": Array [
-        \\"ArtifactsBucketPolicy852CB646\\",
-      ],
-      \\"Properties\\": Object {
-        \\"BucketName\\": Object {
-          \\"Ref\\": \\"ArtifactsBucket2AAC5544\\",
-        },
-        \\"ServiceToken\\": Object {
-          \\"Fn::GetAtt\\": Array [
-            \\"CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F\\",
-            \\"Arn\\",
-          ],
-        },
-      },
-      \\"Type\\": \\"Custom::S3AutoDeleteObjects\\",
-      \\"UpdateReplacePolicy\\": \\"Delete\\",
-    },
-    \\"ArtifactsBucketPolicy852CB646\\": Object {
-      \\"Properties\\": Object {
-        \\"Bucket\\": Object {
-          \\"Ref\\": \\"ArtifactsBucket2AAC5544\\",
-        },
-        \\"PolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": \\"s3:*\\",
-              \\"Condition\\": Object {
-                \\"Bool\\": Object {
-                  \\"aws:SecureTransport\\": \\"false\\",
-                },
-              },
-              \\"Effect\\": \\"Deny\\",
-              \\"Principal\\": Object {
-                \\"AWS\\": \\"*\\",
-              },
-              \\"Resource\\": Array [
-                Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ArtifactsBucket2AAC5544\\",
-                    \\"Arn\\",
-                  ],
-                },
-                Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      Object {
-                        \\"Fn::GetAtt\\": Array [
-                          \\"ArtifactsBucket2AAC5544\\",
-                          \\"Arn\\",
-                        ],
-                      },
-                      \\"/*\\",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"s3:GetBucket*\\",
-                \\"s3:List*\\",
-                \\"s3:DeleteObject*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Principal\\": Object {
-                \\"AWS\\": Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092\\",
-                    \\"Arn\\",
-                  ],
-                },
-              },
-              \\"Resource\\": Array [
-                Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ArtifactsBucket2AAC5544\\",
-                    \\"Arn\\",
-                  ],
-                },
-                Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      Object {
-                        \\"Fn::GetAtt\\": Array [
-                          \\"ArtifactsBucket2AAC5544\\",
-                          \\"Arn\\",
-                        ],
-                      },
-                      \\"/*\\",
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-      },
-      \\"Type\\": \\"AWS::S3::BucketPolicy\\",
-    },
-    \\"CodePipelineB74E5936\\": Object {
-      \\"DependsOn\\": Array [
-        \\"CodePipelineRoleDefaultPolicy8D520A8D\\",
-        \\"CodePipelineRoleB3A660B4\\",
-      ],
-      \\"Properties\\": Object {
-        \\"ArtifactStore\\": Object {
-          \\"EncryptionKey\\": Object {
-            \\"Id\\": Object {
-              \\"Fn::GetAtt\\": Array [
-                \\"ArtifactKey8D84C5F0\\",
-                \\"Arn\\",
-              ],
-            },
-            \\"Type\\": \\"KMS\\",
-          },
-          \\"Location\\": Object {
-            \\"Ref\\": \\"ArtifactsBucket2AAC5544\\",
-          },
-          \\"Type\\": \\"S3\\",
-        },
-        \\"RestartExecutionOnUpdate\\": true,
-        \\"RoleArn\\": Object {
-          \\"Fn::GetAtt\\": Array [
-            \\"CodePipelineRoleB3A660B4\\",
-            \\"Arn\\",
-          ],
-        },
-        \\"Stages\\": Array [
-          Object {
-            \\"Actions\\": Array [
-              Object {
-                \\"ActionTypeId\\": Object {
-                  \\"Category\\": \\"Source\\",
-                  \\"Owner\\": \\"AWS\\",
-                  \\"Provider\\": \\"CodeCommit\\",
-                  \\"Version\\": \\"1\\",
-                },
-                \\"Configuration\\": Object {
-                  \\"BranchName\\": \\"mainline\\",
-                  \\"PollForSourceChanges\\": false,
-                  \\"RepositoryName\\": Object {
-                    \\"Fn::GetAtt\\": Array [
-                      \\"CodeRepositoryBA42F94A\\",
-                      \\"Name\\",
-                    ],
-                  },
-                },
-                \\"Name\\": Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"CodeRepositoryBA42F94A\\",
-                    \\"Name\\",
-                  ],
-                },
-                \\"OutputArtifacts\\": Array [
-                  Object {
-                    \\"Name\\": \\"c825c34765dfb5e99261fa6cab9fea074f8881c7c4_Source\\",
-                  },
-                ],
-                \\"RoleArn\\": Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70\\",
-                    \\"Arn\\",
-                  ],
-                },
-                \\"RunOrder\\": 1,
-              },
-            ],
-            \\"Name\\": \\"Source\\",
-          },
-          Object {
-            \\"Actions\\": Array [
-              Object {
-                \\"ActionTypeId\\": Object {
-                  \\"Category\\": \\"Build\\",
-                  \\"Owner\\": \\"AWS\\",
-                  \\"Provider\\": \\"CodeBuild\\",
-                  \\"Version\\": \\"1\\",
-                },
-                \\"Configuration\\": Object {
-                  \\"EnvironmentVariables\\": \\"[{\\\\\\\\\\"name\\\\\\\\\\":\\\\\\\\\\"_PROJECT_CONFIG_HASH\\\\\\\\\\",\\\\\\\\\\"type\\\\\\\\\\":\\\\\\\\\\"PLAINTEXT\\\\\\\\\\",\\\\\\\\\\"value\\\\\\\\\\":\\\\\\\\\\"13fb1f6f3f0a665500d00a30e46cf5c67342362be94a9d79d179c2ea7436a504\\\\\\\\\\"}]\\",
-                  \\"ProjectName\\": Object {
-                    \\"Ref\\": \\"CodePipelineBuildSynthCdkBuildProjectEDF0E7B6\\",
-                  },
-                },
-                \\"InputArtifacts\\": Array [
-                  Object {
-                    \\"Name\\": \\"c825c34765dfb5e99261fa6cab9fea074f8881c7c4_Source\\",
-                  },
-                ],
-                \\"Name\\": \\"Synth\\",
-                \\"OutputArtifacts\\": Array [
-                  Object {
-                    \\"Name\\": \\"Synth_Output\\",
-                  },
-                  Object {
-                    \\"Name\\": \\"Synth__\\",
-                  },
-                ],
-                \\"RoleArn\\": Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ApplicationPipelineCodeBuildActionRole155C9984\\",
-                    \\"Arn\\",
-                  ],
-                },
-                \\"RunOrder\\": 1,
-              },
-            ],
-            \\"Name\\": \\"Build\\",
-          },
-          Object {
-            \\"Actions\\": Array [
-              Object {
-                \\"ActionTypeId\\": Object {
-                  \\"Category\\": \\"Build\\",
-                  \\"Owner\\": \\"AWS\\",
-                  \\"Provider\\": \\"CodeBuild\\",
-                  \\"Version\\": \\"1\\",
-                },
-                \\"Configuration\\": Object {
-                  \\"EnvironmentVariables\\": \\"[{\\\\\\\\\\"name\\\\\\\\\\":\\\\\\\\\\"_PROJECT_CONFIG_HASH\\\\\\\\\\",\\\\\\\\\\"type\\\\\\\\\\":\\\\\\\\\\"PLAINTEXT\\\\\\\\\\",\\\\\\\\\\"value\\\\\\\\\\":\\\\\\\\\\"2e13b99bcda0cb81fc6053cd8a65f303945d49fe774f18ad2c20d178423d9be6\\\\\\\\\\"}]\\",
-                  \\"ProjectName\\": Object {
-                    \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation36D37AA8\\",
-                  },
-                },
-                \\"InputArtifacts\\": Array [
-                  Object {
-                    \\"Name\\": \\"Synth_Output\\",
-                  },
-                ],
-                \\"Name\\": \\"SelfMutate\\",
-                \\"RoleArn\\": Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ApplicationPipelineCodeBuildActionRole155C9984\\",
-                    \\"Arn\\",
-                  ],
-                },
-                \\"RunOrder\\": 1,
-              },
-            ],
-            \\"Name\\": \\"UpdatePipeline\\",
-          },
-        ],
-      },
-      \\"Type\\": \\"AWS::CodePipeline::Pipeline\\",
-    },
-    \\"CodePipelineBuildSynthCdkBuildProjectEDF0E7B6\\": Object {
-      \\"Properties\\": Object {
-        \\"Artifacts\\": Object {
-          \\"Type\\": \\"CODEPIPELINE\\",
-        },
-        \\"Cache\\": Object {
-          \\"Type\\": \\"NO_CACHE\\",
-        },
-        \\"Description\\": \\"Pipeline step pipeline-test/CodePipeline/Build/Synth\\",
-        \\"EncryptionKey\\": Object {
-          \\"Fn::GetAtt\\": Array [
-            \\"ArtifactKey8D84C5F0\\",
-            \\"Arn\\",
-          ],
-        },
-        \\"Environment\\": Object {
-          \\"ComputeType\\": \\"BUILD_GENERAL1_SMALL\\",
-          \\"Image\\": \\"aws/codebuild/standard:6.0\\",
-          \\"ImagePullCredentialsType\\": \\"CODEBUILD\\",
-          \\"PrivilegedMode\\": false,
-          \\"Type\\": \\"LINUX_CONTAINER\\",
-        },
-        \\"ServiceRole\\": Object {
-          \\"Fn::GetAtt\\": Array [
-            \\"CodePipelineBuildSynthCdkBuildProjectRoleB73287D4\\",
-            \\"Arn\\",
-          ],
-        },
-        \\"Source\\": Object {
-          \\"BuildSpec\\": \\"{
-  \\\\\\\\\\"version\\\\\\\\\\": \\\\\\\\\\"0.2\\\\\\\\\\",
-  \\\\\\\\\\"phases\\\\\\\\\\": {
-    \\\\\\\\\\"install\\\\\\\\\\": {
-      \\\\\\\\\\"commands\\\\\\\\\\": [
-        \\\\\\\\\\"npm install -g aws-cdk\\\\\\\\\\",
-        \\\\\\\\\\"yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile\\\\\\\\\\"
-      ]
-    },
-    \\\\\\\\\\"build\\\\\\\\\\": {
-      \\\\\\\\\\"commands\\\\\\\\\\": [
-        \\\\\\\\\\"npx nx run-many --target=build --all\\\\\\\\\\"
-      ]
-    }
-  },
-  \\\\\\\\\\"artifacts\\\\\\\\\\": {
-    \\\\\\\\\\"secondary-artifacts\\\\\\\\\\": {
-      \\\\\\\\\\"Synth_Output\\\\\\\\\\": {
-        \\\\\\\\\\"base-directory\\\\\\\\\\": \\\\\\\\\\"packages/infra/cdk.out\\\\\\\\\\",
-        \\\\\\\\\\"files\\\\\\\\\\": \\\\\\\\\\"**/*\\\\\\\\\\"
-      },
-      \\\\\\\\\\"Synth__\\\\\\\\\\": {
-        \\\\\\\\\\"base-directory\\\\\\\\\\": \\\\\\\\\\".\\\\\\\\\\",
-        \\\\\\\\\\"files\\\\\\\\\\": \\\\\\\\\\"**/*\\\\\\\\\\"
-      }
-    }
-  }
-}\\",
-          \\"Type\\": \\"CODEPIPELINE\\",
-        },
-      },
-      \\"Type\\": \\"AWS::CodeBuild::Project\\",
-    },
-    \\"CodePipelineBuildSynthCdkBuildProjectRoleB73287D4\\": Object {
-      \\"Properties\\": Object {
-        \\"AssumeRolePolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": \\"sts:AssumeRole\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Principal\\": Object {
-                \\"Service\\": \\"codebuild.amazonaws.com\\",
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-      },
-      \\"Type\\": \\"AWS::IAM::Role\\",
-    },
-    \\"CodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyB7EDB705\\": Object {
-      \\"Metadata\\": Object {
-        \\"cdk_nag\\": Object {
-          \\"rules_to_suppress\\": Array [
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to create report groups that are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to create report groups that are dynamically determined.\\",
-            },
-          ],
-        },
-      },
-      \\"Properties\\": Object {
-        \\"PolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": Array [
-                \\"logs:CreateLogGroup\\",
-                \\"logs:CreateLogStream\\",
-                \\"logs:PutLogEvents\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Array [
-                Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      \\"arn:\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::Partition\\",
-                      },
-                      \\":logs:\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::Region\\",
-                      },
-                      \\":\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::AccountId\\",
-                      },
-                      \\":log-group:/aws/codebuild/\\",
-                      Object {
-                        \\"Ref\\": \\"CodePipelineBuildSynthCdkBuildProjectEDF0E7B6\\",
-                      },
-                    ],
-                  ],
-                },
-                Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      \\"arn:\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::Partition\\",
-                      },
-                      \\":logs:\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::Region\\",
-                      },
-                      \\":\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::AccountId\\",
-                      },
-                      \\":log-group:/aws/codebuild/\\",
-                      Object {
-                        \\"Ref\\": \\"CodePipelineBuildSynthCdkBuildProjectEDF0E7B6\\",
-                      },
-                      \\":*\\",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"codebuild:CreateReportGroup\\",
-                \\"codebuild:CreateReport\\",
-                \\"codebuild:UpdateReport\\",
-                \\"codebuild:BatchPutTestCases\\",
-                \\"codebuild:BatchPutCodeCoverages\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::Join\\": Array [
-                  \\"\\",
-                  Array [
-                    \\"arn:\\",
-                    Object {
-                      \\"Ref\\": \\"AWS::Partition\\",
-                    },
-                    \\":codebuild:\\",
-                    Object {
-                      \\"Ref\\": \\"AWS::Region\\",
-                    },
-                    \\":\\",
-                    Object {
-                      \\"Ref\\": \\"AWS::AccountId\\",
-                    },
-                    \\":report-group/\\",
-                    Object {
-                      \\"Ref\\": \\"CodePipelineBuildSynthCdkBuildProjectEDF0E7B6\\",
-                    },
-                    \\"-*\\",
-                  ],
-                ],
-              },
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"s3:GetObject*\\",
-                \\"s3:GetBucket*\\",
-                \\"s3:List*\\",
-                \\"s3:DeleteObject*\\",
-                \\"s3:PutObject\\",
-                \\"s3:PutObjectLegalHold\\",
-                \\"s3:PutObjectRetention\\",
-                \\"s3:PutObjectTagging\\",
-                \\"s3:PutObjectVersionTagging\\",
-                \\"s3:Abort*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Array [
-                Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ArtifactsBucket2AAC5544\\",
-                    \\"Arn\\",
-                  ],
-                },
-                Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      Object {
-                        \\"Fn::GetAtt\\": Array [
-                          \\"ArtifactsBucket2AAC5544\\",
-                          \\"Arn\\",
-                        ],
-                      },
-                      \\"/*\\",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"kms:Decrypt\\",
-                \\"kms:DescribeKey\\",
-                \\"kms:Encrypt\\",
-                \\"kms:ReEncrypt*\\",
-                \\"kms:GenerateDataKey*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::GetAtt\\": Array [
-                  \\"ArtifactKey8D84C5F0\\",
-                  \\"Arn\\",
-                ],
-              },
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"kms:Decrypt\\",
-                \\"kms:Encrypt\\",
-                \\"kms:ReEncrypt*\\",
-                \\"kms:GenerateDataKey*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::GetAtt\\": Array [
-                  \\"ArtifactKey8D84C5F0\\",
-                  \\"Arn\\",
-                ],
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-        \\"PolicyName\\": \\"CodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyB7EDB705\\",
-        \\"Roles\\": Array [
-          Object {
-            \\"Ref\\": \\"CodePipelineBuildSynthCdkBuildProjectRoleB73287D4\\",
-          },
-        ],
-      },
-      \\"Type\\": \\"AWS::IAM::Policy\\",
-    },
-    \\"CodePipelineEventsRole4196480D\\": Object {
-      \\"Properties\\": Object {
-        \\"AssumeRolePolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": \\"sts:AssumeRole\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Principal\\": Object {
-                \\"Service\\": \\"events.amazonaws.com\\",
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-      },
-      \\"Type\\": \\"AWS::IAM::Role\\",
-    },
-    \\"CodePipelineEventsRoleDefaultPolicy13DBD2D2\\": Object {
-      \\"Properties\\": Object {
-        \\"PolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": \\"codepipeline:StartPipelineExecution\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::Join\\": Array [
-                  \\"\\",
-                  Array [
-                    \\"arn:\\",
-                    Object {
-                      \\"Ref\\": \\"AWS::Partition\\",
-                    },
-                    \\":codepipeline:\\",
-                    Object {
-                      \\"Ref\\": \\"AWS::Region\\",
-                    },
-                    \\":\\",
-                    Object {
-                      \\"Ref\\": \\"AWS::AccountId\\",
-                    },
-                    \\":\\",
-                    Object {
-                      \\"Ref\\": \\"CodePipelineB74E5936\\",
-                    },
-                  ],
-                ],
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-        \\"PolicyName\\": \\"CodePipelineEventsRoleDefaultPolicy13DBD2D2\\",
-        \\"Roles\\": Array [
-          Object {
-            \\"Ref\\": \\"CodePipelineEventsRole4196480D\\",
-          },
-        ],
-      },
-      \\"Type\\": \\"AWS::IAM::Policy\\",
-    },
-    \\"CodePipelineRoleB3A660B4\\": Object {
-      \\"Properties\\": Object {
-        \\"AssumeRolePolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": \\"sts:AssumeRole\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Principal\\": Object {
-                \\"Service\\": \\"codepipeline.amazonaws.com\\",
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-      },
-      \\"Type\\": \\"AWS::IAM::Role\\",
-    },
-    \\"CodePipelineRoleDefaultPolicy8D520A8D\\": Object {
-      \\"Metadata\\": Object {
-        \\"cdk_nag\\": Object {
-          \\"rules_to_suppress\\": Array [
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-          ],
-        },
-      },
-      \\"Properties\\": Object {
-        \\"PolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": Array [
-                \\"s3:GetObject*\\",
-                \\"s3:GetBucket*\\",
-                \\"s3:List*\\",
-                \\"s3:DeleteObject*\\",
-                \\"s3:PutObject\\",
-                \\"s3:PutObjectLegalHold\\",
-                \\"s3:PutObjectRetention\\",
-                \\"s3:PutObjectTagging\\",
-                \\"s3:PutObjectVersionTagging\\",
-                \\"s3:Abort*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Array [
-                Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ArtifactsBucket2AAC5544\\",
-                    \\"Arn\\",
-                  ],
-                },
-                Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      Object {
-                        \\"Fn::GetAtt\\": Array [
-                          \\"ArtifactsBucket2AAC5544\\",
-                          \\"Arn\\",
-                        ],
-                      },
-                      \\"/*\\",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"kms:Decrypt\\",
-                \\"kms:DescribeKey\\",
-                \\"kms:Encrypt\\",
-                \\"kms:ReEncrypt*\\",
-                \\"kms:GenerateDataKey*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::GetAtt\\": Array [
-                  \\"ArtifactKey8D84C5F0\\",
-                  \\"Arn\\",
-                ],
-              },
-            },
-            Object {
-              \\"Action\\": \\"sts:AssumeRole\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::GetAtt\\": Array [
-                  \\"CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70\\",
-                  \\"Arn\\",
-                ],
-              },
-            },
-            Object {
-              \\"Action\\": \\"sts:AssumeRole\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::GetAtt\\": Array [
-                  \\"ApplicationPipelineCodeBuildActionRole155C9984\\",
-                  \\"Arn\\",
-                ],
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-        \\"PolicyName\\": \\"CodePipelineRoleDefaultPolicy8D520A8D\\",
-        \\"Roles\\": Array [
-          Object {
-            \\"Ref\\": \\"CodePipelineRoleB3A660B4\\",
-          },
-        ],
-      },
-      \\"Type\\": \\"AWS::IAM::Policy\\",
-    },
-    \\"CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70\\": Object {
-      \\"Properties\\": Object {
-        \\"AssumeRolePolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": \\"sts:AssumeRole\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Principal\\": Object {
-                \\"AWS\\": Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      \\"arn:\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::Partition\\",
-                      },
-                      \\":iam::\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::AccountId\\",
-                      },
-                      \\":root\\",
-                    ],
-                  ],
-                },
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-      },
-      \\"Type\\": \\"AWS::IAM::Role\\",
-    },
-    \\"CodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyAFBD34E4\\": Object {
-      \\"Metadata\\": Object {
-        \\"cdk_nag\\": Object {
-          \\"rules_to_suppress\\": Array [
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-          ],
-        },
-      },
-      \\"Properties\\": Object {
-        \\"PolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": Array [
-                \\"s3:GetObject*\\",
-                \\"s3:GetBucket*\\",
-                \\"s3:List*\\",
-                \\"s3:DeleteObject*\\",
-                \\"s3:PutObject\\",
-                \\"s3:PutObjectLegalHold\\",
-                \\"s3:PutObjectRetention\\",
-                \\"s3:PutObjectTagging\\",
-                \\"s3:PutObjectVersionTagging\\",
-                \\"s3:Abort*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Array [
-                Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ArtifactsBucket2AAC5544\\",
-                    \\"Arn\\",
-                  ],
-                },
-                Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      Object {
-                        \\"Fn::GetAtt\\": Array [
-                          \\"ArtifactsBucket2AAC5544\\",
-                          \\"Arn\\",
-                        ],
-                      },
-                      \\"/*\\",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"kms:Decrypt\\",
-                \\"kms:DescribeKey\\",
-                \\"kms:Encrypt\\",
-                \\"kms:ReEncrypt*\\",
-                \\"kms:GenerateDataKey*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::GetAtt\\": Array [
-                  \\"ArtifactKey8D84C5F0\\",
-                  \\"Arn\\",
-                ],
-              },
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"codecommit:GetBranch\\",
-                \\"codecommit:GetCommit\\",
-                \\"codecommit:UploadArchive\\",
-                \\"codecommit:GetUploadArchiveStatus\\",
-                \\"codecommit:CancelUploadArchive\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::GetAtt\\": Array [
-                  \\"CodeRepositoryBA42F94A\\",
-                  \\"Arn\\",
-                ],
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-        \\"PolicyName\\": \\"CodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyAFBD34E4\\",
-        \\"Roles\\": Array [
-          Object {
-            \\"Ref\\": \\"CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70\\",
-          },
-        ],
-      },
-      \\"Type\\": \\"AWS::IAM::Policy\\",
-    },
-    \\"CodeRepositoryBA42F94A\\": Object {
-      \\"DeletionPolicy\\": \\"Retain\\",
-      \\"Properties\\": Object {
-        \\"RepositoryName\\": \\"monorepo\\",
-      },
-      \\"Type\\": \\"AWS::CodeCommit::Repository\\",
-      \\"UpdateReplacePolicy\\": \\"Retain\\",
-    },
-    \\"CodeRepositorypipelinetestCodePipelineC82F8C25mainlineEventRule152901D1\\": Object {
-      \\"Properties\\": Object {
-        \\"EventPattern\\": Object {
-          \\"detail\\": Object {
-            \\"event\\": Array [
-              \\"referenceCreated\\",
-              \\"referenceUpdated\\",
-            ],
-            \\"referenceName\\": Array [
-              \\"mainline\\",
-            ],
-          },
-          \\"detail-type\\": Array [
-            \\"CodeCommit Repository State Change\\",
-          ],
-          \\"resources\\": Array [
-            Object {
-              \\"Fn::GetAtt\\": Array [
-                \\"CodeRepositoryBA42F94A\\",
-                \\"Arn\\",
-              ],
-            },
-          ],
-          \\"source\\": Array [
-            \\"aws.codecommit\\",
-          ],
-        },
-        \\"State\\": \\"ENABLED\\",
-        \\"Targets\\": Array [
-          Object {
-            \\"Arn\\": Object {
-              \\"Fn::Join\\": Array [
-                \\"\\",
-                Array [
-                  \\"arn:\\",
-                  Object {
-                    \\"Ref\\": \\"AWS::Partition\\",
-                  },
-                  \\":codepipeline:\\",
-                  Object {
-                    \\"Ref\\": \\"AWS::Region\\",
-                  },
-                  \\":\\",
-                  Object {
-                    \\"Ref\\": \\"AWS::AccountId\\",
-                  },
-                  \\":\\",
-                  Object {
-                    \\"Ref\\": \\"CodePipelineB74E5936\\",
-                  },
-                ],
-              ],
-            },
-            \\"Id\\": \\"Target0\\",
-            \\"RoleArn\\": Object {
-              \\"Fn::GetAtt\\": Array [
-                \\"CodePipelineEventsRole4196480D\\",
-                \\"Arn\\",
-              ],
-            },
-          },
-        ],
-      },
-      \\"Type\\": \\"AWS::Events::Rule\\",
     },
     \\"CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F\\": Object {
       \\"DependsOn\\": Array [
@@ -6015,7 +5269,7 @@ Object {
             Array [
               \\"Lambda function for auto-deleting objects in \\",
               Object {
-                \\"Ref\\": \\"AccessLogsBucket83982689\\",
+                \\"Ref\\": \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
               },
               \\" S3 bucket.\\",
             ],
@@ -7235,30 +6489,8 @@ app.synth();
 
 exports[\`Snapshot 1\`] = \`
 Object {
-  \\"Metadata\\": Object {
-    \\"cdk_nag\\": Object {
-      \\"rules_to_suppress\\": Array [
-        Object {
-          \\"id\\": \\"AwsSolutions-CB4\\",
-          \\"reason\\": \\"Encryption of Codebuild is not required.\\",
-        },
-        Object {
-          \\"id\\": \\"AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts\\",
-          \\"reason\\": \\"Encryption of Codebuild is not required.\\",
-        },
-        Object {
-          \\"id\\": \\"AwsSolutions-S1\\",
-          \\"reason\\": \\"Access Log buckets should not have s3 bucket logging\\",
-        },
-        Object {
-          \\"id\\": \\"AwsPrototyping-S3BucketLoggingEnabled\\",
-          \\"reason\\": \\"Access Log buckets should not have s3 bucket logging\\",
-        },
-      ],
-    },
-  },
   \\"Outputs\\": Object {
-    \\"CodeRepositoryGRCUrl\\": Object {
+    \\"ApplicationPipelineCodeRepositoryGRCUrl52F51C17\\": Object {
       \\"Value\\": Object {
         \\"Fn::Join\\": Array [
           \\"\\",
@@ -7270,7 +6502,7 @@ Object {
             \\"://\\",
             Object {
               \\"Fn::GetAtt\\": Array [
-                \\"CodeRepositoryBA42F94A\\",
+                \\"ApplicationPipelineCodeRepositoryA734F3FA\\",
                 \\"Name\\",
               ],
             },
@@ -7287,16 +6519,22 @@ Object {
     },
   },
   \\"Resources\\": Object {
-    \\"AccessLogsBucket83982689\\": Object {
+    \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\": Object {
       \\"DeletionPolicy\\": \\"Delete\\",
       \\"Properties\\": Object {
-        \\"AccessControl\\": \\"LogDeliveryWrite\\",
         \\"BucketEncryption\\": Object {
           \\"ServerSideEncryptionConfiguration\\": Array [
             Object {
               \\"ServerSideEncryptionByDefault\\": Object {
                 \\"SSEAlgorithm\\": \\"AES256\\",
               },
+            },
+          ],
+        },
+        \\"OwnershipControls\\": Object {
+          \\"Rules\\": Array [
+            Object {
+              \\"ObjectOwnership\\": \\"BucketOwnerEnforced\\",
             },
           ],
         },
@@ -7316,14 +6554,14 @@ Object {
       \\"Type\\": \\"AWS::S3::Bucket\\",
       \\"UpdateReplacePolicy\\": \\"Delete\\",
     },
-    \\"AccessLogsBucketAutoDeleteObjectsCustomResource93F9213A\\": Object {
+    \\"ApplicationPipelineAccessLogsBucketAutoDeleteObjectsCustomResource86C84D8B\\": Object {
       \\"DeletionPolicy\\": \\"Delete\\",
       \\"DependsOn\\": Array [
-        \\"AccessLogsBucketPolicy7F77476F\\",
+        \\"ApplicationPipelineAccessLogsBucketPolicy9D7CCAB8\\",
       ],
       \\"Properties\\": Object {
         \\"BucketName\\": Object {
-          \\"Ref\\": \\"AccessLogsBucket83982689\\",
+          \\"Ref\\": \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
         },
         \\"ServiceToken\\": Object {
           \\"Fn::GetAtt\\": Array [
@@ -7335,10 +6573,10 @@ Object {
       \\"Type\\": \\"Custom::S3AutoDeleteObjects\\",
       \\"UpdateReplacePolicy\\": \\"Delete\\",
     },
-    \\"AccessLogsBucketPolicy7F77476F\\": Object {
+    \\"ApplicationPipelineAccessLogsBucketPolicy9D7CCAB8\\": Object {
       \\"Properties\\": Object {
         \\"Bucket\\": Object {
-          \\"Ref\\": \\"AccessLogsBucket83982689\\",
+          \\"Ref\\": \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
         },
         \\"PolicyDocument\\": Object {
           \\"Statement\\": Array [
@@ -7356,7 +6594,7 @@ Object {
               \\"Resource\\": Array [
                 Object {
                   \\"Fn::GetAtt\\": Array [
-                    \\"AccessLogsBucket83982689\\",
+                    \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
                     \\"Arn\\",
                   ],
                 },
@@ -7366,7 +6604,7 @@ Object {
                     Array [
                       Object {
                         \\"Fn::GetAtt\\": Array [
-                          \\"AccessLogsBucket83982689\\",
+                          \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
                           \\"Arn\\",
                         ],
                       },
@@ -7394,7 +6632,7 @@ Object {
               \\"Resource\\": Array [
                 Object {
                   \\"Fn::GetAtt\\": Array [
-                    \\"AccessLogsBucket83982689\\",
+                    \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
                     \\"Arn\\",
                   ],
                 },
@@ -7404,7 +6642,230 @@ Object {
                     Array [
                       Object {
                         \\"Fn::GetAtt\\": Array [
-                          \\"AccessLogsBucket83982689\\",
+                          \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
+                          \\"Arn\\",
+                        ],
+                      },
+                      \\"/*\\",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              \\"Action\\": \\"s3:PutObject\\",
+              \\"Condition\\": Object {
+                \\"ArnLike\\": Object {
+                  \\"aws:SourceArn\\": Object {
+                    \\"Fn::GetAtt\\": Array [
+                      \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                      \\"Arn\\",
+                    ],
+                  },
+                },
+                \\"StringEquals\\": Object {
+                  \\"aws:SourceAccount\\": Object {
+                    \\"Ref\\": \\"AWS::AccountId\\",
+                  },
+                },
+              },
+              \\"Effect\\": \\"Allow\\",
+              \\"Principal\\": Object {
+                \\"Service\\": \\"logging.s3.amazonaws.com\\",
+              },
+              \\"Resource\\": Object {
+                \\"Fn::Join\\": Array [
+                  \\"\\",
+                  Array [
+                    Object {
+                      \\"Fn::GetAtt\\": Array [
+                        \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
+                        \\"Arn\\",
+                      ],
+                    },
+                    \\"/access-logs*\\",
+                  ],
+                ],
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+      },
+      \\"Type\\": \\"AWS::S3::BucketPolicy\\",
+    },
+    \\"ApplicationPipelineArtifactKey284E3A3C\\": Object {
+      \\"DeletionPolicy\\": \\"Delete\\",
+      \\"Properties\\": Object {
+        \\"EnableKeyRotation\\": true,
+        \\"KeyPolicy\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": \\"kms:*\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Principal\\": Object {
+                \\"AWS\\": Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      \\"arn:\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::Partition\\",
+                      },
+                      \\":iam::\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::AccountId\\",
+                      },
+                      \\":root\\",
+                    ],
+                  ],
+                },
+              },
+              \\"Resource\\": \\"*\\",
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+      },
+      \\"Type\\": \\"AWS::KMS::Key\\",
+      \\"UpdateReplacePolicy\\": \\"Delete\\",
+    },
+    \\"ApplicationPipelineArtifactsBucketAutoDeleteObjectsCustomResource349BB700\\": Object {
+      \\"DeletionPolicy\\": \\"Delete\\",
+      \\"DependsOn\\": Array [
+        \\"ApplicationPipelineArtifactsBucketPolicy0F22EB48\\",
+      ],
+      \\"Properties\\": Object {
+        \\"BucketName\\": Object {
+          \\"Ref\\": \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+        },
+        \\"ServiceToken\\": Object {
+          \\"Fn::GetAtt\\": Array [
+            \\"CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F\\",
+            \\"Arn\\",
+          ],
+        },
+      },
+      \\"Type\\": \\"Custom::S3AutoDeleteObjects\\",
+      \\"UpdateReplacePolicy\\": \\"Delete\\",
+    },
+    \\"ApplicationPipelineArtifactsBucketD6B45A16\\": Object {
+      \\"DeletionPolicy\\": \\"Delete\\",
+      \\"Properties\\": Object {
+        \\"BucketEncryption\\": Object {
+          \\"ServerSideEncryptionConfiguration\\": Array [
+            Object {
+              \\"ServerSideEncryptionByDefault\\": Object {
+                \\"KMSMasterKeyID\\": Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineArtifactKey284E3A3C\\",
+                    \\"Arn\\",
+                  ],
+                },
+                \\"SSEAlgorithm\\": \\"aws:kms\\",
+              },
+            },
+          ],
+        },
+        \\"LoggingConfiguration\\": Object {
+          \\"DestinationBucketName\\": Object {
+            \\"Ref\\": \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
+          },
+          \\"LogFilePrefix\\": \\"access-logs\\",
+        },
+        \\"OwnershipControls\\": Object {
+          \\"Rules\\": Array [
+            Object {
+              \\"ObjectOwnership\\": \\"BucketOwnerEnforced\\",
+            },
+          ],
+        },
+        \\"PublicAccessBlockConfiguration\\": Object {
+          \\"BlockPublicAcls\\": true,
+          \\"BlockPublicPolicy\\": true,
+          \\"IgnorePublicAcls\\": true,
+          \\"RestrictPublicBuckets\\": true,
+        },
+        \\"Tags\\": Array [
+          Object {
+            \\"Key\\": \\"aws-cdk:auto-delete-objects\\",
+            \\"Value\\": \\"true\\",
+          },
+        ],
+      },
+      \\"Type\\": \\"AWS::S3::Bucket\\",
+      \\"UpdateReplacePolicy\\": \\"Delete\\",
+    },
+    \\"ApplicationPipelineArtifactsBucketPolicy0F22EB48\\": Object {
+      \\"Properties\\": Object {
+        \\"Bucket\\": Object {
+          \\"Ref\\": \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+        },
+        \\"PolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": \\"s3:*\\",
+              \\"Condition\\": Object {
+                \\"Bool\\": Object {
+                  \\"aws:SecureTransport\\": \\"false\\",
+                },
+              },
+              \\"Effect\\": \\"Deny\\",
+              \\"Principal\\": Object {
+                \\"AWS\\": \\"*\\",
+              },
+              \\"Resource\\": Array [
+                Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                    \\"Arn\\",
+                  ],
+                },
+                Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      Object {
+                        \\"Fn::GetAtt\\": Array [
+                          \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                          \\"Arn\\",
+                        ],
+                      },
+                      \\"/*\\",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"s3:GetBucket*\\",
+                \\"s3:List*\\",
+                \\"s3:DeleteObject*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Principal\\": Object {
+                \\"AWS\\": Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092\\",
+                    \\"Arn\\",
+                  ],
+                },
+              },
+              \\"Resource\\": Array [
+                Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                    \\"Arn\\",
+                  ],
+                },
+                Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      Object {
+                        \\"Fn::GetAtt\\": Array [
+                          \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
                           \\"Arn\\",
                         ],
                       },
@@ -7420,7 +6881,7 @@ Object {
       },
       \\"Type\\": \\"AWS::S3::BucketPolicy\\",
     },
-    \\"ApplicationPipelineCodeBuildActionRole155C9984\\": Object {
+    \\"ApplicationPipelineCodeBuildActionRole98AD1444\\": Object {
       \\"Properties\\": Object {
         \\"AssumeRolePolicyDocument\\": Object {
           \\"Statement\\": Array [
@@ -7457,7 +6918,7 @@ Object {
       },
       \\"Type\\": \\"AWS::IAM::Role\\",
     },
-    \\"ApplicationPipelineCodeBuildActionRoleDefaultPolicyC8190973\\": Object {
+    \\"ApplicationPipelineCodeBuildActionRoleDefaultPolicyFE7AFEF3\\": Object {
       \\"Properties\\": Object {
         \\"PolicyDocument\\": Object {
           \\"Statement\\": Array [
@@ -7470,7 +6931,7 @@ Object {
               \\"Effect\\": \\"Allow\\",
               \\"Resource\\": Object {
                 \\"Fn::GetAtt\\": Array [
-                  \\"CodePipelineBuildSynthCdkBuildProjectEDF0E7B6\\",
+                  \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A\\",
                   \\"Arn\\",
                 ],
               },
@@ -7484,7 +6945,7 @@ Object {
               \\"Effect\\": \\"Allow\\",
               \\"Resource\\": Object {
                 \\"Fn::GetAtt\\": Array [
-                  \\"ApplicationPipelineUpdatePipelineSelfMutation36D37AA8\\",
+                  \\"ApplicationPipelineUpdatePipelineSelfMutation66D95DA8\\",
                   \\"Arn\\",
                 ],
               },
@@ -7492,16 +6953,162 @@ Object {
           ],
           \\"Version\\": \\"2012-10-17\\",
         },
-        \\"PolicyName\\": \\"ApplicationPipelineCodeBuildActionRoleDefaultPolicyC8190973\\",
+        \\"PolicyName\\": \\"ApplicationPipelineCodeBuildActionRoleDefaultPolicyFE7AFEF3\\",
         \\"Roles\\": Array [
           Object {
-            \\"Ref\\": \\"ApplicationPipelineCodeBuildActionRole155C9984\\",
+            \\"Ref\\": \\"ApplicationPipelineCodeBuildActionRole98AD1444\\",
           },
         ],
       },
       \\"Type\\": \\"AWS::IAM::Policy\\",
     },
-    \\"ApplicationPipelineUpdatePipelineSelfMutation36D37AA8\\": Object {
+    \\"ApplicationPipelineCodePipeline92ED701F\\": Object {
+      \\"DependsOn\\": Array [
+        \\"ApplicationPipelineCodePipelineRoleDefaultPolicy02E04067\\",
+        \\"ApplicationPipelineCodePipelineRole53E5791D\\",
+      ],
+      \\"Properties\\": Object {
+        \\"ArtifactStore\\": Object {
+          \\"EncryptionKey\\": Object {
+            \\"Id\\": Object {
+              \\"Fn::GetAtt\\": Array [
+                \\"ApplicationPipelineArtifactKey284E3A3C\\",
+                \\"Arn\\",
+              ],
+            },
+            \\"Type\\": \\"KMS\\",
+          },
+          \\"Location\\": Object {
+            \\"Ref\\": \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+          },
+          \\"Type\\": \\"S3\\",
+        },
+        \\"RestartExecutionOnUpdate\\": true,
+        \\"RoleArn\\": Object {
+          \\"Fn::GetAtt\\": Array [
+            \\"ApplicationPipelineCodePipelineRole53E5791D\\",
+            \\"Arn\\",
+          ],
+        },
+        \\"Stages\\": Array [
+          Object {
+            \\"Actions\\": Array [
+              Object {
+                \\"ActionTypeId\\": Object {
+                  \\"Category\\": \\"Source\\",
+                  \\"Owner\\": \\"AWS\\",
+                  \\"Provider\\": \\"CodeCommit\\",
+                  \\"Version\\": \\"1\\",
+                },
+                \\"Configuration\\": Object {
+                  \\"BranchName\\": \\"mainline\\",
+                  \\"PollForSourceChanges\\": false,
+                  \\"RepositoryName\\": Object {
+                    \\"Fn::GetAtt\\": Array [
+                      \\"ApplicationPipelineCodeRepositoryA734F3FA\\",
+                      \\"Name\\",
+                    ],
+                  },
+                },
+                \\"Name\\": Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineCodeRepositoryA734F3FA\\",
+                    \\"Name\\",
+                  ],
+                },
+                \\"OutputArtifacts\\": Array [
+                  Object {
+                    \\"Name\\": \\"c8dccfc7b4b06e6314cb1dc9e5680d002e559b8933_Source\\",
+                  },
+                ],
+                \\"RoleArn\\": Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRole0900531A\\",
+                    \\"Arn\\",
+                  ],
+                },
+                \\"RunOrder\\": 1,
+              },
+            ],
+            \\"Name\\": \\"Source\\",
+          },
+          Object {
+            \\"Actions\\": Array [
+              Object {
+                \\"ActionTypeId\\": Object {
+                  \\"Category\\": \\"Build\\",
+                  \\"Owner\\": \\"AWS\\",
+                  \\"Provider\\": \\"CodeBuild\\",
+                  \\"Version\\": \\"1\\",
+                },
+                \\"Configuration\\": Object {
+                  \\"EnvironmentVariables\\": \\"[{\\\\\\\\\\"name\\\\\\\\\\":\\\\\\\\\\"_PROJECT_CONFIG_HASH\\\\\\\\\\",\\\\\\\\\\"type\\\\\\\\\\":\\\\\\\\\\"PLAINTEXT\\\\\\\\\\",\\\\\\\\\\"value\\\\\\\\\\":\\\\\\\\\\"13fb1f6f3f0a665500d00a30e46cf5c67342362be94a9d79d179c2ea7436a504\\\\\\\\\\"}]\\",
+                  \\"ProjectName\\": Object {
+                    \\"Ref\\": \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A\\",
+                  },
+                },
+                \\"InputArtifacts\\": Array [
+                  Object {
+                    \\"Name\\": \\"c8dccfc7b4b06e6314cb1dc9e5680d002e559b8933_Source\\",
+                  },
+                ],
+                \\"Name\\": \\"Synth\\",
+                \\"OutputArtifacts\\": Array [
+                  Object {
+                    \\"Name\\": \\"Synth_Output\\",
+                  },
+                  Object {
+                    \\"Name\\": \\"Synth__\\",
+                  },
+                ],
+                \\"RoleArn\\": Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineCodeBuildActionRole98AD1444\\",
+                    \\"Arn\\",
+                  ],
+                },
+                \\"RunOrder\\": 1,
+              },
+            ],
+            \\"Name\\": \\"Build\\",
+          },
+          Object {
+            \\"Actions\\": Array [
+              Object {
+                \\"ActionTypeId\\": Object {
+                  \\"Category\\": \\"Build\\",
+                  \\"Owner\\": \\"AWS\\",
+                  \\"Provider\\": \\"CodeBuild\\",
+                  \\"Version\\": \\"1\\",
+                },
+                \\"Configuration\\": Object {
+                  \\"EnvironmentVariables\\": \\"[{\\\\\\\\\\"name\\\\\\\\\\":\\\\\\\\\\"_PROJECT_CONFIG_HASH\\\\\\\\\\",\\\\\\\\\\"type\\\\\\\\\\":\\\\\\\\\\"PLAINTEXT\\\\\\\\\\",\\\\\\\\\\"value\\\\\\\\\\":\\\\\\\\\\"2e13b99bcda0cb81fc6053cd8a65f303945d49fe774f18ad2c20d178423d9be6\\\\\\\\\\"}]\\",
+                  \\"ProjectName\\": Object {
+                    \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation66D95DA8\\",
+                  },
+                },
+                \\"InputArtifacts\\": Array [
+                  Object {
+                    \\"Name\\": \\"Synth_Output\\",
+                  },
+                ],
+                \\"Name\\": \\"SelfMutate\\",
+                \\"RoleArn\\": Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineCodeBuildActionRole98AD1444\\",
+                    \\"Arn\\",
+                  ],
+                },
+                \\"RunOrder\\": 1,
+              },
+            ],
+            \\"Name\\": \\"UpdatePipeline\\",
+          },
+        ],
+      },
+      \\"Type\\": \\"AWS::CodePipeline::Pipeline\\",
+    },
+    \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A\\": Object {
       \\"Properties\\": Object {
         \\"Artifacts\\": Object {
           \\"Type\\": \\"CODEPIPELINE\\",
@@ -7509,10 +7116,10 @@ Object {
         \\"Cache\\": Object {
           \\"Type\\": \\"NO_CACHE\\",
         },
-        \\"Description\\": \\"Pipeline step pipeline-test/CodePipeline/UpdatePipeline/SelfMutate\\",
+        \\"Description\\": \\"Pipeline step pipeline-test/CodePipeline/Build/Synth\\",
         \\"EncryptionKey\\": Object {
           \\"Fn::GetAtt\\": Array [
-            \\"ArtifactKey8D84C5F0\\",
+            \\"ApplicationPipelineArtifactKey284E3A3C\\",
             \\"Arn\\",
           ],
         },
@@ -7525,7 +7132,7 @@ Object {
         },
         \\"ServiceRole\\": Object {
           \\"Fn::GetAtt\\": Array [
-            \\"ApplicationPipelineUpdatePipelineSelfMutationRole59A20D82\\",
+            \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectRole75D1C6E6\\",
             \\"Arn\\",
           ],
         },
@@ -7535,13 +7142,26 @@ Object {
   \\\\\\\\\\"phases\\\\\\\\\\": {
     \\\\\\\\\\"install\\\\\\\\\\": {
       \\\\\\\\\\"commands\\\\\\\\\\": [
-        \\\\\\\\\\"npm install -g aws-cdk@2\\\\\\\\\\"
+        \\\\\\\\\\"npm install -g aws-cdk\\\\\\\\\\",
+        \\\\\\\\\\"yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile\\\\\\\\\\"
       ]
     },
     \\\\\\\\\\"build\\\\\\\\\\": {
       \\\\\\\\\\"commands\\\\\\\\\\": [
-        \\\\\\\\\\"cdk -a . deploy pipeline-test --require-approval=never --verbose\\\\\\\\\\"
+        \\\\\\\\\\"npx nx run-many --target=build --all\\\\\\\\\\"
       ]
+    }
+  },
+  \\\\\\\\\\"artifacts\\\\\\\\\\": {
+    \\\\\\\\\\"secondary-artifacts\\\\\\\\\\": {
+      \\\\\\\\\\"Synth_Output\\\\\\\\\\": {
+        \\\\\\\\\\"base-directory\\\\\\\\\\": \\\\\\\\\\"packages/infra/cdk.out\\\\\\\\\\",
+        \\\\\\\\\\"files\\\\\\\\\\": \\\\\\\\\\"**/*\\\\\\\\\\"
+      },
+      \\\\\\\\\\"Synth__\\\\\\\\\\": {
+        \\\\\\\\\\"base-directory\\\\\\\\\\": \\\\\\\\\\".\\\\\\\\\\",
+        \\\\\\\\\\"files\\\\\\\\\\": \\\\\\\\\\"**/*\\\\\\\\\\"
+      }
     }
   }
 }\\",
@@ -7550,7 +7170,7 @@ Object {
       },
       \\"Type\\": \\"AWS::CodeBuild::Project\\",
     },
-    \\"ApplicationPipelineUpdatePipelineSelfMutationRole59A20D82\\": Object {
+    \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectRole75D1C6E6\\": Object {
       \\"Properties\\": Object {
         \\"AssumeRolePolicyDocument\\": Object {
           \\"Statement\\": Array [
@@ -7567,191 +7187,7 @@ Object {
       },
       \\"Type\\": \\"AWS::IAM::Role\\",
     },
-    \\"ApplicationPipelineUpdatePipelineSelfMutationRoleDefaultPolicy88A56583\\": Object {
-      \\"Metadata\\": Object {
-        \\"cdk_nag\\": Object {
-          \\"rules_to_suppress\\": Array [
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<ApplicationPipelineUpdatePipelineSelfMutation.*>-\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to create report groups that are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:\\\\\\\\\\\\\\\\*:iam::<AWS::AccountId>:role/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to assume a role from within the current account in order to deploy.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to list all buckets and stacks.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": Object {
-                    \\"Fn::Join\\": Array [
-                      \\"\\",
-                      Array [
-                        \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|\\",
-                        Object {
-                          \\"Ref\\": \\"AWS::AccountId\\",
-                        },
-                        \\"):log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\\\\\\\\\\\\\*$/g\\",
-                      ],
-                    ],
-                  },
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<ApplicationPipelineUpdatePipelineSelfMutation.*>-\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to create report groups that are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:\\\\\\\\\\\\\\\\*:iam::<AWS::AccountId>:role/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to assume a role from within the current account in order to deploy.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to list all buckets and stacks.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": Object {
-                    \\"Fn::Join\\": Array [
-                      \\"\\",
-                      Array [
-                        \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|\\",
-                        Object {
-                          \\"Ref\\": \\"AWS::AccountId\\",
-                        },
-                        \\"):log-group:/aws/codebuild/<ApplicationPipelineUpdatePipelineSelfMutation.*>:\\\\\\\\\\\\\\\\*$/g\\",
-                      ],
-                    ],
-                  },
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-          ],
-        },
-      },
+    \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicy4B9195CC\\": Object {
       \\"Properties\\": Object {
         \\"PolicyDocument\\": Object {
           \\"Statement\\": Array [
@@ -7781,7 +7217,7 @@ Object {
                       },
                       \\":log-group:/aws/codebuild/\\",
                       Object {
-                        \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation36D37AA8\\",
+                        \\"Ref\\": \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A\\",
                       },
                     ],
                   ],
@@ -7804,7 +7240,7 @@ Object {
                       },
                       \\":log-group:/aws/codebuild/\\",
                       Object {
-                        \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation36D37AA8\\",
+                        \\"Ref\\": \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A\\",
                       },
                       \\":*\\",
                     ],
@@ -7839,7 +7275,604 @@ Object {
                     },
                     \\":report-group/\\",
                     Object {
-                      \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation36D37AA8\\",
+                      \\"Ref\\": \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A\\",
+                    },
+                    \\"-*\\",
+                  ],
+                ],
+              },
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"s3:GetObject*\\",
+                \\"s3:GetBucket*\\",
+                \\"s3:List*\\",
+                \\"s3:DeleteObject*\\",
+                \\"s3:PutObject\\",
+                \\"s3:PutObjectLegalHold\\",
+                \\"s3:PutObjectRetention\\",
+                \\"s3:PutObjectTagging\\",
+                \\"s3:PutObjectVersionTagging\\",
+                \\"s3:Abort*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Array [
+                Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                    \\"Arn\\",
+                  ],
+                },
+                Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      Object {
+                        \\"Fn::GetAtt\\": Array [
+                          \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                          \\"Arn\\",
+                        ],
+                      },
+                      \\"/*\\",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"kms:Decrypt\\",
+                \\"kms:DescribeKey\\",
+                \\"kms:Encrypt\\",
+                \\"kms:ReEncrypt*\\",
+                \\"kms:GenerateDataKey*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::GetAtt\\": Array [
+                  \\"ApplicationPipelineArtifactKey284E3A3C\\",
+                  \\"Arn\\",
+                ],
+              },
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"kms:Decrypt\\",
+                \\"kms:Encrypt\\",
+                \\"kms:ReEncrypt*\\",
+                \\"kms:GenerateDataKey*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::GetAtt\\": Array [
+                  \\"ApplicationPipelineArtifactKey284E3A3C\\",
+                  \\"Arn\\",
+                ],
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+        \\"PolicyName\\": \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicy4B9195CC\\",
+        \\"Roles\\": Array [
+          Object {
+            \\"Ref\\": \\"ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectRole75D1C6E6\\",
+          },
+        ],
+      },
+      \\"Type\\": \\"AWS::IAM::Policy\\",
+    },
+    \\"ApplicationPipelineCodePipelineEventsRoleCF718FC7\\": Object {
+      \\"Properties\\": Object {
+        \\"AssumeRolePolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": \\"sts:AssumeRole\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Principal\\": Object {
+                \\"Service\\": \\"events.amazonaws.com\\",
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+      },
+      \\"Type\\": \\"AWS::IAM::Role\\",
+    },
+    \\"ApplicationPipelineCodePipelineEventsRoleDefaultPolicy4A96451E\\": Object {
+      \\"Properties\\": Object {
+        \\"PolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": \\"codepipeline:StartPipelineExecution\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::Join\\": Array [
+                  \\"\\",
+                  Array [
+                    \\"arn:\\",
+                    Object {
+                      \\"Ref\\": \\"AWS::Partition\\",
+                    },
+                    \\":codepipeline:\\",
+                    Object {
+                      \\"Ref\\": \\"AWS::Region\\",
+                    },
+                    \\":\\",
+                    Object {
+                      \\"Ref\\": \\"AWS::AccountId\\",
+                    },
+                    \\":\\",
+                    Object {
+                      \\"Ref\\": \\"ApplicationPipelineCodePipeline92ED701F\\",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+        \\"PolicyName\\": \\"ApplicationPipelineCodePipelineEventsRoleDefaultPolicy4A96451E\\",
+        \\"Roles\\": Array [
+          Object {
+            \\"Ref\\": \\"ApplicationPipelineCodePipelineEventsRoleCF718FC7\\",
+          },
+        ],
+      },
+      \\"Type\\": \\"AWS::IAM::Policy\\",
+    },
+    \\"ApplicationPipelineCodePipelineRole53E5791D\\": Object {
+      \\"Properties\\": Object {
+        \\"AssumeRolePolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": \\"sts:AssumeRole\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Principal\\": Object {
+                \\"Service\\": \\"codepipeline.amazonaws.com\\",
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+      },
+      \\"Type\\": \\"AWS::IAM::Role\\",
+    },
+    \\"ApplicationPipelineCodePipelineRoleDefaultPolicy02E04067\\": Object {
+      \\"Properties\\": Object {
+        \\"PolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": Array [
+                \\"s3:GetObject*\\",
+                \\"s3:GetBucket*\\",
+                \\"s3:List*\\",
+                \\"s3:DeleteObject*\\",
+                \\"s3:PutObject\\",
+                \\"s3:PutObjectLegalHold\\",
+                \\"s3:PutObjectRetention\\",
+                \\"s3:PutObjectTagging\\",
+                \\"s3:PutObjectVersionTagging\\",
+                \\"s3:Abort*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Array [
+                Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                    \\"Arn\\",
+                  ],
+                },
+                Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      Object {
+                        \\"Fn::GetAtt\\": Array [
+                          \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                          \\"Arn\\",
+                        ],
+                      },
+                      \\"/*\\",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"kms:Decrypt\\",
+                \\"kms:DescribeKey\\",
+                \\"kms:Encrypt\\",
+                \\"kms:ReEncrypt*\\",
+                \\"kms:GenerateDataKey*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::GetAtt\\": Array [
+                  \\"ApplicationPipelineArtifactKey284E3A3C\\",
+                  \\"Arn\\",
+                ],
+              },
+            },
+            Object {
+              \\"Action\\": \\"sts:AssumeRole\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::GetAtt\\": Array [
+                  \\"ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRole0900531A\\",
+                  \\"Arn\\",
+                ],
+              },
+            },
+            Object {
+              \\"Action\\": \\"sts:AssumeRole\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::GetAtt\\": Array [
+                  \\"ApplicationPipelineCodeBuildActionRole98AD1444\\",
+                  \\"Arn\\",
+                ],
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+        \\"PolicyName\\": \\"ApplicationPipelineCodePipelineRoleDefaultPolicy02E04067\\",
+        \\"Roles\\": Array [
+          Object {
+            \\"Ref\\": \\"ApplicationPipelineCodePipelineRole53E5791D\\",
+          },
+        ],
+      },
+      \\"Type\\": \\"AWS::IAM::Policy\\",
+    },
+    \\"ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRole0900531A\\": Object {
+      \\"Properties\\": Object {
+        \\"AssumeRolePolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": \\"sts:AssumeRole\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Principal\\": Object {
+                \\"AWS\\": Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      \\"arn:\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::Partition\\",
+                      },
+                      \\":iam::\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::AccountId\\",
+                      },
+                      \\":root\\",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+      },
+      \\"Type\\": \\"AWS::IAM::Role\\",
+    },
+    \\"ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyE92AF83A\\": Object {
+      \\"Properties\\": Object {
+        \\"PolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": Array [
+                \\"s3:GetObject*\\",
+                \\"s3:GetBucket*\\",
+                \\"s3:List*\\",
+                \\"s3:DeleteObject*\\",
+                \\"s3:PutObject\\",
+                \\"s3:PutObjectLegalHold\\",
+                \\"s3:PutObjectRetention\\",
+                \\"s3:PutObjectTagging\\",
+                \\"s3:PutObjectVersionTagging\\",
+                \\"s3:Abort*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Array [
+                Object {
+                  \\"Fn::GetAtt\\": Array [
+                    \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                    \\"Arn\\",
+                  ],
+                },
+                Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      Object {
+                        \\"Fn::GetAtt\\": Array [
+                          \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
+                          \\"Arn\\",
+                        ],
+                      },
+                      \\"/*\\",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"kms:Decrypt\\",
+                \\"kms:DescribeKey\\",
+                \\"kms:Encrypt\\",
+                \\"kms:ReEncrypt*\\",
+                \\"kms:GenerateDataKey*\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::GetAtt\\": Array [
+                  \\"ApplicationPipelineArtifactKey284E3A3C\\",
+                  \\"Arn\\",
+                ],
+              },
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"codecommit:GetBranch\\",
+                \\"codecommit:GetCommit\\",
+                \\"codecommit:UploadArchive\\",
+                \\"codecommit:GetUploadArchiveStatus\\",
+                \\"codecommit:CancelUploadArchive\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::GetAtt\\": Array [
+                  \\"ApplicationPipelineCodeRepositoryA734F3FA\\",
+                  \\"Arn\\",
+                ],
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+        \\"PolicyName\\": \\"ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyE92AF83A\\",
+        \\"Roles\\": Array [
+          Object {
+            \\"Ref\\": \\"ApplicationPipelineCodePipelineSourceCodeCommitCodePipelineActionRole0900531A\\",
+          },
+        ],
+      },
+      \\"Type\\": \\"AWS::IAM::Policy\\",
+    },
+    \\"ApplicationPipelineCodeRepositoryA734F3FA\\": Object {
+      \\"DeletionPolicy\\": \\"Retain\\",
+      \\"Properties\\": Object {
+        \\"RepositoryName\\": \\"monorepo\\",
+      },
+      \\"Type\\": \\"AWS::CodeCommit::Repository\\",
+      \\"UpdateReplacePolicy\\": \\"Retain\\",
+    },
+    \\"ApplicationPipelineCodeRepositorypipelinetestApplicationPipelineCodePipeline31AB4045mainlineEventRule30640423\\": Object {
+      \\"Properties\\": Object {
+        \\"EventPattern\\": Object {
+          \\"detail\\": Object {
+            \\"event\\": Array [
+              \\"referenceCreated\\",
+              \\"referenceUpdated\\",
+            ],
+            \\"referenceName\\": Array [
+              \\"mainline\\",
+            ],
+          },
+          \\"detail-type\\": Array [
+            \\"CodeCommit Repository State Change\\",
+          ],
+          \\"resources\\": Array [
+            Object {
+              \\"Fn::GetAtt\\": Array [
+                \\"ApplicationPipelineCodeRepositoryA734F3FA\\",
+                \\"Arn\\",
+              ],
+            },
+          ],
+          \\"source\\": Array [
+            \\"aws.codecommit\\",
+          ],
+        },
+        \\"State\\": \\"ENABLED\\",
+        \\"Targets\\": Array [
+          Object {
+            \\"Arn\\": Object {
+              \\"Fn::Join\\": Array [
+                \\"\\",
+                Array [
+                  \\"arn:\\",
+                  Object {
+                    \\"Ref\\": \\"AWS::Partition\\",
+                  },
+                  \\":codepipeline:\\",
+                  Object {
+                    \\"Ref\\": \\"AWS::Region\\",
+                  },
+                  \\":\\",
+                  Object {
+                    \\"Ref\\": \\"AWS::AccountId\\",
+                  },
+                  \\":\\",
+                  Object {
+                    \\"Ref\\": \\"ApplicationPipelineCodePipeline92ED701F\\",
+                  },
+                ],
+              ],
+            },
+            \\"Id\\": \\"Target0\\",
+            \\"RoleArn\\": Object {
+              \\"Fn::GetAtt\\": Array [
+                \\"ApplicationPipelineCodePipelineEventsRoleCF718FC7\\",
+                \\"Arn\\",
+              ],
+            },
+          },
+        ],
+      },
+      \\"Type\\": \\"AWS::Events::Rule\\",
+    },
+    \\"ApplicationPipelineUpdatePipelineSelfMutation66D95DA8\\": Object {
+      \\"Properties\\": Object {
+        \\"Artifacts\\": Object {
+          \\"Type\\": \\"CODEPIPELINE\\",
+        },
+        \\"Cache\\": Object {
+          \\"Type\\": \\"NO_CACHE\\",
+        },
+        \\"Description\\": \\"Pipeline step pipeline-test/CodePipeline/UpdatePipeline/SelfMutate\\",
+        \\"EncryptionKey\\": Object {
+          \\"Fn::GetAtt\\": Array [
+            \\"ApplicationPipelineArtifactKey284E3A3C\\",
+            \\"Arn\\",
+          ],
+        },
+        \\"Environment\\": Object {
+          \\"ComputeType\\": \\"BUILD_GENERAL1_SMALL\\",
+          \\"Image\\": \\"aws/codebuild/standard:6.0\\",
+          \\"ImagePullCredentialsType\\": \\"CODEBUILD\\",
+          \\"PrivilegedMode\\": false,
+          \\"Type\\": \\"LINUX_CONTAINER\\",
+        },
+        \\"ServiceRole\\": Object {
+          \\"Fn::GetAtt\\": Array [
+            \\"ApplicationPipelineUpdatePipelineSelfMutationRoleD476D3E4\\",
+            \\"Arn\\",
+          ],
+        },
+        \\"Source\\": Object {
+          \\"BuildSpec\\": \\"{
+  \\\\\\\\\\"version\\\\\\\\\\": \\\\\\\\\\"0.2\\\\\\\\\\",
+  \\\\\\\\\\"phases\\\\\\\\\\": {
+    \\\\\\\\\\"install\\\\\\\\\\": {
+      \\\\\\\\\\"commands\\\\\\\\\\": [
+        \\\\\\\\\\"npm install -g aws-cdk@2\\\\\\\\\\"
+      ]
+    },
+    \\\\\\\\\\"build\\\\\\\\\\": {
+      \\\\\\\\\\"commands\\\\\\\\\\": [
+        \\\\\\\\\\"cdk -a . deploy pipeline-test --require-approval=never --verbose\\\\\\\\\\"
+      ]
+    }
+  }
+}\\",
+          \\"Type\\": \\"CODEPIPELINE\\",
+        },
+      },
+      \\"Type\\": \\"AWS::CodeBuild::Project\\",
+    },
+    \\"ApplicationPipelineUpdatePipelineSelfMutationRoleD476D3E4\\": Object {
+      \\"Properties\\": Object {
+        \\"AssumeRolePolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": \\"sts:AssumeRole\\",
+              \\"Effect\\": \\"Allow\\",
+              \\"Principal\\": Object {
+                \\"Service\\": \\"codebuild.amazonaws.com\\",
+              },
+            },
+          ],
+          \\"Version\\": \\"2012-10-17\\",
+        },
+      },
+      \\"Type\\": \\"AWS::IAM::Role\\",
+    },
+    \\"ApplicationPipelineUpdatePipelineSelfMutationRoleDefaultPolicyE74ACD15\\": Object {
+      \\"Properties\\": Object {
+        \\"PolicyDocument\\": Object {
+          \\"Statement\\": Array [
+            Object {
+              \\"Action\\": Array [
+                \\"logs:CreateLogGroup\\",
+                \\"logs:CreateLogStream\\",
+                \\"logs:PutLogEvents\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Array [
+                Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      \\"arn:\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::Partition\\",
+                      },
+                      \\":logs:\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::Region\\",
+                      },
+                      \\":\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::AccountId\\",
+                      },
+                      \\":log-group:/aws/codebuild/\\",
+                      Object {
+                        \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation66D95DA8\\",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  \\"Fn::Join\\": Array [
+                    \\"\\",
+                    Array [
+                      \\"arn:\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::Partition\\",
+                      },
+                      \\":logs:\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::Region\\",
+                      },
+                      \\":\\",
+                      Object {
+                        \\"Ref\\": \\"AWS::AccountId\\",
+                      },
+                      \\":log-group:/aws/codebuild/\\",
+                      Object {
+                        \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation66D95DA8\\",
+                      },
+                      \\":*\\",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              \\"Action\\": Array [
+                \\"codebuild:CreateReportGroup\\",
+                \\"codebuild:CreateReport\\",
+                \\"codebuild:UpdateReport\\",
+                \\"codebuild:BatchPutTestCases\\",
+                \\"codebuild:BatchPutCodeCoverages\\",
+              ],
+              \\"Effect\\": \\"Allow\\",
+              \\"Resource\\": Object {
+                \\"Fn::Join\\": Array [
+                  \\"\\",
+                  Array [
+                    \\"arn:\\",
+                    Object {
+                      \\"Ref\\": \\"AWS::Partition\\",
+                    },
+                    \\":codebuild:\\",
+                    Object {
+                      \\"Ref\\": \\"AWS::Region\\",
+                    },
+                    \\":\\",
+                    Object {
+                      \\"Ref\\": \\"AWS::AccountId\\",
+                    },
+                    \\":report-group/\\",
+                    Object {
+                      \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation66D95DA8\\",
                     },
                     \\"-*\\",
                   ],
@@ -7891,7 +7924,7 @@ Object {
               \\"Resource\\": Array [
                 Object {
                   \\"Fn::GetAtt\\": Array [
-                    \\"ArtifactsBucket2AAC5544\\",
+                    \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
                     \\"Arn\\",
                   ],
                 },
@@ -7901,7 +7934,7 @@ Object {
                     Array [
                       Object {
                         \\"Fn::GetAtt\\": Array [
-                          \\"ArtifactsBucket2AAC5544\\",
+                          \\"ApplicationPipelineArtifactsBucketD6B45A16\\",
                           \\"Arn\\",
                         ],
                       },
@@ -7919,7 +7952,7 @@ Object {
               \\"Effect\\": \\"Allow\\",
               \\"Resource\\": Object {
                 \\"Fn::GetAtt\\": Array [
-                  \\"ArtifactKey8D84C5F0\\",
+                  \\"ApplicationPipelineArtifactKey284E3A3C\\",
                   \\"Arn\\",
                 ],
               },
@@ -7934,7 +7967,7 @@ Object {
               \\"Effect\\": \\"Allow\\",
               \\"Resource\\": Object {
                 \\"Fn::GetAtt\\": Array [
-                  \\"ArtifactKey8D84C5F0\\",
+                  \\"ApplicationPipelineArtifactKey284E3A3C\\",
                   \\"Arn\\",
                 ],
               },
@@ -7942,1166 +7975,14 @@ Object {
           ],
           \\"Version\\": \\"2012-10-17\\",
         },
-        \\"PolicyName\\": \\"ApplicationPipelineUpdatePipelineSelfMutationRoleDefaultPolicy88A56583\\",
+        \\"PolicyName\\": \\"ApplicationPipelineUpdatePipelineSelfMutationRoleDefaultPolicyE74ACD15\\",
         \\"Roles\\": Array [
           Object {
-            \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutationRole59A20D82\\",
+            \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutationRoleD476D3E4\\",
           },
         ],
       },
       \\"Type\\": \\"AWS::IAM::Policy\\",
-    },
-    \\"ArtifactKey8D84C5F0\\": Object {
-      \\"DeletionPolicy\\": \\"Delete\\",
-      \\"Properties\\": Object {
-        \\"EnableKeyRotation\\": true,
-        \\"KeyPolicy\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": \\"kms:*\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Principal\\": Object {
-                \\"AWS\\": Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      \\"arn:\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::Partition\\",
-                      },
-                      \\":iam::\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::AccountId\\",
-                      },
-                      \\":root\\",
-                    ],
-                  ],
-                },
-              },
-              \\"Resource\\": \\"*\\",
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-      },
-      \\"Type\\": \\"AWS::KMS::Key\\",
-      \\"UpdateReplacePolicy\\": \\"Delete\\",
-    },
-    \\"ArtifactsBucket2AAC5544\\": Object {
-      \\"DeletionPolicy\\": \\"Delete\\",
-      \\"Properties\\": Object {
-        \\"BucketEncryption\\": Object {
-          \\"ServerSideEncryptionConfiguration\\": Array [
-            Object {
-              \\"ServerSideEncryptionByDefault\\": Object {
-                \\"KMSMasterKeyID\\": Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ArtifactKey8D84C5F0\\",
-                    \\"Arn\\",
-                  ],
-                },
-                \\"SSEAlgorithm\\": \\"aws:kms\\",
-              },
-            },
-          ],
-        },
-        \\"LoggingConfiguration\\": Object {
-          \\"DestinationBucketName\\": Object {
-            \\"Ref\\": \\"AccessLogsBucket83982689\\",
-          },
-          \\"LogFilePrefix\\": \\"access-logs\\",
-        },
-        \\"PublicAccessBlockConfiguration\\": Object {
-          \\"BlockPublicAcls\\": true,
-          \\"BlockPublicPolicy\\": true,
-          \\"IgnorePublicAcls\\": true,
-          \\"RestrictPublicBuckets\\": true,
-        },
-        \\"Tags\\": Array [
-          Object {
-            \\"Key\\": \\"aws-cdk:auto-delete-objects\\",
-            \\"Value\\": \\"true\\",
-          },
-        ],
-      },
-      \\"Type\\": \\"AWS::S3::Bucket\\",
-      \\"UpdateReplacePolicy\\": \\"Delete\\",
-    },
-    \\"ArtifactsBucketAutoDeleteObjectsCustomResource0E3B4320\\": Object {
-      \\"DeletionPolicy\\": \\"Delete\\",
-      \\"DependsOn\\": Array [
-        \\"ArtifactsBucketPolicy852CB646\\",
-      ],
-      \\"Properties\\": Object {
-        \\"BucketName\\": Object {
-          \\"Ref\\": \\"ArtifactsBucket2AAC5544\\",
-        },
-        \\"ServiceToken\\": Object {
-          \\"Fn::GetAtt\\": Array [
-            \\"CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F\\",
-            \\"Arn\\",
-          ],
-        },
-      },
-      \\"Type\\": \\"Custom::S3AutoDeleteObjects\\",
-      \\"UpdateReplacePolicy\\": \\"Delete\\",
-    },
-    \\"ArtifactsBucketPolicy852CB646\\": Object {
-      \\"Properties\\": Object {
-        \\"Bucket\\": Object {
-          \\"Ref\\": \\"ArtifactsBucket2AAC5544\\",
-        },
-        \\"PolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": \\"s3:*\\",
-              \\"Condition\\": Object {
-                \\"Bool\\": Object {
-                  \\"aws:SecureTransport\\": \\"false\\",
-                },
-              },
-              \\"Effect\\": \\"Deny\\",
-              \\"Principal\\": Object {
-                \\"AWS\\": \\"*\\",
-              },
-              \\"Resource\\": Array [
-                Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ArtifactsBucket2AAC5544\\",
-                    \\"Arn\\",
-                  ],
-                },
-                Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      Object {
-                        \\"Fn::GetAtt\\": Array [
-                          \\"ArtifactsBucket2AAC5544\\",
-                          \\"Arn\\",
-                        ],
-                      },
-                      \\"/*\\",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"s3:GetBucket*\\",
-                \\"s3:List*\\",
-                \\"s3:DeleteObject*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Principal\\": Object {
-                \\"AWS\\": Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092\\",
-                    \\"Arn\\",
-                  ],
-                },
-              },
-              \\"Resource\\": Array [
-                Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ArtifactsBucket2AAC5544\\",
-                    \\"Arn\\",
-                  ],
-                },
-                Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      Object {
-                        \\"Fn::GetAtt\\": Array [
-                          \\"ArtifactsBucket2AAC5544\\",
-                          \\"Arn\\",
-                        ],
-                      },
-                      \\"/*\\",
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-      },
-      \\"Type\\": \\"AWS::S3::BucketPolicy\\",
-    },
-    \\"CodePipelineB74E5936\\": Object {
-      \\"DependsOn\\": Array [
-        \\"CodePipelineRoleDefaultPolicy8D520A8D\\",
-        \\"CodePipelineRoleB3A660B4\\",
-      ],
-      \\"Properties\\": Object {
-        \\"ArtifactStore\\": Object {
-          \\"EncryptionKey\\": Object {
-            \\"Id\\": Object {
-              \\"Fn::GetAtt\\": Array [
-                \\"ArtifactKey8D84C5F0\\",
-                \\"Arn\\",
-              ],
-            },
-            \\"Type\\": \\"KMS\\",
-          },
-          \\"Location\\": Object {
-            \\"Ref\\": \\"ArtifactsBucket2AAC5544\\",
-          },
-          \\"Type\\": \\"S3\\",
-        },
-        \\"RestartExecutionOnUpdate\\": true,
-        \\"RoleArn\\": Object {
-          \\"Fn::GetAtt\\": Array [
-            \\"CodePipelineRoleB3A660B4\\",
-            \\"Arn\\",
-          ],
-        },
-        \\"Stages\\": Array [
-          Object {
-            \\"Actions\\": Array [
-              Object {
-                \\"ActionTypeId\\": Object {
-                  \\"Category\\": \\"Source\\",
-                  \\"Owner\\": \\"AWS\\",
-                  \\"Provider\\": \\"CodeCommit\\",
-                  \\"Version\\": \\"1\\",
-                },
-                \\"Configuration\\": Object {
-                  \\"BranchName\\": \\"mainline\\",
-                  \\"PollForSourceChanges\\": false,
-                  \\"RepositoryName\\": Object {
-                    \\"Fn::GetAtt\\": Array [
-                      \\"CodeRepositoryBA42F94A\\",
-                      \\"Name\\",
-                    ],
-                  },
-                },
-                \\"Name\\": Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"CodeRepositoryBA42F94A\\",
-                    \\"Name\\",
-                  ],
-                },
-                \\"OutputArtifacts\\": Array [
-                  Object {
-                    \\"Name\\": \\"c825c34765dfb5e99261fa6cab9fea074f8881c7c4_Source\\",
-                  },
-                ],
-                \\"RoleArn\\": Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70\\",
-                    \\"Arn\\",
-                  ],
-                },
-                \\"RunOrder\\": 1,
-              },
-            ],
-            \\"Name\\": \\"Source\\",
-          },
-          Object {
-            \\"Actions\\": Array [
-              Object {
-                \\"ActionTypeId\\": Object {
-                  \\"Category\\": \\"Build\\",
-                  \\"Owner\\": \\"AWS\\",
-                  \\"Provider\\": \\"CodeBuild\\",
-                  \\"Version\\": \\"1\\",
-                },
-                \\"Configuration\\": Object {
-                  \\"EnvironmentVariables\\": \\"[{\\\\\\\\\\"name\\\\\\\\\\":\\\\\\\\\\"_PROJECT_CONFIG_HASH\\\\\\\\\\",\\\\\\\\\\"type\\\\\\\\\\":\\\\\\\\\\"PLAINTEXT\\\\\\\\\\",\\\\\\\\\\"value\\\\\\\\\\":\\\\\\\\\\"13fb1f6f3f0a665500d00a30e46cf5c67342362be94a9d79d179c2ea7436a504\\\\\\\\\\"}]\\",
-                  \\"ProjectName\\": Object {
-                    \\"Ref\\": \\"CodePipelineBuildSynthCdkBuildProjectEDF0E7B6\\",
-                  },
-                },
-                \\"InputArtifacts\\": Array [
-                  Object {
-                    \\"Name\\": \\"c825c34765dfb5e99261fa6cab9fea074f8881c7c4_Source\\",
-                  },
-                ],
-                \\"Name\\": \\"Synth\\",
-                \\"OutputArtifacts\\": Array [
-                  Object {
-                    \\"Name\\": \\"Synth_Output\\",
-                  },
-                  Object {
-                    \\"Name\\": \\"Synth__\\",
-                  },
-                ],
-                \\"RoleArn\\": Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ApplicationPipelineCodeBuildActionRole155C9984\\",
-                    \\"Arn\\",
-                  ],
-                },
-                \\"RunOrder\\": 1,
-              },
-            ],
-            \\"Name\\": \\"Build\\",
-          },
-          Object {
-            \\"Actions\\": Array [
-              Object {
-                \\"ActionTypeId\\": Object {
-                  \\"Category\\": \\"Build\\",
-                  \\"Owner\\": \\"AWS\\",
-                  \\"Provider\\": \\"CodeBuild\\",
-                  \\"Version\\": \\"1\\",
-                },
-                \\"Configuration\\": Object {
-                  \\"EnvironmentVariables\\": \\"[{\\\\\\\\\\"name\\\\\\\\\\":\\\\\\\\\\"_PROJECT_CONFIG_HASH\\\\\\\\\\",\\\\\\\\\\"type\\\\\\\\\\":\\\\\\\\\\"PLAINTEXT\\\\\\\\\\",\\\\\\\\\\"value\\\\\\\\\\":\\\\\\\\\\"2e13b99bcda0cb81fc6053cd8a65f303945d49fe774f18ad2c20d178423d9be6\\\\\\\\\\"}]\\",
-                  \\"ProjectName\\": Object {
-                    \\"Ref\\": \\"ApplicationPipelineUpdatePipelineSelfMutation36D37AA8\\",
-                  },
-                },
-                \\"InputArtifacts\\": Array [
-                  Object {
-                    \\"Name\\": \\"Synth_Output\\",
-                  },
-                ],
-                \\"Name\\": \\"SelfMutate\\",
-                \\"RoleArn\\": Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ApplicationPipelineCodeBuildActionRole155C9984\\",
-                    \\"Arn\\",
-                  ],
-                },
-                \\"RunOrder\\": 1,
-              },
-            ],
-            \\"Name\\": \\"UpdatePipeline\\",
-          },
-        ],
-      },
-      \\"Type\\": \\"AWS::CodePipeline::Pipeline\\",
-    },
-    \\"CodePipelineBuildSynthCdkBuildProjectEDF0E7B6\\": Object {
-      \\"Properties\\": Object {
-        \\"Artifacts\\": Object {
-          \\"Type\\": \\"CODEPIPELINE\\",
-        },
-        \\"Cache\\": Object {
-          \\"Type\\": \\"NO_CACHE\\",
-        },
-        \\"Description\\": \\"Pipeline step pipeline-test/CodePipeline/Build/Synth\\",
-        \\"EncryptionKey\\": Object {
-          \\"Fn::GetAtt\\": Array [
-            \\"ArtifactKey8D84C5F0\\",
-            \\"Arn\\",
-          ],
-        },
-        \\"Environment\\": Object {
-          \\"ComputeType\\": \\"BUILD_GENERAL1_SMALL\\",
-          \\"Image\\": \\"aws/codebuild/standard:6.0\\",
-          \\"ImagePullCredentialsType\\": \\"CODEBUILD\\",
-          \\"PrivilegedMode\\": false,
-          \\"Type\\": \\"LINUX_CONTAINER\\",
-        },
-        \\"ServiceRole\\": Object {
-          \\"Fn::GetAtt\\": Array [
-            \\"CodePipelineBuildSynthCdkBuildProjectRoleB73287D4\\",
-            \\"Arn\\",
-          ],
-        },
-        \\"Source\\": Object {
-          \\"BuildSpec\\": \\"{
-  \\\\\\\\\\"version\\\\\\\\\\": \\\\\\\\\\"0.2\\\\\\\\\\",
-  \\\\\\\\\\"phases\\\\\\\\\\": {
-    \\\\\\\\\\"install\\\\\\\\\\": {
-      \\\\\\\\\\"commands\\\\\\\\\\": [
-        \\\\\\\\\\"npm install -g aws-cdk\\\\\\\\\\",
-        \\\\\\\\\\"yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile\\\\\\\\\\"
-      ]
-    },
-    \\\\\\\\\\"build\\\\\\\\\\": {
-      \\\\\\\\\\"commands\\\\\\\\\\": [
-        \\\\\\\\\\"npx nx run-many --target=build --all\\\\\\\\\\"
-      ]
-    }
-  },
-  \\\\\\\\\\"artifacts\\\\\\\\\\": {
-    \\\\\\\\\\"secondary-artifacts\\\\\\\\\\": {
-      \\\\\\\\\\"Synth_Output\\\\\\\\\\": {
-        \\\\\\\\\\"base-directory\\\\\\\\\\": \\\\\\\\\\"packages/infra/cdk.out\\\\\\\\\\",
-        \\\\\\\\\\"files\\\\\\\\\\": \\\\\\\\\\"**/*\\\\\\\\\\"
-      },
-      \\\\\\\\\\"Synth__\\\\\\\\\\": {
-        \\\\\\\\\\"base-directory\\\\\\\\\\": \\\\\\\\\\".\\\\\\\\\\",
-        \\\\\\\\\\"files\\\\\\\\\\": \\\\\\\\\\"**/*\\\\\\\\\\"
-      }
-    }
-  }
-}\\",
-          \\"Type\\": \\"CODEPIPELINE\\",
-        },
-      },
-      \\"Type\\": \\"AWS::CodeBuild::Project\\",
-    },
-    \\"CodePipelineBuildSynthCdkBuildProjectRoleB73287D4\\": Object {
-      \\"Properties\\": Object {
-        \\"AssumeRolePolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": \\"sts:AssumeRole\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Principal\\": Object {
-                \\"Service\\": \\"codebuild.amazonaws.com\\",
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-      },
-      \\"Type\\": \\"AWS::IAM::Role\\",
-    },
-    \\"CodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyB7EDB705\\": Object {
-      \\"Metadata\\": Object {
-        \\"cdk_nag\\": Object {
-          \\"rules_to_suppress\\": Array [
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to create report groups that are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to manage logs and streams whose names are dynamically determined.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to create report groups that are dynamically determined.\\",
-            },
-          ],
-        },
-      },
-      \\"Properties\\": Object {
-        \\"PolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": Array [
-                \\"logs:CreateLogGroup\\",
-                \\"logs:CreateLogStream\\",
-                \\"logs:PutLogEvents\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Array [
-                Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      \\"arn:\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::Partition\\",
-                      },
-                      \\":logs:\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::Region\\",
-                      },
-                      \\":\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::AccountId\\",
-                      },
-                      \\":log-group:/aws/codebuild/\\",
-                      Object {
-                        \\"Ref\\": \\"CodePipelineBuildSynthCdkBuildProjectEDF0E7B6\\",
-                      },
-                    ],
-                  ],
-                },
-                Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      \\"arn:\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::Partition\\",
-                      },
-                      \\":logs:\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::Region\\",
-                      },
-                      \\":\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::AccountId\\",
-                      },
-                      \\":log-group:/aws/codebuild/\\",
-                      Object {
-                        \\"Ref\\": \\"CodePipelineBuildSynthCdkBuildProjectEDF0E7B6\\",
-                      },
-                      \\":*\\",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"codebuild:CreateReportGroup\\",
-                \\"codebuild:CreateReport\\",
-                \\"codebuild:UpdateReport\\",
-                \\"codebuild:BatchPutTestCases\\",
-                \\"codebuild:BatchPutCodeCoverages\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::Join\\": Array [
-                  \\"\\",
-                  Array [
-                    \\"arn:\\",
-                    Object {
-                      \\"Ref\\": \\"AWS::Partition\\",
-                    },
-                    \\":codebuild:\\",
-                    Object {
-                      \\"Ref\\": \\"AWS::Region\\",
-                    },
-                    \\":\\",
-                    Object {
-                      \\"Ref\\": \\"AWS::AccountId\\",
-                    },
-                    \\":report-group/\\",
-                    Object {
-                      \\"Ref\\": \\"CodePipelineBuildSynthCdkBuildProjectEDF0E7B6\\",
-                    },
-                    \\"-*\\",
-                  ],
-                ],
-              },
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"s3:GetObject*\\",
-                \\"s3:GetBucket*\\",
-                \\"s3:List*\\",
-                \\"s3:DeleteObject*\\",
-                \\"s3:PutObject\\",
-                \\"s3:PutObjectLegalHold\\",
-                \\"s3:PutObjectRetention\\",
-                \\"s3:PutObjectTagging\\",
-                \\"s3:PutObjectVersionTagging\\",
-                \\"s3:Abort*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Array [
-                Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ArtifactsBucket2AAC5544\\",
-                    \\"Arn\\",
-                  ],
-                },
-                Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      Object {
-                        \\"Fn::GetAtt\\": Array [
-                          \\"ArtifactsBucket2AAC5544\\",
-                          \\"Arn\\",
-                        ],
-                      },
-                      \\"/*\\",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"kms:Decrypt\\",
-                \\"kms:DescribeKey\\",
-                \\"kms:Encrypt\\",
-                \\"kms:ReEncrypt*\\",
-                \\"kms:GenerateDataKey*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::GetAtt\\": Array [
-                  \\"ArtifactKey8D84C5F0\\",
-                  \\"Arn\\",
-                ],
-              },
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"kms:Decrypt\\",
-                \\"kms:Encrypt\\",
-                \\"kms:ReEncrypt*\\",
-                \\"kms:GenerateDataKey*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::GetAtt\\": Array [
-                  \\"ArtifactKey8D84C5F0\\",
-                  \\"Arn\\",
-                ],
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-        \\"PolicyName\\": \\"CodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyB7EDB705\\",
-        \\"Roles\\": Array [
-          Object {
-            \\"Ref\\": \\"CodePipelineBuildSynthCdkBuildProjectRoleB73287D4\\",
-          },
-        ],
-      },
-      \\"Type\\": \\"AWS::IAM::Policy\\",
-    },
-    \\"CodePipelineEventsRole4196480D\\": Object {
-      \\"Properties\\": Object {
-        \\"AssumeRolePolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": \\"sts:AssumeRole\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Principal\\": Object {
-                \\"Service\\": \\"events.amazonaws.com\\",
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-      },
-      \\"Type\\": \\"AWS::IAM::Role\\",
-    },
-    \\"CodePipelineEventsRoleDefaultPolicy13DBD2D2\\": Object {
-      \\"Properties\\": Object {
-        \\"PolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": \\"codepipeline:StartPipelineExecution\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::Join\\": Array [
-                  \\"\\",
-                  Array [
-                    \\"arn:\\",
-                    Object {
-                      \\"Ref\\": \\"AWS::Partition\\",
-                    },
-                    \\":codepipeline:\\",
-                    Object {
-                      \\"Ref\\": \\"AWS::Region\\",
-                    },
-                    \\":\\",
-                    Object {
-                      \\"Ref\\": \\"AWS::AccountId\\",
-                    },
-                    \\":\\",
-                    Object {
-                      \\"Ref\\": \\"CodePipelineB74E5936\\",
-                    },
-                  ],
-                ],
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-        \\"PolicyName\\": \\"CodePipelineEventsRoleDefaultPolicy13DBD2D2\\",
-        \\"Roles\\": Array [
-          Object {
-            \\"Ref\\": \\"CodePipelineEventsRole4196480D\\",
-          },
-        ],
-      },
-      \\"Type\\": \\"AWS::IAM::Policy\\",
-    },
-    \\"CodePipelineRoleB3A660B4\\": Object {
-      \\"Properties\\": Object {
-        \\"AssumeRolePolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": \\"sts:AssumeRole\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Principal\\": Object {
-                \\"Service\\": \\"codepipeline.amazonaws.com\\",
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-      },
-      \\"Type\\": \\"AWS::IAM::Role\\",
-    },
-    \\"CodePipelineRoleDefaultPolicy8D520A8D\\": Object {
-      \\"Metadata\\": Object {
-        \\"cdk_nag\\": Object {
-          \\"rules_to_suppress\\": Array [
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-          ],
-        },
-      },
-      \\"Properties\\": Object {
-        \\"PolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": Array [
-                \\"s3:GetObject*\\",
-                \\"s3:GetBucket*\\",
-                \\"s3:List*\\",
-                \\"s3:DeleteObject*\\",
-                \\"s3:PutObject\\",
-                \\"s3:PutObjectLegalHold\\",
-                \\"s3:PutObjectRetention\\",
-                \\"s3:PutObjectTagging\\",
-                \\"s3:PutObjectVersionTagging\\",
-                \\"s3:Abort*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Array [
-                Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ArtifactsBucket2AAC5544\\",
-                    \\"Arn\\",
-                  ],
-                },
-                Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      Object {
-                        \\"Fn::GetAtt\\": Array [
-                          \\"ArtifactsBucket2AAC5544\\",
-                          \\"Arn\\",
-                        ],
-                      },
-                      \\"/*\\",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"kms:Decrypt\\",
-                \\"kms:DescribeKey\\",
-                \\"kms:Encrypt\\",
-                \\"kms:ReEncrypt*\\",
-                \\"kms:GenerateDataKey*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::GetAtt\\": Array [
-                  \\"ArtifactKey8D84C5F0\\",
-                  \\"Arn\\",
-                ],
-              },
-            },
-            Object {
-              \\"Action\\": \\"sts:AssumeRole\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::GetAtt\\": Array [
-                  \\"CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70\\",
-                  \\"Arn\\",
-                ],
-              },
-            },
-            Object {
-              \\"Action\\": \\"sts:AssumeRole\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::GetAtt\\": Array [
-                  \\"ApplicationPipelineCodeBuildActionRole155C9984\\",
-                  \\"Arn\\",
-                ],
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-        \\"PolicyName\\": \\"CodePipelineRoleDefaultPolicy8D520A8D\\",
-        \\"Roles\\": Array [
-          Object {
-            \\"Ref\\": \\"CodePipelineRoleB3A660B4\\",
-          },
-        ],
-      },
-      \\"Type\\": \\"AWS::IAM::Policy\\",
-    },
-    \\"CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70\\": Object {
-      \\"Properties\\": Object {
-        \\"AssumeRolePolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": \\"sts:AssumeRole\\",
-              \\"Effect\\": \\"Allow\\",
-              \\"Principal\\": Object {
-                \\"AWS\\": Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      \\"arn:\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::Partition\\",
-                      },
-                      \\":iam::\\",
-                      Object {
-                        \\"Ref\\": \\"AWS::AccountId\\",
-                      },
-                      \\":root\\",
-                    ],
-                  ],
-                },
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-      },
-      \\"Type\\": \\"AWS::IAM::Role\\",
-    },
-    \\"CodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyAFBD34E4\\": Object {
-      \\"Metadata\\": Object {
-        \\"cdk_nag\\": Object {
-          \\"rules_to_suppress\\": Array [
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsSolutions-IAM5\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Action::s3:.*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"Actions contain wildcards which are valid for CodePipeline as all of these operations are required.\\",
-            },
-            Object {
-              \\"applies_to\\": Array [
-                Object {
-                  \\"regex\\": \\"/^Resource::<ArtifactsBucket.*.Arn>/\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:ReEncrypt\\\\\\\\\\\\\\\\*$/g\\",
-                },
-                Object {
-                  \\"regex\\": \\"/^Action::kms:GenerateDataKey\\\\\\\\\\\\\\\\*$/g\\",
-                },
-              ],
-              \\"id\\": \\"AwsPrototyping-IAMNoWildcardPermissions\\",
-              \\"reason\\": \\"CodePipeline requires access to any and all artifacts in the ArtifactsBucket.\\",
-            },
-          ],
-        },
-      },
-      \\"Properties\\": Object {
-        \\"PolicyDocument\\": Object {
-          \\"Statement\\": Array [
-            Object {
-              \\"Action\\": Array [
-                \\"s3:GetObject*\\",
-                \\"s3:GetBucket*\\",
-                \\"s3:List*\\",
-                \\"s3:DeleteObject*\\",
-                \\"s3:PutObject\\",
-                \\"s3:PutObjectLegalHold\\",
-                \\"s3:PutObjectRetention\\",
-                \\"s3:PutObjectTagging\\",
-                \\"s3:PutObjectVersionTagging\\",
-                \\"s3:Abort*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Array [
-                Object {
-                  \\"Fn::GetAtt\\": Array [
-                    \\"ArtifactsBucket2AAC5544\\",
-                    \\"Arn\\",
-                  ],
-                },
-                Object {
-                  \\"Fn::Join\\": Array [
-                    \\"\\",
-                    Array [
-                      Object {
-                        \\"Fn::GetAtt\\": Array [
-                          \\"ArtifactsBucket2AAC5544\\",
-                          \\"Arn\\",
-                        ],
-                      },
-                      \\"/*\\",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"kms:Decrypt\\",
-                \\"kms:DescribeKey\\",
-                \\"kms:Encrypt\\",
-                \\"kms:ReEncrypt*\\",
-                \\"kms:GenerateDataKey*\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::GetAtt\\": Array [
-                  \\"ArtifactKey8D84C5F0\\",
-                  \\"Arn\\",
-                ],
-              },
-            },
-            Object {
-              \\"Action\\": Array [
-                \\"codecommit:GetBranch\\",
-                \\"codecommit:GetCommit\\",
-                \\"codecommit:UploadArchive\\",
-                \\"codecommit:GetUploadArchiveStatus\\",
-                \\"codecommit:CancelUploadArchive\\",
-              ],
-              \\"Effect\\": \\"Allow\\",
-              \\"Resource\\": Object {
-                \\"Fn::GetAtt\\": Array [
-                  \\"CodeRepositoryBA42F94A\\",
-                  \\"Arn\\",
-                ],
-              },
-            },
-          ],
-          \\"Version\\": \\"2012-10-17\\",
-        },
-        \\"PolicyName\\": \\"CodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyAFBD34E4\\",
-        \\"Roles\\": Array [
-          Object {
-            \\"Ref\\": \\"CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70\\",
-          },
-        ],
-      },
-      \\"Type\\": \\"AWS::IAM::Policy\\",
-    },
-    \\"CodeRepositoryBA42F94A\\": Object {
-      \\"DeletionPolicy\\": \\"Retain\\",
-      \\"Properties\\": Object {
-        \\"RepositoryName\\": \\"monorepo\\",
-      },
-      \\"Type\\": \\"AWS::CodeCommit::Repository\\",
-      \\"UpdateReplacePolicy\\": \\"Retain\\",
-    },
-    \\"CodeRepositorypipelinetestCodePipelineC82F8C25mainlineEventRule152901D1\\": Object {
-      \\"Properties\\": Object {
-        \\"EventPattern\\": Object {
-          \\"detail\\": Object {
-            \\"event\\": Array [
-              \\"referenceCreated\\",
-              \\"referenceUpdated\\",
-            ],
-            \\"referenceName\\": Array [
-              \\"mainline\\",
-            ],
-          },
-          \\"detail-type\\": Array [
-            \\"CodeCommit Repository State Change\\",
-          ],
-          \\"resources\\": Array [
-            Object {
-              \\"Fn::GetAtt\\": Array [
-                \\"CodeRepositoryBA42F94A\\",
-                \\"Arn\\",
-              ],
-            },
-          ],
-          \\"source\\": Array [
-            \\"aws.codecommit\\",
-          ],
-        },
-        \\"State\\": \\"ENABLED\\",
-        \\"Targets\\": Array [
-          Object {
-            \\"Arn\\": Object {
-              \\"Fn::Join\\": Array [
-                \\"\\",
-                Array [
-                  \\"arn:\\",
-                  Object {
-                    \\"Ref\\": \\"AWS::Partition\\",
-                  },
-                  \\":codepipeline:\\",
-                  Object {
-                    \\"Ref\\": \\"AWS::Region\\",
-                  },
-                  \\":\\",
-                  Object {
-                    \\"Ref\\": \\"AWS::AccountId\\",
-                  },
-                  \\":\\",
-                  Object {
-                    \\"Ref\\": \\"CodePipelineB74E5936\\",
-                  },
-                ],
-              ],
-            },
-            \\"Id\\": \\"Target0\\",
-            \\"RoleArn\\": Object {
-              \\"Fn::GetAtt\\": Array [
-                \\"CodePipelineEventsRole4196480D\\",
-                \\"Arn\\",
-              ],
-            },
-          },
-        ],
-      },
-      \\"Type\\": \\"AWS::Events::Rule\\",
     },
     \\"CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F\\": Object {
       \\"DependsOn\\": Array [
@@ -9120,7 +8001,7 @@ Object {
             Array [
               \\"Lambda function for auto-deleting objects in \\",
               Object {
-                \\"Ref\\": \\"AccessLogsBucket83982689\\",
+                \\"Ref\\": \\"ApplicationPipelineAccessLogsBucketAFC4E2E4\\",
               },
               \\" S3 bucket.\\",
             ],

--- a/packages/pipeline/test/__snapshots__/pdk-pipeline.test.ts.snap
+++ b/packages/pipeline/test/__snapshots__/pdk-pipeline.test.ts.snap
@@ -2,30 +2,8 @@
 
 exports[`PDK Pipeline Unit Tests CrossAccount - using AwsPrototyping NagPack 1`] = `
 Object {
-  "Metadata": Object {
-    "cdk_nag": Object {
-      "rules_to_suppress": Array [
-        Object {
-          "id": "AwsSolutions-CB4",
-          "reason": "Encryption of Codebuild is not required.",
-        },
-        Object {
-          "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
-          "reason": "Encryption of Codebuild is not required.",
-        },
-        Object {
-          "id": "AwsSolutions-S1",
-          "reason": "Access Log buckets should not have s3 bucket logging",
-        },
-        Object {
-          "id": "AwsPrototyping-S3BucketLoggingEnabled",
-          "reason": "Access Log buckets should not have s3 bucket logging",
-        },
-      ],
-    },
-  },
   "Outputs": Object {
-    "CodeRepositoryGRCUrl": Object {
+    "CrossAccountCodeRepositoryGRCUrlA496E759": Object {
       "Value": Object {
         "Fn::Join": Array [
           "",
@@ -37,7 +15,7 @@ Object {
             "://",
             Object {
               "Fn::GetAtt": Array [
-                "CodeRepositoryBA42F94A",
+                "CrossAccountCodeRepositoryCF9338D3",
                 "Name",
               ],
             },
@@ -59,16 +37,101 @@ Object {
     },
   },
   "Resources": Object {
-    "AccessLogsBucket83982689": Object {
+    "CrossAccountAccessLogsBucketAutoDeleteObjectsCustomResourceBF4BDBC9": Object {
       "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "CrossAccountAccessLogsBucketPolicy04189EE5",
+      ],
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
-        "AccessControl": "LogDeliveryWrite",
+        "BucketName": Object {
+          "Ref": "CrossAccountAccessLogsBucketD7D72FC7",
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "CrossAccountAccessLogsBucketD7D72FC7": Object {
+      "DeletionPolicy": "Delete",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
         "BucketEncryption": Object {
           "ServerSideEncryptionConfiguration": Array [
             Object {
               "ServerSideEncryptionByDefault": Object {
                 "SSEAlgorithm": "AES256",
               },
+            },
+          ],
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
             },
           ],
         },
@@ -88,29 +151,40 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Delete",
     },
-    "AccessLogsBucketAutoDeleteObjectsCustomResource93F9213A": Object {
-      "DeletionPolicy": "Delete",
-      "DependsOn": Array [
-        "AccessLogsBucketPolicy7F77476F",
-      ],
-      "Properties": Object {
-        "BucketName": Object {
-          "Ref": "AccessLogsBucket83982689",
-        },
-        "ServiceToken": Object {
-          "Fn::GetAtt": Array [
-            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
-            "Arn",
+    "CrossAccountAccessLogsBucketPolicy04189EE5": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
           ],
         },
       },
-      "Type": "Custom::S3AutoDeleteObjects",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "AccessLogsBucketPolicy7F77476F": Object {
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "AccessLogsBucket83982689",
+          "Ref": "CrossAccountAccessLogsBucketD7D72FC7",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -128,7 +202,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "AccessLogsBucket83982689",
+                    "CrossAccountAccessLogsBucketD7D72FC7",
                     "Arn",
                   ],
                 },
@@ -138,7 +212,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "AccessLogsBucket83982689",
+                          "CrossAccountAccessLogsBucketD7D72FC7",
                           "Arn",
                         ],
                       },
@@ -166,7 +240,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "AccessLogsBucket83982689",
+                    "CrossAccountAccessLogsBucketD7D72FC7",
                     "Arn",
                   ],
                 },
@@ -176,7 +250,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "AccessLogsBucket83982689",
+                          "CrossAccountAccessLogsBucketD7D72FC7",
                           "Arn",
                         ],
                       },
@@ -186,14 +260,80 @@ Object {
                 },
               ],
             },
+            Object {
+              "Action": "s3:PutObject",
+              "Condition": Object {
+                "ArnLike": Object {
+                  "aws:SourceArn": Object {
+                    "Fn::GetAtt": Array [
+                      "CrossAccountArtifactsBucketA490794E",
+                      "Arn",
+                    ],
+                  },
+                },
+                "StringEquals": Object {
+                  "aws:SourceAccount": Object {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "logging.s3.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "CrossAccountAccessLogsBucketD7D72FC7",
+                        "Arn",
+                      ],
+                    },
+                    "/access-logs*",
+                  ],
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "ArtifactKey8D84C5F0": Object {
+    "CrossAccountArtifactKey7D4916D3": Object {
       "DeletionPolicy": "Delete",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "EnableKeyRotation": true,
         "KeyPolicy": Object {
@@ -261,8 +401,38 @@ Object {
       "Type": "AWS::KMS::Key",
       "UpdateReplacePolicy": "Delete",
     },
-    "ArtifactsBucket2AAC5544": Object {
+    "CrossAccountArtifactsBucketA490794E": Object {
       "DeletionPolicy": "Delete",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "BucketEncryption": Object {
           "ServerSideEncryptionConfiguration": Array [
@@ -270,7 +440,7 @@ Object {
               "ServerSideEncryptionByDefault": Object {
                 "KMSMasterKeyID": Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactKey8D84C5F0",
+                    "CrossAccountArtifactKey7D4916D3",
                     "Arn",
                   ],
                 },
@@ -281,9 +451,16 @@ Object {
         },
         "LoggingConfiguration": Object {
           "DestinationBucketName": Object {
-            "Ref": "AccessLogsBucket83982689",
+            "Ref": "CrossAccountAccessLogsBucketD7D72FC7",
           },
           "LogFilePrefix": "access-logs",
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
+            },
+          ],
         },
         "PublicAccessBlockConfiguration": Object {
           "BlockPublicAcls": true,
@@ -301,14 +478,44 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Delete",
     },
-    "ArtifactsBucketAutoDeleteObjectsCustomResource0E3B4320": Object {
+    "CrossAccountArtifactsBucketAutoDeleteObjectsCustomResourceDA0BD596": Object {
       "DeletionPolicy": "Delete",
       "DependsOn": Array [
-        "ArtifactsBucketPolicy852CB646",
+        "CrossAccountArtifactsBucketPolicyA1EA6713",
       ],
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "BucketName": Object {
-          "Ref": "ArtifactsBucket2AAC5544",
+          "Ref": "CrossAccountArtifactsBucketA490794E",
         },
         "ServiceToken": Object {
           "Fn::GetAtt": Array [
@@ -320,10 +527,40 @@ Object {
       "Type": "Custom::S3AutoDeleteObjects",
       "UpdateReplacePolicy": "Delete",
     },
-    "ArtifactsBucketPolicy852CB646": Object {
+    "CrossAccountArtifactsBucketPolicyA1EA6713": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "ArtifactsBucket2AAC5544",
+          "Ref": "CrossAccountArtifactsBucketA490794E",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -341,7 +578,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "CrossAccountArtifactsBucketA490794E",
                     "Arn",
                   ],
                 },
@@ -351,7 +588,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "CrossAccountArtifactsBucketA490794E",
                           "Arn",
                         ],
                       },
@@ -379,7 +616,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "CrossAccountArtifactsBucketA490794E",
                     "Arn",
                   ],
                 },
@@ -389,7 +626,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "CrossAccountArtifactsBucketA490794E",
                           "Arn",
                         ],
                       },
@@ -434,7 +671,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "CrossAccountArtifactsBucketA490794E",
                     "Arn",
                   ],
                 },
@@ -444,7 +681,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "CrossAccountArtifactsBucketA490794E",
                           "Arn",
                         ],
                       },
@@ -460,31 +697,991 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "CodePipelineB74E5936": Object {
+    "CrossAccountAssetsFileAsset1A747E04B": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Artifacts": Object {
+          "Type": "CODEPIPELINE",
+        },
+        "Cache": Object {
+          "Type": "NO_CACHE",
+        },
+        "Description": "Pipeline step Default/CodePipeline/Assets/FileAsset1",
+        "EncryptionKey": Object {
+          "Fn::GetAtt": Array [
+            "CrossAccountArtifactKey7D4916D3",
+            "Arn",
+          ],
+        },
+        "Environment": Object {
+          "ComputeType": "BUILD_GENERAL1_SMALL",
+          "Image": "aws/codebuild/standard:6.0",
+          "ImagePullCredentialsType": "CODEBUILD",
+          "PrivilegedMode": false,
+          "Type": "LINUX_CONTAINER",
+        },
+        "ServiceRole": Object {
+          "Fn::GetAtt": Array [
+            "CrossAccountAssetsFileRoleA62CD5A0",
+            "Arn",
+          ],
+        },
+        "Source": Object {
+          "BuildSpec": "{
+  \\"version\\": \\"0.2\\",
+  \\"phases\\": {
+    \\"install\\": {
+      \\"commands\\": [
+        \\"npm install -g cdk-assets@2\\"
+      ]
+    },
+    \\"build\\": {
+      \\"commands\\": [
+        \\"cdk-assets --path \\\\\\"assembly-Stage/StageAppStack7618C9EF.assets.json\\\\\\" --verbose publish \\\\\\"824fe84db24bbf4d297bea3c89c9f634f2379cc336ccbe96772c4cc0eab472e3:current_account-current_region\\\\\\"\\"
+      ]
+    }
+  }
+}",
+          "Type": "CODEPIPELINE",
+        },
+      },
+      "Type": "AWS::CodeBuild::Project",
+    },
+    "CrossAccountAssetsFileRoleA62CD5A0": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "codebuild.amazonaws.com",
+              },
+            },
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CrossAccountAssetsFileRoleDefaultPolicy75C80F22": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":logs:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":log-group:/aws/codebuild/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:CreateReportGroup",
+                "codebuild:CreateReport",
+                "codebuild:UpdateReport",
+                "codebuild:BatchPutTestCases",
+                "codebuild:BatchPutCodeCoverages",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":codebuild:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":report-group/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Sub": "arn:\${AWS::Partition}:iam::\${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-\${AWS::AccountId}-\${AWS::Region}",
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "CrossAccountArtifactsBucketA490794E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "CrossAccountArtifactsBucketA490794E",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "kms:Decrypt",
+                "kms:DescribeKey",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CrossAccountArtifactKey7D4916D3",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CrossAccountAssetsFileRoleDefaultPolicy75C80F22",
+        "Roles": Array [
+          Object {
+            "Ref": "CrossAccountAssetsFileRoleA62CD5A0",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CrossAccountCodeBuildActionRoleAD915E6A": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:ViaAWSService": "codepipeline.amazonaws.com",
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CrossAccountCodeBuildActionRoleDefaultPolicy49AAE258": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CrossAccountCodePipelineBuildSynthCdkBuildProject938B55FC",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CrossAccountUpdatePipelineSelfMutationEC1756F0",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CrossAccountAssetsFileAsset1A747E04B",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CrossAccountCodeBuildActionRoleDefaultPolicy49AAE258",
+        "Roles": Array [
+          Object {
+            "Ref": "CrossAccountCodeBuildActionRoleAD915E6A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CrossAccountCodePipelineBuildSynthCdkBuildProject938B55FC": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Artifacts": Object {
+          "Type": "CODEPIPELINE",
+        },
+        "Cache": Object {
+          "Type": "NO_CACHE",
+        },
+        "Description": "Pipeline step Default/CodePipeline/Build/Synth",
+        "EncryptionKey": Object {
+          "Fn::GetAtt": Array [
+            "CrossAccountArtifactKey7D4916D3",
+            "Arn",
+          ],
+        },
+        "Environment": Object {
+          "ComputeType": "BUILD_GENERAL1_SMALL",
+          "Image": "aws/codebuild/standard:6.0",
+          "ImagePullCredentialsType": "CODEBUILD",
+          "PrivilegedMode": false,
+          "Type": "LINUX_CONTAINER",
+        },
+        "ServiceRole": Object {
+          "Fn::GetAtt": Array [
+            "CrossAccountCodePipelineBuildSynthCdkBuildProjectRole06CF955F",
+            "Arn",
+          ],
+        },
+        "Source": Object {
+          "BuildSpec": "{
+  \\"version\\": \\"0.2\\",
+  \\"phases\\": {
+    \\"install\\": {
+      \\"commands\\": [
+        \\"npm install -g aws-cdk\\",
+        \\"yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile\\"
+      ]
+    },
+    \\"build\\": {
+      \\"commands\\": [
+        \\"npx nx run-many --target=build --all\\"
+      ]
+    }
+  },
+  \\"artifacts\\": {
+    \\"secondary-artifacts\\": {
+      \\"Synth_Output\\": {
+        \\"base-directory\\": \\"cdk.out\\",
+        \\"files\\": \\"**/*\\"
+      },
+      \\"Synth__\\": {
+        \\"base-directory\\": \\".\\",
+        \\"files\\": \\"**/*\\"
+      }
+    }
+  }
+}",
+          "Type": "CODEPIPELINE",
+        },
+      },
+      "Type": "AWS::CodeBuild::Project",
+    },
+    "CrossAccountCodePipelineBuildSynthCdkBuildProjectRole06CF955F": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "codebuild.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CrossAccountCodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicy94879C97": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":logs:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":log-group:/aws/codebuild/",
+                      Object {
+                        "Ref": "CrossAccountCodePipelineBuildSynthCdkBuildProject938B55FC",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":logs:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":log-group:/aws/codebuild/",
+                      Object {
+                        "Ref": "CrossAccountCodePipelineBuildSynthCdkBuildProject938B55FC",
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "codebuild:CreateReportGroup",
+                "codebuild:CreateReport",
+                "codebuild:UpdateReport",
+                "codebuild:BatchPutTestCases",
+                "codebuild:BatchPutCodeCoverages",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":codebuild:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":report-group/",
+                    Object {
+                      "Ref": "CrossAccountCodePipelineBuildSynthCdkBuildProject938B55FC",
+                    },
+                    "-*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "CrossAccountArtifactsBucketA490794E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "CrossAccountArtifactsBucketA490794E",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "kms:Decrypt",
+                "kms:DescribeKey",
+                "kms:Encrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CrossAccountArtifactKey7D4916D3",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "kms:Decrypt",
+                "kms:Encrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CrossAccountArtifactKey7D4916D3",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CrossAccountCodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicy94879C97",
+        "Roles": Array [
+          Object {
+            "Ref": "CrossAccountCodePipelineBuildSynthCdkBuildProjectRole06CF955F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CrossAccountCodePipelineEventsRoleCF998AEF": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CrossAccountCodePipelineEventsRoleDefaultPolicyCDDAD89A": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "codepipeline:StartPipelineExecution",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":codepipeline:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "CrossAccountCodePipelineFE6BA407",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CrossAccountCodePipelineEventsRoleDefaultPolicyCDDAD89A",
+        "Roles": Array [
+          Object {
+            "Ref": "CrossAccountCodePipelineEventsRoleCF998AEF",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CrossAccountCodePipelineFE6BA407": Object {
       "DependsOn": Array [
-        "CodePipelineRoleDefaultPolicy8D520A8D",
-        "CodePipelineRoleB3A660B4",
+        "CrossAccountCodePipelineRoleDefaultPolicyB81D2E54",
+        "CrossAccountCodePipelineRole6867FC22",
       ],
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "ArtifactStore": Object {
           "EncryptionKey": Object {
             "Id": Object {
               "Fn::GetAtt": Array [
-                "ArtifactKey8D84C5F0",
+                "CrossAccountArtifactKey7D4916D3",
                 "Arn",
               ],
             },
             "Type": "KMS",
           },
           "Location": Object {
-            "Ref": "ArtifactsBucket2AAC5544",
+            "Ref": "CrossAccountArtifactsBucketA490794E",
           },
           "Type": "S3",
         },
         "RestartExecutionOnUpdate": true,
         "RoleArn": Object {
           "Fn::GetAtt": Array [
-            "CodePipelineRoleB3A660B4",
+            "CrossAccountCodePipelineRole6867FC22",
             "Arn",
           ],
         },
@@ -503,25 +1700,25 @@ Object {
                   "PollForSourceChanges": false,
                   "RepositoryName": Object {
                     "Fn::GetAtt": Array [
-                      "CodeRepositoryBA42F94A",
+                      "CrossAccountCodeRepositoryCF9338D3",
                       "Name",
                     ],
                   },
                 },
                 "Name": Object {
                   "Fn::GetAtt": Array [
-                    "CodeRepositoryBA42F94A",
+                    "CrossAccountCodeRepositoryCF9338D3",
                     "Name",
                   ],
                 },
                 "OutputArtifacts": Array [
                   Object {
-                    "Name": "c8b95ca81f750a44513d18b27868db0afa191aa92e_Source",
+                    "Name": "c8323abab1481846407037ff91e03fe414541ba20b_Source",
                   },
                 ],
                 "RoleArn": Object {
                   "Fn::GetAtt": Array [
-                    "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70",
+                    "CrossAccountCodePipelineSourceCodeCommitCodePipelineActionRole1A00297F",
                     "Arn",
                   ],
                 },
@@ -542,12 +1739,12 @@ Object {
                 "Configuration": Object {
                   "EnvironmentVariables": "[{\\"name\\":\\"_PROJECT_CONFIG_HASH\\",\\"type\\":\\"PLAINTEXT\\",\\"value\\":\\"9b6cac2596443c465eb42c0d0d84de22a8632cbeb9388a40d13889341f9b20c5\\"}]",
                   "ProjectName": Object {
-                    "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                    "Ref": "CrossAccountCodePipelineBuildSynthCdkBuildProject938B55FC",
                   },
                 },
                 "InputArtifacts": Array [
                   Object {
-                    "Name": "c8b95ca81f750a44513d18b27868db0afa191aa92e_Source",
+                    "Name": "c8323abab1481846407037ff91e03fe414541ba20b_Source",
                   },
                 ],
                 "Name": "Synth",
@@ -561,7 +1758,7 @@ Object {
                 ],
                 "RoleArn": Object {
                   "Fn::GetAtt": Array [
-                    "CrossAccountCodeBuildActionRoleAAA68524",
+                    "CrossAccountCodeBuildActionRoleAD915E6A",
                     "Arn",
                   ],
                 },
@@ -582,7 +1779,7 @@ Object {
                 "Configuration": Object {
                   "EnvironmentVariables": "[{\\"name\\":\\"_PROJECT_CONFIG_HASH\\",\\"type\\":\\"PLAINTEXT\\",\\"value\\":\\"e437283b833a76d1459ba3b9b11f0bf0f0c58fc4c9c6a130298f52e21508b79e\\"}]",
                   "ProjectName": Object {
-                    "Ref": "CrossAccountUpdatePipelineSelfMutation8D616EE5",
+                    "Ref": "CrossAccountUpdatePipelineSelfMutationEC1756F0",
                   },
                 },
                 "InputArtifacts": Array [
@@ -593,7 +1790,7 @@ Object {
                 "Name": "SelfMutate",
                 "RoleArn": Object {
                   "Fn::GetAtt": Array [
-                    "CrossAccountCodeBuildActionRoleAAA68524",
+                    "CrossAccountCodeBuildActionRoleAD915E6A",
                     "Arn",
                   ],
                 },
@@ -613,7 +1810,7 @@ Object {
                 },
                 "Configuration": Object {
                   "ProjectName": Object {
-                    "Ref": "CrossAccountAssetsFileAsset11C4C6E29",
+                    "Ref": "CrossAccountAssetsFileAsset1A747E04B",
                   },
                 },
                 "InputArtifacts": Array [
@@ -624,7 +1821,7 @@ Object {
                 "Name": "FileAsset1",
                 "RoleArn": Object {
                   "Fn::GetAtt": Array [
-                    "CrossAccountCodeBuildActionRoleAAA68524",
+                    "CrossAccountCodeBuildActionRoleAD915E6A",
                     "Arn",
                   ],
                 },
@@ -748,411 +1945,37 @@ Object {
       },
       "Type": "AWS::CodePipeline::Pipeline",
     },
-    "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6": Object {
-      "Properties": Object {
-        "Artifacts": Object {
-          "Type": "CODEPIPELINE",
-        },
-        "Cache": Object {
-          "Type": "NO_CACHE",
-        },
-        "Description": "Pipeline step Default/CodePipeline/Build/Synth",
-        "EncryptionKey": Object {
-          "Fn::GetAtt": Array [
-            "ArtifactKey8D84C5F0",
-            "Arn",
-          ],
-        },
-        "Environment": Object {
-          "ComputeType": "BUILD_GENERAL1_SMALL",
-          "Image": "aws/codebuild/standard:6.0",
-          "ImagePullCredentialsType": "CODEBUILD",
-          "PrivilegedMode": false,
-          "Type": "LINUX_CONTAINER",
-        },
-        "ServiceRole": Object {
-          "Fn::GetAtt": Array [
-            "CodePipelineBuildSynthCdkBuildProjectRoleB73287D4",
-            "Arn",
-          ],
-        },
-        "Source": Object {
-          "BuildSpec": "{
-  \\"version\\": \\"0.2\\",
-  \\"phases\\": {
-    \\"install\\": {
-      \\"commands\\": [
-        \\"npm install -g aws-cdk\\",
-        \\"yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile\\"
-      ]
-    },
-    \\"build\\": {
-      \\"commands\\": [
-        \\"npx nx run-many --target=build --all\\"
-      ]
-    }
-  },
-  \\"artifacts\\": {
-    \\"secondary-artifacts\\": {
-      \\"Synth_Output\\": {
-        \\"base-directory\\": \\"cdk.out\\",
-        \\"files\\": \\"**/*\\"
-      },
-      \\"Synth__\\": {
-        \\"base-directory\\": \\".\\",
-        \\"files\\": \\"**/*\\"
-      }
-    }
-  }
-}",
-          "Type": "CODEPIPELINE",
-        },
-      },
-      "Type": "AWS::CodeBuild::Project",
-    },
-    "CodePipelineBuildSynthCdkBuildProjectRoleB73287D4": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "codebuild.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyB7EDB705": Object {
+    "CrossAccountCodePipelineRole6867FC22": Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsSolutions-IAM5",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
           ],
         },
       },
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "logs:CreateLogGroup",
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":logs:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":log-group:/aws/codebuild/",
-                      Object {
-                        "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
-                      },
-                    ],
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":logs:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":log-group:/aws/codebuild/",
-                      Object {
-                        "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
-                      },
-                      ":*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "codebuild:CreateReportGroup",
-                "codebuild:CreateReport",
-                "codebuild:UpdateReport",
-                "codebuild:BatchPutTestCases",
-                "codebuild:BatchPutCodeCoverages",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:",
-                    Object {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":codebuild:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":report-group/",
-                    Object {
-                      "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
-                    },
-                    "-*",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-                "s3:DeleteObject*",
-                "s3:PutObject",
-                "s3:PutObjectLegalHold",
-                "s3:PutObjectRetention",
-                "s3:PutObjectTagging",
-                "s3:PutObjectVersionTagging",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "kms:Decrypt",
-                "kms:DescribeKey",
-                "kms:Encrypt",
-                "kms:ReEncrypt*",
-                "kms:GenerateDataKey*",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "ArtifactKey8D84C5F0",
-                  "Arn",
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "kms:Decrypt",
-                "kms:Encrypt",
-                "kms:ReEncrypt*",
-                "kms:GenerateDataKey*",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "ArtifactKey8D84C5F0",
-                  "Arn",
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "CodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyB7EDB705",
-        "Roles": Array [
-          Object {
-            "Ref": "CodePipelineBuildSynthCdkBuildProjectRoleB73287D4",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "CodePipelineEventsRole4196480D": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "events.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CodePipelineEventsRoleDefaultPolicy13DBD2D2": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "codepipeline:StartPipelineExecution",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:",
-                    Object {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":codepipeline:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "CodePipelineB74E5936",
-                    },
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "CodePipelineEventsRoleDefaultPolicy13DBD2D2",
-        "Roles": Array [
-          Object {
-            "Ref": "CodePipelineEventsRole4196480D",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "CodePipelineRoleB3A660B4": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -1169,75 +1992,33 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "CodePipelineRoleDefaultPolicy8D520A8D": Object {
+    "CrossAccountCodePipelineRoleDefaultPolicyB81D2E54": Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsSolutions-IAM5",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
           ],
         },
@@ -1262,7 +2043,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "CrossAccountArtifactsBucketA490794E",
                     "Arn",
                   ],
                 },
@@ -1272,7 +2053,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "CrossAccountArtifactsBucketA490794E",
                           "Arn",
                         ],
                       },
@@ -1293,7 +2074,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "ArtifactKey8D84C5F0",
+                  "CrossAccountArtifactKey7D4916D3",
                   "Arn",
                 ],
               },
@@ -1303,7 +2084,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70",
+                  "CrossAccountCodePipelineSourceCodeCommitCodePipelineActionRole1A00297F",
                   "Arn",
                 ],
               },
@@ -1313,7 +2094,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "CrossAccountCodeBuildActionRoleAAA68524",
+                  "CrossAccountCodeBuildActionRoleAD915E6A",
                   "Arn",
                 ],
               },
@@ -1348,16 +2129,46 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "CodePipelineRoleDefaultPolicy8D520A8D",
+        "PolicyName": "CrossAccountCodePipelineRoleDefaultPolicyB81D2E54",
         "Roles": Array [
           Object {
-            "Ref": "CodePipelineRoleB3A660B4",
+            "Ref": "CrossAccountCodePipelineRole6867FC22",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70": Object {
+    "CrossAccountCodePipelineSourceCodeCommitCodePipelineActionRole1A00297F": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -1389,57 +2200,33 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "CodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyAFBD34E4": Object {
+    "CrossAccountCodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicy443B61A0": Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsSolutions-IAM5",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
           ],
         },
@@ -1464,7 +2251,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "CrossAccountArtifactsBucketA490794E",
                     "Arn",
                   ],
                 },
@@ -1474,7 +2261,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "CrossAccountArtifactsBucketA490794E",
                           "Arn",
                         ],
                       },
@@ -1495,7 +2282,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "ArtifactKey8D84C5F0",
+                  "CrossAccountArtifactKey7D4916D3",
                   "Arn",
                 ],
               },
@@ -1511,7 +2298,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "CodeRepositoryBA42F94A",
+                  "CrossAccountCodeRepositoryCF9338D3",
                   "Arn",
                 ],
               },
@@ -1519,24 +2306,84 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "CodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyAFBD34E4",
+        "PolicyName": "CrossAccountCodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicy443B61A0",
         "Roles": Array [
           Object {
-            "Ref": "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70",
+            "Ref": "CrossAccountCodePipelineSourceCodeCommitCodePipelineActionRole1A00297F",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "CodeRepositoryBA42F94A": Object {
+    "CrossAccountCodeRepositoryCF9338D3": Object {
       "DeletionPolicy": "Retain",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "RepositoryName": "Defaults",
       },
       "Type": "AWS::CodeCommit::Repository",
       "UpdateReplacePolicy": "Retain",
     },
-    "CodeRepositoryCodePipelinemainlineEventRuleEDE9EDAA": Object {
+    "CrossAccountCodeRepositoryCrossAccountCodePipelineE9B4FFC3mainlineEventRule3B7BD205": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "EventPattern": Object {
           "detail": Object {
@@ -1554,7 +2401,7 @@ Object {
           "resources": Array [
             Object {
               "Fn::GetAtt": Array [
-                "CodeRepositoryBA42F94A",
+                "CrossAccountCodeRepositoryCF9338D3",
                 "Arn",
               ],
             },
@@ -1584,7 +2431,7 @@ Object {
                   },
                   ":",
                   Object {
-                    "Ref": "CodePipelineB74E5936",
+                    "Ref": "CrossAccountCodePipelineFE6BA407",
                   },
                 ],
               ],
@@ -1592,7 +2439,7 @@ Object {
             "Id": "Target0",
             "RoleArn": Object {
               "Fn::GetAtt": Array [
-                "CodePipelineEventsRole4196480D",
+                "CrossAccountCodePipelineEventsRoleCF998AEF",
                 "Arn",
               ],
             },
@@ -1600,336 +2447,6 @@ Object {
         ],
       },
       "Type": "AWS::Events::Rule",
-    },
-    "CrossAccountAssetsFileAsset11C4C6E29": Object {
-      "Properties": Object {
-        "Artifacts": Object {
-          "Type": "CODEPIPELINE",
-        },
-        "Cache": Object {
-          "Type": "NO_CACHE",
-        },
-        "Description": "Pipeline step Default/CodePipeline/Assets/FileAsset1",
-        "EncryptionKey": Object {
-          "Fn::GetAtt": Array [
-            "ArtifactKey8D84C5F0",
-            "Arn",
-          ],
-        },
-        "Environment": Object {
-          "ComputeType": "BUILD_GENERAL1_SMALL",
-          "Image": "aws/codebuild/standard:6.0",
-          "ImagePullCredentialsType": "CODEBUILD",
-          "PrivilegedMode": false,
-          "Type": "LINUX_CONTAINER",
-        },
-        "ServiceRole": Object {
-          "Fn::GetAtt": Array [
-            "CrossAccountAssetsFileRole790499C9",
-            "Arn",
-          ],
-        },
-        "Source": Object {
-          "BuildSpec": "{
-  \\"version\\": \\"0.2\\",
-  \\"phases\\": {
-    \\"install\\": {
-      \\"commands\\": [
-        \\"npm install -g cdk-assets@2\\"
-      ]
-    },
-    \\"build\\": {
-      \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-Stage/StageAppStack7618C9EF.assets.json\\\\\\" --verbose publish \\\\\\"824fe84db24bbf4d297bea3c89c9f634f2379cc336ccbe96772c4cc0eab472e3:current_account-current_region\\\\\\"\\"
-      ]
-    }
-  }
-}",
-          "Type": "CODEPIPELINE",
-        },
-      },
-      "Type": "AWS::CodeBuild::Project",
-    },
-    "CrossAccountAssetsFileRole790499C9": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "codebuild.amazonaws.com",
-              },
-            },
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":iam::",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":root",
-                    ],
-                  ],
-                },
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CrossAccountAssetsFileRoleDefaultPolicy70E781AB": Object {
-      "Metadata": Object {
-        "cdk_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "id": "AwsSolutions-IAM5",
-              "reason": "Asset role requires access to the Artifacts Bucket",
-            },
-            Object {
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Asset role requires access to the Artifacts Bucket",
-            },
-          ],
-        },
-      },
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "logs:CreateLogGroup",
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:",
-                    Object {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":logs:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":log-group:/aws/codebuild/*",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "codebuild:CreateReportGroup",
-                "codebuild:CreateReport",
-                "codebuild:UpdateReport",
-                "codebuild:BatchPutTestCases",
-                "codebuild:BatchPutCodeCoverages",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:",
-                    Object {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":codebuild:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":report-group/*",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "codebuild:BatchGetBuilds",
-                "codebuild:StartBuild",
-                "codebuild:StopBuild",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Sub": "arn:\${AWS::Partition}:iam::\${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-\${AWS::AccountId}-\${AWS::Region}",
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "kms:Decrypt",
-                "kms:DescribeKey",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "ArtifactKey8D84C5F0",
-                  "Arn",
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "CrossAccountAssetsFileRoleDefaultPolicy70E781AB",
-        "Roles": Array [
-          Object {
-            "Ref": "CrossAccountAssetsFileRole790499C9",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "CrossAccountCodeBuildActionRoleAAA68524": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Condition": Object {
-                "Bool": Object {
-                  "aws:ViaAWSService": "codepipeline.amazonaws.com",
-                },
-              },
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":iam::",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":root",
-                    ],
-                  ],
-                },
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CrossAccountCodeBuildActionRoleDefaultPolicyCD3511D6": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "codebuild:BatchGetBuilds",
-                "codebuild:StartBuild",
-                "codebuild:StopBuild",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
-                  "Arn",
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "codebuild:BatchGetBuilds",
-                "codebuild:StartBuild",
-                "codebuild:StopBuild",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "CrossAccountUpdatePipelineSelfMutation8D616EE5",
-                  "Arn",
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "codebuild:BatchGetBuilds",
-                "codebuild:StartBuild",
-                "codebuild:StopBuild",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "CrossAccountAssetsFileAsset11C4C6E29",
-                  "Arn",
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "CrossAccountCodeBuildActionRoleDefaultPolicyCD3511D6",
-        "Roles": Array [
-          Object {
-            "Ref": "CrossAccountCodeBuildActionRoleAAA68524",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
     },
     "CrossAccountSonarCodeScannerSonarQubeToken76921F1B": Object {
       "DeletionPolicy": "Delete",
@@ -1944,6 +2461,30 @@ Object {
               "id": "AwsPrototyping-SecretsManagerRotationEnabled",
               "reason": "Key rotation is not possible as a user token needs to be generated from Sonarqube",
             },
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
           ],
         },
       },
@@ -1954,6 +2495,36 @@ Object {
       "UpdateReplacePolicy": "Delete",
     },
     "CrossAccountSonarCodeScannerSynthBuildProjectOnSynthSuccessD24D011A": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "EventPattern": Object {
           "detail": Object {
@@ -1975,7 +2546,7 @@ Object {
                               ":",
                               Object {
                                 "Fn::GetAtt": Array [
-                                  "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                                  "CrossAccountCodePipelineBuildSynthCdkBuildProject938B55FC",
                                   "Arn",
                                 ],
                               },
@@ -2024,6 +2595,36 @@ Object {
       "Type": "AWS::Events::Rule",
     },
     "CrossAccountSonarCodeScannerValidationProjectAA1083C3": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Artifacts": Object {
           "Type": "NO_ARTIFACTS",
@@ -2108,6 +2709,36 @@ Object {
       "Type": "AWS::CodeBuild::Project",
     },
     "CrossAccountSonarCodeScannerValidationProjectEventsRole551D56DA": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -2125,6 +2756,36 @@ Object {
       "Type": "AWS::IAM::Role",
     },
     "CrossAccountSonarCodeScannerValidationProjectEventsRoleDefaultPolicy1B23C513": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -2190,6 +2851,30 @@ Object {
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
               "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
             },
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
           ],
         },
       },
@@ -2248,6 +2933,30 @@ Object {
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
               "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
+            },
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
           ],
         },
@@ -2358,7 +3067,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                  "CrossAccountCodePipelineBuildSynthCdkBuildProject938B55FC",
                   "Arn",
                 ],
               },
@@ -2369,7 +3078,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "CrossAccountArtifactsBucketA490794E",
                     "Arn",
                   ],
                 },
@@ -2379,7 +3088,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "CrossAccountArtifactsBucketA490794E",
                           "Arn",
                         ],
                       },
@@ -2397,7 +3106,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "ArtifactKey8D84C5F0",
+                  "CrossAccountArtifactKey7D4916D3",
                   "Arn",
                 ],
               },
@@ -2414,7 +3123,37 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
-    "CrossAccountUpdatePipelineSelfMutation8D616EE5": Object {
+    "CrossAccountUpdatePipelineSelfMutationEC1756F0": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Artifacts": Object {
           "Type": "CODEPIPELINE",
@@ -2425,7 +3164,7 @@ Object {
         "Description": "Pipeline step Default/CodePipeline/UpdatePipeline/SelfMutate",
         "EncryptionKey": Object {
           "Fn::GetAtt": Array [
-            "ArtifactKey8D84C5F0",
+            "CrossAccountArtifactKey7D4916D3",
             "Arn",
           ],
         },
@@ -2438,7 +3177,7 @@ Object {
         },
         "ServiceRole": Object {
           "Fn::GetAtt": Array [
-            "CrossAccountUpdatePipelineSelfMutationRoleBEAB3750",
+            "CrossAccountUpdatePipelineSelfMutationRole0F9342FC",
             "Arn",
           ],
         },
@@ -2463,7 +3202,37 @@ Object {
       },
       "Type": "AWS::CodeBuild::Project",
     },
-    "CrossAccountUpdatePipelineSelfMutationRoleBEAB3750": Object {
+    "CrossAccountUpdatePipelineSelfMutationRole0F9342FC": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -2480,187 +3249,33 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "CrossAccountUpdatePipelineSelfMutationRoleDefaultPolicy53F5B99B": Object {
+    "CrossAccountUpdatePipelineSelfMutationRoleDefaultPolicyA7DA8F1E": Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CrossAccountUpdatePipelineSelfMutation.*>:\\\\*$/g",
-                },
-              ],
               "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CrossAccountUpdatePipelineSelfMutation.*>-\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:\\\\*:iam::<AWS::AccountId>:role/\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to assume a role from within the current account in order to deploy.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to list all buckets and stacks.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": Object {
-                    "Fn::Join": Array [
-                      "",
-                      Array [
-                        "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|",
-                        Object {
-                          "Ref": "AWS::AccountId",
-                        },
-                        "):log-group:/aws/codebuild/<CrossAccountUpdatePipelineSelfMutation.*>:\\\\*$/g",
-                      ],
-                    ],
-                  },
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CrossAccountUpdatePipelineSelfMutation.*>:\\\\*$/g",
-                },
-              ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CrossAccountUpdatePipelineSelfMutation.*>-\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:\\\\*:iam::<AWS::AccountId>:role/\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to assume a role from within the current account in order to deploy.",
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to list all buckets and stacks.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": Object {
-                    "Fn::Join": Array [
-                      "",
-                      Array [
-                        "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|",
-                        Object {
-                          "Ref": "AWS::AccountId",
-                        },
-                        "):log-group:/aws/codebuild/<CrossAccountUpdatePipelineSelfMutation.*>:\\\\*$/g",
-                      ],
-                    ],
-                  },
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
           ],
         },
@@ -2694,7 +3309,7 @@ Object {
                       },
                       ":log-group:/aws/codebuild/",
                       Object {
-                        "Ref": "CrossAccountUpdatePipelineSelfMutation8D616EE5",
+                        "Ref": "CrossAccountUpdatePipelineSelfMutationEC1756F0",
                       },
                     ],
                   ],
@@ -2717,7 +3332,7 @@ Object {
                       },
                       ":log-group:/aws/codebuild/",
                       Object {
-                        "Ref": "CrossAccountUpdatePipelineSelfMutation8D616EE5",
+                        "Ref": "CrossAccountUpdatePipelineSelfMutationEC1756F0",
                       },
                       ":*",
                     ],
@@ -2752,7 +3367,7 @@ Object {
                     },
                     ":report-group/",
                     Object {
-                      "Ref": "CrossAccountUpdatePipelineSelfMutation8D616EE5",
+                      "Ref": "CrossAccountUpdatePipelineSelfMutationEC1756F0",
                     },
                     "-*",
                   ],
@@ -2804,7 +3419,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "CrossAccountArtifactsBucketA490794E",
                     "Arn",
                   ],
                 },
@@ -2814,7 +3429,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "CrossAccountArtifactsBucketA490794E",
                           "Arn",
                         ],
                       },
@@ -2832,7 +3447,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "ArtifactKey8D84C5F0",
+                  "CrossAccountArtifactKey7D4916D3",
                   "Arn",
                 ],
               },
@@ -2847,7 +3462,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "ArtifactKey8D84C5F0",
+                  "CrossAccountArtifactKey7D4916D3",
                   "Arn",
                 ],
               },
@@ -2855,10 +3470,10 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "CrossAccountUpdatePipelineSelfMutationRoleDefaultPolicy53F5B99B",
+        "PolicyName": "CrossAccountUpdatePipelineSelfMutationRoleDefaultPolicyA7DA8F1E",
         "Roles": Array [
           Object {
-            "Ref": "CrossAccountUpdatePipelineSelfMutationRoleBEAB3750",
+            "Ref": "CrossAccountUpdatePipelineSelfMutationRole0F9342FC",
           },
         ],
       },
@@ -2881,7 +3496,7 @@ Object {
             Array [
               "Lambda function for auto-deleting objects in ",
               Object {
-                "Ref": "AccessLogsBucket83982689",
+                "Ref": "CrossAccountAccessLogsBucketD7D72FC7",
               },
               " S3 bucket.",
             ],
@@ -2955,30 +3570,8 @@ Object {
 
 exports[`PDK Pipeline Unit Tests CrossAccount 1`] = `
 Object {
-  "Metadata": Object {
-    "cdk_nag": Object {
-      "rules_to_suppress": Array [
-        Object {
-          "id": "AwsSolutions-CB4",
-          "reason": "Encryption of Codebuild is not required.",
-        },
-        Object {
-          "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
-          "reason": "Encryption of Codebuild is not required.",
-        },
-        Object {
-          "id": "AwsSolutions-S1",
-          "reason": "Access Log buckets should not have s3 bucket logging",
-        },
-        Object {
-          "id": "AwsPrototyping-S3BucketLoggingEnabled",
-          "reason": "Access Log buckets should not have s3 bucket logging",
-        },
-      ],
-    },
-  },
   "Outputs": Object {
-    "CodeRepositoryGRCUrl": Object {
+    "CrossAccountCodeRepositoryGRCUrlA496E759": Object {
       "Value": Object {
         "Fn::Join": Array [
           "",
@@ -2990,7 +3583,7 @@ Object {
             "://",
             Object {
               "Fn::GetAtt": Array [
-                "CodeRepositoryBA42F94A",
+                "CrossAccountCodeRepositoryCF9338D3",
                 "Name",
               ],
             },
@@ -3012,16 +3605,101 @@ Object {
     },
   },
   "Resources": Object {
-    "AccessLogsBucket83982689": Object {
+    "CrossAccountAccessLogsBucketAutoDeleteObjectsCustomResourceBF4BDBC9": Object {
       "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "CrossAccountAccessLogsBucketPolicy04189EE5",
+      ],
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
-        "AccessControl": "LogDeliveryWrite",
+        "BucketName": Object {
+          "Ref": "CrossAccountAccessLogsBucketD7D72FC7",
+        },
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::S3AutoDeleteObjects",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "CrossAccountAccessLogsBucketD7D72FC7": Object {
+      "DeletionPolicy": "Delete",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
         "BucketEncryption": Object {
           "ServerSideEncryptionConfiguration": Array [
             Object {
               "ServerSideEncryptionByDefault": Object {
                 "SSEAlgorithm": "AES256",
               },
+            },
+          ],
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
             },
           ],
         },
@@ -3041,29 +3719,40 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Delete",
     },
-    "AccessLogsBucketAutoDeleteObjectsCustomResource93F9213A": Object {
-      "DeletionPolicy": "Delete",
-      "DependsOn": Array [
-        "AccessLogsBucketPolicy7F77476F",
-      ],
-      "Properties": Object {
-        "BucketName": Object {
-          "Ref": "AccessLogsBucket83982689",
-        },
-        "ServiceToken": Object {
-          "Fn::GetAtt": Array [
-            "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
-            "Arn",
+    "CrossAccountAccessLogsBucketPolicy04189EE5": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
           ],
         },
       },
-      "Type": "Custom::S3AutoDeleteObjects",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "AccessLogsBucketPolicy7F77476F": Object {
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "AccessLogsBucket83982689",
+          "Ref": "CrossAccountAccessLogsBucketD7D72FC7",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -3081,7 +3770,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "AccessLogsBucket83982689",
+                    "CrossAccountAccessLogsBucketD7D72FC7",
                     "Arn",
                   ],
                 },
@@ -3091,7 +3780,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "AccessLogsBucket83982689",
+                          "CrossAccountAccessLogsBucketD7D72FC7",
                           "Arn",
                         ],
                       },
@@ -3119,7 +3808,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "AccessLogsBucket83982689",
+                    "CrossAccountAccessLogsBucketD7D72FC7",
                     "Arn",
                   ],
                 },
@@ -3129,7 +3818,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "AccessLogsBucket83982689",
+                          "CrossAccountAccessLogsBucketD7D72FC7",
                           "Arn",
                         ],
                       },
@@ -3139,14 +3828,80 @@ Object {
                 },
               ],
             },
+            Object {
+              "Action": "s3:PutObject",
+              "Condition": Object {
+                "ArnLike": Object {
+                  "aws:SourceArn": Object {
+                    "Fn::GetAtt": Array [
+                      "CrossAccountArtifactsBucketA490794E",
+                      "Arn",
+                    ],
+                  },
+                },
+                "StringEquals": Object {
+                  "aws:SourceAccount": Object {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "logging.s3.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "CrossAccountAccessLogsBucketD7D72FC7",
+                        "Arn",
+                      ],
+                    },
+                    "/access-logs*",
+                  ],
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "ArtifactKey8D84C5F0": Object {
+    "CrossAccountArtifactKey7D4916D3": Object {
       "DeletionPolicy": "Delete",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "EnableKeyRotation": true,
         "KeyPolicy": Object {
@@ -3214,8 +3969,38 @@ Object {
       "Type": "AWS::KMS::Key",
       "UpdateReplacePolicy": "Delete",
     },
-    "ArtifactsBucket2AAC5544": Object {
+    "CrossAccountArtifactsBucketA490794E": Object {
       "DeletionPolicy": "Delete",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "BucketEncryption": Object {
           "ServerSideEncryptionConfiguration": Array [
@@ -3223,7 +4008,7 @@ Object {
               "ServerSideEncryptionByDefault": Object {
                 "KMSMasterKeyID": Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactKey8D84C5F0",
+                    "CrossAccountArtifactKey7D4916D3",
                     "Arn",
                   ],
                 },
@@ -3234,9 +4019,16 @@ Object {
         },
         "LoggingConfiguration": Object {
           "DestinationBucketName": Object {
-            "Ref": "AccessLogsBucket83982689",
+            "Ref": "CrossAccountAccessLogsBucketD7D72FC7",
           },
           "LogFilePrefix": "access-logs",
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
+            },
+          ],
         },
         "PublicAccessBlockConfiguration": Object {
           "BlockPublicAcls": true,
@@ -3254,14 +4046,44 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Delete",
     },
-    "ArtifactsBucketAutoDeleteObjectsCustomResource0E3B4320": Object {
+    "CrossAccountArtifactsBucketAutoDeleteObjectsCustomResourceDA0BD596": Object {
       "DeletionPolicy": "Delete",
       "DependsOn": Array [
-        "ArtifactsBucketPolicy852CB646",
+        "CrossAccountArtifactsBucketPolicyA1EA6713",
       ],
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "BucketName": Object {
-          "Ref": "ArtifactsBucket2AAC5544",
+          "Ref": "CrossAccountArtifactsBucketA490794E",
         },
         "ServiceToken": Object {
           "Fn::GetAtt": Array [
@@ -3273,10 +4095,40 @@ Object {
       "Type": "Custom::S3AutoDeleteObjects",
       "UpdateReplacePolicy": "Delete",
     },
-    "ArtifactsBucketPolicy852CB646": Object {
+    "CrossAccountArtifactsBucketPolicyA1EA6713": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "ArtifactsBucket2AAC5544",
+          "Ref": "CrossAccountArtifactsBucketA490794E",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -3294,7 +4146,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "CrossAccountArtifactsBucketA490794E",
                     "Arn",
                   ],
                 },
@@ -3304,7 +4156,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "CrossAccountArtifactsBucketA490794E",
                           "Arn",
                         ],
                       },
@@ -3332,7 +4184,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "CrossAccountArtifactsBucketA490794E",
                     "Arn",
                   ],
                 },
@@ -3342,7 +4194,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "CrossAccountArtifactsBucketA490794E",
                           "Arn",
                         ],
                       },
@@ -3387,7 +4239,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "CrossAccountArtifactsBucketA490794E",
                     "Arn",
                   ],
                 },
@@ -3397,7 +4249,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "CrossAccountArtifactsBucketA490794E",
                           "Arn",
                         ],
                       },
@@ -3413,31 +4265,991 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "CodePipelineB74E5936": Object {
+    "CrossAccountAssetsFileAsset1A747E04B": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Artifacts": Object {
+          "Type": "CODEPIPELINE",
+        },
+        "Cache": Object {
+          "Type": "NO_CACHE",
+        },
+        "Description": "Pipeline step Default/CodePipeline/Assets/FileAsset1",
+        "EncryptionKey": Object {
+          "Fn::GetAtt": Array [
+            "CrossAccountArtifactKey7D4916D3",
+            "Arn",
+          ],
+        },
+        "Environment": Object {
+          "ComputeType": "BUILD_GENERAL1_SMALL",
+          "Image": "aws/codebuild/standard:6.0",
+          "ImagePullCredentialsType": "CODEBUILD",
+          "PrivilegedMode": false,
+          "Type": "LINUX_CONTAINER",
+        },
+        "ServiceRole": Object {
+          "Fn::GetAtt": Array [
+            "CrossAccountAssetsFileRoleA62CD5A0",
+            "Arn",
+          ],
+        },
+        "Source": Object {
+          "BuildSpec": "{
+  \\"version\\": \\"0.2\\",
+  \\"phases\\": {
+    \\"install\\": {
+      \\"commands\\": [
+        \\"npm install -g cdk-assets@2\\"
+      ]
+    },
+    \\"build\\": {
+      \\"commands\\": [
+        \\"cdk-assets --path \\\\\\"assembly-Stage/StageAppStack7618C9EF.assets.json\\\\\\" --verbose publish \\\\\\"824fe84db24bbf4d297bea3c89c9f634f2379cc336ccbe96772c4cc0eab472e3:current_account-current_region\\\\\\"\\"
+      ]
+    }
+  }
+}",
+          "Type": "CODEPIPELINE",
+        },
+      },
+      "Type": "AWS::CodeBuild::Project",
+    },
+    "CrossAccountAssetsFileRoleA62CD5A0": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "codebuild.amazonaws.com",
+              },
+            },
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CrossAccountAssetsFileRoleDefaultPolicy75C80F22": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":logs:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":log-group:/aws/codebuild/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:CreateReportGroup",
+                "codebuild:CreateReport",
+                "codebuild:UpdateReport",
+                "codebuild:BatchPutTestCases",
+                "codebuild:BatchPutCodeCoverages",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":codebuild:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":report-group/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Sub": "arn:\${AWS::Partition}:iam::\${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-\${AWS::AccountId}-\${AWS::Region}",
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "CrossAccountArtifactsBucketA490794E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "CrossAccountArtifactsBucketA490794E",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "kms:Decrypt",
+                "kms:DescribeKey",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CrossAccountArtifactKey7D4916D3",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CrossAccountAssetsFileRoleDefaultPolicy75C80F22",
+        "Roles": Array [
+          Object {
+            "Ref": "CrossAccountAssetsFileRoleA62CD5A0",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CrossAccountCodeBuildActionRoleAD915E6A": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:ViaAWSService": "codepipeline.amazonaws.com",
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CrossAccountCodeBuildActionRoleDefaultPolicy49AAE258": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CrossAccountCodePipelineBuildSynthCdkBuildProject938B55FC",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CrossAccountUpdatePipelineSelfMutationEC1756F0",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CrossAccountAssetsFileAsset1A747E04B",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CrossAccountCodeBuildActionRoleDefaultPolicy49AAE258",
+        "Roles": Array [
+          Object {
+            "Ref": "CrossAccountCodeBuildActionRoleAD915E6A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CrossAccountCodePipelineBuildSynthCdkBuildProject938B55FC": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Artifacts": Object {
+          "Type": "CODEPIPELINE",
+        },
+        "Cache": Object {
+          "Type": "NO_CACHE",
+        },
+        "Description": "Pipeline step Default/CodePipeline/Build/Synth",
+        "EncryptionKey": Object {
+          "Fn::GetAtt": Array [
+            "CrossAccountArtifactKey7D4916D3",
+            "Arn",
+          ],
+        },
+        "Environment": Object {
+          "ComputeType": "BUILD_GENERAL1_SMALL",
+          "Image": "aws/codebuild/standard:6.0",
+          "ImagePullCredentialsType": "CODEBUILD",
+          "PrivilegedMode": false,
+          "Type": "LINUX_CONTAINER",
+        },
+        "ServiceRole": Object {
+          "Fn::GetAtt": Array [
+            "CrossAccountCodePipelineBuildSynthCdkBuildProjectRole06CF955F",
+            "Arn",
+          ],
+        },
+        "Source": Object {
+          "BuildSpec": "{
+  \\"version\\": \\"0.2\\",
+  \\"phases\\": {
+    \\"install\\": {
+      \\"commands\\": [
+        \\"npm install -g aws-cdk\\",
+        \\"yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile\\"
+      ]
+    },
+    \\"build\\": {
+      \\"commands\\": [
+        \\"npx nx run-many --target=build --all\\"
+      ]
+    }
+  },
+  \\"artifacts\\": {
+    \\"secondary-artifacts\\": {
+      \\"Synth_Output\\": {
+        \\"base-directory\\": \\"cdk.out\\",
+        \\"files\\": \\"**/*\\"
+      },
+      \\"Synth__\\": {
+        \\"base-directory\\": \\".\\",
+        \\"files\\": \\"**/*\\"
+      }
+    }
+  }
+}",
+          "Type": "CODEPIPELINE",
+        },
+      },
+      "Type": "AWS::CodeBuild::Project",
+    },
+    "CrossAccountCodePipelineBuildSynthCdkBuildProjectRole06CF955F": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "codebuild.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CrossAccountCodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicy94879C97": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":logs:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":log-group:/aws/codebuild/",
+                      Object {
+                        "Ref": "CrossAccountCodePipelineBuildSynthCdkBuildProject938B55FC",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":logs:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":log-group:/aws/codebuild/",
+                      Object {
+                        "Ref": "CrossAccountCodePipelineBuildSynthCdkBuildProject938B55FC",
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "codebuild:CreateReportGroup",
+                "codebuild:CreateReport",
+                "codebuild:UpdateReport",
+                "codebuild:BatchPutTestCases",
+                "codebuild:BatchPutCodeCoverages",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":codebuild:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":report-group/",
+                    Object {
+                      "Ref": "CrossAccountCodePipelineBuildSynthCdkBuildProject938B55FC",
+                    },
+                    "-*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "CrossAccountArtifactsBucketA490794E",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "CrossAccountArtifactsBucketA490794E",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "kms:Decrypt",
+                "kms:DescribeKey",
+                "kms:Encrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CrossAccountArtifactKey7D4916D3",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "kms:Decrypt",
+                "kms:Encrypt",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "CrossAccountArtifactKey7D4916D3",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CrossAccountCodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicy94879C97",
+        "Roles": Array [
+          Object {
+            "Ref": "CrossAccountCodePipelineBuildSynthCdkBuildProjectRole06CF955F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CrossAccountCodePipelineEventsRoleCF998AEF": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CrossAccountCodePipelineEventsRoleDefaultPolicyCDDAD89A": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "codepipeline:StartPipelineExecution",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":codepipeline:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "CrossAccountCodePipelineFE6BA407",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CrossAccountCodePipelineEventsRoleDefaultPolicyCDDAD89A",
+        "Roles": Array [
+          Object {
+            "Ref": "CrossAccountCodePipelineEventsRoleCF998AEF",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CrossAccountCodePipelineFE6BA407": Object {
       "DependsOn": Array [
-        "CodePipelineRoleDefaultPolicy8D520A8D",
-        "CodePipelineRoleB3A660B4",
+        "CrossAccountCodePipelineRoleDefaultPolicyB81D2E54",
+        "CrossAccountCodePipelineRole6867FC22",
       ],
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "ArtifactStore": Object {
           "EncryptionKey": Object {
             "Id": Object {
               "Fn::GetAtt": Array [
-                "ArtifactKey8D84C5F0",
+                "CrossAccountArtifactKey7D4916D3",
                 "Arn",
               ],
             },
             "Type": "KMS",
           },
           "Location": Object {
-            "Ref": "ArtifactsBucket2AAC5544",
+            "Ref": "CrossAccountArtifactsBucketA490794E",
           },
           "Type": "S3",
         },
         "RestartExecutionOnUpdate": true,
         "RoleArn": Object {
           "Fn::GetAtt": Array [
-            "CodePipelineRoleB3A660B4",
+            "CrossAccountCodePipelineRole6867FC22",
             "Arn",
           ],
         },
@@ -3456,25 +5268,25 @@ Object {
                   "PollForSourceChanges": false,
                   "RepositoryName": Object {
                     "Fn::GetAtt": Array [
-                      "CodeRepositoryBA42F94A",
+                      "CrossAccountCodeRepositoryCF9338D3",
                       "Name",
                     ],
                   },
                 },
                 "Name": Object {
                   "Fn::GetAtt": Array [
-                    "CodeRepositoryBA42F94A",
+                    "CrossAccountCodeRepositoryCF9338D3",
                     "Name",
                   ],
                 },
                 "OutputArtifacts": Array [
                   Object {
-                    "Name": "c8b95ca81f750a44513d18b27868db0afa191aa92e_Source",
+                    "Name": "c8323abab1481846407037ff91e03fe414541ba20b_Source",
                   },
                 ],
                 "RoleArn": Object {
                   "Fn::GetAtt": Array [
-                    "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70",
+                    "CrossAccountCodePipelineSourceCodeCommitCodePipelineActionRole1A00297F",
                     "Arn",
                   ],
                 },
@@ -3495,12 +5307,12 @@ Object {
                 "Configuration": Object {
                   "EnvironmentVariables": "[{\\"name\\":\\"_PROJECT_CONFIG_HASH\\",\\"type\\":\\"PLAINTEXT\\",\\"value\\":\\"9b6cac2596443c465eb42c0d0d84de22a8632cbeb9388a40d13889341f9b20c5\\"}]",
                   "ProjectName": Object {
-                    "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                    "Ref": "CrossAccountCodePipelineBuildSynthCdkBuildProject938B55FC",
                   },
                 },
                 "InputArtifacts": Array [
                   Object {
-                    "Name": "c8b95ca81f750a44513d18b27868db0afa191aa92e_Source",
+                    "Name": "c8323abab1481846407037ff91e03fe414541ba20b_Source",
                   },
                 ],
                 "Name": "Synth",
@@ -3514,7 +5326,7 @@ Object {
                 ],
                 "RoleArn": Object {
                   "Fn::GetAtt": Array [
-                    "CrossAccountCodeBuildActionRoleAAA68524",
+                    "CrossAccountCodeBuildActionRoleAD915E6A",
                     "Arn",
                   ],
                 },
@@ -3535,7 +5347,7 @@ Object {
                 "Configuration": Object {
                   "EnvironmentVariables": "[{\\"name\\":\\"_PROJECT_CONFIG_HASH\\",\\"type\\":\\"PLAINTEXT\\",\\"value\\":\\"e437283b833a76d1459ba3b9b11f0bf0f0c58fc4c9c6a130298f52e21508b79e\\"}]",
                   "ProjectName": Object {
-                    "Ref": "CrossAccountUpdatePipelineSelfMutation8D616EE5",
+                    "Ref": "CrossAccountUpdatePipelineSelfMutationEC1756F0",
                   },
                 },
                 "InputArtifacts": Array [
@@ -3546,7 +5358,7 @@ Object {
                 "Name": "SelfMutate",
                 "RoleArn": Object {
                   "Fn::GetAtt": Array [
-                    "CrossAccountCodeBuildActionRoleAAA68524",
+                    "CrossAccountCodeBuildActionRoleAD915E6A",
                     "Arn",
                   ],
                 },
@@ -3566,7 +5378,7 @@ Object {
                 },
                 "Configuration": Object {
                   "ProjectName": Object {
-                    "Ref": "CrossAccountAssetsFileAsset11C4C6E29",
+                    "Ref": "CrossAccountAssetsFileAsset1A747E04B",
                   },
                 },
                 "InputArtifacts": Array [
@@ -3577,7 +5389,7 @@ Object {
                 "Name": "FileAsset1",
                 "RoleArn": Object {
                   "Fn::GetAtt": Array [
-                    "CrossAccountCodeBuildActionRoleAAA68524",
+                    "CrossAccountCodeBuildActionRoleAD915E6A",
                     "Arn",
                   ],
                 },
@@ -3701,411 +5513,37 @@ Object {
       },
       "Type": "AWS::CodePipeline::Pipeline",
     },
-    "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6": Object {
-      "Properties": Object {
-        "Artifacts": Object {
-          "Type": "CODEPIPELINE",
-        },
-        "Cache": Object {
-          "Type": "NO_CACHE",
-        },
-        "Description": "Pipeline step Default/CodePipeline/Build/Synth",
-        "EncryptionKey": Object {
-          "Fn::GetAtt": Array [
-            "ArtifactKey8D84C5F0",
-            "Arn",
-          ],
-        },
-        "Environment": Object {
-          "ComputeType": "BUILD_GENERAL1_SMALL",
-          "Image": "aws/codebuild/standard:6.0",
-          "ImagePullCredentialsType": "CODEBUILD",
-          "PrivilegedMode": false,
-          "Type": "LINUX_CONTAINER",
-        },
-        "ServiceRole": Object {
-          "Fn::GetAtt": Array [
-            "CodePipelineBuildSynthCdkBuildProjectRoleB73287D4",
-            "Arn",
-          ],
-        },
-        "Source": Object {
-          "BuildSpec": "{
-  \\"version\\": \\"0.2\\",
-  \\"phases\\": {
-    \\"install\\": {
-      \\"commands\\": [
-        \\"npm install -g aws-cdk\\",
-        \\"yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile\\"
-      ]
-    },
-    \\"build\\": {
-      \\"commands\\": [
-        \\"npx nx run-many --target=build --all\\"
-      ]
-    }
-  },
-  \\"artifacts\\": {
-    \\"secondary-artifacts\\": {
-      \\"Synth_Output\\": {
-        \\"base-directory\\": \\"cdk.out\\",
-        \\"files\\": \\"**/*\\"
-      },
-      \\"Synth__\\": {
-        \\"base-directory\\": \\".\\",
-        \\"files\\": \\"**/*\\"
-      }
-    }
-  }
-}",
-          "Type": "CODEPIPELINE",
-        },
-      },
-      "Type": "AWS::CodeBuild::Project",
-    },
-    "CodePipelineBuildSynthCdkBuildProjectRoleB73287D4": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "codebuild.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyB7EDB705": Object {
+    "CrossAccountCodePipelineRole6867FC22": Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsSolutions-IAM5",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
           ],
         },
       },
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "logs:CreateLogGroup",
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":logs:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":log-group:/aws/codebuild/",
-                      Object {
-                        "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
-                      },
-                    ],
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":logs:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":log-group:/aws/codebuild/",
-                      Object {
-                        "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
-                      },
-                      ":*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "codebuild:CreateReportGroup",
-                "codebuild:CreateReport",
-                "codebuild:UpdateReport",
-                "codebuild:BatchPutTestCases",
-                "codebuild:BatchPutCodeCoverages",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:",
-                    Object {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":codebuild:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":report-group/",
-                    Object {
-                      "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
-                    },
-                    "-*",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-                "s3:DeleteObject*",
-                "s3:PutObject",
-                "s3:PutObjectLegalHold",
-                "s3:PutObjectRetention",
-                "s3:PutObjectTagging",
-                "s3:PutObjectVersionTagging",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "kms:Decrypt",
-                "kms:DescribeKey",
-                "kms:Encrypt",
-                "kms:ReEncrypt*",
-                "kms:GenerateDataKey*",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "ArtifactKey8D84C5F0",
-                  "Arn",
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "kms:Decrypt",
-                "kms:Encrypt",
-                "kms:ReEncrypt*",
-                "kms:GenerateDataKey*",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "ArtifactKey8D84C5F0",
-                  "Arn",
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "CodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyB7EDB705",
-        "Roles": Array [
-          Object {
-            "Ref": "CodePipelineBuildSynthCdkBuildProjectRoleB73287D4",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "CodePipelineEventsRole4196480D": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "events.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CodePipelineEventsRoleDefaultPolicy13DBD2D2": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "codepipeline:StartPipelineExecution",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:",
-                    Object {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":codepipeline:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "CodePipelineB74E5936",
-                    },
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "CodePipelineEventsRoleDefaultPolicy13DBD2D2",
-        "Roles": Array [
-          Object {
-            "Ref": "CodePipelineEventsRole4196480D",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "CodePipelineRoleB3A660B4": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -4122,75 +5560,33 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "CodePipelineRoleDefaultPolicy8D520A8D": Object {
+    "CrossAccountCodePipelineRoleDefaultPolicyB81D2E54": Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsSolutions-IAM5",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
           ],
         },
@@ -4215,7 +5611,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "CrossAccountArtifactsBucketA490794E",
                     "Arn",
                   ],
                 },
@@ -4225,7 +5621,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "CrossAccountArtifactsBucketA490794E",
                           "Arn",
                         ],
                       },
@@ -4246,7 +5642,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "ArtifactKey8D84C5F0",
+                  "CrossAccountArtifactKey7D4916D3",
                   "Arn",
                 ],
               },
@@ -4256,7 +5652,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70",
+                  "CrossAccountCodePipelineSourceCodeCommitCodePipelineActionRole1A00297F",
                   "Arn",
                 ],
               },
@@ -4266,7 +5662,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "CrossAccountCodeBuildActionRoleAAA68524",
+                  "CrossAccountCodeBuildActionRoleAD915E6A",
                   "Arn",
                 ],
               },
@@ -4301,16 +5697,46 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "CodePipelineRoleDefaultPolicy8D520A8D",
+        "PolicyName": "CrossAccountCodePipelineRoleDefaultPolicyB81D2E54",
         "Roles": Array [
           Object {
-            "Ref": "CodePipelineRoleB3A660B4",
+            "Ref": "CrossAccountCodePipelineRole6867FC22",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70": Object {
+    "CrossAccountCodePipelineSourceCodeCommitCodePipelineActionRole1A00297F": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -4342,57 +5768,33 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "CodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyAFBD34E4": Object {
+    "CrossAccountCodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicy443B61A0": Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsSolutions-IAM5",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
           ],
         },
@@ -4417,7 +5819,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "CrossAccountArtifactsBucketA490794E",
                     "Arn",
                   ],
                 },
@@ -4427,7 +5829,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "CrossAccountArtifactsBucketA490794E",
                           "Arn",
                         ],
                       },
@@ -4448,7 +5850,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "ArtifactKey8D84C5F0",
+                  "CrossAccountArtifactKey7D4916D3",
                   "Arn",
                 ],
               },
@@ -4464,7 +5866,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "CodeRepositoryBA42F94A",
+                  "CrossAccountCodeRepositoryCF9338D3",
                   "Arn",
                 ],
               },
@@ -4472,24 +5874,84 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "CodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyAFBD34E4",
+        "PolicyName": "CrossAccountCodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicy443B61A0",
         "Roles": Array [
           Object {
-            "Ref": "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70",
+            "Ref": "CrossAccountCodePipelineSourceCodeCommitCodePipelineActionRole1A00297F",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "CodeRepositoryBA42F94A": Object {
+    "CrossAccountCodeRepositoryCF9338D3": Object {
       "DeletionPolicy": "Retain",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "RepositoryName": "Defaults",
       },
       "Type": "AWS::CodeCommit::Repository",
       "UpdateReplacePolicy": "Retain",
     },
-    "CodeRepositoryCodePipelinemainlineEventRuleEDE9EDAA": Object {
+    "CrossAccountCodeRepositoryCrossAccountCodePipelineE9B4FFC3mainlineEventRule3B7BD205": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "EventPattern": Object {
           "detail": Object {
@@ -4507,7 +5969,7 @@ Object {
           "resources": Array [
             Object {
               "Fn::GetAtt": Array [
-                "CodeRepositoryBA42F94A",
+                "CrossAccountCodeRepositoryCF9338D3",
                 "Arn",
               ],
             },
@@ -4537,7 +5999,7 @@ Object {
                   },
                   ":",
                   Object {
-                    "Ref": "CodePipelineB74E5936",
+                    "Ref": "CrossAccountCodePipelineFE6BA407",
                   },
                 ],
               ],
@@ -4545,7 +6007,7 @@ Object {
             "Id": "Target0",
             "RoleArn": Object {
               "Fn::GetAtt": Array [
-                "CodePipelineEventsRole4196480D",
+                "CrossAccountCodePipelineEventsRoleCF998AEF",
                 "Arn",
               ],
             },
@@ -4553,336 +6015,6 @@ Object {
         ],
       },
       "Type": "AWS::Events::Rule",
-    },
-    "CrossAccountAssetsFileAsset11C4C6E29": Object {
-      "Properties": Object {
-        "Artifacts": Object {
-          "Type": "CODEPIPELINE",
-        },
-        "Cache": Object {
-          "Type": "NO_CACHE",
-        },
-        "Description": "Pipeline step Default/CodePipeline/Assets/FileAsset1",
-        "EncryptionKey": Object {
-          "Fn::GetAtt": Array [
-            "ArtifactKey8D84C5F0",
-            "Arn",
-          ],
-        },
-        "Environment": Object {
-          "ComputeType": "BUILD_GENERAL1_SMALL",
-          "Image": "aws/codebuild/standard:6.0",
-          "ImagePullCredentialsType": "CODEBUILD",
-          "PrivilegedMode": false,
-          "Type": "LINUX_CONTAINER",
-        },
-        "ServiceRole": Object {
-          "Fn::GetAtt": Array [
-            "CrossAccountAssetsFileRole790499C9",
-            "Arn",
-          ],
-        },
-        "Source": Object {
-          "BuildSpec": "{
-  \\"version\\": \\"0.2\\",
-  \\"phases\\": {
-    \\"install\\": {
-      \\"commands\\": [
-        \\"npm install -g cdk-assets@2\\"
-      ]
-    },
-    \\"build\\": {
-      \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-Stage/StageAppStack7618C9EF.assets.json\\\\\\" --verbose publish \\\\\\"824fe84db24bbf4d297bea3c89c9f634f2379cc336ccbe96772c4cc0eab472e3:current_account-current_region\\\\\\"\\"
-      ]
-    }
-  }
-}",
-          "Type": "CODEPIPELINE",
-        },
-      },
-      "Type": "AWS::CodeBuild::Project",
-    },
-    "CrossAccountAssetsFileRole790499C9": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "codebuild.amazonaws.com",
-              },
-            },
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":iam::",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":root",
-                    ],
-                  ],
-                },
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CrossAccountAssetsFileRoleDefaultPolicy70E781AB": Object {
-      "Metadata": Object {
-        "cdk_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "id": "AwsSolutions-IAM5",
-              "reason": "Asset role requires access to the Artifacts Bucket",
-            },
-            Object {
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Asset role requires access to the Artifacts Bucket",
-            },
-          ],
-        },
-      },
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "logs:CreateLogGroup",
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:",
-                    Object {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":logs:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":log-group:/aws/codebuild/*",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "codebuild:CreateReportGroup",
-                "codebuild:CreateReport",
-                "codebuild:UpdateReport",
-                "codebuild:BatchPutTestCases",
-                "codebuild:BatchPutCodeCoverages",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:",
-                    Object {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":codebuild:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":report-group/*",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "codebuild:BatchGetBuilds",
-                "codebuild:StartBuild",
-                "codebuild:StopBuild",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Sub": "arn:\${AWS::Partition}:iam::\${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-\${AWS::AccountId}-\${AWS::Region}",
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "kms:Decrypt",
-                "kms:DescribeKey",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "ArtifactKey8D84C5F0",
-                  "Arn",
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "CrossAccountAssetsFileRoleDefaultPolicy70E781AB",
-        "Roles": Array [
-          Object {
-            "Ref": "CrossAccountAssetsFileRole790499C9",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "CrossAccountCodeBuildActionRoleAAA68524": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Condition": Object {
-                "Bool": Object {
-                  "aws:ViaAWSService": "codepipeline.amazonaws.com",
-                },
-              },
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":iam::",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":root",
-                    ],
-                  ],
-                },
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CrossAccountCodeBuildActionRoleDefaultPolicyCD3511D6": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "codebuild:BatchGetBuilds",
-                "codebuild:StartBuild",
-                "codebuild:StopBuild",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
-                  "Arn",
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "codebuild:BatchGetBuilds",
-                "codebuild:StartBuild",
-                "codebuild:StopBuild",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "CrossAccountUpdatePipelineSelfMutation8D616EE5",
-                  "Arn",
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "codebuild:BatchGetBuilds",
-                "codebuild:StartBuild",
-                "codebuild:StopBuild",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "CrossAccountAssetsFileAsset11C4C6E29",
-                  "Arn",
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "CrossAccountCodeBuildActionRoleDefaultPolicyCD3511D6",
-        "Roles": Array [
-          Object {
-            "Ref": "CrossAccountCodeBuildActionRoleAAA68524",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
     },
     "CrossAccountSonarCodeScannerSonarQubeToken76921F1B": Object {
       "DeletionPolicy": "Delete",
@@ -4897,6 +6029,30 @@ Object {
               "id": "AwsPrototyping-SecretsManagerRotationEnabled",
               "reason": "Key rotation is not possible as a user token needs to be generated from Sonarqube",
             },
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
           ],
         },
       },
@@ -4907,6 +6063,36 @@ Object {
       "UpdateReplacePolicy": "Delete",
     },
     "CrossAccountSonarCodeScannerSynthBuildProjectOnSynthSuccessD24D011A": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "EventPattern": Object {
           "detail": Object {
@@ -4928,7 +6114,7 @@ Object {
                               ":",
                               Object {
                                 "Fn::GetAtt": Array [
-                                  "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                                  "CrossAccountCodePipelineBuildSynthCdkBuildProject938B55FC",
                                   "Arn",
                                 ],
                               },
@@ -4977,6 +6163,36 @@ Object {
       "Type": "AWS::Events::Rule",
     },
     "CrossAccountSonarCodeScannerValidationProjectAA1083C3": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Artifacts": Object {
           "Type": "NO_ARTIFACTS",
@@ -5061,6 +6277,36 @@ Object {
       "Type": "AWS::CodeBuild::Project",
     },
     "CrossAccountSonarCodeScannerValidationProjectEventsRole551D56DA": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -5078,6 +6324,36 @@ Object {
       "Type": "AWS::IAM::Role",
     },
     "CrossAccountSonarCodeScannerValidationProjectEventsRoleDefaultPolicy1B23C513": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -5143,6 +6419,30 @@ Object {
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
               "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
             },
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
           ],
         },
       },
@@ -5201,6 +6501,30 @@ Object {
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
               "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
+            },
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
           ],
         },
@@ -5311,7 +6635,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                  "CrossAccountCodePipelineBuildSynthCdkBuildProject938B55FC",
                   "Arn",
                 ],
               },
@@ -5322,7 +6646,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "CrossAccountArtifactsBucketA490794E",
                     "Arn",
                   ],
                 },
@@ -5332,7 +6656,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "CrossAccountArtifactsBucketA490794E",
                           "Arn",
                         ],
                       },
@@ -5350,7 +6674,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "ArtifactKey8D84C5F0",
+                  "CrossAccountArtifactKey7D4916D3",
                   "Arn",
                 ],
               },
@@ -5367,7 +6691,37 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
-    "CrossAccountUpdatePipelineSelfMutation8D616EE5": Object {
+    "CrossAccountUpdatePipelineSelfMutationEC1756F0": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Artifacts": Object {
           "Type": "CODEPIPELINE",
@@ -5378,7 +6732,7 @@ Object {
         "Description": "Pipeline step Default/CodePipeline/UpdatePipeline/SelfMutate",
         "EncryptionKey": Object {
           "Fn::GetAtt": Array [
-            "ArtifactKey8D84C5F0",
+            "CrossAccountArtifactKey7D4916D3",
             "Arn",
           ],
         },
@@ -5391,7 +6745,7 @@ Object {
         },
         "ServiceRole": Object {
           "Fn::GetAtt": Array [
-            "CrossAccountUpdatePipelineSelfMutationRoleBEAB3750",
+            "CrossAccountUpdatePipelineSelfMutationRole0F9342FC",
             "Arn",
           ],
         },
@@ -5416,7 +6770,37 @@ Object {
       },
       "Type": "AWS::CodeBuild::Project",
     },
-    "CrossAccountUpdatePipelineSelfMutationRoleBEAB3750": Object {
+    "CrossAccountUpdatePipelineSelfMutationRole0F9342FC": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -5433,187 +6817,33 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "CrossAccountUpdatePipelineSelfMutationRoleDefaultPolicy53F5B99B": Object {
+    "CrossAccountUpdatePipelineSelfMutationRoleDefaultPolicyA7DA8F1E": Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CrossAccountUpdatePipelineSelfMutation.*>:\\\\*$/g",
-                },
-              ],
               "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CrossAccountUpdatePipelineSelfMutation.*>-\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:\\\\*:iam::<AWS::AccountId>:role/\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to assume a role from within the current account in order to deploy.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to list all buckets and stacks.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": Object {
-                    "Fn::Join": Array [
-                      "",
-                      Array [
-                        "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|",
-                        Object {
-                          "Ref": "AWS::AccountId",
-                        },
-                        "):log-group:/aws/codebuild/<CrossAccountUpdatePipelineSelfMutation.*>:\\\\*$/g",
-                      ],
-                    ],
-                  },
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CrossAccountUpdatePipelineSelfMutation.*>:\\\\*$/g",
-                },
-              ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CrossAccountUpdatePipelineSelfMutation.*>-\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:\\\\*:iam::<AWS::AccountId>:role/\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to assume a role from within the current account in order to deploy.",
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to list all buckets and stacks.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": Object {
-                    "Fn::Join": Array [
-                      "",
-                      Array [
-                        "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|",
-                        Object {
-                          "Ref": "AWS::AccountId",
-                        },
-                        "):log-group:/aws/codebuild/<CrossAccountUpdatePipelineSelfMutation.*>:\\\\*$/g",
-                      ],
-                    ],
-                  },
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
           ],
         },
@@ -5647,7 +6877,7 @@ Object {
                       },
                       ":log-group:/aws/codebuild/",
                       Object {
-                        "Ref": "CrossAccountUpdatePipelineSelfMutation8D616EE5",
+                        "Ref": "CrossAccountUpdatePipelineSelfMutationEC1756F0",
                       },
                     ],
                   ],
@@ -5670,7 +6900,7 @@ Object {
                       },
                       ":log-group:/aws/codebuild/",
                       Object {
-                        "Ref": "CrossAccountUpdatePipelineSelfMutation8D616EE5",
+                        "Ref": "CrossAccountUpdatePipelineSelfMutationEC1756F0",
                       },
                       ":*",
                     ],
@@ -5705,7 +6935,7 @@ Object {
                     },
                     ":report-group/",
                     Object {
-                      "Ref": "CrossAccountUpdatePipelineSelfMutation8D616EE5",
+                      "Ref": "CrossAccountUpdatePipelineSelfMutationEC1756F0",
                     },
                     "-*",
                   ],
@@ -5757,7 +6987,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "CrossAccountArtifactsBucketA490794E",
                     "Arn",
                   ],
                 },
@@ -5767,7 +6997,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "CrossAccountArtifactsBucketA490794E",
                           "Arn",
                         ],
                       },
@@ -5785,7 +7015,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "ArtifactKey8D84C5F0",
+                  "CrossAccountArtifactKey7D4916D3",
                   "Arn",
                 ],
               },
@@ -5800,7 +7030,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "ArtifactKey8D84C5F0",
+                  "CrossAccountArtifactKey7D4916D3",
                   "Arn",
                 ],
               },
@@ -5808,10 +7038,10 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "CrossAccountUpdatePipelineSelfMutationRoleDefaultPolicy53F5B99B",
+        "PolicyName": "CrossAccountUpdatePipelineSelfMutationRoleDefaultPolicyA7DA8F1E",
         "Roles": Array [
           Object {
-            "Ref": "CrossAccountUpdatePipelineSelfMutationRoleBEAB3750",
+            "Ref": "CrossAccountUpdatePipelineSelfMutationRole0F9342FC",
           },
         ],
       },
@@ -5834,7 +7064,7 @@ Object {
             Array [
               "Lambda function for auto-deleting objects in ",
               Object {
-                "Ref": "AccessLogsBucket83982689",
+                "Ref": "CrossAccountAccessLogsBucketD7D72FC7",
               },
               " S3 bucket.",
             ],
@@ -5908,30 +7138,8 @@ Object {
 
 exports[`PDK Pipeline Unit Tests Defaults - using AwsPrototyping NagPack 1`] = `
 Object {
-  "Metadata": Object {
-    "cdk_nag": Object {
-      "rules_to_suppress": Array [
-        Object {
-          "id": "AwsSolutions-CB4",
-          "reason": "Encryption of Codebuild is not required.",
-        },
-        Object {
-          "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
-          "reason": "Encryption of Codebuild is not required.",
-        },
-        Object {
-          "id": "AwsSolutions-S1",
-          "reason": "Access Log buckets should not have s3 bucket logging",
-        },
-        Object {
-          "id": "AwsPrototyping-S3BucketLoggingEnabled",
-          "reason": "Access Log buckets should not have s3 bucket logging",
-        },
-      ],
-    },
-  },
   "Outputs": Object {
-    "CodeRepositoryGRCUrl": Object {
+    "DefaultsCodeRepositoryGRCUrlF9B2453F": Object {
       "Value": Object {
         "Fn::Join": Array [
           "",
@@ -5943,7 +7151,7 @@ Object {
             "://",
             Object {
               "Fn::GetAtt": Array [
-                "CodeRepositoryBA42F94A",
+                "DefaultsCodeRepositoryBDE0B808",
                 "Name",
               ],
             },
@@ -5965,16 +7173,110 @@ Object {
     },
   },
   "Resources": Object {
-    "AccessLogsBucket83982689": Object {
-      "DeletionPolicy": "Delete",
+    "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F": Object {
+      "DependsOn": Array [
+        "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+      ],
       "Properties": Object {
-        "AccessControl": "LogDeliveryWrite",
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "350185a1069fa20a23a583e20c77f6844218bd73097902362dc94f1a108f5d89.zip",
+        },
+        "Description": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "Lambda function for auto-deleting objects in ",
+              Object {
+                "Ref": "DefaultsAccessLogsBucket1E788CBC",
+              },
+              " S3 bucket.",
+            ],
+          ],
+        },
+        "Handler": "__entrypoint__.handler",
+        "MemorySize": 128,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsAccessLogsBucket1E788CBC": Object {
+      "DeletionPolicy": "Delete",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
         "BucketEncryption": Object {
           "ServerSideEncryptionConfiguration": Array [
             Object {
               "ServerSideEncryptionByDefault": Object {
                 "SSEAlgorithm": "AES256",
               },
+            },
+          ],
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
             },
           ],
         },
@@ -5994,14 +7296,44 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Delete",
     },
-    "AccessLogsBucketAutoDeleteObjectsCustomResource93F9213A": Object {
+    "DefaultsAccessLogsBucketAutoDeleteObjectsCustomResourceB315E04B": Object {
       "DeletionPolicy": "Delete",
       "DependsOn": Array [
-        "AccessLogsBucketPolicy7F77476F",
+        "DefaultsAccessLogsBucketPolicy87291CAB",
       ],
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "BucketName": Object {
-          "Ref": "AccessLogsBucket83982689",
+          "Ref": "DefaultsAccessLogsBucket1E788CBC",
         },
         "ServiceToken": Object {
           "Fn::GetAtt": Array [
@@ -6013,10 +7345,40 @@ Object {
       "Type": "Custom::S3AutoDeleteObjects",
       "UpdateReplacePolicy": "Delete",
     },
-    "AccessLogsBucketPolicy7F77476F": Object {
+    "DefaultsAccessLogsBucketPolicy87291CAB": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "AccessLogsBucket83982689",
+          "Ref": "DefaultsAccessLogsBucket1E788CBC",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -6034,7 +7396,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "AccessLogsBucket83982689",
+                    "DefaultsAccessLogsBucket1E788CBC",
                     "Arn",
                   ],
                 },
@@ -6044,7 +7406,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "AccessLogsBucket83982689",
+                          "DefaultsAccessLogsBucket1E788CBC",
                           "Arn",
                         ],
                       },
@@ -6072,7 +7434,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "AccessLogsBucket83982689",
+                    "DefaultsAccessLogsBucket1E788CBC",
                     "Arn",
                   ],
                 },
@@ -6082,7 +7444,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "AccessLogsBucket83982689",
+                          "DefaultsAccessLogsBucket1E788CBC",
                           "Arn",
                         ],
                       },
@@ -6092,14 +7454,80 @@ Object {
                 },
               ],
             },
+            Object {
+              "Action": "s3:PutObject",
+              "Condition": Object {
+                "ArnLike": Object {
+                  "aws:SourceArn": Object {
+                    "Fn::GetAtt": Array [
+                      "DefaultsArtifactsBucket267E29E1",
+                      "Arn",
+                    ],
+                  },
+                },
+                "StringEquals": Object {
+                  "aws:SourceAccount": Object {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "logging.s3.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "DefaultsAccessLogsBucket1E788CBC",
+                        "Arn",
+                      ],
+                    },
+                    "/access-logs*",
+                  ],
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "ArtifactsBucket2AAC5544": Object {
+    "DefaultsArtifactsBucket267E29E1": Object {
       "DeletionPolicy": "Delete",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "BucketEncryption": Object {
           "ServerSideEncryptionConfiguration": Array [
@@ -6112,9 +7540,16 @@ Object {
         },
         "LoggingConfiguration": Object {
           "DestinationBucketName": Object {
-            "Ref": "AccessLogsBucket83982689",
+            "Ref": "DefaultsAccessLogsBucket1E788CBC",
           },
           "LogFilePrefix": "access-logs",
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
+            },
+          ],
         },
         "PublicAccessBlockConfiguration": Object {
           "BlockPublicAcls": true,
@@ -6132,14 +7567,44 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Delete",
     },
-    "ArtifactsBucketAutoDeleteObjectsCustomResource0E3B4320": Object {
+    "DefaultsArtifactsBucketAutoDeleteObjectsCustomResourceED1B0B57": Object {
       "DeletionPolicy": "Delete",
       "DependsOn": Array [
-        "ArtifactsBucketPolicy852CB646",
+        "DefaultsArtifactsBucketPolicyA6159620",
       ],
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "BucketName": Object {
-          "Ref": "ArtifactsBucket2AAC5544",
+          "Ref": "DefaultsArtifactsBucket267E29E1",
         },
         "ServiceToken": Object {
           "Fn::GetAtt": Array [
@@ -6151,10 +7616,40 @@ Object {
       "Type": "Custom::S3AutoDeleteObjects",
       "UpdateReplacePolicy": "Delete",
     },
-    "ArtifactsBucketPolicy852CB646": Object {
+    "DefaultsArtifactsBucketPolicyA6159620": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "ArtifactsBucket2AAC5544",
+          "Ref": "DefaultsArtifactsBucket267E29E1",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -6172,7 +7667,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "DefaultsArtifactsBucket267E29E1",
                     "Arn",
                   ],
                 },
@@ -6182,7 +7677,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "DefaultsArtifactsBucket267E29E1",
                           "Arn",
                         ],
                       },
@@ -6210,7 +7705,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "DefaultsArtifactsBucket267E29E1",
                     "Arn",
                   ],
                 },
@@ -6220,7 +7715,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "DefaultsArtifactsBucket267E29E1",
                           "Arn",
                         ],
                       },
@@ -6265,7 +7760,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "DefaultsArtifactsBucket267E29E1",
                     "Arn",
                   ],
                 },
@@ -6275,7 +7770,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "DefaultsArtifactsBucket267E29E1",
                           "Arn",
                         ],
                       },
@@ -6291,22 +7786,808 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "CodePipelineB74E5936": Object {
+    "DefaultsAssetsFileAsset1C016008C": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Artifacts": Object {
+          "Type": "CODEPIPELINE",
+        },
+        "Cache": Object {
+          "Type": "NO_CACHE",
+        },
+        "Description": "Pipeline step Default/CodePipeline/Assets/FileAsset1",
+        "EncryptionKey": "alias/aws/s3",
+        "Environment": Object {
+          "ComputeType": "BUILD_GENERAL1_SMALL",
+          "Image": "aws/codebuild/standard:6.0",
+          "ImagePullCredentialsType": "CODEBUILD",
+          "PrivilegedMode": false,
+          "Type": "LINUX_CONTAINER",
+        },
+        "ServiceRole": Object {
+          "Fn::GetAtt": Array [
+            "DefaultsAssetsFileRole651D25B9",
+            "Arn",
+          ],
+        },
+        "Source": Object {
+          "BuildSpec": "{
+  \\"version\\": \\"0.2\\",
+  \\"phases\\": {
+    \\"install\\": {
+      \\"commands\\": [
+        \\"npm install -g cdk-assets@2\\"
+      ]
+    },
+    \\"build\\": {
+      \\"commands\\": [
+        \\"cdk-assets --path \\\\\\"assembly-Stage/StageAppStack7618C9EF.assets.json\\\\\\" --verbose publish \\\\\\"824fe84db24bbf4d297bea3c89c9f634f2379cc336ccbe96772c4cc0eab472e3:current_account-current_region\\\\\\"\\"
+      ]
+    }
+  }
+}",
+          "Type": "CODEPIPELINE",
+        },
+      },
+      "Type": "AWS::CodeBuild::Project",
+    },
+    "DefaultsAssetsFileRole651D25B9": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "codebuild.amazonaws.com",
+              },
+            },
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsAssetsFileRoleDefaultPolicy3887BD04": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":logs:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":log-group:/aws/codebuild/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:CreateReportGroup",
+                "codebuild:CreateReport",
+                "codebuild:UpdateReport",
+                "codebuild:BatchPutTestCases",
+                "codebuild:BatchPutCodeCoverages",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":codebuild:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":report-group/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Sub": "arn:\${AWS::Partition}:iam::\${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-\${AWS::AccountId}-\${AWS::Region}",
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsArtifactsBucket267E29E1",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DefaultsArtifactsBucket267E29E1",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DefaultsAssetsFileRoleDefaultPolicy3887BD04",
+        "Roles": Array [
+          Object {
+            "Ref": "DefaultsAssetsFileRole651D25B9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DefaultsCodeBuildActionRole26049CBA": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:ViaAWSService": "codepipeline.amazonaws.com",
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsCodeBuildActionRoleDefaultPolicy0F3A543D": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "DefaultsCodePipelineBuildSynthCdkBuildProject81772484",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "DefaultsUpdatePipelineSelfMutationD1F1D812",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "DefaultsAssetsFileAsset1C016008C",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DefaultsCodeBuildActionRoleDefaultPolicy0F3A543D",
+        "Roles": Array [
+          Object {
+            "Ref": "DefaultsCodeBuildActionRole26049CBA",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DefaultsCodePipelineBuildSynthCdkBuildProject81772484": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Artifacts": Object {
+          "Type": "CODEPIPELINE",
+        },
+        "Cache": Object {
+          "Type": "NO_CACHE",
+        },
+        "Description": "Pipeline step Default/CodePipeline/Build/Synth",
+        "EncryptionKey": "alias/aws/s3",
+        "Environment": Object {
+          "ComputeType": "BUILD_GENERAL1_SMALL",
+          "Image": "aws/codebuild/standard:6.0",
+          "ImagePullCredentialsType": "CODEBUILD",
+          "PrivilegedMode": false,
+          "Type": "LINUX_CONTAINER",
+        },
+        "ServiceRole": Object {
+          "Fn::GetAtt": Array [
+            "DefaultsCodePipelineBuildSynthCdkBuildProjectRoleA72DCE39",
+            "Arn",
+          ],
+        },
+        "Source": Object {
+          "BuildSpec": "{
+  \\"version\\": \\"0.2\\",
+  \\"phases\\": {
+    \\"install\\": {
+      \\"commands\\": [
+        \\"npm install -g aws-cdk\\",
+        \\"yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile\\"
+      ]
+    },
+    \\"build\\": {
+      \\"commands\\": [
+        \\"npx nx run-many --target=build --all\\"
+      ]
+    }
+  },
+  \\"artifacts\\": {
+    \\"secondary-artifacts\\": {
+      \\"Synth_Output\\": {
+        \\"base-directory\\": \\"cdk.out\\",
+        \\"files\\": \\"**/*\\"
+      },
+      \\"Synth__\\": {
+        \\"base-directory\\": \\".\\",
+        \\"files\\": \\"**/*\\"
+      }
+    }
+  }
+}",
+          "Type": "CODEPIPELINE",
+        },
+      },
+      "Type": "AWS::CodeBuild::Project",
+    },
+    "DefaultsCodePipelineBuildSynthCdkBuildProjectRoleA72DCE39": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "codebuild.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsCodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyC0AFF59F": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":logs:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":log-group:/aws/codebuild/",
+                      Object {
+                        "Ref": "DefaultsCodePipelineBuildSynthCdkBuildProject81772484",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":logs:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":log-group:/aws/codebuild/",
+                      Object {
+                        "Ref": "DefaultsCodePipelineBuildSynthCdkBuildProject81772484",
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "codebuild:CreateReportGroup",
+                "codebuild:CreateReport",
+                "codebuild:UpdateReport",
+                "codebuild:BatchPutTestCases",
+                "codebuild:BatchPutCodeCoverages",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":codebuild:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":report-group/",
+                    Object {
+                      "Ref": "DefaultsCodePipelineBuildSynthCdkBuildProject81772484",
+                    },
+                    "-*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsArtifactsBucket267E29E1",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DefaultsArtifactsBucket267E29E1",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DefaultsCodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyC0AFF59F",
+        "Roles": Array [
+          Object {
+            "Ref": "DefaultsCodePipelineBuildSynthCdkBuildProjectRoleA72DCE39",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DefaultsCodePipelineDAB2FB72": Object {
       "DependsOn": Array [
-        "CodePipelineRoleDefaultPolicy8D520A8D",
-        "CodePipelineRoleB3A660B4",
+        "DefaultsCodePipelineRoleDefaultPolicyF4A44365",
+        "DefaultsCodePipelineRoleF466C0E3",
       ],
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "ArtifactStore": Object {
           "Location": Object {
-            "Ref": "ArtifactsBucket2AAC5544",
+            "Ref": "DefaultsArtifactsBucket267E29E1",
           },
           "Type": "S3",
         },
         "RestartExecutionOnUpdate": true,
         "RoleArn": Object {
           "Fn::GetAtt": Array [
-            "CodePipelineRoleB3A660B4",
+            "DefaultsCodePipelineRoleF466C0E3",
             "Arn",
           ],
         },
@@ -6325,25 +8606,25 @@ Object {
                   "PollForSourceChanges": false,
                   "RepositoryName": Object {
                     "Fn::GetAtt": Array [
-                      "CodeRepositoryBA42F94A",
+                      "DefaultsCodeRepositoryBDE0B808",
                       "Name",
                     ],
                   },
                 },
                 "Name": Object {
                   "Fn::GetAtt": Array [
-                    "CodeRepositoryBA42F94A",
+                    "DefaultsCodeRepositoryBDE0B808",
                     "Name",
                   ],
                 },
                 "OutputArtifacts": Array [
                   Object {
-                    "Name": "c8b95ca81f750a44513d18b27868db0afa191aa92e_Source",
+                    "Name": "c8be7966da6130450b89fe7dd9dced39142a8f041d_Source",
                   },
                 ],
                 "RoleArn": Object {
                   "Fn::GetAtt": Array [
-                    "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70",
+                    "DefaultsCodePipelineSourceCodeCommitCodePipelineActionRole1F53CA96",
                     "Arn",
                   ],
                 },
@@ -6364,12 +8645,12 @@ Object {
                 "Configuration": Object {
                   "EnvironmentVariables": "[{\\"name\\":\\"_PROJECT_CONFIG_HASH\\",\\"type\\":\\"PLAINTEXT\\",\\"value\\":\\"9b6cac2596443c465eb42c0d0d84de22a8632cbeb9388a40d13889341f9b20c5\\"}]",
                   "ProjectName": Object {
-                    "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                    "Ref": "DefaultsCodePipelineBuildSynthCdkBuildProject81772484",
                   },
                 },
                 "InputArtifacts": Array [
                   Object {
-                    "Name": "c8b95ca81f750a44513d18b27868db0afa191aa92e_Source",
+                    "Name": "c8be7966da6130450b89fe7dd9dced39142a8f041d_Source",
                   },
                 ],
                 "Name": "Synth",
@@ -6383,7 +8664,7 @@ Object {
                 ],
                 "RoleArn": Object {
                   "Fn::GetAtt": Array [
-                    "DefaultsCodeBuildActionRole4BF10433",
+                    "DefaultsCodeBuildActionRole26049CBA",
                     "Arn",
                   ],
                 },
@@ -6404,7 +8685,7 @@ Object {
                 "Configuration": Object {
                   "EnvironmentVariables": "[{\\"name\\":\\"_PROJECT_CONFIG_HASH\\",\\"type\\":\\"PLAINTEXT\\",\\"value\\":\\"e437283b833a76d1459ba3b9b11f0bf0f0c58fc4c9c6a130298f52e21508b79e\\"}]",
                   "ProjectName": Object {
-                    "Ref": "DefaultsUpdatePipelineSelfMutation28F7C994",
+                    "Ref": "DefaultsUpdatePipelineSelfMutationD1F1D812",
                   },
                 },
                 "InputArtifacts": Array [
@@ -6415,7 +8696,7 @@ Object {
                 "Name": "SelfMutate",
                 "RoleArn": Object {
                   "Fn::GetAtt": Array [
-                    "DefaultsCodeBuildActionRole4BF10433",
+                    "DefaultsCodeBuildActionRole26049CBA",
                     "Arn",
                   ],
                 },
@@ -6435,7 +8716,7 @@ Object {
                 },
                 "Configuration": Object {
                   "ProjectName": Object {
-                    "Ref": "DefaultsAssetsFileAsset189C03802",
+                    "Ref": "DefaultsAssetsFileAsset1C016008C",
                   },
                 },
                 "InputArtifacts": Array [
@@ -6446,7 +8727,7 @@ Object {
                 "Name": "FileAsset1",
                 "RoleArn": Object {
                   "Fn::GetAtt": Array [
-                    "DefaultsCodeBuildActionRole4BF10433",
+                    "DefaultsCodeBuildActionRole26049CBA",
                     "Arn",
                   ],
                 },
@@ -6570,315 +8851,37 @@ Object {
       },
       "Type": "AWS::CodePipeline::Pipeline",
     },
-    "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6": Object {
-      "Properties": Object {
-        "Artifacts": Object {
-          "Type": "CODEPIPELINE",
-        },
-        "Cache": Object {
-          "Type": "NO_CACHE",
-        },
-        "Description": "Pipeline step Default/CodePipeline/Build/Synth",
-        "EncryptionKey": "alias/aws/s3",
-        "Environment": Object {
-          "ComputeType": "BUILD_GENERAL1_SMALL",
-          "Image": "aws/codebuild/standard:6.0",
-          "ImagePullCredentialsType": "CODEBUILD",
-          "PrivilegedMode": false,
-          "Type": "LINUX_CONTAINER",
-        },
-        "ServiceRole": Object {
-          "Fn::GetAtt": Array [
-            "CodePipelineBuildSynthCdkBuildProjectRoleB73287D4",
-            "Arn",
-          ],
-        },
-        "Source": Object {
-          "BuildSpec": "{
-  \\"version\\": \\"0.2\\",
-  \\"phases\\": {
-    \\"install\\": {
-      \\"commands\\": [
-        \\"npm install -g aws-cdk\\",
-        \\"yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile\\"
-      ]
-    },
-    \\"build\\": {
-      \\"commands\\": [
-        \\"npx nx run-many --target=build --all\\"
-      ]
-    }
-  },
-  \\"artifacts\\": {
-    \\"secondary-artifacts\\": {
-      \\"Synth_Output\\": {
-        \\"base-directory\\": \\"cdk.out\\",
-        \\"files\\": \\"**/*\\"
-      },
-      \\"Synth__\\": {
-        \\"base-directory\\": \\".\\",
-        \\"files\\": \\"**/*\\"
-      }
-    }
-  }
-}",
-          "Type": "CODEPIPELINE",
-        },
-      },
-      "Type": "AWS::CodeBuild::Project",
-    },
-    "CodePipelineBuildSynthCdkBuildProjectRoleB73287D4": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "codebuild.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyB7EDB705": Object {
+    "DefaultsCodePipelineEventsRole44B0ACD2": Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsSolutions-IAM5",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
           ],
         },
       },
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "logs:CreateLogGroup",
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":logs:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":log-group:/aws/codebuild/",
-                      Object {
-                        "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
-                      },
-                    ],
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":logs:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":log-group:/aws/codebuild/",
-                      Object {
-                        "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
-                      },
-                      ":*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "codebuild:CreateReportGroup",
-                "codebuild:CreateReport",
-                "codebuild:UpdateReport",
-                "codebuild:BatchPutTestCases",
-                "codebuild:BatchPutCodeCoverages",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:",
-                    Object {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":codebuild:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":report-group/",
-                    Object {
-                      "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
-                    },
-                    "-*",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-                "s3:DeleteObject*",
-                "s3:PutObject",
-                "s3:PutObjectLegalHold",
-                "s3:PutObjectRetention",
-                "s3:PutObjectTagging",
-                "s3:PutObjectVersionTagging",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "CodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyB7EDB705",
-        "Roles": Array [
-          Object {
-            "Ref": "CodePipelineBuildSynthCdkBuildProjectRoleB73287D4",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "CodePipelineEventsRole4196480D": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -6895,7 +8898,37 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "CodePipelineEventsRoleDefaultPolicy13DBD2D2": Object {
+    "DefaultsCodePipelineEventsRoleDefaultPolicyB0676072": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -6920,7 +8953,7 @@ Object {
                     },
                     ":",
                     Object {
-                      "Ref": "CodePipelineB74E5936",
+                      "Ref": "DefaultsCodePipelineDAB2FB72",
                     },
                   ],
                 ],
@@ -6929,101 +8962,42 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "CodePipelineEventsRoleDefaultPolicy13DBD2D2",
+        "PolicyName": "DefaultsCodePipelineEventsRoleDefaultPolicyB0676072",
         "Roles": Array [
           Object {
-            "Ref": "CodePipelineEventsRole4196480D",
+            "Ref": "DefaultsCodePipelineEventsRole44B0ACD2",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "CodePipelineRoleB3A660B4": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "codepipeline.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CodePipelineRoleDefaultPolicy8D520A8D": Object {
+    "DefaultsCodePipelineRoleDefaultPolicyF4A44365": Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsSolutions-IAM5",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
           ],
         },
@@ -7048,7 +9022,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "DefaultsArtifactsBucket267E29E1",
                     "Arn",
                   ],
                 },
@@ -7058,7 +9032,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "DefaultsArtifactsBucket267E29E1",
                           "Arn",
                         ],
                       },
@@ -7073,7 +9047,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70",
+                  "DefaultsCodePipelineSourceCodeCommitCodePipelineActionRole1F53CA96",
                   "Arn",
                 ],
               },
@@ -7083,7 +9057,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "DefaultsCodeBuildActionRole4BF10433",
+                  "DefaultsCodeBuildActionRole26049CBA",
                   "Arn",
                 ],
               },
@@ -7118,16 +9092,93 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "CodePipelineRoleDefaultPolicy8D520A8D",
+        "PolicyName": "DefaultsCodePipelineRoleDefaultPolicyF4A44365",
         "Roles": Array [
           Object {
-            "Ref": "CodePipelineRoleB3A660B4",
+            "Ref": "DefaultsCodePipelineRoleF466C0E3",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70": Object {
+    "DefaultsCodePipelineRoleF466C0E3": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "codepipeline.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsCodePipelineSourceCodeCommitCodePipelineActionRole1F53CA96": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -7159,57 +9210,33 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "CodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyAFBD34E4": Object {
+    "DefaultsCodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyF3026D6A": Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsSolutions-IAM5",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
           ],
         },
@@ -7234,7 +9261,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "DefaultsArtifactsBucket267E29E1",
                     "Arn",
                   ],
                 },
@@ -7244,7 +9271,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "DefaultsArtifactsBucket267E29E1",
                           "Arn",
                         ],
                       },
@@ -7265,7 +9292,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "CodeRepositoryBA42F94A",
+                  "DefaultsCodeRepositoryBDE0B808",
                   "Arn",
                 ],
               },
@@ -7273,24 +9300,84 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "CodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyAFBD34E4",
+        "PolicyName": "DefaultsCodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyF3026D6A",
         "Roles": Array [
           Object {
-            "Ref": "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70",
+            "Ref": "DefaultsCodePipelineSourceCodeCommitCodePipelineActionRole1F53CA96",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "CodeRepositoryBA42F94A": Object {
+    "DefaultsCodeRepositoryBDE0B808": Object {
       "DeletionPolicy": "Retain",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "RepositoryName": "Defaults",
       },
       "Type": "AWS::CodeCommit::Repository",
       "UpdateReplacePolicy": "Retain",
     },
-    "CodeRepositoryCodePipelinemainlineEventRuleEDE9EDAA": Object {
+    "DefaultsCodeRepositoryDefaultsCodePipeline4E276C62mainlineEventRule67A64C52": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "EventPattern": Object {
           "detail": Object {
@@ -7308,7 +9395,7 @@ Object {
           "resources": Array [
             Object {
               "Fn::GetAtt": Array [
-                "CodeRepositoryBA42F94A",
+                "DefaultsCodeRepositoryBDE0B808",
                 "Arn",
               ],
             },
@@ -7338,7 +9425,7 @@ Object {
                   },
                   ":",
                   Object {
-                    "Ref": "CodePipelineB74E5936",
+                    "Ref": "DefaultsCodePipelineDAB2FB72",
                   },
                 ],
               ],
@@ -7346,7 +9433,7 @@ Object {
             "Id": "Target0",
             "RoleArn": Object {
               "Fn::GetAtt": Array [
-                "CodePipelineEventsRole4196480D",
+                "DefaultsCodePipelineEventsRole44B0ACD2",
                 "Arn",
               ],
             },
@@ -7354,376 +9441,6 @@ Object {
         ],
       },
       "Type": "AWS::Events::Rule",
-    },
-    "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F": Object {
-      "DependsOn": Array [
-        "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
-      ],
-      "Properties": Object {
-        "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "350185a1069fa20a23a583e20c77f6844218bd73097902362dc94f1a108f5d89.zip",
-        },
-        "Description": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "Lambda function for auto-deleting objects in ",
-              Object {
-                "Ref": "AccessLogsBucket83982689",
-              },
-              " S3 bucket.",
-            ],
-          ],
-        },
-        "Handler": "__entrypoint__.handler",
-        "MemorySize": 128,
-        "Role": Object {
-          "Fn::GetAtt": Array [
-            "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs14.x",
-        "Timeout": 900,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": Array [
-          Object {
-            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "DefaultsAssetsFileAsset189C03802": Object {
-      "Properties": Object {
-        "Artifacts": Object {
-          "Type": "CODEPIPELINE",
-        },
-        "Cache": Object {
-          "Type": "NO_CACHE",
-        },
-        "Description": "Pipeline step Default/CodePipeline/Assets/FileAsset1",
-        "EncryptionKey": "alias/aws/s3",
-        "Environment": Object {
-          "ComputeType": "BUILD_GENERAL1_SMALL",
-          "Image": "aws/codebuild/standard:6.0",
-          "ImagePullCredentialsType": "CODEBUILD",
-          "PrivilegedMode": false,
-          "Type": "LINUX_CONTAINER",
-        },
-        "ServiceRole": Object {
-          "Fn::GetAtt": Array [
-            "DefaultsAssetsFileRole6F73FFFF",
-            "Arn",
-          ],
-        },
-        "Source": Object {
-          "BuildSpec": "{
-  \\"version\\": \\"0.2\\",
-  \\"phases\\": {
-    \\"install\\": {
-      \\"commands\\": [
-        \\"npm install -g cdk-assets@2\\"
-      ]
-    },
-    \\"build\\": {
-      \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-Stage/StageAppStack7618C9EF.assets.json\\\\\\" --verbose publish \\\\\\"824fe84db24bbf4d297bea3c89c9f634f2379cc336ccbe96772c4cc0eab472e3:current_account-current_region\\\\\\"\\"
-      ]
-    }
-  }
-}",
-          "Type": "CODEPIPELINE",
-        },
-      },
-      "Type": "AWS::CodeBuild::Project",
-    },
-    "DefaultsAssetsFileRole6F73FFFF": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "codebuild.amazonaws.com",
-              },
-            },
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":iam::",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":root",
-                    ],
-                  ],
-                },
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "DefaultsAssetsFileRoleDefaultPolicy62E6E856": Object {
-      "Metadata": Object {
-        "cdk_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "id": "AwsSolutions-IAM5",
-              "reason": "Asset role requires access to the Artifacts Bucket",
-            },
-            Object {
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Asset role requires access to the Artifacts Bucket",
-            },
-          ],
-        },
-      },
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "logs:CreateLogGroup",
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:",
-                    Object {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":logs:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":log-group:/aws/codebuild/*",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "codebuild:CreateReportGroup",
-                "codebuild:CreateReport",
-                "codebuild:UpdateReport",
-                "codebuild:BatchPutTestCases",
-                "codebuild:BatchPutCodeCoverages",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:",
-                    Object {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":codebuild:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":report-group/*",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "codebuild:BatchGetBuilds",
-                "codebuild:StartBuild",
-                "codebuild:StopBuild",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Sub": "arn:\${AWS::Partition}:iam::\${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-\${AWS::AccountId}-\${AWS::Region}",
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "DefaultsAssetsFileRoleDefaultPolicy62E6E856",
-        "Roles": Array [
-          Object {
-            "Ref": "DefaultsAssetsFileRole6F73FFFF",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "DefaultsCodeBuildActionRole4BF10433": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Condition": Object {
-                "Bool": Object {
-                  "aws:ViaAWSService": "codepipeline.amazonaws.com",
-                },
-              },
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":iam::",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":root",
-                    ],
-                  ],
-                },
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "DefaultsCodeBuildActionRoleDefaultPolicyB6B439B3": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "codebuild:BatchGetBuilds",
-                "codebuild:StartBuild",
-                "codebuild:StopBuild",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
-                  "Arn",
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "codebuild:BatchGetBuilds",
-                "codebuild:StartBuild",
-                "codebuild:StopBuild",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "DefaultsUpdatePipelineSelfMutation28F7C994",
-                  "Arn",
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "codebuild:BatchGetBuilds",
-                "codebuild:StartBuild",
-                "codebuild:StopBuild",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "DefaultsAssetsFileAsset189C03802",
-                  "Arn",
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "DefaultsCodeBuildActionRoleDefaultPolicyB6B439B3",
-        "Roles": Array [
-          Object {
-            "Ref": "DefaultsCodeBuildActionRole4BF10433",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
     },
     "DefaultsSonarCodeScannerSonarQubeTokenD1898305": Object {
       "DeletionPolicy": "Delete",
@@ -7738,6 +9455,30 @@ Object {
               "id": "AwsPrototyping-SecretsManagerRotationEnabled",
               "reason": "Key rotation is not possible as a user token needs to be generated from Sonarqube",
             },
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
           ],
         },
       },
@@ -7748,6 +9489,36 @@ Object {
       "UpdateReplacePolicy": "Delete",
     },
     "DefaultsSonarCodeScannerSynthBuildProjectOnSynthSuccessE7E65027": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "EventPattern": Object {
           "detail": Object {
@@ -7769,7 +9540,7 @@ Object {
                               ":",
                               Object {
                                 "Fn::GetAtt": Array [
-                                  "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                                  "DefaultsCodePipelineBuildSynthCdkBuildProject81772484",
                                   "Arn",
                                 ],
                               },
@@ -7818,6 +9589,36 @@ Object {
       "Type": "AWS::Events::Rule",
     },
     "DefaultsSonarCodeScannerValidationProjectEventsRole18DD9D4A": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -7835,6 +9636,36 @@ Object {
       "Type": "AWS::IAM::Role",
     },
     "DefaultsSonarCodeScannerValidationProjectEventsRoleDefaultPolicy6C4FE447": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -7861,6 +9692,36 @@ Object {
       "Type": "AWS::IAM::Policy",
     },
     "DefaultsSonarCodeScannerValidationProjectFAE7BAD0": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Artifacts": Object {
           "Type": "NO_ARTIFACTS",
@@ -7984,6 +9845,30 @@ Object {
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
               "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
             },
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
           ],
         },
       },
@@ -8042,6 +9927,30 @@ Object {
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
               "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
+            },
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
           ],
         },
@@ -8152,7 +10061,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                  "DefaultsCodePipelineBuildSynthCdkBuildProject81772484",
                   "Arn",
                 ],
               },
@@ -8163,7 +10072,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "DefaultsArtifactsBucket267E29E1",
                     "Arn",
                   ],
                 },
@@ -8173,7 +10082,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "DefaultsArtifactsBucket267E29E1",
                           "Arn",
                         ],
                       },
@@ -8195,7 +10104,37 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
-    "DefaultsUpdatePipelineSelfMutation28F7C994": Object {
+    "DefaultsUpdatePipelineSelfMutationD1F1D812": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Artifacts": Object {
           "Type": "CODEPIPELINE",
@@ -8214,7 +10153,7 @@ Object {
         },
         "ServiceRole": Object {
           "Fn::GetAtt": Array [
-            "DefaultsUpdatePipelineSelfMutationRole2FF40065",
+            "DefaultsUpdatePipelineSelfMutationRole0C19159A",
             "Arn",
           ],
         },
@@ -8239,7 +10178,37 @@ Object {
       },
       "Type": "AWS::CodeBuild::Project",
     },
-    "DefaultsUpdatePipelineSelfMutationRole2FF40065": Object {
+    "DefaultsUpdatePipelineSelfMutationRole0C19159A": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -8256,187 +10225,33 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "DefaultsUpdatePipelineSelfMutationRoleDefaultPolicyB0C671E4": Object {
+    "DefaultsUpdatePipelineSelfMutationRoleDefaultPolicyCE04D82F": Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<DefaultsUpdatePipelineSelfMutation.*>:\\\\*$/g",
-                },
-              ],
               "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<DefaultsUpdatePipelineSelfMutation.*>-\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:\\\\*:iam::<AWS::AccountId>:role/\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to assume a role from within the current account in order to deploy.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to list all buckets and stacks.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": Object {
-                    "Fn::Join": Array [
-                      "",
-                      Array [
-                        "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|",
-                        Object {
-                          "Ref": "AWS::AccountId",
-                        },
-                        "):log-group:/aws/codebuild/<DefaultsUpdatePipelineSelfMutation.*>:\\\\*$/g",
-                      ],
-                    ],
-                  },
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<DefaultsUpdatePipelineSelfMutation.*>:\\\\*$/g",
-                },
-              ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<DefaultsUpdatePipelineSelfMutation.*>-\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:\\\\*:iam::<AWS::AccountId>:role/\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to assume a role from within the current account in order to deploy.",
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to list all buckets and stacks.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": Object {
-                    "Fn::Join": Array [
-                      "",
-                      Array [
-                        "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|",
-                        Object {
-                          "Ref": "AWS::AccountId",
-                        },
-                        "):log-group:/aws/codebuild/<DefaultsUpdatePipelineSelfMutation.*>:\\\\*$/g",
-                      ],
-                    ],
-                  },
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
           ],
         },
@@ -8470,7 +10285,7 @@ Object {
                       },
                       ":log-group:/aws/codebuild/",
                       Object {
-                        "Ref": "DefaultsUpdatePipelineSelfMutation28F7C994",
+                        "Ref": "DefaultsUpdatePipelineSelfMutationD1F1D812",
                       },
                     ],
                   ],
@@ -8493,7 +10308,7 @@ Object {
                       },
                       ":log-group:/aws/codebuild/",
                       Object {
-                        "Ref": "DefaultsUpdatePipelineSelfMutation28F7C994",
+                        "Ref": "DefaultsUpdatePipelineSelfMutationD1F1D812",
                       },
                       ":*",
                     ],
@@ -8528,7 +10343,7 @@ Object {
                     },
                     ":report-group/",
                     Object {
-                      "Ref": "DefaultsUpdatePipelineSelfMutation28F7C994",
+                      "Ref": "DefaultsUpdatePipelineSelfMutationD1F1D812",
                     },
                     "-*",
                   ],
@@ -8580,7 +10395,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "DefaultsArtifactsBucket267E29E1",
                     "Arn",
                   ],
                 },
@@ -8590,7 +10405,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "DefaultsArtifactsBucket267E29E1",
                           "Arn",
                         ],
                       },
@@ -8603,10 +10418,10 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "DefaultsUpdatePipelineSelfMutationRoleDefaultPolicyB0C671E4",
+        "PolicyName": "DefaultsUpdatePipelineSelfMutationRoleDefaultPolicyCE04D82F",
         "Roles": Array [
           Object {
-            "Ref": "DefaultsUpdatePipelineSelfMutationRole2FF40065",
+            "Ref": "DefaultsUpdatePipelineSelfMutationRole0C19159A",
           },
         ],
       },
@@ -8645,30 +10460,8 @@ Object {
 
 exports[`PDK Pipeline Unit Tests Defaults 1`] = `
 Object {
-  "Metadata": Object {
-    "cdk_nag": Object {
-      "rules_to_suppress": Array [
-        Object {
-          "id": "AwsSolutions-CB4",
-          "reason": "Encryption of Codebuild is not required.",
-        },
-        Object {
-          "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
-          "reason": "Encryption of Codebuild is not required.",
-        },
-        Object {
-          "id": "AwsSolutions-S1",
-          "reason": "Access Log buckets should not have s3 bucket logging",
-        },
-        Object {
-          "id": "AwsPrototyping-S3BucketLoggingEnabled",
-          "reason": "Access Log buckets should not have s3 bucket logging",
-        },
-      ],
-    },
-  },
   "Outputs": Object {
-    "CodeRepositoryGRCUrl": Object {
+    "DefaultsCodeRepositoryGRCUrlF9B2453F": Object {
       "Value": Object {
         "Fn::Join": Array [
           "",
@@ -8680,7 +10473,7 @@ Object {
             "://",
             Object {
               "Fn::GetAtt": Array [
-                "CodeRepositoryBA42F94A",
+                "DefaultsCodeRepositoryBDE0B808",
                 "Name",
               ],
             },
@@ -8702,16 +10495,110 @@ Object {
     },
   },
   "Resources": Object {
-    "AccessLogsBucket83982689": Object {
-      "DeletionPolicy": "Delete",
+    "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F": Object {
+      "DependsOn": Array [
+        "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+      ],
       "Properties": Object {
-        "AccessControl": "LogDeliveryWrite",
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "350185a1069fa20a23a583e20c77f6844218bd73097902362dc94f1a108f5d89.zip",
+        },
+        "Description": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "Lambda function for auto-deleting objects in ",
+              Object {
+                "Ref": "DefaultsAccessLogsBucket1E788CBC",
+              },
+              " S3 bucket.",
+            ],
+          ],
+        },
+        "Handler": "__entrypoint__.handler",
+        "MemorySize": 128,
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs14.x",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsAccessLogsBucket1E788CBC": Object {
+      "DeletionPolicy": "Delete",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
         "BucketEncryption": Object {
           "ServerSideEncryptionConfiguration": Array [
             Object {
               "ServerSideEncryptionByDefault": Object {
                 "SSEAlgorithm": "AES256",
               },
+            },
+          ],
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
             },
           ],
         },
@@ -8731,14 +10618,44 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Delete",
     },
-    "AccessLogsBucketAutoDeleteObjectsCustomResource93F9213A": Object {
+    "DefaultsAccessLogsBucketAutoDeleteObjectsCustomResourceB315E04B": Object {
       "DeletionPolicy": "Delete",
       "DependsOn": Array [
-        "AccessLogsBucketPolicy7F77476F",
+        "DefaultsAccessLogsBucketPolicy87291CAB",
       ],
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "BucketName": Object {
-          "Ref": "AccessLogsBucket83982689",
+          "Ref": "DefaultsAccessLogsBucket1E788CBC",
         },
         "ServiceToken": Object {
           "Fn::GetAtt": Array [
@@ -8750,10 +10667,40 @@ Object {
       "Type": "Custom::S3AutoDeleteObjects",
       "UpdateReplacePolicy": "Delete",
     },
-    "AccessLogsBucketPolicy7F77476F": Object {
+    "DefaultsAccessLogsBucketPolicy87291CAB": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "AccessLogsBucket83982689",
+          "Ref": "DefaultsAccessLogsBucket1E788CBC",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -8771,7 +10718,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "AccessLogsBucket83982689",
+                    "DefaultsAccessLogsBucket1E788CBC",
                     "Arn",
                   ],
                 },
@@ -8781,7 +10728,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "AccessLogsBucket83982689",
+                          "DefaultsAccessLogsBucket1E788CBC",
                           "Arn",
                         ],
                       },
@@ -8809,7 +10756,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "AccessLogsBucket83982689",
+                    "DefaultsAccessLogsBucket1E788CBC",
                     "Arn",
                   ],
                 },
@@ -8819,7 +10766,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "AccessLogsBucket83982689",
+                          "DefaultsAccessLogsBucket1E788CBC",
                           "Arn",
                         ],
                       },
@@ -8829,14 +10776,80 @@ Object {
                 },
               ],
             },
+            Object {
+              "Action": "s3:PutObject",
+              "Condition": Object {
+                "ArnLike": Object {
+                  "aws:SourceArn": Object {
+                    "Fn::GetAtt": Array [
+                      "DefaultsArtifactsBucket267E29E1",
+                      "Arn",
+                    ],
+                  },
+                },
+                "StringEquals": Object {
+                  "aws:SourceAccount": Object {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "logging.s3.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "DefaultsAccessLogsBucket1E788CBC",
+                        "Arn",
+                      ],
+                    },
+                    "/access-logs*",
+                  ],
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "ArtifactsBucket2AAC5544": Object {
+    "DefaultsArtifactsBucket267E29E1": Object {
       "DeletionPolicy": "Delete",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "BucketEncryption": Object {
           "ServerSideEncryptionConfiguration": Array [
@@ -8849,9 +10862,16 @@ Object {
         },
         "LoggingConfiguration": Object {
           "DestinationBucketName": Object {
-            "Ref": "AccessLogsBucket83982689",
+            "Ref": "DefaultsAccessLogsBucket1E788CBC",
           },
           "LogFilePrefix": "access-logs",
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
+            },
+          ],
         },
         "PublicAccessBlockConfiguration": Object {
           "BlockPublicAcls": true,
@@ -8869,14 +10889,44 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Delete",
     },
-    "ArtifactsBucketAutoDeleteObjectsCustomResource0E3B4320": Object {
+    "DefaultsArtifactsBucketAutoDeleteObjectsCustomResourceED1B0B57": Object {
       "DeletionPolicy": "Delete",
       "DependsOn": Array [
-        "ArtifactsBucketPolicy852CB646",
+        "DefaultsArtifactsBucketPolicyA6159620",
       ],
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "BucketName": Object {
-          "Ref": "ArtifactsBucket2AAC5544",
+          "Ref": "DefaultsArtifactsBucket267E29E1",
         },
         "ServiceToken": Object {
           "Fn::GetAtt": Array [
@@ -8888,10 +10938,40 @@ Object {
       "Type": "Custom::S3AutoDeleteObjects",
       "UpdateReplacePolicy": "Delete",
     },
-    "ArtifactsBucketPolicy852CB646": Object {
+    "DefaultsArtifactsBucketPolicyA6159620": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Bucket": Object {
-          "Ref": "ArtifactsBucket2AAC5544",
+          "Ref": "DefaultsArtifactsBucket267E29E1",
         },
         "PolicyDocument": Object {
           "Statement": Array [
@@ -8909,7 +10989,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "DefaultsArtifactsBucket267E29E1",
                     "Arn",
                   ],
                 },
@@ -8919,7 +10999,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "DefaultsArtifactsBucket267E29E1",
                           "Arn",
                         ],
                       },
@@ -8947,7 +11027,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "DefaultsArtifactsBucket267E29E1",
                     "Arn",
                   ],
                 },
@@ -8957,7 +11037,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "DefaultsArtifactsBucket267E29E1",
                           "Arn",
                         ],
                       },
@@ -9002,7 +11082,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "DefaultsArtifactsBucket267E29E1",
                     "Arn",
                   ],
                 },
@@ -9012,7 +11092,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "DefaultsArtifactsBucket267E29E1",
                           "Arn",
                         ],
                       },
@@ -9028,22 +11108,808 @@ Object {
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "CodePipelineB74E5936": Object {
+    "DefaultsAssetsFileAsset1C016008C": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Artifacts": Object {
+          "Type": "CODEPIPELINE",
+        },
+        "Cache": Object {
+          "Type": "NO_CACHE",
+        },
+        "Description": "Pipeline step Default/CodePipeline/Assets/FileAsset1",
+        "EncryptionKey": "alias/aws/s3",
+        "Environment": Object {
+          "ComputeType": "BUILD_GENERAL1_SMALL",
+          "Image": "aws/codebuild/standard:6.0",
+          "ImagePullCredentialsType": "CODEBUILD",
+          "PrivilegedMode": false,
+          "Type": "LINUX_CONTAINER",
+        },
+        "ServiceRole": Object {
+          "Fn::GetAtt": Array [
+            "DefaultsAssetsFileRole651D25B9",
+            "Arn",
+          ],
+        },
+        "Source": Object {
+          "BuildSpec": "{
+  \\"version\\": \\"0.2\\",
+  \\"phases\\": {
+    \\"install\\": {
+      \\"commands\\": [
+        \\"npm install -g cdk-assets@2\\"
+      ]
+    },
+    \\"build\\": {
+      \\"commands\\": [
+        \\"cdk-assets --path \\\\\\"assembly-Stage/StageAppStack7618C9EF.assets.json\\\\\\" --verbose publish \\\\\\"824fe84db24bbf4d297bea3c89c9f634f2379cc336ccbe96772c4cc0eab472e3:current_account-current_region\\\\\\"\\"
+      ]
+    }
+  }
+}",
+          "Type": "CODEPIPELINE",
+        },
+      },
+      "Type": "AWS::CodeBuild::Project",
+    },
+    "DefaultsAssetsFileRole651D25B9": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "codebuild.amazonaws.com",
+              },
+            },
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsAssetsFileRoleDefaultPolicy3887BD04": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":logs:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":log-group:/aws/codebuild/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:CreateReportGroup",
+                "codebuild:CreateReport",
+                "codebuild:UpdateReport",
+                "codebuild:BatchPutTestCases",
+                "codebuild:BatchPutCodeCoverages",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":codebuild:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":report-group/*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Sub": "arn:\${AWS::Partition}:iam::\${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-\${AWS::AccountId}-\${AWS::Region}",
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsArtifactsBucket267E29E1",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DefaultsArtifactsBucket267E29E1",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DefaultsAssetsFileRoleDefaultPolicy3887BD04",
+        "Roles": Array [
+          Object {
+            "Ref": "DefaultsAssetsFileRole651D25B9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DefaultsCodeBuildActionRole26049CBA": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:ViaAWSService": "codepipeline.amazonaws.com",
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "AWS": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":root",
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsCodeBuildActionRoleDefaultPolicy0F3A543D": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "DefaultsCodePipelineBuildSynthCdkBuildProject81772484",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "DefaultsUpdatePipelineSelfMutationD1F1D812",
+                  "Arn",
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::GetAtt": Array [
+                  "DefaultsAssetsFileAsset1C016008C",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DefaultsCodeBuildActionRoleDefaultPolicy0F3A543D",
+        "Roles": Array [
+          Object {
+            "Ref": "DefaultsCodeBuildActionRole26049CBA",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DefaultsCodePipelineBuildSynthCdkBuildProject81772484": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "Artifacts": Object {
+          "Type": "CODEPIPELINE",
+        },
+        "Cache": Object {
+          "Type": "NO_CACHE",
+        },
+        "Description": "Pipeline step Default/CodePipeline/Build/Synth",
+        "EncryptionKey": "alias/aws/s3",
+        "Environment": Object {
+          "ComputeType": "BUILD_GENERAL1_SMALL",
+          "Image": "aws/codebuild/standard:6.0",
+          "ImagePullCredentialsType": "CODEBUILD",
+          "PrivilegedMode": false,
+          "Type": "LINUX_CONTAINER",
+        },
+        "ServiceRole": Object {
+          "Fn::GetAtt": Array [
+            "DefaultsCodePipelineBuildSynthCdkBuildProjectRoleA72DCE39",
+            "Arn",
+          ],
+        },
+        "Source": Object {
+          "BuildSpec": "{
+  \\"version\\": \\"0.2\\",
+  \\"phases\\": {
+    \\"install\\": {
+      \\"commands\\": [
+        \\"npm install -g aws-cdk\\",
+        \\"yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile\\"
+      ]
+    },
+    \\"build\\": {
+      \\"commands\\": [
+        \\"npx nx run-many --target=build --all\\"
+      ]
+    }
+  },
+  \\"artifacts\\": {
+    \\"secondary-artifacts\\": {
+      \\"Synth_Output\\": {
+        \\"base-directory\\": \\"cdk.out\\",
+        \\"files\\": \\"**/*\\"
+      },
+      \\"Synth__\\": {
+        \\"base-directory\\": \\".\\",
+        \\"files\\": \\"**/*\\"
+      }
+    }
+  }
+}",
+          "Type": "CODEPIPELINE",
+        },
+      },
+      "Type": "AWS::CodeBuild::Project",
+    },
+    "DefaultsCodePipelineBuildSynthCdkBuildProjectRoleA72DCE39": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "codebuild.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsCodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyC0AFF59F": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":logs:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":log-group:/aws/codebuild/",
+                      Object {
+                        "Ref": "DefaultsCodePipelineBuildSynthCdkBuildProject81772484",
+                      },
+                    ],
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "arn:",
+                      Object {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":logs:",
+                      Object {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      Object {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":log-group:/aws/codebuild/",
+                      Object {
+                        "Ref": "DefaultsCodePipelineBuildSynthCdkBuildProject81772484",
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            Object {
+              "Action": Array [
+                "codebuild:CreateReportGroup",
+                "codebuild:CreateReport",
+                "codebuild:UpdateReport",
+                "codebuild:BatchPutTestCases",
+                "codebuild:BatchPutCodeCoverages",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":codebuild:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":report-group/",
+                    Object {
+                      "Ref": "DefaultsCodePipelineBuildSynthCdkBuildProject81772484",
+                    },
+                    "-*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": Array [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DefaultsArtifactsBucket267E29E1",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DefaultsArtifactsBucket267E29E1",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DefaultsCodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyC0AFF59F",
+        "Roles": Array [
+          Object {
+            "Ref": "DefaultsCodePipelineBuildSynthCdkBuildProjectRoleA72DCE39",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DefaultsCodePipelineDAB2FB72": Object {
       "DependsOn": Array [
-        "CodePipelineRoleDefaultPolicy8D520A8D",
-        "CodePipelineRoleB3A660B4",
+        "DefaultsCodePipelineRoleDefaultPolicyF4A44365",
+        "DefaultsCodePipelineRoleF466C0E3",
       ],
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "ArtifactStore": Object {
           "Location": Object {
-            "Ref": "ArtifactsBucket2AAC5544",
+            "Ref": "DefaultsArtifactsBucket267E29E1",
           },
           "Type": "S3",
         },
         "RestartExecutionOnUpdate": true,
         "RoleArn": Object {
           "Fn::GetAtt": Array [
-            "CodePipelineRoleB3A660B4",
+            "DefaultsCodePipelineRoleF466C0E3",
             "Arn",
           ],
         },
@@ -9062,25 +11928,25 @@ Object {
                   "PollForSourceChanges": false,
                   "RepositoryName": Object {
                     "Fn::GetAtt": Array [
-                      "CodeRepositoryBA42F94A",
+                      "DefaultsCodeRepositoryBDE0B808",
                       "Name",
                     ],
                   },
                 },
                 "Name": Object {
                   "Fn::GetAtt": Array [
-                    "CodeRepositoryBA42F94A",
+                    "DefaultsCodeRepositoryBDE0B808",
                     "Name",
                   ],
                 },
                 "OutputArtifacts": Array [
                   Object {
-                    "Name": "c8b95ca81f750a44513d18b27868db0afa191aa92e_Source",
+                    "Name": "c8be7966da6130450b89fe7dd9dced39142a8f041d_Source",
                   },
                 ],
                 "RoleArn": Object {
                   "Fn::GetAtt": Array [
-                    "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70",
+                    "DefaultsCodePipelineSourceCodeCommitCodePipelineActionRole1F53CA96",
                     "Arn",
                   ],
                 },
@@ -9101,12 +11967,12 @@ Object {
                 "Configuration": Object {
                   "EnvironmentVariables": "[{\\"name\\":\\"_PROJECT_CONFIG_HASH\\",\\"type\\":\\"PLAINTEXT\\",\\"value\\":\\"9b6cac2596443c465eb42c0d0d84de22a8632cbeb9388a40d13889341f9b20c5\\"}]",
                   "ProjectName": Object {
-                    "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                    "Ref": "DefaultsCodePipelineBuildSynthCdkBuildProject81772484",
                   },
                 },
                 "InputArtifacts": Array [
                   Object {
-                    "Name": "c8b95ca81f750a44513d18b27868db0afa191aa92e_Source",
+                    "Name": "c8be7966da6130450b89fe7dd9dced39142a8f041d_Source",
                   },
                 ],
                 "Name": "Synth",
@@ -9120,7 +11986,7 @@ Object {
                 ],
                 "RoleArn": Object {
                   "Fn::GetAtt": Array [
-                    "DefaultsCodeBuildActionRole4BF10433",
+                    "DefaultsCodeBuildActionRole26049CBA",
                     "Arn",
                   ],
                 },
@@ -9141,7 +12007,7 @@ Object {
                 "Configuration": Object {
                   "EnvironmentVariables": "[{\\"name\\":\\"_PROJECT_CONFIG_HASH\\",\\"type\\":\\"PLAINTEXT\\",\\"value\\":\\"e437283b833a76d1459ba3b9b11f0bf0f0c58fc4c9c6a130298f52e21508b79e\\"}]",
                   "ProjectName": Object {
-                    "Ref": "DefaultsUpdatePipelineSelfMutation28F7C994",
+                    "Ref": "DefaultsUpdatePipelineSelfMutationD1F1D812",
                   },
                 },
                 "InputArtifacts": Array [
@@ -9152,7 +12018,7 @@ Object {
                 "Name": "SelfMutate",
                 "RoleArn": Object {
                   "Fn::GetAtt": Array [
-                    "DefaultsCodeBuildActionRole4BF10433",
+                    "DefaultsCodeBuildActionRole26049CBA",
                     "Arn",
                   ],
                 },
@@ -9172,7 +12038,7 @@ Object {
                 },
                 "Configuration": Object {
                   "ProjectName": Object {
-                    "Ref": "DefaultsAssetsFileAsset189C03802",
+                    "Ref": "DefaultsAssetsFileAsset1C016008C",
                   },
                 },
                 "InputArtifacts": Array [
@@ -9183,7 +12049,7 @@ Object {
                 "Name": "FileAsset1",
                 "RoleArn": Object {
                   "Fn::GetAtt": Array [
-                    "DefaultsCodeBuildActionRole4BF10433",
+                    "DefaultsCodeBuildActionRole26049CBA",
                     "Arn",
                   ],
                 },
@@ -9307,315 +12173,37 @@ Object {
       },
       "Type": "AWS::CodePipeline::Pipeline",
     },
-    "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6": Object {
-      "Properties": Object {
-        "Artifacts": Object {
-          "Type": "CODEPIPELINE",
-        },
-        "Cache": Object {
-          "Type": "NO_CACHE",
-        },
-        "Description": "Pipeline step Default/CodePipeline/Build/Synth",
-        "EncryptionKey": "alias/aws/s3",
-        "Environment": Object {
-          "ComputeType": "BUILD_GENERAL1_SMALL",
-          "Image": "aws/codebuild/standard:6.0",
-          "ImagePullCredentialsType": "CODEBUILD",
-          "PrivilegedMode": false,
-          "Type": "LINUX_CONTAINER",
-        },
-        "ServiceRole": Object {
-          "Fn::GetAtt": Array [
-            "CodePipelineBuildSynthCdkBuildProjectRoleB73287D4",
-            "Arn",
-          ],
-        },
-        "Source": Object {
-          "BuildSpec": "{
-  \\"version\\": \\"0.2\\",
-  \\"phases\\": {
-    \\"install\\": {
-      \\"commands\\": [
-        \\"npm install -g aws-cdk\\",
-        \\"yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile\\"
-      ]
-    },
-    \\"build\\": {
-      \\"commands\\": [
-        \\"npx nx run-many --target=build --all\\"
-      ]
-    }
-  },
-  \\"artifacts\\": {
-    \\"secondary-artifacts\\": {
-      \\"Synth_Output\\": {
-        \\"base-directory\\": \\"cdk.out\\",
-        \\"files\\": \\"**/*\\"
-      },
-      \\"Synth__\\": {
-        \\"base-directory\\": \\".\\",
-        \\"files\\": \\"**/*\\"
-      }
-    }
-  }
-}",
-          "Type": "CODEPIPELINE",
-        },
-      },
-      "Type": "AWS::CodeBuild::Project",
-    },
-    "CodePipelineBuildSynthCdkBuildProjectRoleB73287D4": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "codebuild.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyB7EDB705": Object {
+    "DefaultsCodePipelineEventsRole44B0ACD2": Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsSolutions-IAM5",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<CodePipelineBuildSynthCdkBuildProject.*>:\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<CodePipelineBuildSynthCdkBuildProject.*>-\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
           ],
         },
       },
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "logs:CreateLogGroup",
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":logs:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":log-group:/aws/codebuild/",
-                      Object {
-                        "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
-                      },
-                    ],
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":logs:",
-                      Object {
-                        "Ref": "AWS::Region",
-                      },
-                      ":",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":log-group:/aws/codebuild/",
-                      Object {
-                        "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
-                      },
-                      ":*",
-                    ],
-                  ],
-                },
-              ],
-            },
-            Object {
-              "Action": Array [
-                "codebuild:CreateReportGroup",
-                "codebuild:CreateReport",
-                "codebuild:UpdateReport",
-                "codebuild:BatchPutTestCases",
-                "codebuild:BatchPutCodeCoverages",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:",
-                    Object {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":codebuild:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":report-group/",
-                    Object {
-                      "Ref": "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
-                    },
-                    "-*",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-                "s3:DeleteObject*",
-                "s3:PutObject",
-                "s3:PutObjectLegalHold",
-                "s3:PutObjectRetention",
-                "s3:PutObjectTagging",
-                "s3:PutObjectVersionTagging",
-                "s3:Abort*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "CodePipelineBuildSynthCdkBuildProjectRoleDefaultPolicyB7EDB705",
-        "Roles": Array [
-          Object {
-            "Ref": "CodePipelineBuildSynthCdkBuildProjectRoleB73287D4",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "CodePipelineEventsRole4196480D": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -9632,7 +12220,37 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "CodePipelineEventsRoleDefaultPolicy13DBD2D2": Object {
+    "DefaultsCodePipelineEventsRoleDefaultPolicyB0676072": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -9657,7 +12275,7 @@ Object {
                     },
                     ":",
                     Object {
-                      "Ref": "CodePipelineB74E5936",
+                      "Ref": "DefaultsCodePipelineDAB2FB72",
                     },
                   ],
                 ],
@@ -9666,101 +12284,42 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "CodePipelineEventsRoleDefaultPolicy13DBD2D2",
+        "PolicyName": "DefaultsCodePipelineEventsRoleDefaultPolicyB0676072",
         "Roles": Array [
           Object {
-            "Ref": "CodePipelineEventsRole4196480D",
+            "Ref": "DefaultsCodePipelineEventsRole44B0ACD2",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "CodePipelineRoleB3A660B4": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "codepipeline.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CodePipelineRoleDefaultPolicy8D520A8D": Object {
+    "DefaultsCodePipelineRoleDefaultPolicyF4A44365": Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsSolutions-IAM5",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
           ],
         },
@@ -9785,7 +12344,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "DefaultsArtifactsBucket267E29E1",
                     "Arn",
                   ],
                 },
@@ -9795,7 +12354,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "DefaultsArtifactsBucket267E29E1",
                           "Arn",
                         ],
                       },
@@ -9810,7 +12369,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70",
+                  "DefaultsCodePipelineSourceCodeCommitCodePipelineActionRole1F53CA96",
                   "Arn",
                 ],
               },
@@ -9820,7 +12379,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "DefaultsCodeBuildActionRole4BF10433",
+                  "DefaultsCodeBuildActionRole26049CBA",
                   "Arn",
                 ],
               },
@@ -9855,16 +12414,93 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "CodePipelineRoleDefaultPolicy8D520A8D",
+        "PolicyName": "DefaultsCodePipelineRoleDefaultPolicyF4A44365",
         "Roles": Array [
           Object {
-            "Ref": "CodePipelineRoleB3A660B4",
+            "Ref": "DefaultsCodePipelineRoleF466C0E3",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70": Object {
+    "DefaultsCodePipelineRoleF466C0E3": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "codepipeline.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DefaultsCodePipelineSourceCodeCommitCodePipelineActionRole1F53CA96": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -9896,57 +12532,33 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "CodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyAFBD34E4": Object {
+    "DefaultsCodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyF3026D6A": Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsSolutions-IAM5",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
           ],
         },
@@ -9971,7 +12583,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "DefaultsArtifactsBucket267E29E1",
                     "Arn",
                   ],
                 },
@@ -9981,7 +12593,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "DefaultsArtifactsBucket267E29E1",
                           "Arn",
                         ],
                       },
@@ -10002,7 +12614,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "CodeRepositoryBA42F94A",
+                  "DefaultsCodeRepositoryBDE0B808",
                   "Arn",
                 ],
               },
@@ -10010,24 +12622,84 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "CodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyAFBD34E4",
+        "PolicyName": "DefaultsCodePipelineSourceCodeCommitCodePipelineActionRoleDefaultPolicyF3026D6A",
         "Roles": Array [
           Object {
-            "Ref": "CodePipelineSourceCodeCommitCodePipelineActionRoleD8DD1B70",
+            "Ref": "DefaultsCodePipelineSourceCodeCommitCodePipelineActionRole1F53CA96",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "CodeRepositoryBA42F94A": Object {
+    "DefaultsCodeRepositoryBDE0B808": Object {
       "DeletionPolicy": "Retain",
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "RepositoryName": "Defaults",
       },
       "Type": "AWS::CodeCommit::Repository",
       "UpdateReplacePolicy": "Retain",
     },
-    "CodeRepositoryCodePipelinemainlineEventRuleEDE9EDAA": Object {
+    "DefaultsCodeRepositoryDefaultsCodePipeline4E276C62mainlineEventRule67A64C52": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "EventPattern": Object {
           "detail": Object {
@@ -10045,7 +12717,7 @@ Object {
           "resources": Array [
             Object {
               "Fn::GetAtt": Array [
-                "CodeRepositoryBA42F94A",
+                "DefaultsCodeRepositoryBDE0B808",
                 "Arn",
               ],
             },
@@ -10075,7 +12747,7 @@ Object {
                   },
                   ":",
                   Object {
-                    "Ref": "CodePipelineB74E5936",
+                    "Ref": "DefaultsCodePipelineDAB2FB72",
                   },
                 ],
               ],
@@ -10083,7 +12755,7 @@ Object {
             "Id": "Target0",
             "RoleArn": Object {
               "Fn::GetAtt": Array [
-                "CodePipelineEventsRole4196480D",
+                "DefaultsCodePipelineEventsRole44B0ACD2",
                 "Arn",
               ],
             },
@@ -10091,376 +12763,6 @@ Object {
         ],
       },
       "Type": "AWS::Events::Rule",
-    },
-    "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F": Object {
-      "DependsOn": Array [
-        "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
-      ],
-      "Properties": Object {
-        "Code": Object {
-          "S3Bucket": Object {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "350185a1069fa20a23a583e20c77f6844218bd73097902362dc94f1a108f5d89.zip",
-        },
-        "Description": Object {
-          "Fn::Join": Array [
-            "",
-            Array [
-              "Lambda function for auto-deleting objects in ",
-              Object {
-                "Ref": "AccessLogsBucket83982689",
-              },
-              " S3 bucket.",
-            ],
-          ],
-        },
-        "Handler": "__entrypoint__.handler",
-        "MemorySize": 128,
-        "Role": Object {
-          "Fn::GetAtt": Array [
-            "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs14.x",
-        "Timeout": 900,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": Array [
-          Object {
-            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "DefaultsAssetsFileAsset189C03802": Object {
-      "Properties": Object {
-        "Artifacts": Object {
-          "Type": "CODEPIPELINE",
-        },
-        "Cache": Object {
-          "Type": "NO_CACHE",
-        },
-        "Description": "Pipeline step Default/CodePipeline/Assets/FileAsset1",
-        "EncryptionKey": "alias/aws/s3",
-        "Environment": Object {
-          "ComputeType": "BUILD_GENERAL1_SMALL",
-          "Image": "aws/codebuild/standard:6.0",
-          "ImagePullCredentialsType": "CODEBUILD",
-          "PrivilegedMode": false,
-          "Type": "LINUX_CONTAINER",
-        },
-        "ServiceRole": Object {
-          "Fn::GetAtt": Array [
-            "DefaultsAssetsFileRole6F73FFFF",
-            "Arn",
-          ],
-        },
-        "Source": Object {
-          "BuildSpec": "{
-  \\"version\\": \\"0.2\\",
-  \\"phases\\": {
-    \\"install\\": {
-      \\"commands\\": [
-        \\"npm install -g cdk-assets@2\\"
-      ]
-    },
-    \\"build\\": {
-      \\"commands\\": [
-        \\"cdk-assets --path \\\\\\"assembly-Stage/StageAppStack7618C9EF.assets.json\\\\\\" --verbose publish \\\\\\"824fe84db24bbf4d297bea3c89c9f634f2379cc336ccbe96772c4cc0eab472e3:current_account-current_region\\\\\\"\\"
-      ]
-    }
-  }
-}",
-          "Type": "CODEPIPELINE",
-        },
-      },
-      "Type": "AWS::CodeBuild::Project",
-    },
-    "DefaultsAssetsFileRole6F73FFFF": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "codebuild.amazonaws.com",
-              },
-            },
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":iam::",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":root",
-                    ],
-                  ],
-                },
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "DefaultsAssetsFileRoleDefaultPolicy62E6E856": Object {
-      "Metadata": Object {
-        "cdk_nag": Object {
-          "rules_to_suppress": Array [
-            Object {
-              "id": "AwsSolutions-IAM5",
-              "reason": "Asset role requires access to the Artifacts Bucket",
-            },
-            Object {
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Asset role requires access to the Artifacts Bucket",
-            },
-          ],
-        },
-      },
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "logs:CreateLogGroup",
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:",
-                    Object {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":logs:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":log-group:/aws/codebuild/*",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "codebuild:CreateReportGroup",
-                "codebuild:CreateReport",
-                "codebuild:UpdateReport",
-                "codebuild:BatchPutTestCases",
-                "codebuild:BatchPutCodeCoverages",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:",
-                    Object {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":codebuild:",
-                    Object {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    Object {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":report-group/*",
-                  ],
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "codebuild:BatchGetBuilds",
-                "codebuild:StartBuild",
-                "codebuild:StopBuild",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Sub": "arn:\${AWS::Partition}:iam::\${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-\${AWS::AccountId}-\${AWS::Region}",
-              },
-            },
-            Object {
-              "Action": Array [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-              ],
-              "Effect": "Allow",
-              "Resource": Array [
-                Object {
-                  "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
-                    "Arn",
-                  ],
-                },
-                Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      Object {
-                        "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
-                          "Arn",
-                        ],
-                      },
-                      "/*",
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "DefaultsAssetsFileRoleDefaultPolicy62E6E856",
-        "Roles": Array [
-          Object {
-            "Ref": "DefaultsAssetsFileRole6F73FFFF",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "DefaultsCodeBuildActionRole4BF10433": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Condition": Object {
-                "Bool": Object {
-                  "aws:ViaAWSService": "codepipeline.amazonaws.com",
-                },
-              },
-              "Effect": "Allow",
-              "Principal": Object {
-                "AWS": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "arn:",
-                      Object {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":iam::",
-                      Object {
-                        "Ref": "AWS::AccountId",
-                      },
-                      ":root",
-                    ],
-                  ],
-                },
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "DefaultsCodeBuildActionRoleDefaultPolicyB6B439B3": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "codebuild:BatchGetBuilds",
-                "codebuild:StartBuild",
-                "codebuild:StopBuild",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
-                  "Arn",
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "codebuild:BatchGetBuilds",
-                "codebuild:StartBuild",
-                "codebuild:StopBuild",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "DefaultsUpdatePipelineSelfMutation28F7C994",
-                  "Arn",
-                ],
-              },
-            },
-            Object {
-              "Action": Array [
-                "codebuild:BatchGetBuilds",
-                "codebuild:StartBuild",
-                "codebuild:StopBuild",
-              ],
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::GetAtt": Array [
-                  "DefaultsAssetsFileAsset189C03802",
-                  "Arn",
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "DefaultsCodeBuildActionRoleDefaultPolicyB6B439B3",
-        "Roles": Array [
-          Object {
-            "Ref": "DefaultsCodeBuildActionRole4BF10433",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
     },
     "DefaultsSonarCodeScannerSonarQubeTokenD1898305": Object {
       "DeletionPolicy": "Delete",
@@ -10475,6 +12777,30 @@ Object {
               "id": "AwsPrototyping-SecretsManagerRotationEnabled",
               "reason": "Key rotation is not possible as a user token needs to be generated from Sonarqube",
             },
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
           ],
         },
       },
@@ -10485,6 +12811,36 @@ Object {
       "UpdateReplacePolicy": "Delete",
     },
     "DefaultsSonarCodeScannerSynthBuildProjectOnSynthSuccessE7E65027": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "EventPattern": Object {
           "detail": Object {
@@ -10506,7 +12862,7 @@ Object {
                               ":",
                               Object {
                                 "Fn::GetAtt": Array [
-                                  "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                                  "DefaultsCodePipelineBuildSynthCdkBuildProject81772484",
                                   "Arn",
                                 ],
                               },
@@ -10555,6 +12911,36 @@ Object {
       "Type": "AWS::Events::Rule",
     },
     "DefaultsSonarCodeScannerValidationProjectEventsRole18DD9D4A": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -10572,6 +12958,36 @@ Object {
       "Type": "AWS::IAM::Role",
     },
     "DefaultsSonarCodeScannerValidationProjectEventsRoleDefaultPolicy6C4FE447": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "PolicyDocument": Object {
           "Statement": Array [
@@ -10598,6 +13014,36 @@ Object {
       "Type": "AWS::IAM::Policy",
     },
     "DefaultsSonarCodeScannerValidationProjectFAE7BAD0": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Artifacts": Object {
           "Type": "NO_ARTIFACTS",
@@ -10721,6 +13167,30 @@ Object {
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
               "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
             },
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
           ],
         },
       },
@@ -10779,6 +13249,30 @@ Object {
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
               "reason": "Validation CodeBuild project requires access to the ArtifactsBucket and ability to create logs.",
+            },
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
           ],
         },
@@ -10889,7 +13383,7 @@ Object {
               "Effect": "Allow",
               "Resource": Object {
                 "Fn::GetAtt": Array [
-                  "CodePipelineBuildSynthCdkBuildProjectEDF0E7B6",
+                  "DefaultsCodePipelineBuildSynthCdkBuildProject81772484",
                   "Arn",
                 ],
               },
@@ -10900,7 +13394,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "DefaultsArtifactsBucket267E29E1",
                     "Arn",
                   ],
                 },
@@ -10910,7 +13404,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "DefaultsArtifactsBucket267E29E1",
                           "Arn",
                         ],
                       },
@@ -10932,7 +13426,37 @@ Object {
       },
       "Type": "AWS::IAM::Policy",
     },
-    "DefaultsUpdatePipelineSelfMutation28F7C994": Object {
+    "DefaultsUpdatePipelineSelfMutationD1F1D812": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "Artifacts": Object {
           "Type": "CODEPIPELINE",
@@ -10951,7 +13475,7 @@ Object {
         },
         "ServiceRole": Object {
           "Fn::GetAtt": Array [
-            "DefaultsUpdatePipelineSelfMutationRole2FF40065",
+            "DefaultsUpdatePipelineSelfMutationRole0C19159A",
             "Arn",
           ],
         },
@@ -10976,7 +13500,37 @@ Object {
       },
       "Type": "AWS::CodeBuild::Project",
     },
-    "DefaultsUpdatePipelineSelfMutationRole2FF40065": Object {
+    "DefaultsUpdatePipelineSelfMutationRole0C19159A": Object {
+      "Metadata": Object {
+        "cdk_nag": Object {
+          "rules_to_suppress": Array [
+            Object {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Wildcards are needed for dynamically created resources.",
+            },
+            Object {
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
+            },
+            Object {
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+            Object {
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
+            },
+          ],
+        },
+      },
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -10993,187 +13547,33 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "DefaultsUpdatePipelineSelfMutationRoleDefaultPolicyB0C671E4": Object {
+    "DefaultsUpdatePipelineSelfMutationRoleDefaultPolicyCE04D82F": Object {
       "Metadata": Object {
         "cdk_nag": Object {
           "rules_to_suppress": Array [
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<DefaultsUpdatePipelineSelfMutation.*>:\\\\*$/g",
-                },
-              ],
               "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<DefaultsUpdatePipelineSelfMutation.*>-\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:\\\\*:iam::<AWS::AccountId>:role/\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to assume a role from within the current account in order to deploy.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to list all buckets and stacks.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": Object {
-                    "Fn::Join": Array [
-                      "",
-                      Array [
-                        "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|",
-                        Object {
-                          "Ref": "AWS::AccountId",
-                        },
-                        "):log-group:/aws/codebuild/<DefaultsUpdatePipelineSelfMutation.*>:\\\\*$/g",
-                      ],
-                    ],
-                  },
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM5",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/codebuild/<DefaultsUpdatePipelineSelfMutation.*>:\\\\*$/g",
-                },
-              ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
+              "reason": "Wildcards are needed for dynamically created resources.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:<AWS::Partition>:codebuild:<AWS::Region>:<AWS::AccountId>:report-group/<DefaultsUpdatePipelineSelfMutation.*>-\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to create report groups that are dynamically determined.",
+              "id": "AwsSolutions-CB4",
+              "reason": "Encryption of Codebuild is not required.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::arn:\\\\*:iam::<AWS::AccountId>:role/\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to assume a role from within the current account in order to deploy.",
+              "id": "AwsPrototyping-CodeBuildProjectKMSEncryptedArtifacts",
+              "reason": "Encryption of Codebuild is not required.",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsSolutions-S1",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
             Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to list all buckets and stacks.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Action::s3:.*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Actions contain wildcards which are valid for CodePipeline as all of these operations are required.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": Object {
-                    "Fn::Join": Array [
-                      "",
-                      Array [
-                        "/^Resource::arn:<AWS::Partition>:logs:<AWS::Region>:(<AWS::AccountId>|",
-                        Object {
-                          "Ref": "AWS::AccountId",
-                        },
-                        "):log-group:/aws/codebuild/<DefaultsUpdatePipelineSelfMutation.*>:\\\\*$/g",
-                      ],
-                    ],
-                  },
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to manage logs and streams whose names are dynamically determined.",
-            },
-            Object {
-              "applies_to": Array [
-                Object {
-                  "regex": "/^Resource::<ArtifactsBucket.*.Arn>/\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:ReEncrypt\\\\*$/g",
-                },
-                Object {
-                  "regex": "/^Action::kms:GenerateDataKey\\\\*$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "CodePipeline requires access to any and all artifacts in the ArtifactsBucket.",
+              "id": "AwsPrototyping-S3BucketLoggingEnabled",
+              "reason": "Access Log buckets should not have s3 bucket logging",
             },
           ],
         },
@@ -11207,7 +13607,7 @@ Object {
                       },
                       ":log-group:/aws/codebuild/",
                       Object {
-                        "Ref": "DefaultsUpdatePipelineSelfMutation28F7C994",
+                        "Ref": "DefaultsUpdatePipelineSelfMutationD1F1D812",
                       },
                     ],
                   ],
@@ -11230,7 +13630,7 @@ Object {
                       },
                       ":log-group:/aws/codebuild/",
                       Object {
-                        "Ref": "DefaultsUpdatePipelineSelfMutation28F7C994",
+                        "Ref": "DefaultsUpdatePipelineSelfMutationD1F1D812",
                       },
                       ":*",
                     ],
@@ -11265,7 +13665,7 @@ Object {
                     },
                     ":report-group/",
                     Object {
-                      "Ref": "DefaultsUpdatePipelineSelfMutation28F7C994",
+                      "Ref": "DefaultsUpdatePipelineSelfMutationD1F1D812",
                     },
                     "-*",
                   ],
@@ -11317,7 +13717,7 @@ Object {
               "Resource": Array [
                 Object {
                   "Fn::GetAtt": Array [
-                    "ArtifactsBucket2AAC5544",
+                    "DefaultsArtifactsBucket267E29E1",
                     "Arn",
                   ],
                 },
@@ -11327,7 +13727,7 @@ Object {
                     Array [
                       Object {
                         "Fn::GetAtt": Array [
-                          "ArtifactsBucket2AAC5544",
+                          "DefaultsArtifactsBucket267E29E1",
                           "Arn",
                         ],
                       },
@@ -11340,10 +13740,10 @@ Object {
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "DefaultsUpdatePipelineSelfMutationRoleDefaultPolicyB0C671E4",
+        "PolicyName": "DefaultsUpdatePipelineSelfMutationRoleDefaultPolicyCE04D82F",
         "Roles": Array [
           Object {
-            "Ref": "DefaultsUpdatePipelineSelfMutationRole2FF40065",
+            "Ref": "DefaultsUpdatePipelineSelfMutationRole0C19159A",
           },
         ],
       },

--- a/packages/static-website/src/static-website.ts
+++ b/packages/static-website/src/static-website.ts
@@ -19,6 +19,7 @@ import {
   Bucket,
   BucketEncryption,
   IBucket,
+  ObjectOwnership,
 } from "aws-cdk-lib/aws-s3";
 import { BucketDeployment, Source } from "aws-cdk-lib/aws-s3-deployment";
 import { NagSuppressions } from "cdk-nag";
@@ -125,6 +126,11 @@ export class StaticWebsite extends Construct {
   constructor(scope: Construct, id: string, props: StaticWebsiteProps) {
     super(scope, id);
 
+    this.node.setContext(
+      "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy",
+      true
+    );
+
     this.validateProps(props);
 
     const accessLogsBucket = new Bucket(this, "AccessLogsBucket", {
@@ -133,6 +139,7 @@ export class StaticWebsite extends Construct {
       autoDeleteObjects: true,
       removalPolicy: RemovalPolicy.DESTROY,
       encryption: BucketEncryption.S3_MANAGED,
+      objectOwnership: ObjectOwnership.BUCKET_OWNER_ENFORCED,
       publicReadAccess: false,
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
     });
@@ -147,6 +154,7 @@ export class StaticWebsite extends Construct {
         removalPolicy: RemovalPolicy.DESTROY,
         encryption:
           props.defaultWebsiteBucketEncryption ?? BucketEncryption.S3_MANAGED,
+        objectOwnership: ObjectOwnership.BUCKET_OWNER_ENFORCED,
         encryptionKey: props.defaultWebsiteBucketEncryptionKey,
         publicReadAccess: false,
         blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
@@ -169,6 +177,7 @@ export class StaticWebsite extends Construct {
         removalPolicy: RemovalPolicy.DESTROY,
         encryption:
           props.defaultWebsiteBucketEncryption ?? BucketEncryption.S3_MANAGED,
+        objectOwnership: ObjectOwnership.BUCKET_OWNER_ENFORCED,
         encryptionKey: props.defaultWebsiteBucketEncryptionKey,
         publicReadAccess: false,
         blockPublicAccess: BlockPublicAccess.BLOCK_ALL,

--- a/packages/static-website/test/__snapshots__/static-website.test.ts.snap
+++ b/packages/static-website/test/__snapshots__/static-website.test.ts.snap
@@ -290,13 +290,19 @@ Object {
     "DefaultsAccessLogsBucket1E788CBC": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
-        "AccessControl": "LogDeliveryWrite",
         "BucketEncryption": Object {
           "ServerSideEncryptionConfiguration": Array [
             Object {
               "ServerSideEncryptionByDefault": Object {
                 "SSEAlgorithm": "AES256",
               },
+            },
+          ],
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
             },
           ],
         },
@@ -414,6 +420,78 @@ Object {
                 },
               ],
             },
+            Object {
+              "Action": "s3:PutObject",
+              "Condition": Object {
+                "ArnLike": Object {
+                  "aws:SourceArn": Object {
+                    "Fn::GetAtt": Array [
+                      "DefaultsWebsiteBucket3263D025",
+                      "Arn",
+                    ],
+                  },
+                },
+                "StringEquals": Object {
+                  "aws:SourceAccount": Object {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "logging.s3.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "DefaultsAccessLogsBucket1E788CBC",
+                        "Arn",
+                      ],
+                    },
+                    "/website-access-logs*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:PutObject",
+              "Condition": Object {
+                "ArnLike": Object {
+                  "aws:SourceArn": Object {
+                    "Fn::GetAtt": Array [
+                      "DefaultsDistributionLogBucket7EA741E2",
+                      "Arn",
+                    ],
+                  },
+                },
+                "StringEquals": Object {
+                  "aws:SourceAccount": Object {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "logging.s3.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "DefaultsAccessLogsBucket1E788CBC",
+                        "Arn",
+                      ],
+                    },
+                    "/distribution-access-logs*",
+                  ],
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -513,6 +591,13 @@ Object {
             "Ref": "DefaultsAccessLogsBucket1E788CBC",
           },
           "LogFilePrefix": "distribution-access-logs",
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
+            },
+          ],
         },
         "PublicAccessBlockConfiguration": Object {
           "BlockPublicAcls": true,
@@ -1120,6 +1205,13 @@ Object {
           },
           "LogFilePrefix": "website-access-logs",
         },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
+            },
+          ],
+        },
         "PublicAccessBlockConfiguration": Object {
           "BlockPublicAcls": true,
           "BlockPublicPolicy": true,
@@ -1632,13 +1724,19 @@ Object {
     "DefaultsAccessLogsBucket1E788CBC": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
-        "AccessControl": "LogDeliveryWrite",
         "BucketEncryption": Object {
           "ServerSideEncryptionConfiguration": Array [
             Object {
               "ServerSideEncryptionByDefault": Object {
                 "SSEAlgorithm": "AES256",
               },
+            },
+          ],
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
             },
           ],
         },
@@ -1756,6 +1854,78 @@ Object {
                 },
               ],
             },
+            Object {
+              "Action": "s3:PutObject",
+              "Condition": Object {
+                "ArnLike": Object {
+                  "aws:SourceArn": Object {
+                    "Fn::GetAtt": Array [
+                      "DefaultsWebsiteBucket3263D025",
+                      "Arn",
+                    ],
+                  },
+                },
+                "StringEquals": Object {
+                  "aws:SourceAccount": Object {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "logging.s3.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "DefaultsAccessLogsBucket1E788CBC",
+                        "Arn",
+                      ],
+                    },
+                    "/website-access-logs*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:PutObject",
+              "Condition": Object {
+                "ArnLike": Object {
+                  "aws:SourceArn": Object {
+                    "Fn::GetAtt": Array [
+                      "DefaultsDistributionLogBucket7EA741E2",
+                      "Arn",
+                    ],
+                  },
+                },
+                "StringEquals": Object {
+                  "aws:SourceAccount": Object {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "logging.s3.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "DefaultsAccessLogsBucket1E788CBC",
+                        "Arn",
+                      ],
+                    },
+                    "/distribution-access-logs*",
+                  ],
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -1855,6 +2025,13 @@ Object {
             "Ref": "DefaultsAccessLogsBucket1E788CBC",
           },
           "LogFilePrefix": "distribution-access-logs",
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
+            },
+          ],
         },
         "PublicAccessBlockConfiguration": Object {
           "BlockPublicAcls": true,
@@ -2439,6 +2616,13 @@ Object {
             "Ref": "DefaultsAccessLogsBucket1E788CBC",
           },
           "LogFilePrefix": "website-access-logs",
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
+            },
+          ],
         },
         "PublicAccessBlockConfiguration": Object {
           "BlockPublicAcls": true,
@@ -2979,13 +3163,19 @@ Object {
     "DefaultsAccessLogsBucket1E788CBC": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
-        "AccessControl": "LogDeliveryWrite",
         "BucketEncryption": Object {
           "ServerSideEncryptionConfiguration": Array [
             Object {
               "ServerSideEncryptionByDefault": Object {
                 "SSEAlgorithm": "AES256",
               },
+            },
+          ],
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
             },
           ],
         },
@@ -3103,6 +3293,78 @@ Object {
                 },
               ],
             },
+            Object {
+              "Action": "s3:PutObject",
+              "Condition": Object {
+                "ArnLike": Object {
+                  "aws:SourceArn": Object {
+                    "Fn::GetAtt": Array [
+                      "DefaultsWebsiteBucket3263D025",
+                      "Arn",
+                    ],
+                  },
+                },
+                "StringEquals": Object {
+                  "aws:SourceAccount": Object {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "logging.s3.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "DefaultsAccessLogsBucket1E788CBC",
+                        "Arn",
+                      ],
+                    },
+                    "/website-access-logs*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:PutObject",
+              "Condition": Object {
+                "ArnLike": Object {
+                  "aws:SourceArn": Object {
+                    "Fn::GetAtt": Array [
+                      "DefaultsDistributionLogBucket7EA741E2",
+                      "Arn",
+                    ],
+                  },
+                },
+                "StringEquals": Object {
+                  "aws:SourceAccount": Object {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "logging.s3.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "DefaultsAccessLogsBucket1E788CBC",
+                        "Arn",
+                      ],
+                    },
+                    "/distribution-access-logs*",
+                  ],
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -3202,6 +3464,13 @@ Object {
             "Ref": "DefaultsAccessLogsBucket1E788CBC",
           },
           "LogFilePrefix": "distribution-access-logs",
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
+            },
+          ],
         },
         "PublicAccessBlockConfiguration": Object {
           "BlockPublicAcls": true,
@@ -3786,6 +4055,13 @@ Object {
             "Ref": "DefaultsAccessLogsBucket1E788CBC",
           },
           "LogFilePrefix": "website-access-logs",
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
+            },
+          ],
         },
         "PublicAccessBlockConfiguration": Object {
           "BlockPublicAcls": true,
@@ -4326,13 +4602,19 @@ Object {
     "DefaultsAccessLogsBucket1E788CBC": Object {
       "DeletionPolicy": "Delete",
       "Properties": Object {
-        "AccessControl": "LogDeliveryWrite",
         "BucketEncryption": Object {
           "ServerSideEncryptionConfiguration": Array [
             Object {
               "ServerSideEncryptionByDefault": Object {
                 "SSEAlgorithm": "AES256",
               },
+            },
+          ],
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
             },
           ],
         },
@@ -4450,6 +4732,78 @@ Object {
                 },
               ],
             },
+            Object {
+              "Action": "s3:PutObject",
+              "Condition": Object {
+                "ArnLike": Object {
+                  "aws:SourceArn": Object {
+                    "Fn::GetAtt": Array [
+                      "DefaultsWebsiteBucket3263D025",
+                      "Arn",
+                    ],
+                  },
+                },
+                "StringEquals": Object {
+                  "aws:SourceAccount": Object {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "logging.s3.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "DefaultsAccessLogsBucket1E788CBC",
+                        "Arn",
+                      ],
+                    },
+                    "/website-access-logs*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:PutObject",
+              "Condition": Object {
+                "ArnLike": Object {
+                  "aws:SourceArn": Object {
+                    "Fn::GetAtt": Array [
+                      "DefaultsDistributionLogBucket7EA741E2",
+                      "Arn",
+                    ],
+                  },
+                },
+                "StringEquals": Object {
+                  "aws:SourceAccount": Object {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "logging.s3.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "DefaultsAccessLogsBucket1E788CBC",
+                        "Arn",
+                      ],
+                    },
+                    "/distribution-access-logs*",
+                  ],
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -4558,6 +4912,13 @@ Object {
             "Ref": "DefaultsAccessLogsBucket1E788CBC",
           },
           "LogFilePrefix": "distribution-access-logs",
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
+            },
+          ],
         },
         "PublicAccessBlockConfiguration": Object {
           "BlockPublicAcls": true,
@@ -5142,6 +5503,13 @@ Object {
             "Ref": "DefaultsAccessLogsBucket1E788CBC",
           },
           "LogFilePrefix": "website-access-logs",
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
+            },
+          ],
         },
         "PublicAccessBlockConfiguration": Object {
           "BlockPublicAcls": true,
@@ -5742,13 +6110,19 @@ Object {
         },
       },
       "Properties": Object {
-        "AccessControl": "LogDeliveryWrite",
         "BucketEncryption": Object {
           "ServerSideEncryptionConfiguration": Array [
             Object {
               "ServerSideEncryptionByDefault": Object {
                 "SSEAlgorithm": "AES256",
               },
+            },
+          ],
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
             },
           ],
         },
@@ -5886,6 +6260,78 @@ Object {
                 },
               ],
             },
+            Object {
+              "Action": "s3:PutObject",
+              "Condition": Object {
+                "ArnLike": Object {
+                  "aws:SourceArn": Object {
+                    "Fn::GetAtt": Array [
+                      "DefaultsWebsiteBucket3263D025",
+                      "Arn",
+                    ],
+                  },
+                },
+                "StringEquals": Object {
+                  "aws:SourceAccount": Object {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "logging.s3.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "DefaultsAccessLogsBucket1E788CBC",
+                        "Arn",
+                      ],
+                    },
+                    "/website-access-logs*",
+                  ],
+                ],
+              },
+            },
+            Object {
+              "Action": "s3:PutObject",
+              "Condition": Object {
+                "ArnLike": Object {
+                  "aws:SourceArn": Object {
+                    "Fn::GetAtt": Array [
+                      "DefaultsDistributionLogBucket7EA741E2",
+                      "Arn",
+                    ],
+                  },
+                },
+                "StringEquals": Object {
+                  "aws:SourceAccount": Object {
+                    "Ref": "AWS::AccountId",
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "logging.s3.amazonaws.com",
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "DefaultsAccessLogsBucket1E788CBC",
+                        "Arn",
+                      ],
+                    },
+                    "/distribution-access-logs*",
+                  ],
+                ],
+              },
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -5999,6 +6445,13 @@ Object {
             "Ref": "DefaultsAccessLogsBucket1E788CBC",
           },
           "LogFilePrefix": "distribution-access-logs",
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
+            },
+          ],
         },
         "PublicAccessBlockConfiguration": Object {
           "BlockPublicAcls": true,
@@ -6659,6 +7112,13 @@ Object {
             "Ref": "DefaultsAccessLogsBucket1E788CBC",
           },
           "LogFilePrefix": "website-access-logs",
+        },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "BucketOwnerEnforced",
+            },
+          ],
         },
         "PublicAccessBlockConfiguration": Object {
           "BlockPublicAcls": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^5
         version: 5.55.0(eslint@8.36.0)(typescript@4.9.5)
+      commitizen:
+        specifier: ^4.3.0
+        version: 4.3.0
       cz-conventional-changelog:
         specifier: ^3.3.0
         version: 3.3.0
@@ -13137,7 +13140,7 @@ packages:
     dependencies:
       semver: 7.3.8
       shelljs: 0.8.5
-      typescript: 5.1.0-dev.20230418
+      typescript: 5.1.0-dev.20230420
     dev: true
 
   /duplexer2@0.0.2:
@@ -24436,8 +24439,8 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
-  /typescript@5.1.0-dev.20230418:
-    resolution: {integrity: sha512-BfA/KV0xddF8ZCAQZxZ0FoS8p+nWKXVaa5fctXW6WNGfcYF04cXlLB6F6uf3uCVbd0iad4YdHchz3KR0722QLg==}
+  /typescript@5.1.0-dev.20230420:
+    resolution: {integrity: sha512-ytvKM7THT08QHjFP6v8kF3RtJWMQ/wWeQTIbe3kveVDcmstVrS5IZ47c9Y9GIYI2WaFVVjNu2YNLwSwIt82Fzg==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true

--- a/private/projects/pdk-monorepo-project.ts
+++ b/private/projects/pdk-monorepo-project.ts
@@ -79,6 +79,7 @@ export class PDKMonorepoProject extends NxMonorepoProject {
         "@aws-prototyping-sdk/pipeline@^0.x",
         "@commitlint/cli",
         "@commitlint/config-conventional",
+        "commitizen",
         "cz-conventional-changelog",
         "eslint-plugin-header",
         "husky",


### PR DESCRIPTION
- Fixes https://aws.amazon.com/about-aws/whats-new/2023/04/amazon-s3-two-security-best-practices-buckets-default/
- Adds commitizen to root as a devDep

BREAKING CHANGE: Pipeline has been refactored into a construct in order to resolve the S3 issue. Accessing CodePipeline methods now require accessing the public pipeline member of PDKPipeline i.e. `pdkPipeline.codePipeline.XXX`