### PR TITLE
feat(type-safe-api): generate method for mocking all integrations

### DIFF
--- a/packages/type-safe-api/docs/developer_guides/type-safe-api/lambda_handlers.md
+++ b/packages/type-safe-api/docs/developer_guides/type-safe-api/lambda_handlers.md
@@ -440,11 +440,16 @@ When you use a handler router, you must specify the same lambda function for eve
 === "TS"
 
     ```ts
+    import { Integrations, Authorizers } from "@aws-prototyping-sdk/type-safe-api";
+    import { Operations } from "myapi-typescript-runtime";
+    import { Api } from "myapi-typescript-infra";
+    import { NodejsFunction } from "aws-cdk-lib/aws-lambda";
+
     new Api(this, "Api", {
       defaultAuthorizer: Authorizers.iam(),
       // Use the same integration for every operation.
       integrations: Operations.all({
-        integration: Integrations.lambda(new NodejsFunction(scope, "router")),
+        integration: Integrations.lambda(new NodejsFunction(this, "router")),
       }),
     });
     ```
@@ -452,8 +457,16 @@ When you use a handler router, you must specify the same lambda function for eve
 === "JAVA"
 
     ```java
+    import software.aws.awsprototypingsdk.typesafeapi.TypeSafeApiIntegration;
+    import software.aws.awsprototypingsdk.typesafeapi.Integrations;
+    import software.aws.awsprototypingsdk.typesafeapi.Authorizers;
+
+    import com.generated.api.myapijavaruntime.runtime.api.Operations;
+    import com.generated.api.myapijavainfra.infra.Api;
+    import com.generated.api.myapijavainfra.infra.ApiProps;
+
     new Api(s, "Api", ApiProps.builder()
-            .defaultAuthorizer(cognitoAuthorizer)
+            .defaultAuthorizer(Authorizers.iam())
             .integrations(Operations.all(TypeSafeApiIntegration.builder()
                     .integration(Integrations.lambda(...))
                     .build()).build())
@@ -463,6 +476,10 @@ When you use a handler router, you must specify the same lambda function for eve
 === "PYTHON"
 
     ```python
+    from aws_prototyping_sdk.type_safe_api import Integrations, TypeSafeApiIntegration, Authorizers
+    from myapi_python_runtime.apis.tags.default_api_operation_config import Operations
+    from myapi_python_infra.api import Api
+
     Api(self, "Api",
         default_authorizer=Authorizers.iam(),
         # Use the same integration for every operation.

--- a/packages/type-safe-api/docs/developer_guides/type-safe-api/mocking_responses.md
+++ b/packages/type-safe-api/docs/developer_guides/type-safe-api/mocking_responses.md
@@ -1,8 +1,108 @@
 # Mocking Responses
 
+You can stand up a working mocked API prior to implementing it, to allow you or others to work on components which interact with it (for example a website) sooner.
+
 To mock an API operation, you can use the `MockIntegrations` class which you'll find in your generated infrastructure package. This contains an integration for every response that can be returned by your operations.
 
 ## Auto-Generated Mock Data
+
+For operations which return JSON structures as responses, you can make use of auto-generated mock responses. 
+
+### Mock All Operations
+
+You can use `MockIntegrations.mockAll` to mock all the operations in your API by returning the first mock response (usually the HTTP 200 response).
+
+
+=== "TS"
+
+    ```ts
+    import { Api, MockIntegrations } from "myapi-typescript-infra";
+
+    new Api(this, "Api", {
+      integrations: MockIntegrations.mockAll(),
+    });
+    ```
+
+=== "JAVA"
+
+    ```java
+    import com.generated.api.myapijavainfra.infra.Api;
+    import com.generated.api.myapijavainfra.infra.ApiProps;
+    import com.generated.api.myapijavainfra.infra.MockIntegrations;
+
+    new Api(this, "Api", ApiProps.builder()
+            .integrations(MockIntegrations.mockAll().build())
+            .build());
+    ```
+
+=== "PYTHON"
+
+    ```python
+    from myapi_python_infra.api import Api
+    from myapi_python_infra.mock_integrations import MockIntegrations
+
+    Api(self, 'Api',
+        integrations=MockIntegrations.mock_all(),
+    )
+    ```
+
+Note that if you have operations which don't return JSON structures and so can't be mocked automatically, these operations will be omitted from those returned by `MockIntegrations.mockAll` so you will need to specify your own integrations in these cases. You can also use this pattern for gradually replacing mocks with real implementations.
+
+
+=== "TS"
+
+    ```ts
+    import { Integrations } from "@aws-prototyping-sdk/type-safe-api";
+    import { Api, MockIntegrations } from "myapi-typescript-infra";
+
+    new Api(this, "Api", {
+      integrations: {
+        ...MockIntegrations.mockAll(),
+        sayHello: {
+            integration: Integrations.lambda(...),
+        },
+      },
+    });
+    ```
+
+=== "JAVA"
+
+    ```java
+    import software.aws.awsprototypingsdk.typesafeapi.TypeSafeApiIntegration;
+    import software.aws.awsprototypingsdk.typesafeapi.Integrations;
+
+    import com.generated.api.myapijavainfra.infra.Api;
+    import com.generated.api.myapijavainfra.infra.ApiProps;
+    import com.generated.api.myapijavainfra.infra.MockIntegrations;
+    import com.generated.api.myapijavaruntime.runtime.api.OperationConfig;
+
+    new Api(this, "Api", ApiProps.builder()
+            .integrations(MockIntegrations.mockAll()
+                    .sayHello(TypeSafeApiIntegration.builder()
+                            .integration(Integrations.lambda(...))
+                            .build()))
+                    .build()
+            .build());
+    ```
+
+=== "PYTHON"
+
+    ```python
+    from aws_prototyping_sdk.type_safe_api import Integrations, TypeSafeApiIntegration
+    from myapi_python_runtime.apis.tags.default_api_operation_config import OperationConfig
+    from myapi_python_infra.api import Api
+    from myapi_python_infra.mock_integrations import MockIntegrations
+
+    Api(self, 'Api',
+        integrations=MockIntegrations.mock_all(
+            say_hello=TypeSafeApiIntegration(
+                integration=Integrations.lambda_(...),
+            ),
+        ),
+    )
+    ```
+
+### Mock Individual Operations
 
 For operations which return JSON structures as responses, you can make use of the auto-generated mock data by omitting arguments passed to the `MockIntegrations` methods, for example:
 

--- a/packages/type-safe-api/scripts/generators/java-cdk-infrastructure/templates/mockIntegrations.mustache
+++ b/packages/type-safe-api/scripts/generators/java-cdk-infrastructure/templates/mockIntegrations.mustache
@@ -1,10 +1,12 @@
 package {{#apiInfo}}{{#apis.0}}{{vendorExtensions.x-infrastructure-package}}{{/apis.0}}{{/apiInfo}};
 
 import {{#apiInfo}}{{#apis.0}}{{vendorExtensions.x-runtime-package}}{{/apis.0}}{{/apiInfo}}.JSON;
+import {{#apiInfo}}{{#apis.0}}{{vendorExtensions.x-runtime-package}}{{/apis.0}}{{/apiInfo}}.api.OperationConfig;
 import {{#apiInfo}}{{#apis.0}}{{vendorExtensions.x-runtime-package}}{{/apis.0}}{{/apiInfo}}.model.*;
 import software.aws.awsprototypingsdk.typesafeapi.Integrations;
 import software.aws.awsprototypingsdk.typesafeapi.MockIntegration;
 import software.aws.awsprototypingsdk.typesafeapi.MockIntegrationResponse;
+import software.aws.awsprototypingsdk.typesafeapi.TypeSafeApiIntegration;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -80,4 +82,31 @@ public class MockIntegrations {
     {{/operations}}
     {{/apis}}
     {{/apiInfo}}
+
+    /**
+     * Mock all operations for which generated JSON data can be returned.
+     * The first available response is used for each operation. In most cases this is the successful 200 response.
+     * @return a builder which you can use to override integrations for operations before calling .build()
+     */
+    public static OperationConfig.OperationConfigBuilder<TypeSafeApiIntegration> mockAll() {
+        return OperationConfig.<TypeSafeApiIntegration>builder()
+                {{#apiInfo}}
+                {{#apis}}
+                {{#operations}}
+                {{#operation}}
+                {{#responses.0}}
+                {{#dataType}}
+                {{^isPrimitiveType}}
+                .{{nickname}}(TypeSafeApiIntegration.builder()
+                        .integration(MockIntegrations.{{nickname}}{{code}}())
+                        .build())
+                {{/isPrimitiveType}}
+                {{/dataType}}
+                {{/responses.0}}
+                {{/operation}}
+                {{/operations}}
+                {{/apis}}
+                {{/apiInfo}}
+                ;
+    }
 }

--- a/packages/type-safe-api/scripts/generators/python-cdk-infrastructure/templates/mockIntegrations.handlebars
+++ b/packages/type-safe-api/scripts/generators/python-cdk-infrastructure/templates/mockIntegrations.handlebars
@@ -1,7 +1,8 @@
 import json
-from aws_prototyping_sdk.type_safe_api import Integrations, MockIntegration
+from aws_prototyping_sdk.type_safe_api import Integrations, MockIntegration, TypeSafeApiIntegration
 from {{#apiInfo}}{{#apis.0}}{{vendorExtensions.x-runtime-module-name}}{{/apis.0}}{{/apiInfo}}.models import *
 from {{#apiInfo}}{{#apis.0}}{{vendorExtensions.x-runtime-module-name}}{{/apis.0}}{{/apiInfo}}.api_client import JSONEncoder
+from {{#apiInfo}}{{#apis.0}}{{vendorExtensions.x-runtime-module-name}}{{/apis.0}}{{/apiInfo}}.apis.tags.default_api_operation_config import OperationConfig
 from os import path
 from pathlib import Path
 
@@ -53,3 +54,38 @@ class MockIntegrations:
     {{/operations}}
     {{/apis}}
     {{/apiInfo}}
+    @staticmethod
+    def mock_all(**kwargs) -> OperationConfig[TypeSafeApiIntegration]:
+        """
+        Mock all operations for which generated JSON data can be returned.
+        The first available response is used for each operation. In most cases this is the successful 200 response.
+        Pass any additional or overridden integrations as kwargs, for example:
+
+        MockIntegrations.mock_all(
+            say_hello=TypeSafeApiIntegration(
+                integration=Integrations.lambda_(...)
+            )
+        )
+        """
+        return OperationConfig(**{
+            **{
+                {{#apiInfo}}
+                {{#apis}}
+                {{#operations}}
+                {{#operation}}
+                {{#responses.0}}
+                {{^simpleType}}
+                {{^isPrimitiveType}}
+                "{{operationId}}": TypeSafeApiIntegration(
+                    integration=MockIntegrations.{{operationId}}_{{code}}(),
+                ),
+                {{/isPrimitiveType}}
+                {{/simpleType}}
+                {{/responses.0}}
+                {{/operation}}
+                {{/operations}}
+                {{/apis}}
+                {{/apiInfo}}
+            },
+            **kwargs
+        })

--- a/packages/type-safe-api/scripts/generators/typescript-cdk-infrastructure/templates/mockIntegrations.mustache
+++ b/packages/type-safe-api/scripts/generators/typescript-cdk-infrastructure/templates/mockIntegrations.mustache
@@ -50,4 +50,30 @@ export class MockIntegrations {
   {{/operations}}
   {{/apis}}
   {{/apiInfo}}
+
+  /**
+   * Mock all operations for which generated JSON data can be returned.
+   * The first available response is used for each operation. In most cases this is the successful 200 response.
+   */
+  public static mockAll() {
+    return {
+      {{#apiInfo}}
+      {{#apis}}
+      {{#operations}}
+      {{#operation}}
+      {{#responses.0}}
+      {{#dataType}}
+      {{^isPrimitiveType}}
+      {{nickname}}: {
+        integration: MockIntegrations.{{nickname}}{{code}}(),
+      },
+      {{/isPrimitiveType}}
+      {{/dataType}}
+      {{/responses.0}}
+      {{/operation}}
+      {{/operations}}
+      {{/apis}}
+      {{/apiInfo}}
+    };
+  }
 }

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/java-cdk-infrastructure.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/java-cdk-infrastructure.test.ts.snap
@@ -128,10 +128,12 @@ exports[`Java Infrastructure Code Generation Script Unit Tests Generates With si
 "package test.test-infra.infra;
 
 import test.test-client.runtime.JSON;
+import test.test-client.runtime.api.OperationConfig;
 import test.test-client.runtime.model.*;
 import software.aws.awsprototypingsdk.typesafeapi.Integrations;
 import software.aws.awsprototypingsdk.typesafeapi.MockIntegration;
 import software.aws.awsprototypingsdk.typesafeapi.MockIntegrationResponse;
+import software.aws.awsprototypingsdk.typesafeapi.TypeSafeApiIntegration;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -285,6 +287,25 @@ public class MockIntegrations {
                 .build());
     }
 
+
+    /**
+     * Mock all operations for which generated JSON data can be returned.
+     * The first available response is used for each operation. In most cases this is the successful 200 response.
+     * @return a builder which you can use to override integrations for operations before calling .build()
+     */
+    public static OperationConfig.OperationConfigBuilder<TypeSafeApiIntegration> mockAll() {
+        return OperationConfig.<TypeSafeApiIntegration>builder()
+                .mapResponse(TypeSafeApiIntegration.builder()
+                        .integration(MockIntegrations.mapResponse200())
+                        .build())
+                .operationOne(TypeSafeApiIntegration.builder()
+                        .integration(MockIntegrations.operationOne200())
+                        .build())
+                .withoutOperationIdDelete(TypeSafeApiIntegration.builder()
+                        .integration(MockIntegrations.withoutOperationIdDelete200())
+                        .build())
+                ;
+    }
 }
 "
 `;

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/python-cdk-infrastructure.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/python-cdk-infrastructure.test.ts.snap
@@ -28,9 +28,10 @@ exports[`Python Infrastructure Code Generation Script Unit Tests Generates With 
 
 exports[`Python Infrastructure Code Generation Script Unit Tests Generates With single.yaml 3`] = `
 "import json
-from aws_prototyping_sdk.type_safe_api import Integrations, MockIntegration
+from aws_prototyping_sdk.type_safe_api import Integrations, MockIntegration, TypeSafeApiIntegration
 from test_client.models import *
 from test_client.api_client import JSONEncoder
+from test_client.apis.tags.default_api_operation_config import OperationConfig
 from os import path
 from pathlib import Path
 
@@ -140,5 +141,29 @@ class MockIntegrations:
             body=response_body,
         )
 
+    @staticmethod
+    def mock_all(**kwargs) -> OperationConfig[TypeSafeApiIntegration]:
+        """
+        Mock all operations for which generated JSON data can be returned.
+        The first available response is used for each operation. In most cases this is the successful 200 response.
+        Pass any additional or overridden integrations as kwargs, for example:
+
+        MockIntegrations.mock_all(
+            say_hello=TypeSafeApiIntegration(
+                integration=Integrations.lambda_(...)
+            )
+        )
+        """
+        return OperationConfig(**{
+            **{
+                "operation_one": TypeSafeApiIntegration(
+                    integration=MockIntegrations.operation_one_200(),
+                ),
+                "without_operation_id_delete": TypeSafeApiIntegration(
+                    integration=MockIntegrations.without_operation_id_delete_200(),
+                ),
+            },
+            **kwargs
+        })
 "
 `;

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript-cdk-infrastructure.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript-cdk-infrastructure.test.ts.snap
@@ -143,6 +143,24 @@ export class MockIntegrations {
     });
   }
 
+
+  /**
+   * Mock all operations for which generated JSON data can be returned.
+   * The first available response is used for each operation. In most cases this is the successful 200 response.
+   */
+  public static mockAll() {
+    return {
+      mapResponse: {
+        integration: MockIntegrations.mapResponse200(),
+      },
+      operationOne: {
+        integration: MockIntegrations.operationOne200(),
+      },
+      withoutOperationIdDelete: {
+        integration: MockIntegrations.withoutOperationIdDelete200(),
+      },
+    };
+  }
 }
 "
 `;


### PR DESCRIPTION
Generate a `MockIntegrations.mockAll` method as part of the generated infrastructure for mocking all operations (which we are able to automatically mock (ie return JSON structures)).
