### PR TITLE
fix(type-safe-api): fix python infrastructure installation

### DIFF
--- a/packages/type-safe-api/src/project/codegen/infrastructure/cdk/generated-python-cdk-infrastructure-project.ts
+++ b/packages/type-safe-api/src/project/codegen/infrastructure/cdk/generated-python-cdk-infrastructure-project.ts
@@ -48,10 +48,10 @@ export class GeneratedPythonCdkInfrastructureProject extends PythonProject {
     this.generatedPythonTypes = options.generatedPythonTypes;
 
     [
-      "aws_prototyping_sdk.type_safe_api@^0.0.0",
-      "constructs@^10.0.0",
-      "aws-cdk-lib@^2.0.0",
-      "cdk-nag@^2.0.0",
+      "aws_prototyping_sdk.type_safe_api@^0",
+      "constructs@^10",
+      "aws-cdk-lib@^2",
+      "cdk-nag@^2",
       `${options.generatedPythonTypes.name}@{path="${path.relative(
         this.outdir,
         options.generatedPythonTypes.outdir
@@ -71,6 +71,17 @@ export class GeneratedPythonCdkInfrastructureProject extends PythonProject {
 
     // Ignore the generated code
     this.gitignore.addPatterns(this.moduleName);
+
+    // The poetry install that runs as part of post synthesis expects there to be some code present, but code isn't
+    // generated until build time. This means that the first install will fail when either generating the project for
+    // the first time or checking out a fresh copy (since generated code is not checked in to version control). We
+    // therefore add a blank __init__.py as our first install step to keep poetry happy until the generator overwrites
+    // it.
+    this.tasks
+      .tryFind("install")
+      ?.prependExec(
+        `mkdir -p ${this.moduleName} && touch ${this.moduleName}/__init__.py`
+      );
   }
 
   public buildGenerateCommand = () => {

--- a/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
@@ -7580,22 +7580,22 @@ openapi_python_python_infra
       {
         "name": "aws_prototyping_sdk.type_safe_api",
         "type": "runtime",
-        "version": "^0.0.0",
+        "version": "^0",
       },
       {
         "name": "aws-cdk-lib",
         "type": "runtime",
-        "version": "^2.0.0",
+        "version": "^2",
       },
       {
         "name": "cdk-nag",
         "type": "runtime",
-        "version": "^2.0.0",
+        "version": "^2",
       },
       {
         "name": "constructs",
         "type": "runtime",
-        "version": "^10.0.0",
+        "version": "^10",
       },
       {
         "name": "openapi-python-python-runtime",
@@ -7671,6 +7671,9 @@ openapi_python_python_infra
         "description": "Install and upgrade dependencies",
         "name": "install",
         "steps": [
+          {
+            "exec": "mkdir -p openapi_python_python_infra && touch openapi_python_python_infra/__init__.py",
+          },
           {
             "exec": "poetry update",
           },
@@ -7750,10 +7753,10 @@ dev-dependencies = { }
   include = "openapi_python_python_infra"
 
   [tool.poetry.dependencies]
-  "aws_prototyping_sdk.type_safe_api" = "^0.0.0"
-  aws-cdk-lib = "^2.0.0"
-  cdk-nag = "^2.0.0"
-  constructs = "^10.0.0"
+  "aws_prototyping_sdk.type_safe_api" = "^0"
+  aws-cdk-lib = "^2"
+  cdk-nag = "^2"
+  constructs = "^10"
   python = "^3.7"
 
     [tool.poetry.dependencies.openapi-python-python-runtime]
@@ -11272,22 +11275,22 @@ openapi_python_python_infra
       {
         "name": "aws_prototyping_sdk.type_safe_api",
         "type": "runtime",
-        "version": "^0.0.0",
+        "version": "^0",
       },
       {
         "name": "aws-cdk-lib",
         "type": "runtime",
-        "version": "^2.0.0",
+        "version": "^2",
       },
       {
         "name": "cdk-nag",
         "type": "runtime",
-        "version": "^2.0.0",
+        "version": "^2",
       },
       {
         "name": "constructs",
         "type": "runtime",
-        "version": "^10.0.0",
+        "version": "^10",
       },
       {
         "name": "openapi-python-python-runtime",
@@ -11358,6 +11361,9 @@ openapi_python_python_infra
         "description": "Install and upgrade dependencies",
         "name": "install",
         "steps": [
+          {
+            "exec": "mkdir -p openapi_python_python_infra && touch openapi_python_python_infra/__init__.py",
+          },
           {
             "exec": "poetry update",
           },
@@ -11528,10 +11534,10 @@ dev-dependencies = { }
   include = "openapi_python_python_infra"
 
   [tool.poetry.dependencies]
-  "aws_prototyping_sdk.type_safe_api" = "^0.0.0"
-  aws-cdk-lib = "^2.0.0"
-  cdk-nag = "^2.0.0"
-  constructs = "^10.0.0"
+  "aws_prototyping_sdk.type_safe_api" = "^0"
+  aws-cdk-lib = "^2"
+  cdk-nag = "^2"
+  constructs = "^10"
   python = "^3.7"
 
     [tool.poetry.dependencies.openapi-python-python-runtime]
@@ -42232,22 +42238,22 @@ smithy_python_python_infra
       {
         "name": "aws_prototyping_sdk.type_safe_api",
         "type": "runtime",
-        "version": "^0.0.0",
+        "version": "^0",
       },
       {
         "name": "aws-cdk-lib",
         "type": "runtime",
-        "version": "^2.0.0",
+        "version": "^2",
       },
       {
         "name": "cdk-nag",
         "type": "runtime",
-        "version": "^2.0.0",
+        "version": "^2",
       },
       {
         "name": "constructs",
         "type": "runtime",
-        "version": "^10.0.0",
+        "version": "^10",
       },
       {
         "name": "smithy-python-python-runtime",
@@ -42323,6 +42329,9 @@ smithy_python_python_infra
         "description": "Install and upgrade dependencies",
         "name": "install",
         "steps": [
+          {
+            "exec": "mkdir -p smithy_python_python_infra && touch smithy_python_python_infra/__init__.py",
+          },
           {
             "exec": "poetry update",
           },
@@ -42402,10 +42411,10 @@ dev-dependencies = { }
   include = "smithy_python_python_infra"
 
   [tool.poetry.dependencies]
-  "aws_prototyping_sdk.type_safe_api" = "^0.0.0"
-  aws-cdk-lib = "^2.0.0"
-  cdk-nag = "^2.0.0"
-  constructs = "^10.0.0"
+  "aws_prototyping_sdk.type_safe_api" = "^0"
+  aws-cdk-lib = "^2"
+  cdk-nag = "^2"
+  constructs = "^10"
   python = "^3.7"
 
     [tool.poetry.dependencies.smithy-python-python-runtime]
@@ -45962,22 +45971,22 @@ smithy_python_python_infra
       {
         "name": "aws_prototyping_sdk.type_safe_api",
         "type": "runtime",
-        "version": "^0.0.0",
+        "version": "^0",
       },
       {
         "name": "aws-cdk-lib",
         "type": "runtime",
-        "version": "^2.0.0",
+        "version": "^2",
       },
       {
         "name": "cdk-nag",
         "type": "runtime",
-        "version": "^2.0.0",
+        "version": "^2",
       },
       {
         "name": "constructs",
         "type": "runtime",
-        "version": "^10.0.0",
+        "version": "^10",
       },
       {
         "name": "smithy-python-python-runtime",
@@ -46048,6 +46057,9 @@ smithy_python_python_infra
         "description": "Install and upgrade dependencies",
         "name": "install",
         "steps": [
+          {
+            "exec": "mkdir -p smithy_python_python_infra && touch smithy_python_python_infra/__init__.py",
+          },
           {
             "exec": "poetry update",
           },
@@ -46218,10 +46230,10 @@ dev-dependencies = { }
   include = "smithy_python_python_infra"
 
   [tool.poetry.dependencies]
-  "aws_prototyping_sdk.type_safe_api" = "^0.0.0"
-  aws-cdk-lib = "^2.0.0"
-  cdk-nag = "^2.0.0"
-  constructs = "^10.0.0"
+  "aws_prototyping_sdk.type_safe_api" = "^0"
+  aws-cdk-lib = "^2"
+  cdk-nag = "^2"
+  constructs = "^10"
   python = "^3.7"
 
     [tool.poetry.dependencies.smithy-python-python-runtime]

--- a/packages/type-safe-api/test/project/codegen/infrastructure/cdk/__snapshots__/generated-python-cdk-infrastructure-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/codegen/infrastructure/cdk/__snapshots__/generated-python-cdk-infrastructure-project.test.ts.snap
@@ -138,22 +138,22 @@ test_infra
       {
         "name": "aws_prototyping_sdk.type_safe_api",
         "type": "runtime",
-        "version": "^0.0.0",
+        "version": "^0",
       },
       {
         "name": "aws-cdk-lib",
         "type": "runtime",
-        "version": "^2.0.0",
+        "version": "^2",
       },
       {
         "name": "cdk-nag",
         "type": "runtime",
-        "version": "^2.0.0",
+        "version": "^2",
       },
       {
         "name": "constructs",
         "type": "runtime",
-        "version": "^10.0.0",
+        "version": "^10",
       },
       {
         "name": "test-python-client",
@@ -277,6 +277,9 @@ test_infra
         "name": "install",
         "steps": [
           {
+            "exec": "mkdir -p test_infra && touch test_infra/__init__.py",
+          },
+          {
             "exec": "poetry update",
           },
         ],
@@ -351,10 +354,10 @@ include = [ "test_infra", "test_infra/**/*.py" ]
   include = "test_infra"
 
   [tool.poetry.dependencies]
-  "aws_prototyping_sdk.type_safe_api" = "^0.0.0"
-  aws-cdk-lib = "^2.0.0"
-  cdk-nag = "^2.0.0"
-  constructs = "^10.0.0"
+  "aws_prototyping_sdk.type_safe_api" = "^0"
+  aws-cdk-lib = "^2"
+  cdk-nag = "^2"
+  constructs = "^10"
   python = "^3.7"
 
     [tool.poetry.dependencies.test-python-client]


### PR DESCRIPTION
When I did my initial testing with python infrastructure, `type-safe-api` wasn't published to pypi so I manually installed my local one into the virtualenv.

Now that it's published, testing without the local install fails due to my misunderstanding of how the caret works with `0.0.0` in poetry!

While `^1.2.3` means `>=1.2.3 <2.0.0`, `0.0.0` means `>=0.0.0 <0.0.1`!

See: https://python-poetry.org/docs/dependency-specification/#caret-requirements

Also add the same write of the empty file to ensure the initial install of the infrastructure package succeeds, which I must've missed in my testing first time round!