### PR TITLE
fix: convert all links to files before publishing

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -195,6 +195,9 @@
     },
     "release": {
       "name": "release",
+      "env": {
+        "RELEASE": "true"
+      },
       "steps": [
         {
           "spawn": "release:init"

--- a/packages/aws-arch/.projen/tasks.json
+++ b/packages/aws-arch/.projen/tasks.json
@@ -191,6 +191,9 @@
           "exec": "pnpm exec license-checker --summary --production --onlyAllow 'MIT;Apache-2.0;Unlicense;BSD;BSD-2-Clause;BSD-3-Clause;ISC;'"
         },
         {
+          "spawn": "resolve-symlinks"
+        },
+        {
           "spawn": "package-all"
         }
       ]
@@ -321,6 +324,15 @@
         }
       ],
       "condition": "[ \"${CI:-false}\" = \"true\" ] && [ -f \"dist/.release.env\" ]"
+    },
+    "resolve-symlinks": {
+      "name": "resolve-symlinks",
+      "steps": [
+        {
+          "exec": "find . -type l -execdir bash -c 'P=$(readlink \"$1\") && rm -rf $1 && cp -r $P $1' bash {} \\;"
+        }
+      ],
+      "condition": "[ \"${CI:-false}\" = \"true\" ] && [ \"${RELEASE:-false}\" = \"true\" ]"
     },
     "test": {
       "name": "test",

--- a/packages/aws-arch/package.json
+++ b/packages/aws-arch/package.json
@@ -32,6 +32,7 @@
     "release:init": "pnpm exec projen release:init",
     "release:prepare": "pnpm exec projen release:prepare",
     "release:publish": "pnpm exec projen release:publish",
+    "resolve-symlinks": "pnpm exec projen resolve-symlinks",
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",
     "watch": "pnpm exec projen watch"

--- a/packages/aws-arch/project.json
+++ b/packages/aws-arch/project.json
@@ -197,6 +197,13 @@
         "cwd": "packages/aws-arch"
       }
     },
+    "resolve-symlinks": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen resolve-symlinks",
+        "cwd": "packages/aws-arch"
+      }
+    },
     "docgen": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/cdk-graph-plugin-diagram/.projen/tasks.json
+++ b/packages/cdk-graph-plugin-diagram/.projen/tasks.json
@@ -120,6 +120,9 @@
           "exec": "pnpm exec license-checker --summary --production --onlyAllow 'MIT;Apache-2.0;Unlicense;BSD;BSD-2-Clause;BSD-3-Clause;ISC;'"
         },
         {
+          "spawn": "resolve-symlinks"
+        },
+        {
           "spawn": "package-all"
         }
       ]
@@ -209,6 +212,15 @@
         }
       ],
       "condition": "[ \"${CI:-false}\" = \"true\" ] && [ -f \"dist/.release.env\" ]"
+    },
+    "resolve-symlinks": {
+      "name": "resolve-symlinks",
+      "steps": [
+        {
+          "exec": "find . -type l -execdir bash -c 'P=$(readlink \"$1\") && rm -rf $1 && cp -r $P $1' bash {} \\;"
+        }
+      ],
+      "condition": "[ \"${CI:-false}\" = \"true\" ] && [ \"${RELEASE:-false}\" = \"true\" ]"
     },
     "sharp:prebuild": {
       "name": "sharp:prebuild",

--- a/packages/cdk-graph-plugin-diagram/package.json
+++ b/packages/cdk-graph-plugin-diagram/package.json
@@ -23,6 +23,7 @@
     "release:init": "pnpm exec projen release:init",
     "release:prepare": "pnpm exec projen release:prepare",
     "release:publish": "pnpm exec projen release:publish",
+    "resolve-symlinks": "pnpm exec projen resolve-symlinks",
     "sharp:prebuild": "pnpm exec projen sharp:prebuild",
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",

--- a/packages/cdk-graph-plugin-diagram/project.json
+++ b/packages/cdk-graph-plugin-diagram/project.json
@@ -169,6 +169,13 @@
         "cwd": "packages/cdk-graph-plugin-diagram"
       }
     },
+    "resolve-symlinks": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen resolve-symlinks",
+        "cwd": "packages/cdk-graph-plugin-diagram"
+      }
+    },
     "docgen": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/cdk-graph/.projen/tasks.json
+++ b/packages/cdk-graph/.projen/tasks.json
@@ -109,6 +109,9 @@
           "exec": "pnpm exec license-checker --summary --production --onlyAllow 'MIT;Apache-2.0;Unlicense;BSD;BSD-2-Clause;BSD-3-Clause;ISC;'"
         },
         {
+          "spawn": "resolve-symlinks"
+        },
+        {
           "spawn": "package-all"
         }
       ]
@@ -195,6 +198,15 @@
         }
       ],
       "condition": "[ \"${CI:-false}\" = \"true\" ] && [ -f \"dist/.release.env\" ]"
+    },
+    "resolve-symlinks": {
+      "name": "resolve-symlinks",
+      "steps": [
+        {
+          "exec": "find . -type l -execdir bash -c 'P=$(readlink \"$1\") && rm -rf $1 && cp -r $P $1' bash {} \\;"
+        }
+      ],
+      "condition": "[ \"${CI:-false}\" = \"true\" ] && [ \"${RELEASE:-false}\" = \"true\" ]"
     },
     "test": {
       "name": "test",

--- a/packages/cdk-graph/package.json
+++ b/packages/cdk-graph/package.json
@@ -22,6 +22,7 @@
     "release:init": "pnpm exec projen release:init",
     "release:prepare": "pnpm exec projen release:prepare",
     "release:publish": "pnpm exec projen release:publish",
+    "resolve-symlinks": "pnpm exec projen resolve-symlinks",
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",
     "watch": "pnpm exec projen watch"

--- a/packages/cdk-graph/project.json
+++ b/packages/cdk-graph/project.json
@@ -164,6 +164,13 @@
         "cwd": "packages/cdk-graph"
       }
     },
+    "resolve-symlinks": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen resolve-symlinks",
+        "cwd": "packages/cdk-graph"
+      }
+    },
     "docgen": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/cloudscape-react-ts-website/.projen/tasks.json
+++ b/packages/cloudscape-react-ts-website/.projen/tasks.json
@@ -112,6 +112,9 @@
           "exec": "pnpm exec license-checker --summary --production --onlyAllow 'MIT;Apache-2.0;Unlicense;BSD;BSD-2-Clause;BSD-3-Clause;ISC;'"
         },
         {
+          "spawn": "resolve-symlinks"
+        },
+        {
           "spawn": "package-all"
         }
       ]
@@ -242,6 +245,15 @@
         }
       ],
       "condition": "[ \"${CI:-false}\" = \"true\" ] && [ -f \"dist/.release.env\" ]"
+    },
+    "resolve-symlinks": {
+      "name": "resolve-symlinks",
+      "steps": [
+        {
+          "exec": "find . -type l -execdir bash -c 'P=$(readlink \"$1\") && rm -rf $1 && cp -r $P $1' bash {} \\;"
+        }
+      ],
+      "condition": "[ \"${CI:-false}\" = \"true\" ] && [ \"${RELEASE:-false}\" = \"true\" ]"
     },
     "test": {
       "name": "test",

--- a/packages/cloudscape-react-ts-website/package.json
+++ b/packages/cloudscape-react-ts-website/package.json
@@ -24,6 +24,7 @@
     "release:init": "pnpm exec projen release:init",
     "release:prepare": "pnpm exec projen release:prepare",
     "release:publish": "pnpm exec projen release:publish",
+    "resolve-symlinks": "pnpm exec projen resolve-symlinks",
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",
     "watch": "pnpm exec projen watch"

--- a/packages/cloudscape-react-ts-website/project.json
+++ b/packages/cloudscape-react-ts-website/project.json
@@ -178,6 +178,13 @@
         "cwd": "packages/cloudscape-react-ts-website"
       }
     },
+    "resolve-symlinks": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen resolve-symlinks",
+        "cwd": "packages/cloudscape-react-ts-website"
+      }
+    },
     "docgen": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/identity/.projen/tasks.json
+++ b/packages/identity/.projen/tasks.json
@@ -112,6 +112,9 @@
           "exec": "pnpm exec license-checker --summary --production --onlyAllow 'MIT;Apache-2.0;Unlicense;BSD;BSD-2-Clause;BSD-3-Clause;ISC;'"
         },
         {
+          "spawn": "resolve-symlinks"
+        },
+        {
           "spawn": "package-all"
         }
       ]
@@ -239,6 +242,15 @@
         }
       ],
       "condition": "[ \"${CI:-false}\" = \"true\" ] && [ -f \"dist/.release.env\" ]"
+    },
+    "resolve-symlinks": {
+      "name": "resolve-symlinks",
+      "steps": [
+        {
+          "exec": "find . -type l -execdir bash -c 'P=$(readlink \"$1\") && rm -rf $1 && cp -r $P $1' bash {} \\;"
+        }
+      ],
+      "condition": "[ \"${CI:-false}\" = \"true\" ] && [ \"${RELEASE:-false}\" = \"true\" ]"
     },
     "test": {
       "name": "test",

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -24,6 +24,7 @@
     "release:init": "pnpm exec projen release:init",
     "release:prepare": "pnpm exec projen release:prepare",
     "release:publish": "pnpm exec projen release:publish",
+    "resolve-symlinks": "pnpm exec projen resolve-symlinks",
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",
     "watch": "pnpm exec projen watch"

--- a/packages/identity/project.json
+++ b/packages/identity/project.json
@@ -178,6 +178,13 @@
         "cwd": "packages/identity"
       }
     },
+    "resolve-symlinks": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen resolve-symlinks",
+        "cwd": "packages/identity"
+      }
+    },
     "docgen": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/nx-monorepo/.projen/tasks.json
+++ b/packages/nx-monorepo/.projen/tasks.json
@@ -118,6 +118,9 @@
           "exec": "pnpm exec license-checker --summary --production --onlyAllow 'MIT;Apache-2.0;Unlicense;BSD;BSD-2-Clause;BSD-3-Clause;ISC;'"
         },
         {
+          "spawn": "resolve-symlinks"
+        },
+        {
           "spawn": "package-all"
         }
       ]
@@ -245,6 +248,15 @@
         }
       ],
       "condition": "[ \"${CI:-false}\" = \"true\" ] && [ -f \"dist/.release.env\" ]"
+    },
+    "resolve-symlinks": {
+      "name": "resolve-symlinks",
+      "steps": [
+        {
+          "exec": "find . -type l -execdir bash -c 'P=$(readlink \"$1\") && rm -rf $1 && cp -r $P $1' bash {} \\;"
+        }
+      ],
+      "condition": "[ \"${CI:-false}\" = \"true\" ] && [ \"${RELEASE:-false}\" = \"true\" ]"
     },
     "test": {
       "name": "test",

--- a/packages/nx-monorepo/package.json
+++ b/packages/nx-monorepo/package.json
@@ -30,6 +30,7 @@
     "release:init": "pnpm exec projen release:init",
     "release:prepare": "pnpm exec projen release:prepare",
     "release:publish": "pnpm exec projen release:publish",
+    "resolve-symlinks": "pnpm exec projen resolve-symlinks",
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",
     "watch": "pnpm exec projen watch"

--- a/packages/nx-monorepo/project.json
+++ b/packages/nx-monorepo/project.json
@@ -178,6 +178,13 @@
         "cwd": "packages/nx-monorepo"
       }
     },
+    "resolve-symlinks": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen resolve-symlinks",
+        "cwd": "packages/nx-monorepo"
+      }
+    },
     "docgen": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/nx-monorepo/scripts/pnpm/link-bundled-transitive-deps.ts
+++ b/packages/nx-monorepo/scripts/pnpm/link-bundled-transitive-deps.ts
@@ -69,7 +69,7 @@ async function linkBundledTransitiveDeps(workspaceDir: string, pkgFolder: string
         throw new Error(`Pnpm dependency path not found: ${dep.path}`);
       }
 
-      fs.copySync(dep.path, _dest, { dereference: true });
+      await fs.createSymlink(dep.path, _dest, "dir");
     }
   }
 

--- a/packages/nx-monorepo/src/components/release/index.ts
+++ b/packages/nx-monorepo/src/components/release/index.ts
@@ -93,6 +93,9 @@ export class NxRelease extends Component {
     });
 
     const releaseTask = this.project.addTask("release", {
+      env: {
+        RELEASE: "true",
+      },
       steps: [
         {
           // prepare for release

--- a/packages/open-api-gateway/.projen/tasks.json
+++ b/packages/open-api-gateway/.projen/tasks.json
@@ -115,6 +115,9 @@
           "exec": "pnpm exec license-checker --summary --production --onlyAllow 'MIT;Apache-2.0;Unlicense;BSD;BSD-2-Clause;BSD-3-Clause;ISC;'"
         },
         {
+          "spawn": "resolve-symlinks"
+        },
+        {
           "spawn": "package-all"
         }
       ]
@@ -242,6 +245,15 @@
         }
       ],
       "condition": "[ \"${CI:-false}\" = \"true\" ] && [ -f \"dist/.release.env\" ]"
+    },
+    "resolve-symlinks": {
+      "name": "resolve-symlinks",
+      "steps": [
+        {
+          "exec": "find . -type l -execdir bash -c 'P=$(readlink \"$1\") && rm -rf $1 && cp -r $P $1' bash {} \\;"
+        }
+      ],
+      "condition": "[ \"${CI:-false}\" = \"true\" ] && [ \"${RELEASE:-false}\" = \"true\" ]"
     },
     "test": {
       "name": "test",

--- a/packages/open-api-gateway/package.json
+++ b/packages/open-api-gateway/package.json
@@ -24,6 +24,7 @@
     "release:init": "pnpm exec projen release:init",
     "release:prepare": "pnpm exec projen release:prepare",
     "release:publish": "pnpm exec projen release:publish",
+    "resolve-symlinks": "pnpm exec projen resolve-symlinks",
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",
     "watch": "pnpm exec projen watch"

--- a/packages/open-api-gateway/project.json
+++ b/packages/open-api-gateway/project.json
@@ -178,6 +178,13 @@
         "cwd": "packages/open-api-gateway"
       }
     },
+    "resolve-symlinks": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen resolve-symlinks",
+        "cwd": "packages/open-api-gateway"
+      }
+    },
     "docgen": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/pdk-nag/.projen/tasks.json
+++ b/packages/pdk-nag/.projen/tasks.json
@@ -112,6 +112,9 @@
           "exec": "pnpm exec license-checker --summary --production --onlyAllow 'MIT;Apache-2.0;Unlicense;BSD;BSD-2-Clause;BSD-3-Clause;ISC;'"
         },
         {
+          "spawn": "resolve-symlinks"
+        },
+        {
           "spawn": "package-all"
         },
         {
@@ -242,6 +245,15 @@
         }
       ],
       "condition": "[ \"${CI:-false}\" = \"true\" ] && [ -f \"dist/.release.env\" ]"
+    },
+    "resolve-symlinks": {
+      "name": "resolve-symlinks",
+      "steps": [
+        {
+          "exec": "find . -type l -execdir bash -c 'P=$(readlink \"$1\") && rm -rf $1 && cp -r $P $1' bash {} \\;"
+        }
+      ],
+      "condition": "[ \"${CI:-false}\" = \"true\" ] && [ \"${RELEASE:-false}\" = \"true\" ]"
     },
     "test": {
       "name": "test",

--- a/packages/pdk-nag/package.json
+++ b/packages/pdk-nag/package.json
@@ -24,6 +24,7 @@
     "release:init": "pnpm exec projen release:init",
     "release:prepare": "pnpm exec projen release:prepare",
     "release:publish": "pnpm exec projen release:publish",
+    "resolve-symlinks": "pnpm exec projen resolve-symlinks",
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",
     "watch": "pnpm exec projen watch"

--- a/packages/pdk-nag/project.json
+++ b/packages/pdk-nag/project.json
@@ -178,6 +178,13 @@
         "cwd": "packages/pdk-nag"
       }
     },
+    "resolve-symlinks": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen resolve-symlinks",
+        "cwd": "packages/pdk-nag"
+      }
+    },
     "docgen": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/pipeline/.projen/tasks.json
+++ b/packages/pipeline/.projen/tasks.json
@@ -112,6 +112,9 @@
           "exec": "pnpm exec license-checker --summary --production --onlyAllow 'MIT;Apache-2.0;Unlicense;BSD;BSD-2-Clause;BSD-3-Clause;ISC;'"
         },
         {
+          "spawn": "resolve-symlinks"
+        },
+        {
           "spawn": "package-all"
         }
       ]
@@ -245,6 +248,15 @@
         }
       ],
       "condition": "[ \"${CI:-false}\" = \"true\" ] && [ -f \"dist/.release.env\" ]"
+    },
+    "resolve-symlinks": {
+      "name": "resolve-symlinks",
+      "steps": [
+        {
+          "exec": "find . -type l -execdir bash -c 'P=$(readlink \"$1\") && rm -rf $1 && cp -r $P $1' bash {} \\;"
+        }
+      ],
+      "condition": "[ \"${CI:-false}\" = \"true\" ] && [ \"${RELEASE:-false}\" = \"true\" ]"
     },
     "test": {
       "name": "test",

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -24,6 +24,7 @@
     "release:init": "pnpm exec projen release:init",
     "release:prepare": "pnpm exec projen release:prepare",
     "release:publish": "pnpm exec projen release:publish",
+    "resolve-symlinks": "pnpm exec projen resolve-symlinks",
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",
     "watch": "pnpm exec projen watch"

--- a/packages/pipeline/project.json
+++ b/packages/pipeline/project.json
@@ -178,6 +178,13 @@
         "cwd": "packages/pipeline"
       }
     },
+    "resolve-symlinks": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen resolve-symlinks",
+        "cwd": "packages/pipeline"
+      }
+    },
     "docgen": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/static-website/.projen/tasks.json
+++ b/packages/static-website/.projen/tasks.json
@@ -112,6 +112,9 @@
           "exec": "pnpm exec license-checker --summary --production --onlyAllow 'MIT;Apache-2.0;Unlicense;BSD;BSD-2-Clause;BSD-3-Clause;ISC;'"
         },
         {
+          "spawn": "resolve-symlinks"
+        },
+        {
           "spawn": "package-all"
         }
       ]
@@ -239,6 +242,15 @@
         }
       ],
       "condition": "[ \"${CI:-false}\" = \"true\" ] && [ -f \"dist/.release.env\" ]"
+    },
+    "resolve-symlinks": {
+      "name": "resolve-symlinks",
+      "steps": [
+        {
+          "exec": "find . -type l -execdir bash -c 'P=$(readlink \"$1\") && rm -rf $1 && cp -r $P $1' bash {} \\;"
+        }
+      ],
+      "condition": "[ \"${CI:-false}\" = \"true\" ] && [ \"${RELEASE:-false}\" = \"true\" ]"
     },
     "test": {
       "name": "test",

--- a/packages/static-website/package.json
+++ b/packages/static-website/package.json
@@ -24,6 +24,7 @@
     "release:init": "pnpm exec projen release:init",
     "release:prepare": "pnpm exec projen release:prepare",
     "release:publish": "pnpm exec projen release:publish",
+    "resolve-symlinks": "pnpm exec projen resolve-symlinks",
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",
     "watch": "pnpm exec projen watch"

--- a/packages/static-website/project.json
+++ b/packages/static-website/project.json
@@ -178,6 +178,13 @@
         "cwd": "packages/static-website"
       }
     },
+    "resolve-symlinks": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen resolve-symlinks",
+        "cwd": "packages/static-website"
+      }
+    },
     "docgen": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/type-safe-api/.projen/tasks.json
+++ b/packages/type-safe-api/.projen/tasks.json
@@ -115,6 +115,9 @@
           "exec": "pnpm exec license-checker --summary --production --onlyAllow 'MIT;Apache-2.0;Unlicense;BSD;BSD-2-Clause;BSD-3-Clause;ISC;'"
         },
         {
+          "spawn": "resolve-symlinks"
+        },
+        {
           "spawn": "package-all"
         }
       ]
@@ -242,6 +245,15 @@
         }
       ],
       "condition": "[ \"${CI:-false}\" = \"true\" ] && [ -f \"dist/.release.env\" ]"
+    },
+    "resolve-symlinks": {
+      "name": "resolve-symlinks",
+      "steps": [
+        {
+          "exec": "find . -type l -execdir bash -c 'P=$(readlink \"$1\") && rm -rf $1 && cp -r $P $1' bash {} \\;"
+        }
+      ],
+      "condition": "[ \"${CI:-false}\" = \"true\" ] && [ \"${RELEASE:-false}\" = \"true\" ]"
     },
     "test": {
       "name": "test",

--- a/packages/type-safe-api/package.json
+++ b/packages/type-safe-api/package.json
@@ -24,6 +24,7 @@
     "release:init": "pnpm exec projen release:init",
     "release:prepare": "pnpm exec projen release:prepare",
     "release:publish": "pnpm exec projen release:publish",
+    "resolve-symlinks": "pnpm exec projen resolve-symlinks",
     "test": "pnpm exec projen test",
     "test:watch": "pnpm exec projen test:watch",
     "watch": "pnpm exec projen watch"

--- a/packages/type-safe-api/project.json
+++ b/packages/type-safe-api/project.json
@@ -178,6 +178,13 @@
         "cwd": "packages/type-safe-api"
       }
     },
+    "resolve-symlinks": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen resolve-symlinks",
+        "cwd": "packages/type-safe-api"
+      }
+    },
     "docgen": {
       "executor": "nx:run-commands",
       "options": {


### PR DESCRIPTION
Still seems to be some rogue symlinks so this hopefully should resolve the hardlink publishing issue for npm.