### PR TITLE
chore(type-safe-api): upgrade script dependencies and use pnpm exec instead of dlx

### DIFF
--- a/packages/type-safe-api/scripts/common/common.sh
+++ b/packages/type-safe-api/scripts/common/common.sh
@@ -50,8 +50,7 @@ run_command() {
   cmd="$@"
 
   if [ "$pkg_manager" == "pnpm" ]; then
-    # pnpx cli was deprecated in v6 --> use pnpm dlx
-    runner="pnpm dlx"
+    runner="pnpm exec"
   else
     runner="npx"
   fi

--- a/packages/type-safe-api/scripts/custom/clean-openapi-generated-code/clean-openapi-generated-code
+++ b/packages/type-safe-api/scripts/custom/clean-openapi-generated-code/clean-openapi-generated-code
@@ -26,10 +26,10 @@ cp -r $script_dir/* .
 
 # Install dependencies
 install_packages \
-  typescript@4.7.2 \
-  @types/node@14.14.20 \
-  ts-node@10.8.1 \
-  ts-command-line-args@2.3.1
+  typescript@5.0.4 \
+  @types/node@20.1.5 \
+  ts-node@10.9.1 \
+  ts-command-line-args@2.4.2
 
 # Run the cleanup script
 run_command "ts-node clean-openapi-generated-code.ts --codePath=$script_dir/$client_path"

--- a/packages/type-safe-api/scripts/custom/docs/html-redoc
+++ b/packages/type-safe-api/scripts/custom/docs/html-redoc
@@ -25,10 +25,10 @@ cd $tmp_dir
 log "html-redoc :: tmp_dir :: $tmp_dir"
 
 # Install dependencies
-install_packages redoc-cli@0.13.20
+install_packages @redocly/cli@1.0.0-beta.126
 
 # Generate
-run_command redoc-cli build "$script_dir/$spec_path" --output "$script_dir/$output_path/index.html"
+run_command redocly build-docs "$script_dir/$spec_path" --output "$script_dir/$output_path/index.html"
 
 echo "HTML Redoc documentation generation done!"
 

--- a/packages/type-safe-api/scripts/custom/infrastructure/cdk/generate-type-safe-cdk-construct
+++ b/packages/type-safe-api/scripts/custom/infrastructure/cdk/generate-type-safe-cdk-construct
@@ -38,11 +38,11 @@ cp -r $script_dir/* .
 
 # Install dependencies
 install_packages \
-  typescript@4.7.2 \
-  @types/node@14.14.20 \
-  ts-node@10.8.1 \
-  ts-command-line-args@2.3.1 \
-  projen@0.67.46
+  typescript@5.0.4 \
+  @types/node@20.1.5 \
+  ts-node@10.9.1 \
+  ts-command-line-args@2.4.2 \
+  projen@0.71.57
 
 # Run the generate script
 run_command "ts-node generate-type-safe-cdk-construct.ts --generatedTypesPackage=$generated_types_package --resourcePath=$script_dir/$resource_path --infraPackage=$infra_package --language=$language --specPath=$script_dir/$spec_path --sourcePath=$script_dir/$source_path"

--- a/packages/type-safe-api/scripts/generators/generate
+++ b/packages/type-safe-api/scripts/generators/generate
@@ -39,7 +39,7 @@ log "generate :: tmp_dir :: $tmp_dir"
 cp -r $script_dir/$generator_dir/* .
 
 # Install dependencies
-install_packages @openapitools/openapi-generator-cli@2.5.1
+install_packages @openapitools/openapi-generator-cli@2.6.0
 
 # Support a special placeholder of {{src}} in config.yaml to ensure our custom templates get written to the correct folder
 sed 's|{{src}}|'"$src_dir"'|g' config.yaml > config.final.yaml
@@ -48,19 +48,23 @@ sed 's|{{src}}|'"$src_dir"'|g' config.yaml > config.final.yaml
 # See: https://github.com/OpenAPITools/openapi-generator/issues/13684
 export JAVA_OPTS="--add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED"
 
+openapi_generate() {
+  run_command openapi-generator-cli generate \
+    --log-to-stderr \
+    --generator-name $generator \
+    --skip-operation-example \
+    --generate-alias-as-model \
+    --minimal-update \
+    --template-dir templates \
+    --config config.final.yaml \
+    --additional-properties="$additional_properties" \
+    ${openapi_normalizer:+"--openapi-normalizer=$openapi_normalizer"} \
+    --input-spec "$script_dir/$spec_path" \
+    --output "$script_dir/$output_path" $@
+}
+
 # Generate the client
-run_command @openapitools/openapi-generator-cli generate \
-  --log-to-stderr \
-  --generator-name $generator \
-  --skip-operation-example \
-  --generate-alias-as-model \
-  --minimal-update \
-  --template-dir templates \
-  --config config.final.yaml \
-  --additional-properties="$additional_properties" \
-  ${openapi_normalizer:+"--openapi-normalizer=$openapi_normalizer"} \
-  --input-spec "$script_dir/$spec_path" \
-  --output "$script_dir/$output_path"
+openapi_generate
 
 # If a .open-api-generator-ignore-handlebars ignore file exists, we run a second pass with the handlebars template engine
 handlebars_ignore_file="$script_dir/$output_path/.openapi-generator-ignore-handlebars"
@@ -72,18 +76,7 @@ if [ -f "$handlebars_ignore_file" ]; then
   fi
 
   # Generate again, using the handlebars engine
-  run_command @openapitools/openapi-generator-cli generate \
-    --log-to-stderr \
-    --generator-name $generator \
-    --skip-operation-example \
-    --generate-alias-as-model \
-    --minimal-update \
-    --template-dir templates \
-    --config config.final.yaml \
-    --additional-properties="$additional_properties" \
-    ${openapi_normalizer:+"--openapi-normalizer=$openapi_normalizer"} \
-    --input-spec "$script_dir/$spec_path" \
-    --output "$script_dir/$output_path" \
+  openapi_generate \
     --engine handlebars \
     --ignore-file-override "$handlebars_ignore_file"
 

--- a/packages/type-safe-api/scripts/parser/parse-openapi-spec
+++ b/packages/type-safe-api/scripts/parser/parse-openapi-spec
@@ -28,13 +28,13 @@ cp -r $script_dir/* .
 # Install dependencies. Note that projen version does not need to be kept in sync with project projen version since
 # this runs in isolation.
 install_packages \
-  typescript@4.7.2 \
-  @types/node@14.14.20 \
-  ts-node@10.8.1 \
-  @apidevtools/swagger-parser@10.0.3 \
-  openapi-types@11.0.1 \
-  ts-command-line-args@2.3.1 \
-  projen@0.67.46
+  typescript@5.0.4 \
+  @types/node@20.1.5 \
+  ts-node@10.9.1 \
+  @apidevtools/swagger-parser@10.1.0 \
+  openapi-types@12.1.0 \
+  ts-command-line-args@2.4.2 \
+  projen@0.71.57
 
 # Run the parse script
 run_command "ts-node parse-openapi-spec.ts --specPath=$script_dir/$spec_path --outputPath=$script_dir/$output_path"


### PR DESCRIPTION
Upgrade the dependencies used in type-safe-api's scripts.

`redoc-cli` [has been deprecated](https://www.npmjs.com/package/redoc-cli) in favour of `@redocly/cli` (even though that only has `-beta.xxx` versions published!)

We use `pnpm exec` instead of `pnpm dlx` for running commands with pnpm so that we can eg run the `redocly` bin for `@redocly/cli` (this should hopefully also offer a slight speedup).

Additionally refactor duplicated openapi generator command into bash function.
