### PR TITLE
fix(nx-monorepo): yarn exec issues

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -224,15 +224,6 @@
         }
       ]
     },
-    "synth-workspace": {
-      "name": "synth-workspace",
-      "description": "Synthesize workspace",
-      "steps": [
-        {
-          "exec": "pnpm exec projen"
-        }
-      ]
-    },
     "test": {
       "name": "test",
       "description": "Run tests for all affected projects",

--- a/package.json
+++ b/package.json
@@ -18,12 +18,11 @@
     "pre-compile": "pnpm exec projen pre-compile",
     "prepare": "pnpm exec projen prepare",
     "run-many": "pnpm exec projen run-many",
-    "synth-workspace": "pnpm exec projen synth-workspace",
     "test": "pnpm exec projen test",
     "upgrade-deps": "pnpm exec projen upgrade-deps",
     "watch": "pnpm exec projen watch",
     "workspace:bin:link": "pnpm exec projen workspace:bin:link",
-    "projen": "pnpm exec projen"
+    "synth-workspace": "pnpm exec projen"
   },
   "devDependencies": {
     "@aws-prototyping-sdk/nx-monorepo": "^0.x",

--- a/packages/aws-arch/package.json
+++ b/packages/aws-arch/package.json
@@ -33,8 +33,7 @@
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",
     "unbump": "pnpm exec projen unbump",
-    "watch": "pnpm exec projen watch",
-    "projen": "pnpm exec projen"
+    "watch": "pnpm exec projen watch"
   },
   "author": {
     "name": "AWS APJ COPE",

--- a/packages/cdk-graph-plugin-diagram/package.json
+++ b/packages/cdk-graph-plugin-diagram/package.json
@@ -25,8 +25,7 @@
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",
     "unbump": "pnpm exec projen unbump",
-    "watch": "pnpm exec projen watch",
-    "projen": "pnpm exec projen"
+    "watch": "pnpm exec projen watch"
   },
   "author": {
     "name": "AWS APJ COPE",

--- a/packages/cdk-graph/package.json
+++ b/packages/cdk-graph/package.json
@@ -23,8 +23,7 @@
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",
     "unbump": "pnpm exec projen unbump",
-    "watch": "pnpm exec projen watch",
-    "projen": "pnpm exec projen"
+    "watch": "pnpm exec projen watch"
   },
   "author": {
     "name": "AWS APJ COPE",

--- a/packages/cloudscape-react-ts-website/package.json
+++ b/packages/cloudscape-react-ts-website/package.json
@@ -25,8 +25,7 @@
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",
     "unbump": "pnpm exec projen unbump",
-    "watch": "pnpm exec projen watch",
-    "projen": "pnpm exec projen"
+    "watch": "pnpm exec projen watch"
   },
   "author": {
     "name": "AWS APJ COPE",

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -25,8 +25,7 @@
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",
     "unbump": "pnpm exec projen unbump",
-    "watch": "pnpm exec projen watch",
-    "projen": "pnpm exec projen"
+    "watch": "pnpm exec projen watch"
   },
   "author": {
     "name": "AWS APJ COPE",

--- a/packages/nx-monorepo/package.json
+++ b/packages/nx-monorepo/package.json
@@ -29,8 +29,7 @@
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",
     "unbump": "pnpm exec projen unbump",
-    "watch": "pnpm exec projen watch",
-    "projen": "pnpm exec projen"
+    "watch": "pnpm exec projen watch"
   },
   "author": {
     "name": "AWS APJ COPE",

--- a/packages/nx-monorepo/src/nx-project.ts
+++ b/packages/nx-monorepo/src/nx-project.ts
@@ -3,7 +3,7 @@ SPDX-License-Identifier: Apache-2.0 */
 import * as path from "path";
 import { Component, JsonFile, Project } from "projen";
 import { NodeProject } from "projen/lib/javascript";
-import { buildDownloadExecutableCommand } from "./nx-monorepo";
+import { NodePackageUtils } from "./utils";
 
 /**
  * Component which manged the project specific NX Config and is added to all NXMonorepo subprojects.
@@ -81,7 +81,7 @@ export class NxProject extends Component {
             [c.name]: {
               executor: "nx:run-commands",
               options: {
-                command: `${buildDownloadExecutableCommand(
+                command: `${NodePackageUtils.command.downloadExec(
                   (this.project.root as NodeProject).package.packageManager,
                   `projen ${c.name}`
                 )}`,

--- a/packages/nx-monorepo/src/utils/index.ts
+++ b/packages/nx-monorepo/src/utils/index.ts
@@ -1,6 +1,3 @@
 /*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0 */
-export * from "./nx-monorepo";
-export * from "./nx-types";
-export * from "./syncpack-options";
-export * from "./utils";
+export * from "./node";

--- a/packages/nx-monorepo/src/utils/node.ts
+++ b/packages/nx-monorepo/src/utils/node.ts
@@ -1,0 +1,120 @@
+/*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0 */
+import { NodePackageManager, NodeProject } from "projen/lib/javascript";
+
+/**
+ * Utility functions for working with different Node package managers.
+ * @experimental
+ */
+export namespace NodePackageUtils {
+  /**
+   * Append arguments to command string.
+   * @internal
+   */
+  function withArgs(cmd: string, args: string[]): string {
+    if (args.length) {
+      return `${cmd} ${args.join(" ")}`;
+    }
+
+    return cmd;
+  }
+
+  /**
+   * Remove the "projen" script from package.json scripts, which causes recursive projen execution
+   * for other scripts in format of "yarn projen [command]".
+   * @param project NodeProject to remove "projen" script
+   * @see https://github.com/projen/projen/blob/37983be94b37ee839ef3337a1b24b014a6c29f4f/src/javascript/node-project.ts#L512
+   */
+  export function removeProjenScript(project: NodeProject): void {
+    project.package.removeScript("projen");
+  }
+
+  /**
+   * Command based utilities
+   */
+  export namespace command {
+    /**
+     * Get command to run a script defined in the package.json
+     */
+    export function runScript(
+      packageManager: NodePackageManager,
+      ...args: string[]
+    ): string {
+      switch (packageManager) {
+        case NodePackageManager.YARN:
+        case NodePackageManager.YARN2:
+          return withArgs("yarn run", args);
+        case NodePackageManager.PNPM:
+          return withArgs("pnpm run", args);
+        default:
+          return withArgs("npm run", args);
+      }
+    }
+
+    /**
+     * Get command to execute projen or a projen task
+     */
+    export function projen(
+      packageManager: NodePackageManager,
+      ...args: string[]
+    ): string {
+      return exec(packageManager, "projen", ...args);
+    }
+
+    /**
+     * Get command to execute a shell command
+     */
+    export function exec(
+      packageManager: NodePackageManager,
+      ...args: string[]
+    ): string {
+      switch (packageManager) {
+        case NodePackageManager.YARN:
+          // "yarn exec" is not propagating transient args (`yarn exec nx run-many --target=build` does not receive `--target=build`)
+          return withArgs("yarn", args);
+        case NodePackageManager.YARN2:
+          return withArgs("yarn exec", args);
+        case NodePackageManager.PNPM:
+          return withArgs("pnpm exec", args);
+        default:
+          return withArgs("npx", args);
+      }
+    }
+
+    /**
+     * Get command to run a package in a temporary environment
+     */
+    export function downloadExec(
+      packageManager: NodePackageManager,
+      ...args: string[]
+    ): string {
+      switch (packageManager) {
+        case NodePackageManager.YARN2:
+          return withArgs("yarn dlx", args);
+        case NodePackageManager.PNPM:
+          return withArgs("pnpm dlx", args);
+        default:
+          return withArgs("npx", args);
+      }
+    }
+
+    /**
+     * Get bash command for executing an executable in the package manager /bin dir.
+     * Example: `$(yarn bin)/${cmd}`
+     */
+    export function bin(
+      packageManager: NodePackageManager,
+      cmd: string
+    ): string {
+      switch (packageManager) {
+        case NodePackageManager.YARN:
+        case NodePackageManager.YARN2:
+          return `$(yarn bin)/${cmd}`;
+        case NodePackageManager.PNPM:
+          return `$(pnpm bin)/${cmd}`;
+        default:
+          return `$(npm bin)/${cmd}`;
+      }
+    }
+  }
+}

--- a/packages/nx-monorepo/test/__snapshots__/nx-monorepo.test.ts.snap
+++ b/packages/nx-monorepo/test/__snapshots__/nx-monorepo.test.ts.snap
@@ -555,15 +555,6 @@ target
           },
         ],
       },
-      "synth-workspace": Object {
-        "description": "Synthesize workspace",
-        "name": "synth-workspace",
-        "steps": Array [
-          Object {
-            "exec": "pnpm exec projen",
-          },
-        ],
-      },
       "test": Object {
         "description": "Run tests for all affected projects",
         "env": Object {
@@ -971,9 +962,8 @@ target
       "post-compile": "pnpm exec projen post-compile",
       "post-upgrade": "pnpm exec projen post-upgrade",
       "pre-compile": "pnpm exec projen pre-compile",
-      "projen": "pnpm exec projen",
       "run-many": "pnpm exec projen run-many",
-      "synth-workspace": "pnpm exec projen synth-workspace",
+      "synth-workspace": "pnpm exec projen",
       "test": "pnpm exec projen test",
       "upgrade": "pnpm exec projen upgrade",
       "upgrade-deps": "pnpm exec projen upgrade-deps",
@@ -1810,7 +1800,6 @@ tsconfig.tsbuildinfo
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
       "pre-compile": "npx projen pre-compile",
-      "projen": "npx projen",
       "test": "npx projen test",
       "test:watch": "npx projen test:watch",
       "upgrade": "npx projen upgrade",
@@ -2529,15 +2518,6 @@ target
           },
         ],
       },
-      "synth-workspace": Object {
-        "description": "Synthesize workspace",
-        "name": "synth-workspace",
-        "steps": Array [
-          Object {
-            "exec": "yarn projen",
-          },
-        ],
-      },
       "test": Object {
         "description": "Run tests for all affected projects",
         "env": Object {
@@ -2943,9 +2923,8 @@ target
       "post-compile": "yarn projen post-compile",
       "post-upgrade": "yarn projen post-upgrade",
       "pre-compile": "yarn projen pre-compile",
-      "projen": "yarn projen",
       "run-many": "yarn projen run-many",
-      "synth-workspace": "yarn projen synth-workspace",
+      "synth-workspace": "yarn projen",
       "test": "yarn projen test",
       "upgrade": "yarn projen upgrade",
       "upgrade-deps": "yarn projen upgrade-deps",
@@ -3781,7 +3760,6 @@ tsconfig.tsbuildinfo
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
       "pre-compile": "npx projen pre-compile",
-      "projen": "npx projen",
       "test": "npx projen test",
       "test:watch": "npx projen test:watch",
       "upgrade": "npx projen upgrade",
@@ -4324,7 +4302,7 @@ target
         "name": "build",
         "steps": Array [
           Object {
-            "exec": "yarn nx run-many --target=build --output-style=stream --nx-bail",
+            "exec": "yarn exec nx run-many --target=build --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -4369,7 +4347,7 @@ target
         "name": "compile",
         "steps": Array [
           Object {
-            "exec": "yarn nx run-many --target=compile --output-style=stream --nx-bail",
+            "exec": "yarn exec nx run-many --target=compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -4403,7 +4381,7 @@ target
         "name": "eslint",
         "steps": Array [
           Object {
-            "exec": "yarn nx run-many --target=eslint --output-style=stream --nx-bail",
+            "exec": "yarn exec nx run-many --target=eslint --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -4413,7 +4391,7 @@ target
         "name": "graph",
         "steps": Array [
           Object {
-            "exec": "yarn nx graph",
+            "exec": "yarn exec nx graph",
             "receiveArgs": true,
           },
         ],
@@ -4444,7 +4422,7 @@ target
         "name": "package",
         "steps": Array [
           Object {
-            "exec": "yarn nx run-many --target=package --output-style=stream --nx-bail",
+            "exec": "yarn exec nx run-many --target=package --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -4457,7 +4435,7 @@ target
         "name": "post-compile",
         "steps": Array [
           Object {
-            "exec": "yarn nx run-many --target=post-compile --output-style=stream --nx-bail",
+            "exec": "yarn exec nx run-many --target=post-compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -4474,7 +4452,7 @@ target
         "name": "pre-compile",
         "steps": Array [
           Object {
-            "exec": "yarn nx run-many --target=pre-compile --output-style=stream --nx-bail",
+            "exec": "yarn exec nx run-many --target=pre-compile --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -4487,17 +4465,8 @@ target
         "name": "run-many",
         "steps": Array [
           Object {
-            "exec": "yarn nx run-many",
+            "exec": "yarn exec nx run-many",
             "receiveArgs": true,
-          },
-        ],
-      },
-      "synth-workspace": Object {
-        "description": "Synthesize workspace",
-        "name": "synth-workspace",
-        "steps": Array [
-          Object {
-            "exec": "yarn projen",
           },
         ],
       },
@@ -4509,7 +4478,7 @@ target
         "name": "test",
         "steps": Array [
           Object {
-            "exec": "yarn nx run-many --target=test --output-style=stream --nx-bail",
+            "exec": "yarn exec nx run-many --target=test --output-style=stream --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -4546,7 +4515,7 @@ target
             "exec": "yarn upgrade",
           },
           Object {
-            "exec": "yarn projen",
+            "exec": "yarn exec projen",
           },
           Object {
             "spawn": "post-upgrade",
@@ -4557,16 +4526,16 @@ target
         "name": "upgrade-deps",
         "steps": Array [
           Object {
-            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u",
+            "exec": "yarn exec npm-check-updates --deep --rejectVersion 0.0.0 -u",
           },
           Object {
-            "exec": "yarn syncpack fix-mismatches",
+            "exec": "yarn exec syncpack fix-mismatches",
           },
           Object {
             "exec": "yarn2 install",
           },
           Object {
-            "exec": "yarn projen",
+            "exec": "yarn exec projen",
           },
         ],
       },
@@ -4578,7 +4547,7 @@ target
         "name": "watch",
         "steps": Array [
           Object {
-            "exec": "yarn nx run-many --target=watch --output-style=stream --skip-nx-cache --nx-ignore-cycles --nx-bail",
+            "exec": "yarn exec nx run-many --target=watch --output-style=stream --skip-nx-cache --nx-ignore-cycles --nx-bail",
             "receiveArgs": true,
           },
         ],
@@ -4880,7 +4849,7 @@ target
     },
     "engines": Object {
       "node": ">=16",
-      "yarn": ">=2 <3",
+      "yarn": ">=2",
     },
     "license": "Apache-2.0",
     "main": "lib/index.js",
@@ -4895,24 +4864,23 @@ target
       "wrap-ansi": "^7.0.0",
     },
     "scripts": Object {
-      "build": "yarn projen build",
-      "clobber": "yarn projen clobber",
-      "compile": "yarn projen compile",
-      "default": "yarn projen default",
-      "eject": "yarn projen eject",
-      "eslint": "yarn projen eslint",
-      "graph": "yarn projen graph",
-      "package": "yarn projen package",
-      "post-compile": "yarn projen post-compile",
-      "post-upgrade": "yarn projen post-upgrade",
-      "pre-compile": "yarn projen pre-compile",
-      "projen": "yarn projen",
-      "run-many": "yarn projen run-many",
-      "synth-workspace": "yarn projen synth-workspace",
-      "test": "yarn projen test",
-      "upgrade": "yarn projen upgrade",
-      "upgrade-deps": "yarn projen upgrade-deps",
-      "watch": "yarn projen watch",
+      "build": "yarn exec projen build",
+      "clobber": "yarn exec projen clobber",
+      "compile": "yarn exec projen compile",
+      "default": "yarn exec projen default",
+      "eject": "yarn exec projen eject",
+      "eslint": "yarn exec projen eslint",
+      "graph": "yarn exec projen graph",
+      "package": "yarn exec projen package",
+      "post-compile": "yarn exec projen post-compile",
+      "post-upgrade": "yarn exec projen post-upgrade",
+      "pre-compile": "yarn exec projen pre-compile",
+      "run-many": "yarn exec projen run-many",
+      "synth-workspace": "yarn exec projen",
+      "test": "yarn exec projen test",
+      "upgrade": "yarn exec projen upgrade",
+      "upgrade-deps": "yarn exec projen upgrade-deps",
+      "watch": "yarn exec projen watch",
     },
     "types": "lib/index.d.ts",
     "version": "0.0.0",
@@ -5744,7 +5712,6 @@ tsconfig.tsbuildinfo
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
       "pre-compile": "npx projen pre-compile",
-      "projen": "npx projen",
       "test": "npx projen test",
       "test:watch": "npx projen test:watch",
       "upgrade": "npx projen upgrade",
@@ -6454,15 +6421,6 @@ target
           },
         ],
       },
-      "synth-workspace": Object {
-        "description": "Synthesize workspace",
-        "name": "synth-workspace",
-        "steps": Array [
-          Object {
-            "exec": "yarn projen",
-          },
-        ],
-      },
       "test": Object {
         "description": "Run tests for all affected projects",
         "env": Object {
@@ -6868,9 +6826,8 @@ target
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
       "pre-compile": "npx projen pre-compile",
-      "projen": "npx projen",
       "run-many": "npx projen run-many",
-      "synth-workspace": "npx projen synth-workspace",
+      "synth-workspace": "yarn projen",
       "test": "npx projen test",
       "upgrade": "npx projen upgrade",
       "upgrade-deps": "npx projen upgrade-deps",
@@ -8333,15 +8290,6 @@ target
           },
         ],
       },
-      "synth-workspace": Object {
-        "description": "Synthesize workspace",
-        "name": "synth-workspace",
-        "steps": Array [
-          Object {
-            "exec": "yarn projen",
-          },
-        ],
-      },
       "test": Object {
         "description": "Run tests for all affected projects",
         "env": Object {
@@ -8753,9 +8701,8 @@ target
       "post-upgrade": "npx projen post-upgrade",
       "postinstall": "npx projen postinstall",
       "pre-compile": "npx projen pre-compile",
-      "projen": "npx projen",
       "run-many": "npx projen run-many",
-      "synth-workspace": "npx projen synth-workspace",
+      "synth-workspace": "yarn projen",
       "test": "npx projen test",
       "upgrade": "npx projen upgrade",
       "upgrade-deps": "npx projen upgrade-deps",
@@ -10091,15 +10038,6 @@ target
           },
         ],
       },
-      "synth-workspace": Object {
-        "description": "Synthesize workspace",
-        "name": "synth-workspace",
-        "steps": Array [
-          Object {
-            "exec": "yarn projen",
-          },
-        ],
-      },
       "test": Object {
         "description": "Run tests for all affected projects",
         "env": Object {
@@ -10505,9 +10443,8 @@ target
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
       "pre-compile": "npx projen pre-compile",
-      "projen": "npx projen",
       "run-many": "npx projen run-many",
-      "synth-workspace": "npx projen synth-workspace",
+      "synth-workspace": "yarn projen",
       "test": "npx projen test",
       "upgrade": "npx projen upgrade",
       "upgrade-deps": "npx projen upgrade-deps",
@@ -11151,15 +11088,6 @@ target
           },
         ],
       },
-      "synth-workspace": Object {
-        "description": "Synthesize workspace",
-        "name": "synth-workspace",
-        "steps": Array [
-          Object {
-            "exec": "yarn projen",
-          },
-        ],
-      },
       "test": Object {
         "description": "Run tests for all affected projects",
         "env": Object {
@@ -11571,9 +11499,8 @@ target
       "post-upgrade": "npx projen post-upgrade",
       "postinstall": "npx projen postinstall",
       "pre-compile": "npx projen pre-compile",
-      "projen": "npx projen",
       "run-many": "npx projen run-many",
-      "synth-workspace": "npx projen synth-workspace",
+      "synth-workspace": "yarn projen",
       "test": "npx projen test",
       "upgrade": "npx projen upgrade",
       "upgrade-deps": "npx projen upgrade-deps",
@@ -12709,7 +12636,6 @@ tsconfig.tsbuildinfo
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
       "pre-compile": "npx projen pre-compile",
-      "projen": "npx projen",
       "test": "npx projen test",
       "test:watch": "npx projen test:watch",
       "upgrade": "npx projen upgrade",
@@ -13620,7 +13546,6 @@ tsconfig.tsbuildinfo
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
       "pre-compile": "npx projen pre-compile",
-      "projen": "npx projen",
       "test": "npx projen test",
       "test:watch": "npx projen test:watch",
       "upgrade": "npx projen upgrade",
@@ -14330,15 +14255,6 @@ target
           },
         ],
       },
-      "synth-workspace": Object {
-        "description": "Synthesize workspace",
-        "name": "synth-workspace",
-        "steps": Array [
-          Object {
-            "exec": "yarn projen",
-          },
-        ],
-      },
       "test": Object {
         "description": "Run tests for all affected projects",
         "env": Object {
@@ -14744,9 +14660,8 @@ target
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
       "pre-compile": "npx projen pre-compile",
-      "projen": "npx projen",
       "run-many": "npx projen run-many",
-      "synth-workspace": "npx projen synth-workspace",
+      "synth-workspace": "yarn projen",
       "test": "npx projen test",
       "upgrade": "npx projen upgrade",
       "upgrade-deps": "npx projen upgrade-deps",
@@ -15384,15 +15299,6 @@ pattern1.txt
           },
         ],
       },
-      "synth-workspace": Object {
-        "description": "Synthesize workspace",
-        "name": "synth-workspace",
-        "steps": Array [
-          Object {
-            "exec": "yarn projen",
-          },
-        ],
-      },
       "test": Object {
         "description": "Run tests for all affected projects",
         "env": Object {
@@ -15798,9 +15704,8 @@ pattern1.txt
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
       "pre-compile": "npx projen pre-compile",
-      "projen": "npx projen",
       "run-many": "npx projen run-many",
-      "synth-workspace": "npx projen synth-workspace",
+      "synth-workspace": "yarn projen",
       "test": "npx projen test",
       "upgrade": "npx projen upgrade",
       "upgrade-deps": "npx projen upgrade-deps",
@@ -16443,15 +16348,6 @@ target
           },
         ],
       },
-      "synth-workspace": Object {
-        "description": "Synthesize workspace",
-        "name": "synth-workspace",
-        "steps": Array [
-          Object {
-            "exec": "pnpm exec projen",
-          },
-        ],
-      },
       "test": Object {
         "description": "Run tests for all affected projects",
         "env": Object {
@@ -16859,9 +16755,8 @@ target
       "post-compile": "pnpm exec projen post-compile",
       "post-upgrade": "pnpm exec projen post-upgrade",
       "pre-compile": "pnpm exec projen pre-compile",
-      "projen": "pnpm exec projen",
       "run-many": "pnpm exec projen run-many",
-      "synth-workspace": "pnpm exec projen synth-workspace",
+      "synth-workspace": "pnpm exec projen",
       "test": "pnpm exec projen test",
       "upgrade": "pnpm exec projen upgrade",
       "upgrade-deps": "pnpm exec projen upgrade-deps",
@@ -17695,7 +17590,6 @@ tsconfig.tsbuildinfo
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
       "pre-compile": "npx projen pre-compile",
-      "projen": "npx projen",
       "test": "npx projen test",
       "test:watch": "npx projen test:watch",
       "upgrade": "npx projen upgrade",
@@ -18410,15 +18304,6 @@ target
           },
         ],
       },
-      "synth-workspace": Object {
-        "description": "Synthesize workspace",
-        "name": "synth-workspace",
-        "steps": Array [
-          Object {
-            "exec": "yarn projen",
-          },
-        ],
-      },
       "test": Object {
         "description": "Run tests for all affected projects",
         "env": Object {
@@ -18824,9 +18709,8 @@ target
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
       "pre-compile": "npx projen pre-compile",
-      "projen": "npx projen",
       "run-many": "npx projen run-many",
-      "synth-workspace": "npx projen synth-workspace",
+      "synth-workspace": "yarn projen",
       "test": "npx projen test",
       "upgrade": "npx projen upgrade",
       "upgrade-deps": "npx projen upgrade-deps",
@@ -19462,15 +19346,6 @@ target
           },
         ],
       },
-      "synth-workspace": Object {
-        "description": "Synthesize workspace",
-        "name": "synth-workspace",
-        "steps": Array [
-          Object {
-            "exec": "yarn projen",
-          },
-        ],
-      },
       "test": Object {
         "description": "Run tests for all affected projects",
         "env": Object {
@@ -19876,9 +19751,8 @@ target
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
       "pre-compile": "npx projen pre-compile",
-      "projen": "npx projen",
       "run-many": "npx projen run-many",
-      "synth-workspace": "npx projen synth-workspace",
+      "synth-workspace": "yarn projen",
       "test": "npx projen test",
       "upgrade": "npx projen upgrade",
       "upgrade-deps": "npx projen upgrade-deps",
@@ -20717,7 +20591,6 @@ tsconfig.tsbuildinfo
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
       "pre-compile": "npx projen pre-compile",
-      "projen": "npx projen",
       "test": "npx projen test",
       "test:watch": "npx projen test:watch",
       "upgrade": "npx projen upgrade",
@@ -21623,7 +21496,6 @@ tsconfig.tsbuildinfo
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
       "pre-compile": "npx projen pre-compile",
-      "projen": "npx projen",
       "test": "npx projen test",
       "test:watch": "npx projen test:watch",
       "upgrade": "npx projen upgrade",
@@ -22529,7 +22401,6 @@ tsconfig.tsbuildinfo
       "post-compile": "npx projen post-compile",
       "post-upgrade": "npx projen post-upgrade",
       "pre-compile": "npx projen pre-compile",
-      "projen": "npx projen",
       "test": "npx projen test",
       "test:watch": "npx projen test:watch",
       "upgrade": "npx projen upgrade",

--- a/packages/open-api-gateway/package.json
+++ b/packages/open-api-gateway/package.json
@@ -25,8 +25,7 @@
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",
     "unbump": "pnpm exec projen unbump",
-    "watch": "pnpm exec projen watch",
-    "projen": "pnpm exec projen"
+    "watch": "pnpm exec projen watch"
   },
   "author": {
     "name": "AWS APJ COPE",

--- a/packages/pdk-nag/package.json
+++ b/packages/pdk-nag/package.json
@@ -25,8 +25,7 @@
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",
     "unbump": "pnpm exec projen unbump",
-    "watch": "pnpm exec projen watch",
-    "projen": "pnpm exec projen"
+    "watch": "pnpm exec projen watch"
   },
   "author": {
     "name": "AWS APJ COPE",

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -25,8 +25,7 @@
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",
     "unbump": "pnpm exec projen unbump",
-    "watch": "pnpm exec projen watch",
-    "projen": "pnpm exec projen"
+    "watch": "pnpm exec projen watch"
   },
   "author": {
     "name": "AWS APJ COPE",

--- a/packages/static-website/package.json
+++ b/packages/static-website/package.json
@@ -25,8 +25,7 @@
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",
     "unbump": "pnpm exec projen unbump",
-    "watch": "pnpm exec projen watch",
-    "projen": "pnpm exec projen"
+    "watch": "pnpm exec projen watch"
   },
   "author": {
     "name": "AWS APJ COPE",

--- a/packages/type-safe-api/package.json
+++ b/packages/type-safe-api/package.json
@@ -25,8 +25,7 @@
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",
     "unbump": "pnpm exec projen unbump",
-    "watch": "pnpm exec projen watch",
-    "projen": "pnpm exec projen"
+    "watch": "pnpm exec projen watch"
   },
   "author": {
     "name": "AWS APJ COPE",

--- a/private/pdk-project.ts
+++ b/private/pdk-project.ts
@@ -15,7 +15,7 @@ import {
   JEST_VERSION,
   NX_TARGET_DEFAULTS,
 } from "./projects/pdk-monorepo-project";
-import { buildExecutableCommand } from "../packages/nx-monorepo/src";
+import { NodePackageUtils } from "../packages/nx-monorepo/src";
 import type { Nx } from "../packages/nx-monorepo/src/nx-types";
 
 export type PublishConfig = _PublishConfig & {
@@ -75,7 +75,7 @@ export abstract class PDKProject extends JsiiProject {
     super({
       ...options,
       packageManager: NodePackageManager.PNPM,
-      projenCommand: buildExecutableCommand(NodePackageManager.PNPM, "projen"),
+      projenCommand: NodePackageUtils.command.projen(NodePackageManager.PNPM),
       stability: options.stability || Stability.EXPERIMENTAL,
       github: false,
       depsUpgrade: false,
@@ -319,7 +319,7 @@ class PDKRelease extends Release {
 
     project.packageTask.reset();
     project.packageTask.exec(
-      buildExecutableCommand(
+      NodePackageUtils.command.exec(
         project.package.packageManager,
         "license-checker",
         "--summary",

--- a/private/projects/cloudscape-react-ts-website.ts
+++ b/private/projects/cloudscape-react-ts-website.ts
@@ -5,7 +5,7 @@ import { Stability } from "projen/lib/cdk";
 import { NodePackageManager } from "projen/lib/javascript";
 import { ReactTypeScriptProject } from "projen/lib/web";
 import { JEST_VERSION } from "./pdk-monorepo-project";
-import { buildExecutableCommand } from "../../packages/nx-monorepo/src";
+import { NodePackageUtils } from "../../packages/nx-monorepo/src";
 import { PDKProject } from "../pdk-project";
 
 /**
@@ -46,7 +46,7 @@ class CloudscapeReactTsSampleWebsiteProject extends ReactTypeScriptProject {
     super({
       parent,
       packageManager: NodePackageManager.PNPM,
-      projenCommand: buildExecutableCommand(NodePackageManager.PNPM, "projen"),
+      projenCommand: NodePackageUtils.command.projen(NodePackageManager.PNPM),
       outdir: "samples/cloudscape-react-ts-website",
       defaultReleaseBranch: "mainline",
       depsUpgrade: false,

--- a/private/projects/docs-project.ts
+++ b/private/projects/docs-project.ts
@@ -3,7 +3,7 @@ SPDX-License-Identifier: Apache-2.0 */
 import { Project } from "projen";
 import { NodePackageManager } from "projen/lib/javascript";
 import { TypeScriptProject } from "projen/lib/typescript";
-import { buildExecutableCommand } from "../../packages/nx-monorepo/src";
+import { NodePackageUtils } from "../../packages/nx-monorepo/src";
 
 /**
  * Contains configuration for the public (docs) package.
@@ -13,7 +13,7 @@ export class DocsProject extends TypeScriptProject {
     super({
       parent,
       packageManager: NodePackageManager.PNPM,
-      projenCommand: buildExecutableCommand(NodePackageManager.PNPM, "projen"),
+      projenCommand: NodePackageUtils.command.projen(NodePackageManager.PNPM),
       outdir: "public/docs", // nx has issues with root directories being called 'docs'
       defaultReleaseBranch: "mainline",
       sampleCode: false,

--- a/private/projects/pipeline-project.ts
+++ b/private/projects/pipeline-project.ts
@@ -9,7 +9,7 @@ import { NodePackageManager } from "projen/lib/javascript";
 import { PythonProject } from "projen/lib/python";
 import { TypeScriptProject } from "projen/lib/typescript";
 import { JEST_VERSION } from "./pdk-monorepo-project";
-import { buildExecutableCommand } from "../../packages/nx-monorepo/src";
+import { NodePackageUtils } from "../../packages/nx-monorepo/src";
 import { PDKProject } from "../pdk-project";
 
 /**
@@ -60,7 +60,7 @@ export class PipelineTypescriptSampleProject extends TypeScriptProject {
     super({
       parent,
       packageManager: NodePackageManager.PNPM,
-      projenCommand: buildExecutableCommand(NodePackageManager.PNPM, "projen"),
+      projenCommand: NodePackageUtils.command.projen(NodePackageManager.PNPM),
       outdir: "samples/pipeline/typescript",
       defaultReleaseBranch: "mainline",
       npmignoreEnabled: false,

--- a/public/docs/package.json
+++ b/public/docs/package.json
@@ -9,8 +9,7 @@
     "post-compile": "pnpm exec projen post-compile",
     "pre-compile": "pnpm exec projen pre-compile",
     "test": "pnpm exec projen test",
-    "watch": "pnpm exec projen watch",
-    "projen": "pnpm exec projen"
+    "watch": "pnpm exec projen watch"
   },
   "devDependencies": {
     "@types/node": "^16",

--- a/samples/cloudscape-react-ts-website/package.json
+++ b/samples/cloudscape-react-ts-website/package.json
@@ -10,8 +10,7 @@
     "post-compile": "pnpm exec projen post-compile",
     "pre-compile": "pnpm exec projen pre-compile",
     "test": "pnpm exec projen test",
-    "watch": "pnpm exec projen watch",
-    "projen": "pnpm exec projen"
+    "watch": "pnpm exec projen watch"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",

--- a/samples/pipeline/typescript/package.json
+++ b/samples/pipeline/typescript/package.json
@@ -10,8 +10,7 @@
     "pre-compile": "pnpm exec projen pre-compile",
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",
-    "watch": "pnpm exec projen watch",
-    "projen": "pnpm exec projen"
+    "watch": "pnpm exec projen watch"
   },
   "devDependencies": {
     "@types/jest": "^27",


### PR DESCRIPTION
- Remove `projen` script from package.json which causes circular issues with `yarn projen build` style commands
- Refactor node package manager utils into consolidated module
- Use `yarn [cmd]` for yarn1, and `yarn exec [cmd]` for yarn2
- Update yarn2 engine to be `>=2` since yarn3 handles it