### PR TITLE
fix: symlinks cannot be published to npm

### DIFF
--- a/.github/actions/pdk-init/action.yml
+++ b/.github/actions/pdk-init/action.yml
@@ -7,6 +7,13 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version: 18
+    - uses: actions/setup-java@v2
+      with:
+        distribution: temurin
+        java-version: 11.x
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
     # https://github.com/pnpm/action-setup
     - uses: pnpm/action-setup@v2
       name: Install pnpm

--- a/packages/nx-monorepo/scripts/pnpm/link-bundled-transitive-deps.ts
+++ b/packages/nx-monorepo/scripts/pnpm/link-bundled-transitive-deps.ts
@@ -69,7 +69,7 @@ async function linkBundledTransitiveDeps(workspaceDir: string, pkgFolder: string
         throw new Error(`Pnpm dependency path not found: ${dep.path}`);
       }
 
-      await fs.createSymlink(dep.path, _dest, "dir");
+      fs.copySync(dep.path, _dest, { dereference: true });
     }
   }
 


### PR DESCRIPTION
Previously, the codebase was uploaded as an artifact and re-downloaded which means any hardlinks would have been dereferenced as part of this process. npm publish would have worked as all files would be non-linked and as such is only a problem for packages with bundledDeps.

To remedy this, we simply change the link-bundled-transitive deps script to use a copy with dereference to ensure all node_module packages are actuals copied files.

In addition, the PDK init was missing an install of Java and Python runtimes.