### PR TITLE
fix(pipeline): only set BRANCH if multi-branch is enabled

### DIFF
--- a/packages/pipeline/test/__snapshots__/pdk-pipeline-ts-project.test.ts.snap
+++ b/packages/pipeline/test/__snapshots__/pdk-pipeline-ts-project.test.ts.snap
@@ -1694,7 +1694,7 @@ exports[\`Snapshot 1\`] = \`
                   "Version": "1",
                 },
                 "Configuration": {
-                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"d8ae97960b7fb4624979583404dbc912635079bb6cb253679bbafd66b2a9d9d8"}]",
+                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"13fb1f6f3f0a665500d00a30e46cf5c67342362be94a9d79d179c2ea7436a504"}]",
                   "ProjectName": {
                     "Ref": "ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A",
                   },
@@ -1777,13 +1777,6 @@ exports[\`Snapshot 1\`] = \`
         },
         "Environment": {
           "ComputeType": "BUILD_GENERAL1_SMALL",
-          "EnvironmentVariables": [
-            {
-              "Name": "BRANCH",
-              "Type": "PLAINTEXT",
-              "Value": "mainline",
-            },
-          ],
           "Image": "aws/codebuild/standard:6.0",
           "ImagePullCredentialsType": "CODEBUILD",
           "PrivilegedMode": false,
@@ -4519,7 +4512,7 @@ exports[\`Snapshot 1\`] = \`
                   "Version": "1",
                 },
                 "Configuration": {
-                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"d8ae97960b7fb4624979583404dbc912635079bb6cb253679bbafd66b2a9d9d8"}]",
+                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"13fb1f6f3f0a665500d00a30e46cf5c67342362be94a9d79d179c2ea7436a504"}]",
                   "ProjectName": {
                     "Ref": "ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A",
                   },
@@ -4602,13 +4595,6 @@ exports[\`Snapshot 1\`] = \`
         },
         "Environment": {
           "ComputeType": "BUILD_GENERAL1_SMALL",
-          "EnvironmentVariables": [
-            {
-              "Name": "BRANCH",
-              "Type": "PLAINTEXT",
-              "Value": "mainline",
-            },
-          ],
           "Image": "aws/codebuild/standard:6.0",
           "ImagePullCredentialsType": "CODEBUILD",
           "PrivilegedMode": false,
@@ -7359,7 +7345,7 @@ exports[\`Snapshot 1\`] = \`
                   "Version": "1",
                 },
                 "Configuration": {
-                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"d8ae97960b7fb4624979583404dbc912635079bb6cb253679bbafd66b2a9d9d8"}]",
+                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"13fb1f6f3f0a665500d00a30e46cf5c67342362be94a9d79d179c2ea7436a504"}]",
                   "ProjectName": {
                     "Ref": "ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A",
                   },
@@ -7442,13 +7428,6 @@ exports[\`Snapshot 1\`] = \`
         },
         "Environment": {
           "ComputeType": "BUILD_GENERAL1_SMALL",
-          "EnvironmentVariables": [
-            {
-              "Name": "BRANCH",
-              "Type": "PLAINTEXT",
-              "Value": "mainline",
-            },
-          ],
           "Image": "aws/codebuild/standard:6.0",
           "ImagePullCredentialsType": "CODEBUILD",
           "PrivilegedMode": false,

--- a/packages/pipeline/test/__snapshots__/pdk-pipeline.test.ts.snap
+++ b/packages/pipeline/test/__snapshots__/pdk-pipeline.test.ts.snap
@@ -1298,13 +1298,6 @@ exports[`PDK Pipeline Unit Tests CrossAccount - using AwsPrototyping NagPack 1`]
         },
         "Environment": {
           "ComputeType": "BUILD_GENERAL1_SMALL",
-          "EnvironmentVariables": [
-            {
-              "Name": "BRANCH",
-              "Type": "PLAINTEXT",
-              "Value": "mainline",
-            },
-          ],
           "Image": "aws/codebuild/standard:6.0",
           "ImagePullCredentialsType": "CODEBUILD",
           "PrivilegedMode": false,
@@ -1832,7 +1825,7 @@ exports[`PDK Pipeline Unit Tests CrossAccount - using AwsPrototyping NagPack 1`]
                   "Version": "1",
                 },
                 "Configuration": {
-                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"7cb930276e2c624899dadc5cd557500f267ff825956ffae5529d532ebc7f659d"}]",
+                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"9b6cac2596443c465eb42c0d0d84de22a8632cbeb9388a40d13889341f9b20c5"}]",
                   "ProjectName": {
                     "Ref": "CrossAccountCodePipelineBuildSynthCdkBuildProject938B55FC",
                   },
@@ -4961,13 +4954,6 @@ exports[`PDK Pipeline Unit Tests CrossAccount 1`] = `
         },
         "Environment": {
           "ComputeType": "BUILD_GENERAL1_SMALL",
-          "EnvironmentVariables": [
-            {
-              "Name": "BRANCH",
-              "Type": "PLAINTEXT",
-              "Value": "mainline",
-            },
-          ],
           "Image": "aws/codebuild/standard:6.0",
           "ImagePullCredentialsType": "CODEBUILD",
           "PrivilegedMode": false,
@@ -5495,7 +5481,7 @@ exports[`PDK Pipeline Unit Tests CrossAccount 1`] = `
                   "Version": "1",
                 },
                 "Configuration": {
-                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"7cb930276e2c624899dadc5cd557500f267ff825956ffae5529d532ebc7f659d"}]",
+                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"9b6cac2596443c465eb42c0d0d84de22a8632cbeb9388a40d13889341f9b20c5"}]",
                   "ProjectName": {
                     "Ref": "CrossAccountCodePipelineBuildSynthCdkBuildProject938B55FC",
                   },
@@ -8554,13 +8540,6 @@ exports[`PDK Pipeline Unit Tests Defaults - using AwsPrototyping NagPack 1`] = `
         "EncryptionKey": "alias/aws/s3",
         "Environment": {
           "ComputeType": "BUILD_GENERAL1_SMALL",
-          "EnvironmentVariables": [
-            {
-              "Name": "BRANCH",
-              "Type": "PLAINTEXT",
-              "Value": "mainline",
-            },
-          ],
           "Image": "aws/codebuild/standard:6.0",
           "ImagePullCredentialsType": "CODEBUILD",
           "PrivilegedMode": false,
@@ -8928,7 +8907,7 @@ exports[`PDK Pipeline Unit Tests Defaults - using AwsPrototyping NagPack 1`] = `
                   "Version": "1",
                 },
                 "Configuration": {
-                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"7cb930276e2c624899dadc5cd557500f267ff825956ffae5529d532ebc7f659d"}]",
+                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"9b6cac2596443c465eb42c0d0d84de22a8632cbeb9388a40d13889341f9b20c5"}]",
                   "ProjectName": {
                     "Ref": "DefaultsCodePipelineBuildSynthCdkBuildProject81772484",
                   },
@@ -11971,13 +11950,6 @@ exports[`PDK Pipeline Unit Tests Defaults 1`] = `
         "EncryptionKey": "alias/aws/s3",
         "Environment": {
           "ComputeType": "BUILD_GENERAL1_SMALL",
-          "EnvironmentVariables": [
-            {
-              "Name": "BRANCH",
-              "Type": "PLAINTEXT",
-              "Value": "mainline",
-            },
-          ],
           "Image": "aws/codebuild/standard:6.0",
           "ImagePullCredentialsType": "CODEBUILD",
           "PrivilegedMode": false,
@@ -12345,7 +12317,7 @@ exports[`PDK Pipeline Unit Tests Defaults 1`] = `
                   "Version": "1",
                 },
                 "Configuration": {
-                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"7cb930276e2c624899dadc5cd557500f267ff825956ffae5529d532ebc7f659d"}]",
+                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"9b6cac2596443c465eb42c0d0d84de22a8632cbeb9388a40d13889341f9b20c5"}]",
                   "ProjectName": {
                     "Ref": "DefaultsCodePipelineBuildSynthCdkBuildProject81772484",
                   },

--- a/samples/pipeline/typescript/test/__snapshots__/pipeline.test.ts.snap
+++ b/samples/pipeline/typescript/test/__snapshots__/pipeline.test.ts.snap
@@ -643,7 +643,7 @@ exports[`Snapshot 1`] = `
                   "Version": "1",
                 },
                 "Configuration": {
-                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"d8ae97960b7fb4624979583404dbc912635079bb6cb253679bbafd66b2a9d9d8"}]",
+                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"13fb1f6f3f0a665500d00a30e46cf5c67342362be94a9d79d179c2ea7436a504"}]",
                   "ProjectName": {
                     "Ref": "ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A",
                   },
@@ -726,13 +726,6 @@ exports[`Snapshot 1`] = `
         },
         "Environment": {
           "ComputeType": "BUILD_GENERAL1_SMALL",
-          "EnvironmentVariables": [
-            {
-              "Name": "BRANCH",
-              "Type": "PLAINTEXT",
-              "Value": "mainline",
-            },
-          ],
           "Image": "aws/codebuild/standard:6.0",
           "ImagePullCredentialsType": "CODEBUILD",
           "PrivilegedMode": false,


### PR DESCRIPTION
Only set the BRANCH environment variable in CodeBuild if multi-branch is enabled by setting `branchNamePrefixes`. This will prevent errors if someone accidentally uses branch based stage name prefixes without using multi-branch.

Also, make `PDKPipeline.isDefaultBranch` easier to read and reason about.

Fixes #414