### PR TITLE
fix: ensure only 1 instance of sharp in prebuild

### DIFF
--- a/packages/cdk-graph-plugin-diagram/.projen/tasks.json
+++ b/packages/cdk-graph-plugin-diagram/.projen/tasks.json
@@ -114,13 +114,13 @@
           "exec": "pdk-pnpm-link-bundled-transitive-deps packages/cdk-graph-plugin-diagram"
         },
         {
-          "spawn": "sharp:prebuild"
-        },
-        {
           "exec": "pnpm exec license-checker --summary --production --onlyAllow 'MIT;Apache-2.0;Unlicense;BSD;BSD-2-Clause;BSD-3-Clause;ISC;'"
         },
         {
           "spawn": "resolve-symlinks"
+        },
+        {
+          "spawn": "sharp:prebuild"
         },
         {
           "spawn": "package-all"

--- a/private/projects/cdk-graph-plugin-diagram.ts
+++ b/private/projects/cdk-graph-plugin-diagram.ts
@@ -69,7 +69,20 @@ export class CdkGraphPluginDiagramProject extends CdkGraphPluginProject {
     const sharpPrebuildTask = this.addTask("sharp:prebuild", {
       exec: "ts-node ./scripts/sharp-prebuild.ts",
     });
-    this.packageTask.prependSpawn(sharpPrebuildTask);
+    const steps = this.packageTask.steps;
+    this.packageTask.reset();
+    steps.forEach((step) => {
+      if (step.exec) {
+        this.packageTask.exec(step.exec, step);
+      } else if (step.spawn) {
+        this.packageTask.spawn(this.tasks.tryFind(step.spawn)!, step);
+        step.spawn === "resolve-symlinks" &&
+          this.packageTask.spawn(sharpPrebuildTask);
+      } else {
+        throw new Error("unknown task");
+      }
+    });
+
     // Ensure build input + output includes `sharp:prebuild` artifacts
     this.nx.setTarget(
       "build",


### PR DESCRIPTION
npm rebuild tried to rebuild any packages matching the name "sharp".