### PR TITLE
fix: nx-monorepo scripts and generator

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -283,10 +283,10 @@
       "name": "workspace:bin:link",
       "steps": [
         {
-          "exec": "ln -s $PWD/packages/nx-monorepo/scripts/nx-dir-hasher.js $(pnpm bin)/pdk@nx-dir-hasher &>/dev/null; exit 0;"
+          "exec": "ln -s $PWD/packages/nx-monorepo/scripts/nx-dir-hasher.js $(pnpm bin)/pdk-nx-dir-hasher &>/dev/null; exit 0;"
         },
         {
-          "exec": "ln -s $PWD/packages/nx-monorepo/scripts/pnpm/link-bundled-transitive-deps.ts $(pnpm bin)/pdk@pnpm-link-bundled-transitive-deps &>/dev/null; exit 0;"
+          "exec": "ln -s $PWD/packages/nx-monorepo/scripts/pnpm/link-bundled-transitive-deps.ts $(pnpm bin)/pdk-pnpm-link-bundled-transitive-deps &>/dev/null; exit 0;"
         }
       ]
     }

--- a/packages/aws-prototyping-sdk/README.md
+++ b/packages/aws-prototyping-sdk/README.md
@@ -1,3 +1,5 @@
+> **DEPRECATION NOTICE:** The `aws-prototyping-sdk` is on path to deprecation. This package is simply a wrapper around the individual `@aws-prototyping-skd/*` packages and has no unique code aside from bundling the other packages. Due to lack of significant value compared to maintenance overhead, this package will be deprecated soon in favor of using the individual packages directly. Please use the individual packages starting now to prevent future migration and loss of update capabilities.
+
 The aws-prototyping-sdk provides stable CDK and Projen constructs, allowing developers to have access to higher level abstractions than provided by the CDK or Projen alone.
 
 For detailed documentation, please refer to the [documentation website](https://aws.github.io/aws-prototyping-sdk/).

--- a/packages/cdk-graph-plugin-diagram/.projen/tasks.json
+++ b/packages/cdk-graph-plugin-diagram/.projen/tasks.json
@@ -128,7 +128,7 @@
       "description": "Creates the distribution package",
       "steps": [
         {
-          "exec": "pdk@pnpm-link-bundled-transitive-deps packages/cdk-graph-plugin-diagram"
+          "exec": "pdk-pnpm-link-bundled-transitive-deps packages/cdk-graph-plugin-diagram"
         },
         {
           "spawn": "sharp:prebuild"

--- a/packages/cdk-graph-plugin-diagram/package.json
+++ b/packages/cdk-graph-plugin-diagram/package.json
@@ -243,7 +243,7 @@
           "default",
           "^default",
           {
-            "runtime": "pnpm exec pdk@nx-dir-hasher {workspaceRoot}/packages/cdk-graph-plugin-diagram/node_modules/sharp"
+            "runtime": "pnpm exec pdk-nx-dir-hasher {workspaceRoot}/packages/cdk-graph-plugin-diagram/node_modules/sharp"
           }
         ]
       }

--- a/packages/cdk-graph/.projen/tasks.json
+++ b/packages/cdk-graph/.projen/tasks.json
@@ -120,7 +120,7 @@
       "description": "Creates the distribution package",
       "steps": [
         {
-          "exec": "pdk@pnpm-link-bundled-transitive-deps packages/cdk-graph"
+          "exec": "pdk-pnpm-link-bundled-transitive-deps packages/cdk-graph"
         },
         {
           "exec": "pnpm exec license-checker --summary --production --onlyAllow 'MIT;Apache-2.0;Unlicense;BSD;BSD-2-Clause;BSD-3-Clause;ISC;'"

--- a/packages/nx-monorepo/.projen/tasks.json
+++ b/packages/nx-monorepo/.projen/tasks.json
@@ -129,7 +129,7 @@
       "description": "Creates the distribution package",
       "steps": [
         {
-          "exec": "pdk@pnpm-link-bundled-transitive-deps packages/nx-monorepo"
+          "exec": "pdk-pnpm-link-bundled-transitive-deps packages/nx-monorepo"
         },
         {
           "exec": "pnpm exec license-checker --summary --production --onlyAllow 'MIT;Apache-2.0;Unlicense;BSD;BSD-2-Clause;BSD-3-Clause;ISC;'"

--- a/packages/nx-monorepo/README.md
+++ b/packages/nx-monorepo/README.md
@@ -8,7 +8,7 @@ The PDK itself uses the nx-monorepo project itself and is a good reference for s
 To get started simply run the following command in an empty directory:
 
 ```bash
-npx projen new --from aws-prototyping-sdk nx-monorepo
+npx projen new --from @aws-prototyping-sdk/nx-monorepo
 ```
 
 This will bootstrap a new Projen monorepo and contain the following in the .projenrc.ts:

--- a/packages/nx-monorepo/package.json
+++ b/packages/nx-monorepo/package.json
@@ -5,8 +5,8 @@
     "url": "https://github.com/aws/aws-prototyping-sdk"
   },
   "bin": {
-    "pdk@nx-dir-hasher": "./scripts/nx-dir-hasher.js",
-    "pdk@pnpm-link-bundled-transitive-deps": "./scripts/pnpm/link-bundled-transitive-deps.ts"
+    "pdk-nx-dir-hasher": "./scripts/nx-dir-hasher.js",
+    "pdk-pnpm-link-bundled-transitive-deps": "./scripts/pnpm/link-bundled-transitive-deps.ts"
   },
   "scripts": {
     "build": "pnpm exec projen build",

--- a/packages/nx-monorepo/src/nx-monorepo.ts
+++ b/packages/nx-monorepo/src/nx-monorepo.ts
@@ -67,7 +67,7 @@ export function buildExecutableCommand(
   switch (packageManager) {
     case NodePackageManager.YARN:
     case NodePackageManager.YARN2:
-      return `yarn exec ${argLiteral}`;
+      return `yarn ${argLiteral}`;
     case NodePackageManager.PNPM:
       return `pnpm exec ${argLiteral}`;
     default:

--- a/packages/nx-monorepo/src/nx-monorepo.ts
+++ b/packages/nx-monorepo/src/nx-monorepo.ts
@@ -740,7 +740,7 @@ export class NxMonorepoProject extends TypeScriptProject {
           // Create a symlink in the sub-project node_modules for all transitive deps
           // before running "package" task
           subProject.packageTask.prependExec(
-            `pdk@pnpm-link-bundled-transitive-deps ${pkgFolder}`
+            `pdk-pnpm-link-bundled-transitive-deps ${pkgFolder}`
           );
         }
       });

--- a/packages/nx-monorepo/test/__snapshots__/nx-monorepo.test.ts.snap
+++ b/packages/nx-monorepo/test/__snapshots__/nx-monorepo.test.ts.snap
@@ -2331,7 +2331,7 @@ target
         "name": "build",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=build --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=build --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -2376,7 +2376,7 @@ target
         "name": "compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -2410,7 +2410,7 @@ target
         "name": "eslint",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=eslint --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=eslint --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -2420,7 +2420,7 @@ target
         "name": "graph",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx graph",
+            "exec": "yarn nx graph",
             "receiveArgs": true,
           },
         ],
@@ -2451,7 +2451,7 @@ target
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=package --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=package --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -2464,7 +2464,7 @@ target
         "name": "post-compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=post-compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=post-compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -2481,7 +2481,7 @@ target
         "name": "pre-compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=pre-compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=pre-compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -2494,7 +2494,7 @@ target
         "name": "run-many",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many",
+            "exec": "yarn nx run-many",
             "receiveArgs": true,
           },
         ],
@@ -2504,7 +2504,7 @@ target
         "name": "synth-workspace",
         "steps": Array [
           Object {
-            "exec": "yarn exec projen",
+            "exec": "yarn projen",
           },
         ],
       },
@@ -2516,7 +2516,7 @@ target
         "name": "test",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=test --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=test --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -2553,7 +2553,7 @@ target
             "exec": "yarn upgrade",
           },
           Object {
-            "exec": "yarn exec projen",
+            "exec": "yarn projen",
           },
           Object {
             "spawn": "post-upgrade",
@@ -2564,16 +2564,16 @@ target
         "name": "upgrade-deps",
         "steps": Array [
           Object {
-            "exec": "yarn exec npm-check-updates --deep --rejectVersion 0.0.0 -u",
+            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u",
           },
           Object {
-            "exec": "yarn exec syncpack fix-mismatches",
+            "exec": "yarn syncpack fix-mismatches",
           },
           Object {
             "exec": "yarn install",
           },
           Object {
-            "exec": "yarn exec projen",
+            "exec": "yarn projen",
           },
         ],
       },
@@ -2585,7 +2585,7 @@ target
         "name": "watch",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=watch --output-style=stream --skip-nx-cache --nx-ignore-cycles --nx-bail",
+            "exec": "yarn nx run-many --target=watch --output-style=stream --skip-nx-cache --nx-ignore-cycles --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -2900,24 +2900,24 @@ target
       "@types/babel__traverse": "7.18.2",
     },
     "scripts": Object {
-      "build": "yarn exec projen build",
-      "clobber": "yarn exec projen clobber",
-      "compile": "yarn exec projen compile",
-      "default": "yarn exec projen default",
-      "eject": "yarn exec projen eject",
-      "eslint": "yarn exec projen eslint",
-      "graph": "yarn exec projen graph",
-      "package": "yarn exec projen package",
-      "post-compile": "yarn exec projen post-compile",
-      "post-upgrade": "yarn exec projen post-upgrade",
-      "pre-compile": "yarn exec projen pre-compile",
-      "projen": "yarn exec projen",
-      "run-many": "yarn exec projen run-many",
-      "synth-workspace": "yarn exec projen synth-workspace",
-      "test": "yarn exec projen test",
-      "upgrade": "yarn exec projen upgrade",
-      "upgrade-deps": "yarn exec projen upgrade-deps",
-      "watch": "yarn exec projen watch",
+      "build": "yarn projen build",
+      "clobber": "yarn projen clobber",
+      "compile": "yarn projen compile",
+      "default": "yarn projen default",
+      "eject": "yarn projen eject",
+      "eslint": "yarn projen eslint",
+      "graph": "yarn projen graph",
+      "package": "yarn projen package",
+      "post-compile": "yarn projen post-compile",
+      "post-upgrade": "yarn projen post-upgrade",
+      "pre-compile": "yarn projen pre-compile",
+      "projen": "yarn projen",
+      "run-many": "yarn projen run-many",
+      "synth-workspace": "yarn projen synth-workspace",
+      "test": "yarn projen test",
+      "upgrade": "yarn projen upgrade",
+      "upgrade-deps": "yarn projen upgrade-deps",
+      "watch": "yarn projen watch",
     },
     "types": "lib/index.d.ts",
     "version": "0.0.0",
@@ -4279,7 +4279,7 @@ target
         "name": "build",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=build --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=build --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -4324,7 +4324,7 @@ target
         "name": "compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -4358,7 +4358,7 @@ target
         "name": "eslint",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=eslint --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=eslint --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -4368,7 +4368,7 @@ target
         "name": "graph",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx graph",
+            "exec": "yarn nx graph",
             "receiveArgs": true,
           },
         ],
@@ -4399,7 +4399,7 @@ target
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=package --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=package --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -4412,7 +4412,7 @@ target
         "name": "post-compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=post-compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=post-compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -4429,7 +4429,7 @@ target
         "name": "pre-compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=pre-compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=pre-compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -4442,7 +4442,7 @@ target
         "name": "run-many",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many",
+            "exec": "yarn nx run-many",
             "receiveArgs": true,
           },
         ],
@@ -4452,7 +4452,7 @@ target
         "name": "synth-workspace",
         "steps": Array [
           Object {
-            "exec": "yarn exec projen",
+            "exec": "yarn projen",
           },
         ],
       },
@@ -4464,7 +4464,7 @@ target
         "name": "test",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=test --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=test --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -4501,7 +4501,7 @@ target
             "exec": "yarn upgrade",
           },
           Object {
-            "exec": "yarn exec projen",
+            "exec": "yarn projen",
           },
           Object {
             "spawn": "post-upgrade",
@@ -4512,16 +4512,16 @@ target
         "name": "upgrade-deps",
         "steps": Array [
           Object {
-            "exec": "yarn exec npm-check-updates --deep --rejectVersion 0.0.0 -u",
+            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u",
           },
           Object {
-            "exec": "yarn exec syncpack fix-mismatches",
+            "exec": "yarn syncpack fix-mismatches",
           },
           Object {
             "exec": "yarn2 install",
           },
           Object {
-            "exec": "yarn exec projen",
+            "exec": "yarn projen",
           },
         ],
       },
@@ -4533,7 +4533,7 @@ target
         "name": "watch",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=watch --output-style=stream --skip-nx-cache --nx-ignore-cycles --nx-bail",
+            "exec": "yarn nx run-many --target=watch --output-style=stream --skip-nx-cache --nx-ignore-cycles --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -4848,24 +4848,24 @@ target
       "@types/babel__traverse": "7.18.2",
     },
     "scripts": Object {
-      "build": "yarn exec projen build",
-      "clobber": "yarn exec projen clobber",
-      "compile": "yarn exec projen compile",
-      "default": "yarn exec projen default",
-      "eject": "yarn exec projen eject",
-      "eslint": "yarn exec projen eslint",
-      "graph": "yarn exec projen graph",
-      "package": "yarn exec projen package",
-      "post-compile": "yarn exec projen post-compile",
-      "post-upgrade": "yarn exec projen post-upgrade",
-      "pre-compile": "yarn exec projen pre-compile",
-      "projen": "yarn exec projen",
-      "run-many": "yarn exec projen run-many",
-      "synth-workspace": "yarn exec projen synth-workspace",
-      "test": "yarn exec projen test",
-      "upgrade": "yarn exec projen upgrade",
-      "upgrade-deps": "yarn exec projen upgrade-deps",
-      "watch": "yarn exec projen watch",
+      "build": "yarn projen build",
+      "clobber": "yarn projen clobber",
+      "compile": "yarn projen compile",
+      "default": "yarn projen default",
+      "eject": "yarn projen eject",
+      "eslint": "yarn projen eslint",
+      "graph": "yarn projen graph",
+      "package": "yarn projen package",
+      "post-compile": "yarn projen post-compile",
+      "post-upgrade": "yarn projen post-upgrade",
+      "pre-compile": "yarn projen pre-compile",
+      "projen": "yarn projen",
+      "run-many": "yarn projen run-many",
+      "synth-workspace": "yarn projen synth-workspace",
+      "test": "yarn projen test",
+      "upgrade": "yarn projen upgrade",
+      "upgrade-deps": "yarn projen upgrade-deps",
+      "watch": "yarn projen watch",
     },
     "types": "lib/index.d.ts",
     "version": "0.0.0",
@@ -6226,7 +6226,7 @@ target
         "name": "build",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=build --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=build --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -6271,7 +6271,7 @@ target
         "name": "compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -6305,7 +6305,7 @@ target
         "name": "eslint",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=eslint --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=eslint --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -6315,7 +6315,7 @@ target
         "name": "graph",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx graph",
+            "exec": "yarn nx graph",
             "receiveArgs": true,
           },
         ],
@@ -6346,7 +6346,7 @@ target
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=package --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=package --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -6359,7 +6359,7 @@ target
         "name": "post-compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=post-compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=post-compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -6376,7 +6376,7 @@ target
         "name": "pre-compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=pre-compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=pre-compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -6389,7 +6389,7 @@ target
         "name": "run-many",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many",
+            "exec": "yarn nx run-many",
             "receiveArgs": true,
           },
         ],
@@ -6399,7 +6399,7 @@ target
         "name": "synth-workspace",
         "steps": Array [
           Object {
-            "exec": "yarn exec projen",
+            "exec": "yarn projen",
           },
         ],
       },
@@ -6411,7 +6411,7 @@ target
         "name": "test",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=test --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=test --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -6459,16 +6459,16 @@ target
         "name": "upgrade-deps",
         "steps": Array [
           Object {
-            "exec": "yarn exec npm-check-updates --deep --rejectVersion 0.0.0 -u",
+            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u",
           },
           Object {
-            "exec": "yarn exec syncpack fix-mismatches",
+            "exec": "yarn syncpack fix-mismatches",
           },
           Object {
             "exec": "yarn install",
           },
           Object {
-            "exec": "yarn exec projen",
+            "exec": "yarn projen",
           },
         ],
       },
@@ -6480,7 +6480,7 @@ target
         "name": "watch",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=watch --output-style=stream --skip-nx-cache --nx-ignore-cycles --nx-bail",
+            "exec": "yarn nx run-many --target=watch --output-style=stream --skip-nx-cache --nx-ignore-cycles --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -8084,7 +8084,7 @@ target
         "name": "build",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=build --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=build --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -8129,7 +8129,7 @@ target
         "name": "compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -8163,7 +8163,7 @@ target
         "name": "eslint",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=eslint --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=eslint --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -8173,7 +8173,7 @@ target
         "name": "graph",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx graph",
+            "exec": "yarn nx graph",
             "receiveArgs": true,
           },
         ],
@@ -8204,7 +8204,7 @@ target
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=package --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=package --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -8217,7 +8217,7 @@ target
         "name": "post-compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=post-compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=post-compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -8230,7 +8230,7 @@ target
         "name": "postinstall",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target install --projects consumer,library --parallel=1",
+            "exec": "yarn nx run-many --target install --projects consumer,library --parallel=1",
           },
         ],
       },
@@ -8242,7 +8242,7 @@ target
         "name": "pre-compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=pre-compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=pre-compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -8255,7 +8255,7 @@ target
         "name": "run-many",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many",
+            "exec": "yarn nx run-many",
             "receiveArgs": true,
           },
         ],
@@ -8265,7 +8265,7 @@ target
         "name": "synth-workspace",
         "steps": Array [
           Object {
-            "exec": "yarn exec projen",
+            "exec": "yarn projen",
           },
         ],
       },
@@ -8277,7 +8277,7 @@ target
         "name": "test",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=test --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=test --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -8325,16 +8325,16 @@ target
         "name": "upgrade-deps",
         "steps": Array [
           Object {
-            "exec": "yarn exec npm-check-updates --deep --rejectVersion 0.0.0 -u",
+            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u",
           },
           Object {
-            "exec": "yarn exec syncpack fix-mismatches",
+            "exec": "yarn syncpack fix-mismatches",
           },
           Object {
             "exec": "yarn install",
           },
           Object {
-            "exec": "yarn exec projen",
+            "exec": "yarn projen",
           },
         ],
       },
@@ -8346,7 +8346,7 @@ target
         "name": "watch",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=watch --output-style=stream --skip-nx-cache --nx-ignore-cycles --nx-bail",
+            "exec": "yarn nx run-many --target=watch --output-style=stream --skip-nx-cache --nx-ignore-cycles --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -9838,7 +9838,7 @@ target
         "name": "build",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=build --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=build --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -9883,7 +9883,7 @@ target
         "name": "compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -9917,7 +9917,7 @@ target
         "name": "eslint",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=eslint --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=eslint --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -9927,7 +9927,7 @@ target
         "name": "graph",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx graph",
+            "exec": "yarn nx graph",
             "receiveArgs": true,
           },
         ],
@@ -9958,7 +9958,7 @@ target
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=package --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=package --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -9971,7 +9971,7 @@ target
         "name": "post-compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=post-compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=post-compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -9988,7 +9988,7 @@ target
         "name": "pre-compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=pre-compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=pre-compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -10001,7 +10001,7 @@ target
         "name": "run-many",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many",
+            "exec": "yarn nx run-many",
             "receiveArgs": true,
           },
         ],
@@ -10011,7 +10011,7 @@ target
         "name": "synth-workspace",
         "steps": Array [
           Object {
-            "exec": "yarn exec projen",
+            "exec": "yarn projen",
           },
         ],
       },
@@ -10023,7 +10023,7 @@ target
         "name": "test",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=test --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=test --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -10071,16 +10071,16 @@ target
         "name": "upgrade-deps",
         "steps": Array [
           Object {
-            "exec": "yarn exec npm-check-updates --deep --rejectVersion 0.0.0 -u",
+            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u",
           },
           Object {
-            "exec": "yarn exec syncpack fix-mismatches",
+            "exec": "yarn syncpack fix-mismatches",
           },
           Object {
             "exec": "yarn install",
           },
           Object {
-            "exec": "yarn exec projen",
+            "exec": "yarn projen",
           },
         ],
       },
@@ -10092,7 +10092,7 @@ target
         "name": "watch",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=watch --output-style=stream --skip-nx-cache --nx-ignore-cycles --nx-bail",
+            "exec": "yarn nx run-many --target=watch --output-style=stream --skip-nx-cache --nx-ignore-cycles --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -10877,7 +10877,7 @@ target
         "name": "build",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=build --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=build --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -10922,7 +10922,7 @@ target
         "name": "compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -10956,7 +10956,7 @@ target
         "name": "eslint",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=eslint --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=eslint --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -10966,7 +10966,7 @@ target
         "name": "graph",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx graph",
+            "exec": "yarn nx graph",
             "receiveArgs": true,
           },
         ],
@@ -10997,7 +10997,7 @@ target
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=package --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=package --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -11010,7 +11010,7 @@ target
         "name": "post-compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=post-compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=post-compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -11023,7 +11023,7 @@ target
         "name": "postinstall",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target install --projects py-subproject --parallel=1",
+            "exec": "yarn nx run-many --target install --projects py-subproject --parallel=1",
           },
         ],
       },
@@ -11035,7 +11035,7 @@ target
         "name": "pre-compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=pre-compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=pre-compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -11048,7 +11048,7 @@ target
         "name": "run-many",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many",
+            "exec": "yarn nx run-many",
             "receiveArgs": true,
           },
         ],
@@ -11058,7 +11058,7 @@ target
         "name": "synth-workspace",
         "steps": Array [
           Object {
-            "exec": "yarn exec projen",
+            "exec": "yarn projen",
           },
         ],
       },
@@ -11070,7 +11070,7 @@ target
         "name": "test",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=test --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=test --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -11118,16 +11118,16 @@ target
         "name": "upgrade-deps",
         "steps": Array [
           Object {
-            "exec": "yarn exec npm-check-updates --deep --rejectVersion 0.0.0 -u",
+            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u",
           },
           Object {
-            "exec": "yarn exec syncpack fix-mismatches",
+            "exec": "yarn syncpack fix-mismatches",
           },
           Object {
             "exec": "yarn install",
           },
           Object {
-            "exec": "yarn exec projen",
+            "exec": "yarn projen",
           },
         ],
       },
@@ -11139,7 +11139,7 @@ target
         "name": "watch",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=watch --output-style=stream --skip-nx-cache --nx-ignore-cycles --nx-bail",
+            "exec": "yarn nx run-many --target=watch --output-style=stream --skip-nx-cache --nx-ignore-cycles --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -14048,7 +14048,7 @@ target
         "name": "build",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=build --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=build --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -14093,7 +14093,7 @@ target
         "name": "compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -14127,7 +14127,7 @@ target
         "name": "eslint",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=eslint --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=eslint --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -14137,7 +14137,7 @@ target
         "name": "graph",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx graph",
+            "exec": "yarn nx graph",
             "receiveArgs": true,
           },
         ],
@@ -14168,7 +14168,7 @@ target
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=package --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=package --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -14181,7 +14181,7 @@ target
         "name": "post-compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=post-compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=post-compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -14198,7 +14198,7 @@ target
         "name": "pre-compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=pre-compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=pre-compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -14211,7 +14211,7 @@ target
         "name": "run-many",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many",
+            "exec": "yarn nx run-many",
             "receiveArgs": true,
           },
         ],
@@ -14221,7 +14221,7 @@ target
         "name": "synth-workspace",
         "steps": Array [
           Object {
-            "exec": "yarn exec projen",
+            "exec": "yarn projen",
           },
         ],
       },
@@ -14233,7 +14233,7 @@ target
         "name": "test",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=test --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=test --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -14281,16 +14281,16 @@ target
         "name": "upgrade-deps",
         "steps": Array [
           Object {
-            "exec": "yarn exec npm-check-updates --deep --rejectVersion 0.0.0 -u",
+            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u",
           },
           Object {
-            "exec": "yarn exec syncpack fix-mismatches",
+            "exec": "yarn syncpack fix-mismatches",
           },
           Object {
             "exec": "yarn install",
           },
           Object {
-            "exec": "yarn exec projen",
+            "exec": "yarn projen",
           },
         ],
       },
@@ -14302,7 +14302,7 @@ target
         "name": "watch",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=watch --output-style=stream --skip-nx-cache --nx-ignore-cycles --nx-bail",
+            "exec": "yarn nx run-many --target=watch --output-style=stream --skip-nx-cache --nx-ignore-cycles --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -15089,7 +15089,7 @@ pattern1.txt
         "name": "build",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=build --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=build --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -15134,7 +15134,7 @@ pattern1.txt
         "name": "compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -15168,7 +15168,7 @@ pattern1.txt
         "name": "eslint",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=eslint --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=eslint --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -15178,7 +15178,7 @@ pattern1.txt
         "name": "graph",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx graph",
+            "exec": "yarn nx graph",
             "receiveArgs": true,
           },
         ],
@@ -15209,7 +15209,7 @@ pattern1.txt
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=package --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=package --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -15222,7 +15222,7 @@ pattern1.txt
         "name": "post-compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=post-compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=post-compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -15239,7 +15239,7 @@ pattern1.txt
         "name": "pre-compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=pre-compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=pre-compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -15252,7 +15252,7 @@ pattern1.txt
         "name": "run-many",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many",
+            "exec": "yarn nx run-many",
             "receiveArgs": true,
           },
         ],
@@ -15262,7 +15262,7 @@ pattern1.txt
         "name": "synth-workspace",
         "steps": Array [
           Object {
-            "exec": "yarn exec projen",
+            "exec": "yarn projen",
           },
         ],
       },
@@ -15274,7 +15274,7 @@ pattern1.txt
         "name": "test",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=test --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=test --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -15322,16 +15322,16 @@ pattern1.txt
         "name": "upgrade-deps",
         "steps": Array [
           Object {
-            "exec": "yarn exec npm-check-updates --deep --rejectVersion 0.0.0 -u",
+            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u",
           },
           Object {
-            "exec": "yarn exec syncpack fix-mismatches",
+            "exec": "yarn syncpack fix-mismatches",
           },
           Object {
             "exec": "yarn install",
           },
           Object {
-            "exec": "yarn exec projen",
+            "exec": "yarn projen",
           },
         ],
       },
@@ -15343,7 +15343,7 @@ pattern1.txt
         "name": "watch",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=watch --output-style=stream --skip-nx-cache --nx-ignore-cycles --nx-bail",
+            "exec": "yarn nx run-many --target=watch --output-style=stream --skip-nx-cache --nx-ignore-cycles --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -18083,7 +18083,7 @@ target
         "name": "build",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=build --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=build --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -18128,7 +18128,7 @@ target
         "name": "compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -18162,7 +18162,7 @@ target
         "name": "eslint",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=eslint --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=eslint --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -18172,7 +18172,7 @@ target
         "name": "graph",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx graph",
+            "exec": "yarn nx graph",
             "receiveArgs": true,
           },
         ],
@@ -18203,7 +18203,7 @@ target
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=package --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=package --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -18216,7 +18216,7 @@ target
         "name": "post-compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=post-compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=post-compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -18233,7 +18233,7 @@ target
         "name": "pre-compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=pre-compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=pre-compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -18246,7 +18246,7 @@ target
         "name": "run-many",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many",
+            "exec": "yarn nx run-many",
             "receiveArgs": true,
           },
         ],
@@ -18256,7 +18256,7 @@ target
         "name": "synth-workspace",
         "steps": Array [
           Object {
-            "exec": "yarn exec projen",
+            "exec": "yarn projen",
           },
         ],
       },
@@ -18268,7 +18268,7 @@ target
         "name": "test",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=test --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=test --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -18316,16 +18316,16 @@ target
         "name": "upgrade-deps",
         "steps": Array [
           Object {
-            "exec": "yarn exec npm-check-updates --deep --rejectVersion 0.0.0 -u",
+            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u",
           },
           Object {
-            "exec": "yarn exec syncpack fix-mismatches",
+            "exec": "yarn syncpack fix-mismatches",
           },
           Object {
             "exec": "yarn install",
           },
           Object {
-            "exec": "yarn exec projen",
+            "exec": "yarn projen",
           },
         ],
       },
@@ -18337,7 +18337,7 @@ target
         "name": "watch",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=watch --output-style=stream --skip-nx-cache --nx-ignore-cycles --nx-bail",
+            "exec": "yarn nx run-many --target=watch --output-style=stream --skip-nx-cache --nx-ignore-cycles --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -19134,7 +19134,7 @@ target
         "name": "build",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=build --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=build --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -19179,7 +19179,7 @@ target
         "name": "compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -19213,7 +19213,7 @@ target
         "name": "eslint",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=eslint --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=eslint --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -19223,7 +19223,7 @@ target
         "name": "graph",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx graph",
+            "exec": "yarn nx graph",
             "receiveArgs": true,
           },
         ],
@@ -19254,7 +19254,7 @@ target
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=package --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=package --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -19267,7 +19267,7 @@ target
         "name": "post-compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=post-compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=post-compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -19284,7 +19284,7 @@ target
         "name": "pre-compile",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=pre-compile --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=pre-compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -19297,7 +19297,7 @@ target
         "name": "run-many",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many",
+            "exec": "yarn nx run-many",
             "receiveArgs": true,
           },
         ],
@@ -19307,7 +19307,7 @@ target
         "name": "synth-workspace",
         "steps": Array [
           Object {
-            "exec": "yarn exec projen",
+            "exec": "yarn projen",
           },
         ],
       },
@@ -19319,7 +19319,7 @@ target
         "name": "test",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=test --output-style=stream --nx-bail",
+            "exec": "yarn nx run-many --target=test --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -19367,16 +19367,16 @@ target
         "name": "upgrade-deps",
         "steps": Array [
           Object {
-            "exec": "yarn exec npm-check-updates --deep --rejectVersion 0.0.0 -u",
+            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u",
           },
           Object {
-            "exec": "yarn exec syncpack fix-mismatches",
+            "exec": "yarn syncpack fix-mismatches",
           },
           Object {
             "exec": "yarn install",
           },
           Object {
-            "exec": "yarn exec projen",
+            "exec": "yarn projen",
           },
         ],
       },
@@ -19388,7 +19388,7 @@ target
         "name": "watch",
         "steps": Array [
           Object {
-            "exec": "yarn exec nx run-many --target=watch --output-style=stream --skip-nx-cache --nx-ignore-cycles --nx-bail",
+            "exec": "yarn nx run-many --target=watch --output-style=stream --skip-nx-cache --nx-ignore-cycles --nx-bail",
             "receiveArgs": true,
           },
         ],

--- a/packages/open-api-gateway/.projen/tasks.json
+++ b/packages/open-api-gateway/.projen/tasks.json
@@ -126,7 +126,7 @@
       "description": "Creates the distribution package",
       "steps": [
         {
-          "exec": "pdk@pnpm-link-bundled-transitive-deps packages/open-api-gateway"
+          "exec": "pdk-pnpm-link-bundled-transitive-deps packages/open-api-gateway"
         },
         {
           "exec": "pnpm exec license-checker --summary --production --onlyAllow 'MIT;Apache-2.0;Unlicense;BSD;BSD-2-Clause;BSD-3-Clause;ISC;'"

--- a/packages/pipeline/README.md
+++ b/packages/pipeline/README.md
@@ -7,11 +7,11 @@ The pipeline module vends an extension to CDK's CodePipeline construct, named PD
 The architecture for the PDKPipeline is as follows:
 
 ```
-CodeCommit repository -> CodePipeline 
+CodeCommit repository -> CodePipeline
                              |-> EventBridge Rule (On Build Succeded) -> CodeBuild (Sonar Scan)
                              |-> Secret (sonarqube token)
 ```
-                            
+
 This module additionally vends multiple Projen Projects, one for each of the supported languages. These projects aim to bootstrap your project by providing sample code which uses the PDKPipeline construct.
 
 For example, in .projenrc.ts:
@@ -31,17 +31,17 @@ Alternatively, you can initialize a project using the cli (in an empty directory
 
 ```bash
 # Typescript
-npx projen new --from aws-prototyping-sdk pdk-pipeline-ts
+npx projen new --from @aws-prototyping-sdk/pdk-pipeline-ts
 ```
 
 ```bash
 # Python
-npx projen new --from aws-prototyping-sdk pdk-pipeline-py
+npx projen new --from @aws-prototyping-sdk/pdk-pipeline-py
 ```
 
 ```bash
 # Java
-npx projen new --from aws-prototyping-sdk pdk-pipeline-java
+npx projen new --from @aws-prototyping-sdk/pdk-pipeline-java
 ```
 
 ### CDK Nag

--- a/packages/type-safe-api/.projen/tasks.json
+++ b/packages/type-safe-api/.projen/tasks.json
@@ -126,7 +126,7 @@
       "description": "Creates the distribution package",
       "steps": [
         {
-          "exec": "pdk@pnpm-link-bundled-transitive-deps packages/type-safe-api"
+          "exec": "pdk-pnpm-link-bundled-transitive-deps packages/type-safe-api"
         },
         {
           "exec": "pnpm exec license-checker --summary --production --onlyAllow 'MIT;Apache-2.0;Unlicense;BSD;BSD-2-Clause;BSD-3-Clause;ISC;'"

--- a/private/projects/cdk-graph-plugin-diagram.ts
+++ b/private/projects/cdk-graph-plugin-diagram.ts
@@ -82,7 +82,7 @@ export class CdkGraphPluginDiagramProject extends CdkGraphPluginProject {
         {
           // To ensure sharp:prebuild artifacts are included in build cache hash
           runtime: this.buildExecuteCommand(
-            "pdk@nx-dir-hasher",
+            "pdk-nx-dir-hasher",
             "{workspaceRoot}/packages/cdk-graph-plugin-diagram/node_modules/sharp"
           ),
         },

--- a/private/projects/nx-monorepo-project.ts
+++ b/private/projects/nx-monorepo-project.ts
@@ -32,10 +32,10 @@ export class NXMonorepoProject extends PDKProject {
       'rsync -a ./src/** ./lib --include="*/" --include="**/*.js" --exclude="*" --prune-empty-dirs'
     );
 
-    this.package.addBin({ "pdk@nx-dir-hasher": "./scripts/nx-dir-hasher.js" });
+    this.package.addBin({ "pdk-nx-dir-hasher": "./scripts/nx-dir-hasher.js" });
 
     this.package.addBin({
-      "pdk@pnpm-link-bundled-transitive-deps":
+      "pdk-pnpm-link-bundled-transitive-deps":
         "./scripts/pnpm/link-bundled-transitive-deps.ts",
     });
   }

--- a/scripts/dev/link-workspace.js
+++ b/scripts/dev/link-workspace.js
@@ -8,7 +8,7 @@ const execa = require("execa");
 /*
 This script links (or unlinks) CDK modules and workspace packages in yarn global via `yarn link`.
 
-This enables using local development version of aws-prototyping-sdk during development
+This enables using local development version of @aws-prototyping-sdk/* during development
 of other projects outside of this workspace.
 
 By passing `unlink` as first arg it will unlink, otherwise will link.


### PR DESCRIPTION
- Update docs to use @aws-prototyping-sdk/nx-monorepo directly to create new projects, which will solve bin linking issues
- Fix yarn exec issue with arg propagation
- Fix bin resolution issue for yarn

Fixes #365 