### PR TITLE
feat(type-safe-api): add additional sigv4 signing header to default cors allow headers

### DIFF
--- a/packages/type-safe-api/src/construct/type-safe-rest-api.ts
+++ b/packages/type-safe-api/src/construct/type-safe-rest-api.ts
@@ -278,7 +278,10 @@ export class TypeSafeRestApi extends Construct {
         defaultAuthorizer
       ),
       corsOptions: corsOptions && {
-        allowHeaders: corsOptions.allowHeaders || Cors.DEFAULT_HEADERS,
+        allowHeaders: corsOptions.allowHeaders || [
+          ...Cors.DEFAULT_HEADERS,
+          "x-amz-content-sha256",
+        ],
         allowMethods: corsOptions.allowMethods || Cors.ALL_METHODS,
         allowOrigins: corsOptions.allowOrigins,
         statusCode: corsOptions.statusCode || 204,

--- a/packages/type-safe-api/test/construct/__snapshots__/type-safe-rest-api.test.ts.snap
+++ b/packages/type-safe-api/test/construct/__snapshots__/type-safe-rest-api.test.ts.snap
@@ -10532,7 +10532,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC478c3d7b9ef89b3ebd4ebe91f7143275c03": {
+    "ApiTestDeployment153EC47802f050830456476b4e7312d9797d932a": {
       "DependsOn": [
         "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
@@ -10624,7 +10624,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTestDeployment153EC478c3d7b9ef89b3ebd4ebe91f7143275c03",
+          "Ref": "ApiTestDeployment153EC47802f050830456476b4e7312d9797d932a",
         },
         "MethodSettings": [
           {
@@ -10867,6 +10867,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
             "X-Api-Key",
             "X-Amz-Security-Token",
             "X-Amz-User-Agent",
+            "x-amz-content-sha256",
           ],
           "allowMethods": [
             "OPTIONS",


### PR DESCRIPTION
Using the sigv4 client from northstar, the request signer adds the `x-amz-content-sha256` header to requests. To save users always specifying this when they enable cors, we update the defaults to include it.
