### PR TITLE
fix(cdk-graph-plugin-diagram): use buffer for svg to png conversion

### DIFF
--- a/packages/cdk-graph-plugin-diagram/src/internal/utils/svg.ts
+++ b/packages/cdk-graph-plugin-diagram/src/internal/utils/svg.ts
@@ -40,8 +40,10 @@ export async function convertSvgImageDefsFromSvgToPng(
   for (const def of defs) {
     const assetKey = def.attributes.id as string;
     const png = sharp(
-      AwsArchitecture.resolveAssetPath(
-        AwsArchitecture.formatAssetPath(assetKey, "png")
+      await fs.readFile(
+        AwsArchitecture.resolveAssetPath(
+          AwsArchitecture.formatAssetPath(assetKey, "png")
+        )
       ),
       { limitInputPixels: false }
     );

--- a/packages/cdk-graph-plugin-diagram/src/plugin.ts
+++ b/packages/cdk-graph-plugin-diagram/src/plugin.ts
@@ -223,16 +223,28 @@ export class CdkGraphDiagramPlugin implements ICdkGraphPlugin {
               )
             );
 
-            await fs.ensureDir(path.dirname(pngFile));
+            try {
+              await fs.ensureDir(path.dirname(pngFile));
 
-            await convertSvg(svg, pngFile);
+              await convertSvg(svg, pngFile);
 
-            context.logArtifact(
-              this,
-              CdkGraphDiagramPlugin.artifactId(config.name, DiagramFormat.PNG),
-              pngFile,
-              `Diagram generated "png" file for ${config.name} - "${config.title}"`
-            );
+              context.logArtifact(
+                this,
+                CdkGraphDiagramPlugin.artifactId(
+                  config.name,
+                  DiagramFormat.PNG
+                ),
+                pngFile,
+                `Diagram generated "png" file for ${config.name} - "${config.title}"`
+              );
+            } catch (error) {
+              console.error(error);
+              throw new Error(
+                `Failed to generate PNG diagram for ${
+                  config.name
+                } at "${pngFile}" - ${String(error)}`
+              );
+            }
           }
         }
       }


### PR DESCRIPTION
Sharp can not read png file within zip, which is used by yarn3.

Fixes #