### PR TITLE
fix(nx-monorepo): bump version of @pnpm/reviewing.dependencies-hierarchy

### DIFF
--- a/packages/nx-monorepo/package.json
+++ b/packages/nx-monorepo/package.json
@@ -67,7 +67,7 @@
     "projen": "^0.71.49"
   },
   "dependencies": {
-    "@pnpm/reviewing.dependencies-hierarchy": "^2.0.4",
+    "@pnpm/reviewing.dependencies-hierarchy": "^2.0.6",
     "fs-extra": "^11.1.1",
     "semver": "^7.5.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 overrides:
   '@types/babel__traverse': 7.18.2
@@ -722,8 +726,8 @@ importers:
   packages/nx-monorepo:
     dependencies:
       '@pnpm/reviewing.dependencies-hierarchy':
-        specifier: ^2.0.4
-        version: 2.0.4(@pnpm/logger@5.0.0)
+        specifier: ^2.0.6
+        version: 2.0.6(@pnpm/logger@5.0.0)
       fs-extra:
         specifier: ^11.1.1
         version: 11.1.1
@@ -5920,8 +5924,8 @@ packages:
     engines: {node: '>=12.22.0'}
     dev: true
 
-  /@pnpm/constants@7.0.0:
-    resolution: {integrity: sha512-YA2EO2+uKrDWhtEhsbLdArJwQBr1n5VpCJzz+cLLQ98gbSKCOHAR8qwbn1wChcZitTVAr0HVyxO146nL/wujXg==}
+  /@pnpm/constants@7.1.0:
+    resolution: {integrity: sha512-PzpiPtGF+bIrmkNaHgOIfBZw669+rkUtt/5UFzHukiETwI4/+BTYz8FAr+m5Dfuns531Y+fYRFOpB0PdbAU0+w==}
     engines: {node: '>=16.14'}
     dev: false
 
@@ -5932,21 +5936,21 @@ packages:
       rfc4648: 1.5.2
     dev: false
 
-  /@pnpm/dependency-path@2.1.1:
-    resolution: {integrity: sha512-nm0uVPyzxEW+pY1XZARgXdnPZ034UO9ISKOKCkAIBySCu5RVIU1IhO31u/rikJojXmSRvh5Wr8WImZP2jCgypw==}
+  /@pnpm/dependency-path@2.1.2:
+    resolution: {integrity: sha512-BXEMdGHZG2y8z7hZAVn+r0z+IdszFZbVPpAp3xyDH3gDN30A4HCVhhCUUf0mthqQZsT131jK4HW82EUwEiW01A==}
     engines: {node: '>=16.14'}
     dependencies:
       '@pnpm/crypto.base32-hash': 2.0.0
-      '@pnpm/types': 9.0.0
+      '@pnpm/types': 9.1.0
       encode-registry: 3.0.0
       semver: 7.5.0
     dev: false
 
-  /@pnpm/error@5.0.0:
-    resolution: {integrity: sha512-8Bezq6YSSorPyaiQIr3lWF7hTIuatBTPWVCO7rbgJAGw4pq6t3DmLoN2K3EznVHMBIaqEBmkfB1lkKvXaJIVbw==}
+  /@pnpm/error@5.0.1:
+    resolution: {integrity: sha512-JQSOeSEqrV6k6+kKgrlSJ7gddJRcjxtNCxSVJRIqwckkGSdSTNpXmKEdGgLlaDuEwElPAZUmLDGSqk5InJ5pMA==}
     engines: {node: '>=16.14'}
     dependencies:
-      '@pnpm/constants': 7.0.0
+      '@pnpm/constants': 7.1.0
     dev: false
 
   /@pnpm/git-utils@1.0.0:
@@ -5956,20 +5960,20 @@ packages:
       execa: /safe-execa@0.1.2
     dev: false
 
-  /@pnpm/lockfile-file@8.0.2(@pnpm/logger@5.0.0):
-    resolution: {integrity: sha512-V4PA48Q/ZqTu5PkSLX7/H8nCS8gmKUICIDFQRRxpoHF8iv54s01chd9uGwuj1ifO8NQPID0R0zh613/oKSL32A==}
+  /@pnpm/lockfile-file@8.1.0(@pnpm/logger@5.0.0):
+    resolution: {integrity: sha512-N9zMQPz0Uo7hKwpHRQAtF+0Dq263/HCOqkQCaNRxusHqgWIk8+f/w/j5fZaGzJ/Sr8nVeW1l6jpElE2UzawoMw==}
     engines: {node: '>=16.14'}
     peerDependencies:
       '@pnpm/logger': ^5.0.0
     dependencies:
-      '@pnpm/constants': 7.0.0
-      '@pnpm/dependency-path': 2.1.1
-      '@pnpm/error': 5.0.0
+      '@pnpm/constants': 7.1.0
+      '@pnpm/dependency-path': 2.1.2
+      '@pnpm/error': 5.0.1
       '@pnpm/git-utils': 1.0.0
-      '@pnpm/lockfile-types': 5.0.0
+      '@pnpm/lockfile-types': 5.1.0
       '@pnpm/logger': 5.0.0
-      '@pnpm/merge-lockfile-changes': 5.0.1
-      '@pnpm/types': 9.0.0
+      '@pnpm/merge-lockfile-changes': 5.0.2
+      '@pnpm/types': 9.1.0
       '@pnpm/util.lex-comparator': 1.0.0
       '@zkochan/rimraf': 2.1.2
       comver-to-semver: 1.0.0
@@ -5982,21 +5986,21 @@ packages:
       write-file-atomic: 5.0.1
     dev: false
 
-  /@pnpm/lockfile-types@5.0.0:
-    resolution: {integrity: sha512-2M82hciNNIczVtWmQF3eSXPFVWvGWBvq+vssBkSIP0tZW/izYyvkUf2NN8ktNrB/w0jDCVEzujC6RXiRR9b1bg==}
+  /@pnpm/lockfile-types@5.1.0:
+    resolution: {integrity: sha512-14eYp9iOdJ7SyOIVXomXhbVnc14DEhzMLS3eKqxYxi9LkANUfxx1/pwRiRY/lTiP9RFS+OkIcTm2QiLsmNEctw==}
     engines: {node: '>=16.14'}
     dependencies:
-      '@pnpm/types': 9.0.0
+      '@pnpm/types': 9.1.0
     dev: false
 
-  /@pnpm/lockfile-utils@7.0.1:
-    resolution: {integrity: sha512-9ZOxYbD3Gk0MfBO+c+M3UVIOCTiuigVbaQ5D7frcE7IH1GdR7Alc68gPo2ZN3+4coO44VH7HTKPv69VP6fl5vA==}
+  /@pnpm/lockfile-utils@8.0.1:
+    resolution: {integrity: sha512-yAgfpKObMXi/7mJXZcqMoHZJ6FqEBtpoDIa4Oxo8PX8DOlOaWEHouPDsw9KL+1mjvJufO4YDdYXOAcTvFTd1MQ==}
     engines: {node: '>=16.14'}
     dependencies:
-      '@pnpm/dependency-path': 2.1.1
-      '@pnpm/lockfile-types': 5.0.0
-      '@pnpm/resolver-base': 10.0.0
-      '@pnpm/types': 9.0.0
+      '@pnpm/dependency-path': 2.1.2
+      '@pnpm/lockfile-types': 5.1.0
+      '@pnpm/resolver-base': 10.0.1
+      '@pnpm/types': 9.1.0
       get-npm-tarball-url: 2.0.3
       ramda: /@pnpm/ramda@0.28.1
     dev: false
@@ -6009,21 +6013,21 @@ packages:
       ndjson: 2.0.0
     dev: false
 
-  /@pnpm/merge-lockfile-changes@5.0.1:
-    resolution: {integrity: sha512-qYu/S2PT+FA1CuBStqdit1ywO35lMkw4gb6jTTSo4PNTcsAycrmiXQ8Q/LzXM7hW/zhz1S4Xs2DwnCvUbe59Ww==}
+  /@pnpm/merge-lockfile-changes@5.0.2:
+    resolution: {integrity: sha512-cswnzLUxumc1MzZp7ZxEiyV9LvEne4h2AtvSwtjdx8BU/+vbj/kjvBueqPw1t+QJl/lual9Kmem0hQaL8v57wQ==}
     engines: {node: '>=16.14'}
     dependencies:
-      '@pnpm/lockfile-types': 5.0.0
+      '@pnpm/lockfile-types': 5.1.0
       comver-to-semver: 1.0.0
       ramda: /@pnpm/ramda@0.28.1
       semver: 7.5.0
     dev: false
 
-  /@pnpm/modules-yaml@12.1.0:
-    resolution: {integrity: sha512-q0Yfe3f+qRQMRLQ4+u5wu33/qJNzc3wJC6338qi4XVBBRjN5gBgombuPnAaNe0OEf9zjWTjXPne1ziBaknuK0Q==}
+  /@pnpm/modules-yaml@12.1.1:
+    resolution: {integrity: sha512-K/le4dsBeWj0mygMJwzaDlUpx2pGlPnoPmLWQlm3ZiW5qLLlI1AV1+z7ddIXovHWyrALWVfSbJEAlWevAeFKKw==}
     engines: {node: '>=16.14'}
     dependencies:
-      '@pnpm/types': 9.0.0
+      '@pnpm/types': 9.1.0
       is-windows: 1.0.2
       ramda: /@pnpm/ramda@0.28.1
       read-yaml-file: 2.1.0
@@ -6037,11 +6041,11 @@ packages:
       graceful-fs: 4.2.10
     dev: true
 
-  /@pnpm/normalize-registries@5.0.0:
-    resolution: {integrity: sha512-siwHLnLcY5wiTXh9MxWpNo3lsStpqKO5FDCXJXml6cc32VPItiUwq8yGsOgeuJjBuOLHA0uTWvKOCW2UBbBeGA==}
+  /@pnpm/normalize-registries@5.0.1:
+    resolution: {integrity: sha512-0TYcuw4+Djl6LFYI5wh7y7n/YEVEJEAJov0MejFpJuuW1BYd059xS+BWOJ45/R/DgEZs40fkXiE3VllagZRfNw==}
     engines: {node: '>=16.14'}
     dependencies:
-      '@pnpm/types': 9.0.0
+      '@pnpm/types': 9.1.0
       normalize-registry-url: 2.0.0
       ramda: /@pnpm/ramda@0.28.1
     dev: false
@@ -6066,35 +6070,35 @@ packages:
       graceful-fs: 4.2.11
     dev: false
 
-  /@pnpm/read-package-json@8.0.0:
-    resolution: {integrity: sha512-euslwUEBp3eAyBkfi2Vh4CNVeo8UUgA0EW1BJ5lOtbMshLgUwf5z3FEoNdRYLj0N7GOfAR88gJCz2mrbE/b6xg==}
+  /@pnpm/read-package-json@8.0.1:
+    resolution: {integrity: sha512-tttbVOsLulg0gxhl3aNo++U10N7vYIR6imP8dvr8ZChF7g8xh0qEcTfzvDhDAbFdvF4yleJMHFS1s5KH/gMQaw==}
     engines: {node: '>=16.14'}
     dependencies:
-      '@pnpm/error': 5.0.0
-      '@pnpm/types': 9.0.0
+      '@pnpm/error': 5.0.1
+      '@pnpm/types': 9.1.0
       load-json-file: 6.2.0
       normalize-package-data: 5.0.0
     dev: false
 
-  /@pnpm/resolver-base@10.0.0:
-    resolution: {integrity: sha512-BWZFv1XPHjt2bvKH6+Ltj9tkN0hQELrznZ2sScbDwVFOje+Eadq6Z1pASo9L09v+rF6F4Bd/npq10cM3/+ERjw==}
+  /@pnpm/resolver-base@10.0.1:
+    resolution: {integrity: sha512-2yufLOpiPKQyNVLbL3dgoytkDuuURB5yBOrFtafiuZieGZJid2AeHmFfPhU9hNc/ZM1+wqH3EuVHe/1DdEgm4Q==}
     engines: {node: '>=16.14'}
     dependencies:
-      '@pnpm/types': 9.0.0
+      '@pnpm/types': 9.1.0
     dev: false
 
-  /@pnpm/reviewing.dependencies-hierarchy@2.0.4(@pnpm/logger@5.0.0):
-    resolution: {integrity: sha512-5/Tt7WeLhCptKVicRb+Ge4rjx7aFjHK4uGclEQCrMVXthRjvdxq6fFLjz0SxjU4ukaPzcG01GBSvo2azxNIK3w==}
+  /@pnpm/reviewing.dependencies-hierarchy@2.0.6(@pnpm/logger@5.0.0):
+    resolution: {integrity: sha512-kO7hxmEPpC7lROahokIPNbpZtAzx2h+njtLElkm3I3qDBgCbetaOyqK76DLlGA6bP762MS8yxIJ52dkaZ8eJCQ==}
     engines: {node: '>=16.14'}
     dependencies:
-      '@pnpm/dependency-path': 2.1.1
-      '@pnpm/lockfile-file': 8.0.2(@pnpm/logger@5.0.0)
-      '@pnpm/lockfile-utils': 7.0.1
-      '@pnpm/modules-yaml': 12.1.0
-      '@pnpm/normalize-registries': 5.0.0
+      '@pnpm/dependency-path': 2.1.2
+      '@pnpm/lockfile-file': 8.1.0(@pnpm/logger@5.0.0)
+      '@pnpm/lockfile-utils': 8.0.1
+      '@pnpm/modules-yaml': 12.1.1
+      '@pnpm/normalize-registries': 5.0.1
       '@pnpm/read-modules-dir': 6.0.0
-      '@pnpm/read-package-json': 8.0.0
-      '@pnpm/types': 9.0.0
+      '@pnpm/read-package-json': 8.0.1
+      '@pnpm/types': 9.1.0
       normalize-path: 3.0.0
       realpath-missing: 1.1.0
       resolve-link-target: 2.0.0
@@ -6104,6 +6108,11 @@ packages:
 
   /@pnpm/types@9.0.0:
     resolution: {integrity: sha512-+nNqpNvqb1u3WW/cHDo7tGjqJBWWe4GAHEdELrz4QMQwGAtG/1GF6NMc0cewdwgU2k67CI3JHGu4quZJnMEUJg==}
+    engines: {node: '>=16.14'}
+    dev: false
+
+  /@pnpm/types@9.1.0:
+    resolution: {integrity: sha512-MMPDMLOY17bfNhLhR9Qmq6/2keoocnR5DWXZfZDC4dKXugrMsE1jB6RnuU8swJIo4zyCsMT/iVSAtl/XK+9Z+A==}
     engines: {node: '>=16.14'}
     dev: false
 
@@ -10057,7 +10066,7 @@ packages:
     dependencies:
       semver: 7.5.0
       shelljs: 0.8.5
-      typescript: 5.2.0-dev.20230517
+      typescript: 5.2.0-dev.20230531
     dev: true
 
   /duplexer2@0.0.2:
@@ -10787,9 +10796,9 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       cross-spawn: 7.0.3
-      get-stream: 6.0.0
+      get-stream: 6.0.1
       human-signals: 2.1.0
-      is-stream: 2.0.0
+      is-stream: 2.0.1
       merge-stream: 2.0.0
       npm-run-path: 4.0.1
       onetime: 5.1.2
@@ -20423,7 +20432,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       del: 6.1.1
-      is-stream: 2.0.0
+      is-stream: 2.0.1
       temp-dir: 2.0.0
       type-fest: 0.16.0
       unique-string: 2.0.0
@@ -20922,8 +20931,8 @@ packages:
     engines: {node: '>=12.20'}
     hasBin: true
 
-  /typescript@5.2.0-dev.20230517:
-    resolution: {integrity: sha512-mTT3ka5HTeudnNirocnOfr/0d2CEvZExrJpP8YXqAvdwlwjwNPJ4TqHHiL1y9lx3RfsUWu6HSX539ZxngUTqeA==}
+  /typescript@5.2.0-dev.20230531:
+    resolution: {integrity: sha512-srFqtcpU2ZMiHj6PXzT4MHXVgASaQmOk0n6gj0T/zt7IW2o4FdKJCnnf/u7tGisG5m/Wk5qjhT++Vij5Cj+GRA==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true


### PR DESCRIPTION
bump version of @pnpm/reviewing.dependencies-hierarchy to support pnpm@8.6.0

fix #437