### PR TITLE
feat(type-safe-api): support for api keys

### DIFF
--- a/packages/type-safe-api/src/construct/prepare-spec-event-handler/constants.ts
+++ b/packages/type-safe-api/src/construct/prepare-spec-event-handler/constants.ts
@@ -20,4 +20,5 @@ export enum HttpMethods {
 export enum DefaultAuthorizerIds {
   NONE = "none",
   IAM = "aws.auth.sigv4",
+  API_KEY = "api_key",
 }

--- a/packages/type-safe-api/src/construct/spec/api-gateway-integrations-types.ts
+++ b/packages/type-safe-api/src/construct/spec/api-gateway-integrations-types.ts
@@ -1,21 +1,37 @@
 /*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0 */
-import { CorsOptions } from "aws-cdk-lib/aws-apigateway";
+import { ApiKeySourceType, CorsOptions } from "aws-cdk-lib/aws-apigateway";
 import { Authorizer } from "../authorizers";
 import { Integration } from "../integrations";
+
+/**
+ * Options for an integration
+ */
+export interface TypeSafeApiIntegrationOptions {
+  /**
+   * Require an API key to invoke this operation. Overrides the default setting if present.
+   * This is only applicable when the API key source is HEADER.
+   * @default false
+   */
+  readonly apiKeyRequired?: boolean;
+}
 
 /**
  * Defines an integration for an individual API operation
  */
 export interface TypeSafeApiIntegration {
   /**
-   * The lambda function to service the api operation
+   * The integration to service the api operation
    */
   readonly integration: Integration;
   /**
    * The authorizer to use for this api operation (overrides the default)
    */
   readonly authorizer?: Authorizer;
+  /**
+   * Options for the integration
+   */
+  readonly options?: TypeSafeApiIntegrationOptions;
 }
 
 /**
@@ -71,6 +87,21 @@ export type OperationLookup = {
 };
 
 /**
+ * Options for API keys
+ */
+export interface ApiKeyOptions {
+  /**
+   * Source type for an API key
+   */
+  readonly source: ApiKeySourceType;
+  /**
+   * Set to true to require an API key on all operations by default.
+   * Only applicable when the source is HEADER.
+   */
+  readonly requiredByDefault?: boolean;
+}
+
+/**
  * Options required alongside an Open API specification to create API Gateway resources
  */
 export interface TypeSafeApiOptions {
@@ -91,6 +122,10 @@ export interface TypeSafeApiOptions {
    * Cross Origin Resource Sharing options for the API
    */
   readonly corsOptions?: CorsOptions;
+  /**
+   * Options for API keys
+   */
+  readonly apiKeyOptions?: ApiKeyOptions;
 }
 
 /**

--- a/packages/type-safe-api/test/construct/__snapshots__/type-safe-rest-api.test.ts.snap
+++ b/packages/type-safe-api/test/construct/__snapshots__/type-safe-rest-api.test.ts.snap
@@ -721,7 +721,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "46d1cd31161ce53de2b8046b4043a2179e271883800882bd78972ba193caac22.zip",
+          "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -1749,7 +1749,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "46d1cd31161ce53de2b8046b4043a2179e271883800882bd78972ba193caac22.zip",
+          "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -3087,7 +3087,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "46d1cd31161ce53de2b8046b4043a2179e271883800882bd78972ba193caac22.zip",
+          "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -4059,7 +4059,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC4782a9c89e48569861da77e29df0fcd0f82": {
+    "ApiTestDeployment153EC47838079670259c24557112d51aa8c99f2d": {
       "DependsOn": [
         "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
@@ -4151,7 +4151,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTestDeployment153EC4782a9c89e48569861da77e29df0fcd0f82",
+          "Ref": "ApiTestDeployment153EC47838079670259c24557112d51aa8c99f2d",
         },
         "MethodSettings": [
           {
@@ -4330,7 +4330,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "46d1cd31161ce53de2b8046b4043a2179e271883800882bd78972ba193caac22.zip",
+          "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -5576,7 +5576,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "46d1cd31161ce53de2b8046b4043a2179e271883800882bd78972ba193caac22.zip",
+          "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -6248,6 +6248,1077 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
 }
 `;
 
+exports[`Type Safe Rest Api Construct Unit Tests Synth 2`] = `
+{
+  "components": {
+    "securitySchemes": {},
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "testOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
+    },
+  },
+}
+`;
+
+exports[`Type Safe Rest Api Construct Unit Tests Synth With ApiKey Configuration 01. Empty 1`] = `
+{
+  "components": {
+    "securitySchemes": {},
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "testOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
+    },
+  },
+}
+`;
+
+exports[`Type Safe Rest Api Construct Unit Tests Synth With ApiKey Configuration 02. Header 1`] = `
+{
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "in": "header",
+        "name": "x-api-key",
+        "type": "apiKey",
+      },
+    },
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "testOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-api-key-source": "HEADER",
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
+    },
+  },
+}
+`;
+
+exports[`Type Safe Rest Api Construct Unit Tests Synth With ApiKey Configuration 03. Authorizer 1`] = `
+{
+  "components": {
+    "securitySchemes": {},
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "testOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-api-key-source": "AUTHORIZER",
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
+    },
+  },
+}
+`;
+
+exports[`Type Safe Rest Api Construct Unit Tests Synth With ApiKey Configuration 04. Header Required 1`] = `
+{
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "in": "header",
+        "name": "x-api-key",
+        "type": "apiKey",
+      },
+    },
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "testOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "security": [
+          {
+            "api_key": [],
+          },
+        ],
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-api-key-source": "HEADER",
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
+    },
+  },
+}
+`;
+
+exports[`Type Safe Rest Api Construct Unit Tests Synth With ApiKey Configuration 05. Header Not Required 1`] = `
+{
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "in": "header",
+        "name": "x-api-key",
+        "type": "apiKey",
+      },
+    },
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "testOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "security": [],
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-api-key-source": "HEADER",
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
+    },
+  },
+}
+`;
+
+exports[`Type Safe Rest Api Construct Unit Tests Synth With ApiKey Configuration 06. Header Required And Default Authorizer 1`] = `
+{
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "in": "header",
+        "name": "x-api-key",
+        "type": "apiKey",
+      },
+      "aws.auth.sigv4": {
+        "in": "header",
+        "name": "Authorization",
+        "type": "apiKey",
+        "x-amazon-apigateway-authtype": "awsSigv4",
+      },
+    },
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "testOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "security": [
+          {
+            "aws.auth.sigv4": [],
+          },
+          {
+            "api_key": [],
+          },
+        ],
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-api-key-source": "HEADER",
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
+    },
+  },
+}
+`;
+
+exports[`Type Safe Rest Api Construct Unit Tests Synth With ApiKey Configuration 07. Header Not Required And Default Authorizer 1`] = `
+{
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "in": "header",
+        "name": "x-api-key",
+        "type": "apiKey",
+      },
+      "aws.auth.sigv4": {
+        "in": "header",
+        "name": "Authorization",
+        "type": "apiKey",
+        "x-amazon-apigateway-authtype": "awsSigv4",
+      },
+    },
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "testOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "security": [
+          {
+            "aws.auth.sigv4": [],
+          },
+        ],
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-api-key-source": "HEADER",
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
+    },
+  },
+}
+`;
+
+exports[`Type Safe Rest Api Construct Unit Tests Synth With ApiKey Configuration 08. Header Required And Method Authorizer 1`] = `
+{
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "in": "header",
+        "name": "x-api-key",
+        "type": "apiKey",
+      },
+      "aws.auth.sigv4": {
+        "in": "header",
+        "name": "Authorization",
+        "type": "apiKey",
+        "x-amazon-apigateway-authtype": "awsSigv4",
+      },
+    },
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "testOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "security": [
+          {
+            "aws.auth.sigv4": [],
+          },
+          {
+            "api_key": [],
+          },
+        ],
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-api-key-source": "HEADER",
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
+    },
+  },
+}
+`;
+
+exports[`Type Safe Rest Api Construct Unit Tests Synth With ApiKey Configuration 09. Header Not Required And Method Authorizer 1`] = `
+{
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "in": "header",
+        "name": "x-api-key",
+        "type": "apiKey",
+      },
+      "aws.auth.sigv4": {
+        "in": "header",
+        "name": "Authorization",
+        "type": "apiKey",
+        "x-amazon-apigateway-authtype": "awsSigv4",
+      },
+    },
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "testOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "security": [
+          {
+            "aws.auth.sigv4": [],
+          },
+        ],
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-api-key-source": "HEADER",
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
+    },
+  },
+}
+`;
+
+exports[`Type Safe Rest Api Construct Unit Tests Synth With ApiKey Configuration 10. Header Required By Default 1`] = `
+{
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "in": "header",
+        "name": "x-api-key",
+        "type": "apiKey",
+      },
+    },
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "testOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "security": [
+          {
+            "api_key": [],
+          },
+        ],
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-api-key-source": "HEADER",
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
+    },
+  },
+}
+`;
+
+exports[`Type Safe Rest Api Construct Unit Tests Synth With ApiKey Configuration 11. Header Required By Default But Not Required For Method 1`] = `
+{
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "in": "header",
+        "name": "x-api-key",
+        "type": "apiKey",
+      },
+    },
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "testOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "security": [],
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-api-key-source": "HEADER",
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
+    },
+  },
+}
+`;
+
+exports[`Type Safe Rest Api Construct Unit Tests Synth With ApiKey Configuration 12. Header Required By Default With Default Authorizer 1`] = `
+{
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "in": "header",
+        "name": "x-api-key",
+        "type": "apiKey",
+      },
+      "aws.auth.sigv4": {
+        "in": "header",
+        "name": "Authorization",
+        "type": "apiKey",
+        "x-amazon-apigateway-authtype": "awsSigv4",
+      },
+    },
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "testOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "security": [
+          {
+            "aws.auth.sigv4": [],
+          },
+          {
+            "api_key": [],
+          },
+        ],
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-api-key-source": "HEADER",
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
+    },
+  },
+}
+`;
+
+exports[`Type Safe Rest Api Construct Unit Tests Synth With ApiKey Configuration 13. Header Required By Default With Method Authorizer 1`] = `
+{
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "in": "header",
+        "name": "x-api-key",
+        "type": "apiKey",
+      },
+      "aws.auth.sigv4": {
+        "in": "header",
+        "name": "Authorization",
+        "type": "apiKey",
+        "x-amazon-apigateway-authtype": "awsSigv4",
+      },
+    },
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "testOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "security": [
+          {
+            "aws.auth.sigv4": [],
+          },
+          {
+            "api_key": [],
+          },
+        ],
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-api-key-source": "HEADER",
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
+    },
+  },
+}
+`;
+
+exports[`Type Safe Rest Api Construct Unit Tests Synth With ApiKey Configuration 14. Header Required By Default With Default Authorizer But Not Required For Method 1`] = `
+{
+  "components": {
+    "securitySchemes": {
+      "api_key": {
+        "in": "header",
+        "name": "x-api-key",
+        "type": "apiKey",
+      },
+      "aws.auth.sigv4": {
+        "in": "header",
+        "name": "Authorization",
+        "type": "apiKey",
+        "x-amazon-apigateway-authtype": "awsSigv4",
+      },
+    },
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "testOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "security": [
+          {
+            "aws.auth.sigv4": [],
+          },
+        ],
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-api-key-source": "HEADER",
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
+    },
+  },
+}
+`;
+
 exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
 {
   "Outputs": {
@@ -6576,7 +7647,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC47863776976cc0e88744938e9841a6d2672": {
+    "ApiTestDeployment153EC4782f7f76b22669fc980f9f7456fe1deff4": {
       "DependsOn": [
         "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
@@ -6668,7 +7739,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTestDeployment153EC47863776976cc0e88744938e9841a6d2672",
+          "Ref": "ApiTestDeployment153EC4782f7f76b22669fc980f9f7456fe1deff4",
         },
         "MethodSettings": [
           {
@@ -6847,7 +7918,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "46d1cd31161ce53de2b8046b4043a2179e271883800882bd78972ba193caac22.zip",
+          "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -7543,6 +8614,83 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
 }
 `;
 
+exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 2`] = `
+{
+  "components": {
+    "securitySchemes": {
+      "myCognitoAuthorizer": {
+        "in": "header",
+        "name": "Authorization",
+        "type": "apiKey",
+        "x-amazon-apigateway-authorizer": {
+          "providerARNs": [
+            "\${<TOKEN>}",
+          ],
+          "type": "COGNITO_USER_POOLS",
+        },
+        "x-amazon-apigateway-authtype": "COGNITO_USER_POOLS",
+      },
+    },
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "testOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "security": [
+          {
+            "myCognitoAuthorizer": [],
+          },
+        ],
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
+    },
+  },
+}
+`;
+
 exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
 {
   "Outputs": {
@@ -7871,7 +9019,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC478098a9965c461523b7750d682a61a3826": {
+    "ApiTestDeployment153EC47803e8a90fd243402c01d0e16cbd6e0535": {
       "DependsOn": [
         "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
@@ -7963,7 +9111,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTestDeployment153EC478098a9965c461523b7750d682a61a3826",
+          "Ref": "ApiTestDeployment153EC47803e8a90fd243402c01d0e16cbd6e0535",
         },
         "MethodSettings": [
           {
@@ -8211,7 +9359,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "46d1cd31161ce53de2b8046b4043a2179e271883800882bd78972ba193caac22.zip",
+          "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -8943,6 +10091,83 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
 }
 `;
 
+exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 2`] = `
+{
+  "components": {
+    "securitySchemes": {
+      "myCustomAuthorizer": {
+        "in": "header",
+        "name": "Authorization",
+        "type": "apiKey",
+        "x-amazon-apigateway-authorizer": {
+          "authorizerResultTtlInSeconds": 300,
+          "authorizerUri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+          "identitySource": "method.request.header.Authorization",
+          "type": "token",
+        },
+        "x-amazon-apigateway-authtype": "CUSTOM",
+      },
+    },
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "testOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "security": [
+          {
+            "myCustomAuthorizer": [],
+          },
+        ],
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
+    },
+  },
+}
+`;
+
 exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] = `
 {
   "Outputs": {
@@ -9560,7 +10785,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "46d1cd31161ce53de2b8046b4043a2179e271883800882bd78972ba193caac22.zip",
+          "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -10532,7 +11757,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC47802f050830456476b4e7312d9797d932a": {
+    "ApiTestDeployment153EC478a540cf96c2f3638f1db06413ff4bc26e": {
       "DependsOn": [
         "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
@@ -10624,7 +11849,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTestDeployment153EC47802f050830456476b4e7312d9797d932a",
+          "Ref": "ApiTestDeployment153EC478a540cf96c2f3638f1db06413ff4bc26e",
         },
         "MethodSettings": [
           {
@@ -10803,7 +12028,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "46d1cd31161ce53de2b8046b4043a2179e271883800882bd78972ba193caac22.zip",
+          "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -11481,6 +12706,148 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
 }
 `;
 
+exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 2`] = `
+{
+  "components": {
+    "securitySchemes": {
+      "aws.auth.sigv4": {
+        "in": "header",
+        "name": "Authorization",
+        "type": "apiKey",
+        "x-amazon-apigateway-authtype": "awsSigv4",
+      },
+    },
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "testOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string",
+                },
+              },
+              "Access-Control-Allow-Methods": {
+                "schema": {
+                  "type": "string",
+                },
+              },
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string",
+                },
+              },
+            },
+          },
+        },
+        "security": [
+          {
+            "aws.auth.sigv4": [],
+          },
+        ],
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+      "options": {
+        "description": "Enable CORS by returning the correct headers",
+        "responses": {
+          "200": {
+            "content": {},
+            "description": "Default response for CORS method",
+            "headers": {
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string",
+                },
+              },
+              "Access-Control-Allow-Methods": {
+                "schema": {
+                  "type": "string",
+                },
+              },
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string",
+                },
+              },
+            },
+          },
+        },
+        "security": [],
+        "summary": "CORS Support",
+        "x-amazon-apigateway-auth": {
+          "type": "NONE",
+        },
+        "x-amazon-apigateway-integration": {
+          "requestTemplates": {
+            "application/json": "{"statusCode": 200}",
+          },
+          "responses": {
+            "default": {
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "responseTemplates": {
+                "application/json": "{}",
+              },
+              "statusCode": "200",
+            },
+          },
+          "type": "mock",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseParameters": {
+        "gatewayresponse.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'",
+        "gatewayresponse.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+        "gatewayresponse.header.Access-Control-Allow-Origin": "'*'",
+      },
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
+    },
+  },
+}
+`;
+
 exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
 {
   "Outputs": {
@@ -11809,7 +13176,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC47860a1edc076720b97c2bb9bf1a3d9c1e4": {
+    "ApiTestDeployment153EC478442bfe1adf67c65dedcf20e4dcaff124": {
       "DependsOn": [
         "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
@@ -11901,7 +13268,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTestDeployment153EC47860a1edc076720b97c2bb9bf1a3d9c1e4",
+          "Ref": "ApiTestDeployment153EC478442bfe1adf67c65dedcf20e4dcaff124",
         },
         "MethodSettings": [
           {
@@ -12356,7 +13723,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "46d1cd31161ce53de2b8046b4043a2179e271883800882bd78972ba193caac22.zip",
+          "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -13259,6 +14626,201 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
 }
 `;
 
+exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 2`] = `
+{
+  "components": {
+    "securitySchemes": {
+      "aws.auth.sigv4": {
+        "in": "header",
+        "name": "Authorization",
+        "type": "apiKey",
+        "x-amazon-apigateway-authtype": "awsSigv4",
+      },
+      "myCognitoAuthorizer": {
+        "in": "header",
+        "name": "Authorization",
+        "type": "apiKey",
+        "x-amazon-apigateway-authorizer": {
+          "providerARNs": [
+            "\${<TOKEN>}",
+          ],
+          "type": "COGNITO_USER_POOLS",
+        },
+        "x-amazon-apigateway-authtype": "COGNITO_USER_POOLS",
+      },
+      "myCustomAuthorizer": {
+        "in": "header",
+        "name": "Unused",
+        "type": "apiKey",
+        "x-amazon-apigateway-authorizer": {
+          "authorizerResultTtlInSeconds": 60,
+          "authorizerUri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+          "identitySource": "method.request.querystring.QueryString1",
+          "type": "request",
+        },
+        "x-amazon-apigateway-authtype": "CUSTOM",
+      },
+    },
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test": {
+      "delete": {
+        "operationId": "deleteOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "security": [
+          {
+            "aws.auth.sigv4": [],
+          },
+        ],
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+      "get": {
+        "operationId": "getOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "security": [
+          {
+            "myCognitoAuthorizer": [
+              "foo/bar",
+            ],
+          },
+        ],
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+      "post": {
+        "operationId": "postOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "security": [
+          {
+            "myCustomAuthorizer": [],
+          },
+        ],
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+      "put": {
+        "operationId": "putOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "security": [
+          {
+            "myCognitoAuthorizer": [
+              "other/scope",
+            ],
+          },
+        ],
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
+    },
+  },
+}
+`;
+
 exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
 {
   "Outputs": {
@@ -13789,7 +15351,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "46d1cd31161ce53de2b8046b4043a2179e271883800882bd78972ba193caac22.zip",
+          "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -14370,6 +15932,74 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
 }
 `;
 
+exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 2`] = `
+{
+  "components": {
+    "securitySchemes": {},
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "testOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "x-amazon-apigateway-integration": {
+          "requestTemplates": {
+            "application/json": "{"statusCode": 200}",
+          },
+          "responses": {
+            "default": {
+              "responseParameters": {},
+              "responseTemplates": {
+                "application/json": "{"message":"message"}",
+              },
+              "statusCode": "200",
+            },
+          },
+          "type": "MOCK",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
+    },
+  },
+}
+`;
+
 exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 1`] = `
 {
   "Outputs": {
@@ -14900,7 +16530,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "46d1cd31161ce53de2b8046b4043a2179e271883800882bd78972ba193caac22.zip",
+          "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -15509,6 +17139,149 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
 }
 `;
 
+exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 2`] = `
+{
+  "components": {
+    "securitySchemes": {},
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "testOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string",
+                },
+              },
+              "Access-Control-Allow-Methods": {
+                "schema": {
+                  "type": "string",
+                },
+              },
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string",
+                },
+              },
+            },
+          },
+        },
+        "x-amazon-apigateway-integration": {
+          "requestTemplates": {
+            "application/json": "{"statusCode": 200}",
+          },
+          "responses": {
+            "default": {
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "responseTemplates": {
+                "application/json": "{"message":"message"}",
+              },
+              "statusCode": "200",
+            },
+          },
+          "type": "MOCK",
+        },
+      },
+      "options": {
+        "description": "Enable CORS by returning the correct headers",
+        "responses": {
+          "204": {
+            "content": {},
+            "description": "Default response for CORS method",
+            "headers": {
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string",
+                },
+              },
+              "Access-Control-Allow-Methods": {
+                "schema": {
+                  "type": "string",
+                },
+              },
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string",
+                },
+              },
+            },
+          },
+        },
+        "security": [],
+        "summary": "CORS Support",
+        "x-amazon-apigateway-auth": {
+          "type": "NONE",
+        },
+        "x-amazon-apigateway-integration": {
+          "requestTemplates": {
+            "application/json": "{"statusCode": 204}",
+          },
+          "responses": {
+            "default": {
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'",
+                "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+              },
+              "responseTemplates": {
+                "application/json": "{}",
+              },
+              "statusCode": "204",
+            },
+          },
+          "type": "mock",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseParameters": {
+        "gatewayresponse.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'",
+        "gatewayresponse.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+        "gatewayresponse.header.Access-Control-Allow-Origin": "'*'",
+      },
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
+    },
+  },
+}
+`;
+
 exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
 {
   "Outputs": {
@@ -16108,7 +17881,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "46d1cd31161ce53de2b8046b4043a2179e271883800882bd78972ba193caac22.zip",
+          "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -16747,6 +18520,65 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
           "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
         },
       ],
+    },
+  },
+}
+`;
+
+exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 2`] = `
+{
+  "components": {
+    "securitySchemes": {},
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test/{param1}/fixed/{param2}/{param3}": {
+      "get": {
+        "operationId": "testOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
     },
   },
 }
@@ -17420,7 +19252,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "46d1cd31161ce53de2b8046b4043a2179e271883800882bd78972ba193caac22.zip",
+          "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",
@@ -18530,7 +20362,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "46d1cd31161ce53de2b8046b4043a2179e271883800882bd78972ba193caac22.zip",
+          "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
         "FunctionName": "Default-PrepareSpec",
         "Handler": "index.handler",


### PR DESCRIPTION
Adds support for api keys via `apiKeyOptions`. API Keys can be required when the API key source is 'HEADER'. Keys can be required by default and/or required/not-required for specific methods.

Note that this change simplifies the way that default authorizers are applied by applying authorizers only at the method level.

I'll add docs for this in my separate docs PR.
