### PR TITLE
fix(component): change static-website distribution log bucket to owner_preferred to permit ACLs

### DIFF
--- a/packages/static-website/src/static-website.ts
+++ b/packages/static-website/src/static-website.ts
@@ -177,7 +177,7 @@ export class StaticWebsite extends Construct {
         removalPolicy: RemovalPolicy.DESTROY,
         encryption:
           props.defaultWebsiteBucketEncryption ?? BucketEncryption.S3_MANAGED,
-        objectOwnership: ObjectOwnership.BUCKET_OWNER_ENFORCED,
+        objectOwnership: ObjectOwnership.BUCKET_OWNER_PREFERRED,
         encryptionKey: props.defaultWebsiteBucketEncryptionKey,
         publicReadAccess: false,
         blockPublicAccess: BlockPublicAccess.BLOCK_ALL,

--- a/packages/static-website/test/__snapshots__/static-website.test.ts.snap
+++ b/packages/static-website/test/__snapshots__/static-website.test.ts.snap
@@ -595,7 +595,7 @@ Object {
         "OwnershipControls": Object {
           "Rules": Array [
             Object {
-              "ObjectOwnership": "BucketOwnerEnforced",
+              "ObjectOwnership": "BucketOwnerPreferred",
             },
           ],
         },
@@ -2029,7 +2029,7 @@ Object {
         "OwnershipControls": Object {
           "Rules": Array [
             Object {
-              "ObjectOwnership": "BucketOwnerEnforced",
+              "ObjectOwnership": "BucketOwnerPreferred",
             },
           ],
         },
@@ -3468,7 +3468,7 @@ Object {
         "OwnershipControls": Object {
           "Rules": Array [
             Object {
-              "ObjectOwnership": "BucketOwnerEnforced",
+              "ObjectOwnership": "BucketOwnerPreferred",
             },
           ],
         },
@@ -4916,7 +4916,7 @@ Object {
         "OwnershipControls": Object {
           "Rules": Array [
             Object {
-              "ObjectOwnership": "BucketOwnerEnforced",
+              "ObjectOwnership": "BucketOwnerPreferred",
             },
           ],
         },
@@ -6449,7 +6449,7 @@ Object {
         "OwnershipControls": Object {
           "Rules": Array [
             Object {
-              "ObjectOwnership": "BucketOwnerEnforced",
+              "ObjectOwnership": "BucketOwnerPreferred",
             },
           ],
         },


### PR DESCRIPTION
A recent change to bucket object ownership within static-website has set all buckets to BUCKET_OWNER_ENFORCED, however this blocks ACLs and causes an error when the staticWebsite construct attempts to deploy. The Cloudwatch distribution log bucket requires ACLs to be permitted.

Issue first noticed: 
When doing a fresh deployment using version 0.17.1 of @aws-prototyping-sdk/* packages

```bash
"Invalid request provided: AWS::CloudFront::Distribution: The S3
bucket that you specified for CloudFront logs does not enable ACL access: my-stack-staticwebsitedist
ributionlogbuckete54478-ulrggnuqkwpc.s3.us-west-2.amazonaws.com (Service: CloudFront, Status Code: 4
00, Request ID: 3e3e64c2-062a-4620-8dad-4e6e19414fc4)" (RequestToken: e68397fa-d759-f11c-b528-c86038
7c8de0, HandlerErrorCode: InvalidRequest)
```