### PR TITLE
fix(type-safe-api): include api key options in generated java cdk construct

### DIFF
--- a/packages/type-safe-api/scripts/generators/java-cdk-infrastructure/templates/api.mustache
+++ b/packages/type-safe-api/scripts/generators/java-cdk-infrastructure/templates/api.mustache
@@ -44,6 +44,7 @@ public class Api extends TypeSafeRestApi {
         super(scope, id, TypeSafeRestApiProps.builder()
                 .defaultAuthorizer(props.getDefaultAuthorizer())
                 .corsOptions(props.getCorsOptions())
+                .apiKeyOptions(props.getApiKeyOptions())
                 .operationLookup(OperationLookup.getOperationLookup()
                         .entrySet()
                         .stream()

--- a/packages/type-safe-api/scripts/generators/java-cdk-infrastructure/templates/apiProps.mustache
+++ b/packages/type-safe-api/scripts/generators/java-cdk-infrastructure/templates/apiProps.mustache
@@ -6,6 +6,7 @@ import software.amazon.awscdk.services.apigateway.RestApiBaseProps;
 import software.amazon.awscdk.services.apigateway.DomainNameOptions;
 import software.amazon.awscdk.services.apigateway.EndpointType;
 import software.amazon.awscdk.services.iam.PolicyDocument;
+import software.aws.awsprototypingsdk.typesafeapi.ApiKeyOptions;
 import software.aws.awsprototypingsdk.typesafeapi.Authorizer;
 import software.aws.awsprototypingsdk.typesafeapi.TypeSafeApiIntegration;
 
@@ -22,6 +23,7 @@ public class ApiProps implements RestApiBaseProps {
     public OperationConfig<TypeSafeApiIntegration> integrations;
     public Authorizer defaultAuthorizer;
     public CorsOptions corsOptions;
+    public ApiKeyOptions apiKeyOptions;
 
     // Rest API Props
     public Boolean cloudWatchRole;

--- a/packages/type-safe-api/src/construct/spec/api-gateway-integrations-types.ts
+++ b/packages/type-safe-api/src/construct/spec/api-gateway-integrations-types.ts
@@ -126,6 +126,10 @@ export interface TypeSafeApiOptions {
    * Options for API keys
    */
   readonly apiKeyOptions?: ApiKeyOptions;
+
+  // IMPORTANT NOTE! If adding a new property here, make sure you update the Java infrastructure
+  // generator's api.mustache and apiProps.mustache to ensure the generated construct can pass
+  // the new property to the TypeSafeRestApi construct.
 }
 
 /**

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/java-cdk-infrastructure.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/java-cdk-infrastructure.test.ts.snap
@@ -47,6 +47,7 @@ public class Api extends TypeSafeRestApi {
         super(scope, id, TypeSafeRestApiProps.builder()
                 .defaultAuthorizer(props.getDefaultAuthorizer())
                 .corsOptions(props.getCorsOptions())
+                .apiKeyOptions(props.getApiKeyOptions())
                 .operationLookup(OperationLookup.getOperationLookup()
                         .entrySet()
                         .stream()
@@ -86,6 +87,7 @@ import software.amazon.awscdk.services.apigateway.RestApiBaseProps;
 import software.amazon.awscdk.services.apigateway.DomainNameOptions;
 import software.amazon.awscdk.services.apigateway.EndpointType;
 import software.amazon.awscdk.services.iam.PolicyDocument;
+import software.aws.awsprototypingsdk.typesafeapi.ApiKeyOptions;
 import software.aws.awsprototypingsdk.typesafeapi.Authorizer;
 import software.aws.awsprototypingsdk.typesafeapi.TypeSafeApiIntegration;
 
@@ -102,6 +104,7 @@ public class ApiProps implements RestApiBaseProps {
     public OperationConfig<TypeSafeApiIntegration> integrations;
     public Authorizer defaultAuthorizer;
     public CorsOptions corsOptions;
+    public ApiKeyOptions apiKeyOptions;
 
     // Rest API Props
     public Boolean cloudWatchRole;


### PR DESCRIPTION
Add missing `apiKeyOptions` to `ApiProps` for the generated `Api` construct in Java.
