### PR TITLE
docs(type-safe-api): api key docs fix and note re inline schemas

### DIFF
--- a/packages/type-safe-api/docs/developer_guides/type-safe-api/api_keys.md
+++ b/packages/type-safe-api/docs/developer_guides/type-safe-api/api_keys.md
@@ -37,6 +37,7 @@ The below example demonstrates requiring an API Key for all operations besides t
     const key = api.api.addApiKey("MyApiKey");
     const plan = api.api.addUsagePlan("MyUsagePlan");
     plan.addApiKey(key);
+    plan.addApiStage({ stage: api.api.deploymentStage });
     ```
 
 === "JAVA"
@@ -60,6 +61,9 @@ The below example demonstrates requiring an API Key for all operations besides t
     IApiKey key = api.getApi().addApiKey("MyApiKey");
     UsagePlan plan = api.getApi().addUsagePlan("MyUsagePlan");
     plan.addApiKey(key);
+    plan.addApiStage(UsagePlanPerApiStage.builder()
+            .stage(api.getApi().getDeploymentStage())
+            .build());
     ```
 
 === "PYTHON"
@@ -84,4 +88,5 @@ The below example demonstrates requiring an API Key for all operations besides t
     key = api.api.add_api_key("MyApiKey")
     plan = api.api.add_usage_plan("MyUsagePlan")
     plan.add_api_key(key)
+    plan.add_api_stage(stage=api.api.deployment_stage)
     ```

--- a/packages/type-safe-api/docs/developer_guides/type-safe-api/using_openapi.md
+++ b/packages/type-safe-api/docs/developer_guides/type-safe-api/using_openapi.md
@@ -162,3 +162,5 @@ properties:
 required:
   - message
 ```
+
+⚠️ Make sure you put all request/response body schemas in the `components` section and use `$ref` to reference them, since the Python generator may not produce expected results with inline request/response body schemas.

--- a/packages/type-safe-api/test/resources/specs/single.yaml
+++ b/packages/type-safe-api/test/resources/specs/single.yaml
@@ -77,21 +77,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  mapProperty:
-                    type: object
-                    additionalProperties:
-                      type: object
-                      properties:
-                        a:
-                          type: string
-                        b:
-                          type: string
-                      required:
-                        - a
-                required:
-                  - mapProperty
+                $ref: "#/components/schemas/MapResponse"
   /any-request-response:
     put:
       operationId: anyRequestResponse
@@ -172,3 +158,19 @@ components:
               - id
       required:
         - messages
+    MapResponse:
+      type: object
+      properties:
+        mapProperty:
+          type: object
+          additionalProperties:
+            type: object
+            properties:
+              a:
+                type: string
+              b:
+                type: string
+            required:
+              - a
+      required:
+        - mapProperty

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/docs.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/docs.test.ts.snap
@@ -887,19 +887,19 @@ ul.nav-tabs {
     }
   }
 };
-    defs["mapResponse_200_response"] = {
+    defs["MapResponse"] = {
   "required" : [ "mapProperty" ],
   "type" : "object",
   "properties" : {
     "mapProperty" : {
       "type" : "object",
       "additionalProperties" : {
-        "$ref" : "#/components/schemas/mapResponse_200_response_mapProperty_value"
+        "$ref" : "#/components/schemas/MapResponse_mapProperty_value"
       }
     }
   }
 };
-    defs["mapResponse_200_response_mapProperty_value"] = {
+    defs["MapResponse_mapProperty_value"] = {
   "required" : [ "a" ],
   "type" : "object",
   "properties" : {
@@ -1654,7 +1654,7 @@ public class DefaultApiExample {
         DefaultApi apiInstance = new DefaultApi();
 
         try {
-            mapResponse_200_response result = apiInstance.mapResponse();
+            MapResponse result = apiInstance.mapResponse();
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#mapResponse");
@@ -1673,7 +1673,7 @@ public class DefaultApiExample {
         DefaultApi apiInstance = new DefaultApi();
 
         try {
-            mapResponse_200_response result = apiInstance.mapResponse();
+            MapResponse result = apiInstance.mapResponse();
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#mapResponse");
@@ -1693,7 +1693,7 @@ public class DefaultApiExample {
 DefaultApi *apiInstance = [[DefaultApi alloc] init];
 
 [apiInstance mapResponseWithCompletionHandler: 
-              ^(mapResponse_200_response output, NSError* error) {
+              ^(MapResponse output, NSError* error) {
     if (output) {
         NSLog(@"%@", output);
     }
@@ -1741,7 +1741,7 @@ namespace Example
             var apiInstance = new DefaultApi();
 
             try {
-                mapResponse_200_response result = apiInstance.mapResponse();
+                MapResponse result = apiInstance.mapResponse();
                 Debug.WriteLine(result);
             } catch (Exception e) {
                 Debug.Print("Exception when calling DefaultApi.mapResponse: " + e.Message );
@@ -5270,11 +5270,11 @@ exports[`Docs Generation Script Unit Tests Generates markdown 1`] = `
   ".openapi-generator/FILES": ".openapi-generator-ignore
 Apis/DefaultApi.md
 Models/ApiError.md
+Models/MapResponse.md
+Models/MapResponse_mapProperty_value.md
 Models/TestRequest.md
 Models/TestResponse.md
 Models/TestResponse_messages_inner.md
-Models/mapResponse_200_response.md
-Models/mapResponse_200_response_mapProperty_value.md
 README.md
 ",
   ".openapi-generator/VERSION": "6.3.0",
@@ -5342,7 +5342,7 @@ No authorization required
 
 <a name="mapResponse"></a>
 # **mapResponse**
-> mapResponse_200_response mapResponse()
+> MapResponse mapResponse()
 
 
 
@@ -5351,7 +5351,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**mapResponse_200_response**](../Models/mapResponse_200_response.md)
+[**MapResponse**](../Models/MapResponse.md)
 
 ### Authorization
 
@@ -5475,6 +5475,27 @@ No authorization required
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 
 ",
+  "Models/MapResponse.md": "# MapResponse
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **mapProperty** | [**Map**](MapResponse_mapProperty_value.md) |  | [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+",
+  "Models/MapResponse_mapProperty_value.md": "# MapResponse_mapProperty_value
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **a** | **String** |  | [default to null] |
+| **b** | **String** |  | [optional] [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+",
   "Models/TestRequest.md": "# TestRequest
 ## Properties
 
@@ -5506,27 +5527,6 @@ No authorization required
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 
 ",
-  "Models/mapResponse_200_response.md": "# mapResponse_200_response
-## Properties
-
-| Name | Type | Description | Notes |
-|------------ | ------------- | ------------- | -------------|
-| **mapProperty** | [**Map**](mapResponse_200_response_mapProperty_value.md) |  | [default to null] |
-
-[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
-
-",
-  "Models/mapResponse_200_response_mapProperty_value.md": "# mapResponse_200_response_mapProperty_value
-## Properties
-
-| Name | Type | Description | Notes |
-|------------ | ------------- | ------------- | -------------|
-| **a** | **String** |  | [default to null] |
-| **b** | **String** |  | [optional] [default to null] |
-
-[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
-
-",
   "README.md": "# Documentation for Example API
 
 <a name="documentation-for-api-endpoints"></a>
@@ -5549,11 +5549,11 @@ All URIs are relative to *http://localhost*
 ## Documentation for Models
 
  - [ApiError](./Models/ApiError.md)
+ - [MapResponse](./Models/MapResponse.md)
+ - [MapResponse_mapProperty_value](./Models/MapResponse_mapProperty_value.md)
  - [TestRequest](./Models/TestRequest.md)
  - [TestResponse](./Models/TestResponse.md)
  - [TestResponse_messages_inner](./Models/TestResponse_messages_inner.md)
- - [mapResponse_200_response](./Models/mapResponse_200_response.md)
- - [mapResponse_200_response_mapProperty_value](./Models/mapResponse_200_response_mapProperty_value.md)
 
 
 <a name="documentation-for-authorization"></a>
@@ -5620,11 +5620,11 @@ entity ApiError {
     * errorMessage: String
 }
 
-entity MapResponse200Response {
+entity MapResponse {
     * mapProperty: Map
 }
 
-entity MapResponse200ResponseMapPropertyValue {
+entity MapResponseMapPropertyValue {
     * a: String
     b: String
 }

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/java-cdk-infrastructure.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/java-cdk-infrastructure.test.ts.snap
@@ -190,7 +190,7 @@ public class MockIntegrations {
     /**
      * Mock integration to return a 200 response from the mapResponse operation
      */
-    public static MockIntegration mapResponse200(final MapResponse200Response body) {
+    public static MockIntegration mapResponse200(final MapResponse body) {
         return Integrations.mock(MockIntegrationResponse.builder()
                 .statusCode(200)
                 .body(body.toJson())

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/java.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/java.test.ts.snap
@@ -5883,8 +5883,8 @@ build.gradle
 build.sbt
 docs/ApiError.md
 docs/DefaultApi.md
-docs/MapResponse200Response.md
-docs/MapResponse200ResponseMapPropertyValue.md
+docs/MapResponse.md
+docs/MapResponseMapPropertyValue.md
 docs/TestRequest.md
 docs/TestResponse.md
 docs/TestResponseMessagesInner.md
@@ -5921,15 +5921,15 @@ src/main/java/test/test/runtime/auth/HttpBasicAuth.java
 src/main/java/test/test/runtime/auth/HttpBearerAuth.java
 src/main/java/test/test/runtime/model/AbstractOpenApiSchema.java
 src/main/java/test/test/runtime/model/ApiError.java
-src/main/java/test/test/runtime/model/MapResponse200Response.java
-src/main/java/test/test/runtime/model/MapResponse200ResponseMapPropertyValue.java
+src/main/java/test/test/runtime/model/MapResponse.java
+src/main/java/test/test/runtime/model/MapResponseMapPropertyValue.java
 src/main/java/test/test/runtime/model/TestRequest.java
 src/main/java/test/test/runtime/model/TestResponse.java
 src/main/java/test/test/runtime/model/TestResponseMessagesInner.java
 src/test/java/test/test/runtime/api/DefaultApiTest.java
 src/test/java/test/test/runtime/model/ApiErrorTest.java
-src/test/java/test/test/runtime/model/MapResponse200ResponseMapPropertyValueTest.java
-src/test/java/test/test/runtime/model/MapResponse200ResponseTest.java
+src/test/java/test/test/runtime/model/MapResponseMapPropertyValueTest.java
+src/test/java/test/test/runtime/model/MapResponseTest.java
 src/test/java/test/test/runtime/model/TestRequestTest.java
 src/test/java/test/test/runtime/model/TestResponseMessagesInnerTest.java
 src/test/java/test/test/runtime/model/TestResponseTest.java
@@ -6064,8 +6064,8 @@ Class | Method | HTTP request | Description
 ## Documentation for Models
 
  - [ApiError](docs/ApiError.md)
- - [MapResponse200Response](docs/MapResponse200Response.md)
- - [MapResponse200ResponseMapPropertyValue](docs/MapResponse200ResponseMapPropertyValue.md)
+ - [MapResponse](docs/MapResponse.md)
+ - [MapResponseMapPropertyValue](docs/MapResponseMapPropertyValue.md)
  - [TestRequest](docs/TestRequest.md)
  - [TestResponse](docs/TestResponse.md)
  - [TestResponseMessagesInner](docs/TestResponseMessagesInner.md)
@@ -6179,7 +6179,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/mapResponse_200_response'
+                $ref: '#/components/schemas/MapResponse'
           description: Successful response
       x-accepts: application/json
   /any-request-response:
@@ -6261,20 +6261,11 @@ components:
       required:
       - messages
       type: object
-    mapResponse_200_response_mapProperty_value:
-      properties:
-        a:
-          type: string
-        b:
-          type: string
-      required:
-      - a
-      type: object
-    mapResponse_200_response:
+    MapResponse:
       properties:
         mapProperty:
           additionalProperties:
-            $ref: '#/components/schemas/mapResponse_200_response_mapProperty_value'
+            $ref: '#/components/schemas/MapResponse_mapProperty_value'
           type: object
       required:
       - mapProperty
@@ -6287,6 +6278,15 @@ components:
           type: integer
       required:
       - id
+      type: object
+    MapResponse_mapProperty_value:
+      properties:
+        a:
+          type: string
+        b:
+          type: string
+      required:
+      - a
       type: object
 
 ",
@@ -6439,7 +6439,7 @@ No authorization required
 
 <a name="mapResponse"></a>
 # **mapResponse**
-> MapResponse200Response mapResponse().execute();
+> MapResponse mapResponse().execute();
 
 
 
@@ -6459,7 +6459,7 @@ public class Example {
 
     DefaultApi apiInstance = new DefaultApi(defaultClient);
     try {
-      MapResponse200Response result = apiInstance.mapResponse()
+      MapResponse result = apiInstance.mapResponse()
             .execute();
       System.out.println(result);
     } catch (ApiException e) {
@@ -6478,7 +6478,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**MapResponse200Response**](MapResponse200Response.md)
+[**MapResponse**](MapResponse.md)
 
 ### Authorization
 
@@ -6747,23 +6747,23 @@ No authorization required
 | **200** | Successful response |  -  |
 
 ",
-  "docs/MapResponse200Response.md": "
+  "docs/MapResponse.md": "
 
-# MapResponse200Response
+# MapResponse
 
 
 ## Properties
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-|**mapProperty** | [**Map&lt;String, MapResponse200ResponseMapPropertyValue&gt;**](MapResponse200ResponseMapPropertyValue.md) |  |  |
+|**mapProperty** | [**Map&lt;String, MapResponseMapPropertyValue&gt;**](MapResponseMapPropertyValue.md) |  |  |
 
 
 
 ",
-  "docs/MapResponse200ResponseMapPropertyValue.md": "
+  "docs/MapResponseMapPropertyValue.md": "
 
-# MapResponse200ResponseMapPropertyValue
+# MapResponseMapPropertyValue
 
 
 ## Properties
@@ -8905,8 +8905,8 @@ public class JSON {
         gsonBuilder.registerTypeAdapter(LocalDate.class, localDateTypeAdapter);
         gsonBuilder.registerTypeAdapter(byte[].class, byteArrayAdapter);
         gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.ApiError.CustomTypeAdapterFactory());
-        gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.MapResponse200Response.CustomTypeAdapterFactory());
-        gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.MapResponse200ResponseMapPropertyValue.CustomTypeAdapterFactory());
+        gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.MapResponse.CustomTypeAdapterFactory());
+        gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.MapResponseMapPropertyValue.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.TestRequest.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.TestResponse.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.TestResponseMessagesInner.CustomTypeAdapterFactory());
@@ -9618,7 +9618,7 @@ import java.io.IOException;
 import test.test.runtime.model.ApiError;
 import java.math.BigDecimal;
 import java.io.File;
-import test.test.runtime.model.MapResponse200Response;
+import test.test.runtime.model.MapResponse;
 import test.test.runtime.model.TestRequest;
 import test.test.runtime.model.TestResponse;
 
@@ -10010,16 +10010,16 @@ public class DefaultApi {
     }
 
 
-    private ApiResponse<MapResponse200Response> mapResponseWithHttpInfo() throws ApiException {
+    private ApiResponse<MapResponse> mapResponseWithHttpInfo() throws ApiException {
         okhttp3.Call localVarCall = mapResponseValidateBeforeCall(null);
-        Type localVarReturnType = new TypeToken<MapResponse200Response>(){}.getType();
+        Type localVarReturnType = new TypeToken<MapResponse>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
-    private okhttp3.Call mapResponseAsync(final ApiCallback<MapResponse200Response> _callback) throws ApiException {
+    private okhttp3.Call mapResponseAsync(final ApiCallback<MapResponse> _callback) throws ApiException {
 
         okhttp3.Call localVarCall = mapResponseValidateBeforeCall(_callback);
-        Type localVarReturnType = new TypeToken<MapResponse200Response>(){}.getType();
+        Type localVarReturnType = new TypeToken<MapResponse>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }
@@ -10046,7 +10046,7 @@ public class DefaultApi {
 
         /**
          * Execute mapResponse request
-         * @return MapResponse200Response
+         * @return MapResponse
          * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
          * @http.response.details
          <table summary="Response Details" border="1">
@@ -10054,14 +10054,14 @@ public class DefaultApi {
             <tr><td> 200 </td><td> Successful response </td><td>  -  </td></tr>
          </table>
          */
-        public MapResponse200Response execute() throws ApiException {
-            ApiResponse<MapResponse200Response> localVarResp = mapResponseWithHttpInfo();
+        public MapResponse execute() throws ApiException {
+            ApiResponse<MapResponse> localVarResp = mapResponseWithHttpInfo();
             return localVarResp.getData();
         }
 
         /**
          * Execute mapResponse request with HTTP info returned
-         * @return ApiResponse&lt;MapResponse200Response&gt;
+         * @return ApiResponse&lt;MapResponse&gt;
          * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
          * @http.response.details
          <table summary="Response Details" border="1">
@@ -10069,7 +10069,7 @@ public class DefaultApi {
             <tr><td> 200 </td><td> Successful response </td><td>  -  </td></tr>
          </table>
          */
-        public ApiResponse<MapResponse200Response> executeWithHttpInfo() throws ApiException {
+        public ApiResponse<MapResponse> executeWithHttpInfo() throws ApiException {
             return mapResponseWithHttpInfo();
         }
 
@@ -10084,7 +10084,7 @@ public class DefaultApi {
             <tr><td> 200 </td><td> Successful response </td><td>  -  </td></tr>
          </table>
          */
-        public okhttp3.Call executeAsync(final ApiCallback<MapResponse200Response> _callback) throws ApiException {
+        public okhttp3.Call executeAsync(final ApiCallback<MapResponse> _callback) throws ApiException {
             return mapResponseAsync(_callback);
         }
     }
@@ -10799,7 +10799,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import test.test.runtime.model.ApiError;
 import java.math.BigDecimal;
 import java.io.File;
-import test.test.runtime.model.MapResponse200Response;
+import test.test.runtime.model.MapResponse;
 import test.test.runtime.model.TestRequest;
 import test.test.runtime.model.TestResponse;
 
@@ -11453,7 +11453,7 @@ public class Handlers {
         private String body;
         private Map<String, String> headers;
 
-        private MapResponse200Response(final MapResponse200Response body, final Map<String, String> headers) {
+        private MapResponse200Response(final MapResponse body, final Map<String, String> headers) {
             this.body = body.toJson();
             this.headers = headers;
         }
@@ -11476,14 +11476,14 @@ public class Handlers {
         /**
          * Create a MapResponse200Response with a body
          */
-        public static MapResponse200Response of(final MapResponse200Response body) {
+        public static MapResponse200Response of(final MapResponse body) {
             return new MapResponse200Response(body, new HashMap<>());
         }
 
         /**
          * Create a MapResponse200Response with a body and headers
          */
-        public static MapResponse200Response of(final MapResponse200Response body, final Map<String, String> headers) {
+        public static MapResponse200Response of(final MapResponse body, final Map<String, String> headers) {
             return new MapResponse200Response(body, headers);
         }
     }
@@ -12770,7 +12770,7 @@ import test.test.runtime.model.*;
 import test.test.runtime.model.ApiError;
 import java.math.BigDecimal;
 import java.io.File;
-import test.test.runtime.model.MapResponse200Response;
+import test.test.runtime.model.MapResponse;
 import test.test.runtime.model.TestRequest;
 import test.test.runtime.model.TestResponse;
 
@@ -12809,7 +12809,7 @@ import test.test.runtime.model.*;
 import test.test.runtime.model.ApiError;
 import java.math.BigDecimal;
 import java.io.File;
-import test.test.runtime.model.MapResponse200Response;
+import test.test.runtime.model.MapResponse;
 import test.test.runtime.model.TestRequest;
 import test.test.runtime.model.TestResponse;
 
@@ -13503,7 +13503,7 @@ public class ApiError {
 }
 
 ",
-  "src/main/java/test/test/runtime/model/MapResponse200Response.java": "/*
+  "src/main/java/test/test/runtime/model/MapResponse.java": "/*
  * Example API
  * No description provided (generated by Openapi Generator https://github.com/openapitools/openapi-generator)
  *
@@ -13528,7 +13528,7 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import test.test.runtime.model.MapResponse200ResponseMapPropertyValue;
+import test.test.runtime.model.MapResponseMapPropertyValue;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -13552,25 +13552,25 @@ import java.util.Set;
 import test.test.runtime.JSON;
 
 /**
- * MapResponse200Response
+ * MapResponse
  */
 @lombok.AllArgsConstructor @lombok.experimental.SuperBuilder
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
-public class MapResponse200Response {
+public class MapResponse {
   public static final String SERIALIZED_NAME_MAP_PROPERTY = "mapProperty";
   @SerializedName(SERIALIZED_NAME_MAP_PROPERTY)
-  private Map<String, MapResponse200ResponseMapPropertyValue> mapProperty = new HashMap<>();
+  private Map<String, MapResponseMapPropertyValue> mapProperty = new HashMap<>();
 
-  public MapResponse200Response() {
+  public MapResponse() {
   }
 
-  public MapResponse200Response mapProperty(Map<String, MapResponse200ResponseMapPropertyValue> mapProperty) {
+  public MapResponse mapProperty(Map<String, MapResponseMapPropertyValue> mapProperty) {
     
     this.mapProperty = mapProperty;
     return this;
   }
 
-  public MapResponse200Response putMapPropertyItem(String key, MapResponse200ResponseMapPropertyValue mapPropertyItem) {
+  public MapResponse putMapPropertyItem(String key, MapResponseMapPropertyValue mapPropertyItem) {
     this.mapProperty.put(key, mapPropertyItem);
     return this;
   }
@@ -13581,12 +13581,12 @@ public class MapResponse200Response {
   **/
   @javax.annotation.Nonnull
 
-  public Map<String, MapResponse200ResponseMapPropertyValue> getMapProperty() {
+  public Map<String, MapResponseMapPropertyValue> getMapProperty() {
     return mapProperty;
   }
 
 
-  public void setMapProperty(Map<String, MapResponse200ResponseMapPropertyValue> mapProperty) {
+  public void setMapProperty(Map<String, MapResponseMapPropertyValue> mapProperty) {
     this.mapProperty = mapProperty;
   }
 
@@ -13600,8 +13600,8 @@ public class MapResponse200Response {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    MapResponse200Response mapResponse200Response = (MapResponse200Response) o;
-    return Objects.equals(this.mapProperty, mapResponse200Response.mapProperty);
+    MapResponse mapResponse = (MapResponse) o;
+    return Objects.equals(this.mapProperty, mapResponse.mapProperty);
   }
 
   @Override
@@ -13612,7 +13612,7 @@ public class MapResponse200Response {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class MapResponse200Response {\\n");
+    sb.append("class MapResponse {\\n");
     sb.append("    mapProperty: ").append(toIndentedString(mapProperty)).append("\\n");
     sb.append("}");
     return sb.toString();
@@ -13647,25 +13647,25 @@ public class MapResponse200Response {
   * Validates the JSON Object and throws an exception if issues found
   *
   * @param jsonObj JSON Object
-  * @throws IOException if the JSON Object is invalid with respect to MapResponse200Response
+  * @throws IOException if the JSON Object is invalid with respect to MapResponse
   */
   public static void validateJsonObject(JsonObject jsonObj) throws IOException {
       if (jsonObj == null) {
-        if (!MapResponse200Response.openapiRequiredFields.isEmpty()) { // has required fields but JSON object is null
-          throw new IllegalArgumentException(String.format("The required field(s) %s in MapResponse200Response is not found in the empty JSON string", MapResponse200Response.openapiRequiredFields.toString()));
+        if (!MapResponse.openapiRequiredFields.isEmpty()) { // has required fields but JSON object is null
+          throw new IllegalArgumentException(String.format("The required field(s) %s in MapResponse is not found in the empty JSON string", MapResponse.openapiRequiredFields.toString()));
         }
       }
 
       Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
       // check to see if the JSON string contains additional fields
       for (Entry<String, JsonElement> entry : entries) {
-        if (!MapResponse200Response.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field \`%s\` in the JSON string is not defined in the \`MapResponse200Response\` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
+        if (!MapResponse.openapiFields.contains(entry.getKey())) {
+          throw new IllegalArgumentException(String.format("The field \`%s\` in the JSON string is not defined in the \`MapResponse\` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
         }
       }
 
       // check to make sure all required properties/fields are present in the JSON string
-      for (String requiredField : MapResponse200Response.openapiRequiredFields) {
+      for (String requiredField : MapResponse.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field \`%s\` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
@@ -13676,22 +13676,22 @@ public class MapResponse200Response {
     @SuppressWarnings("unchecked")
     @Override
     public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-       if (!MapResponse200Response.class.isAssignableFrom(type.getRawType())) {
-         return null; // this class only serializes 'MapResponse200Response' and its subtypes
+       if (!MapResponse.class.isAssignableFrom(type.getRawType())) {
+         return null; // this class only serializes 'MapResponse' and its subtypes
        }
        final TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
-       final TypeAdapter<MapResponse200Response> thisAdapter
-                        = gson.getDelegateAdapter(this, TypeToken.get(MapResponse200Response.class));
+       final TypeAdapter<MapResponse> thisAdapter
+                        = gson.getDelegateAdapter(this, TypeToken.get(MapResponse.class));
 
-       return (TypeAdapter<T>) new TypeAdapter<MapResponse200Response>() {
+       return (TypeAdapter<T>) new TypeAdapter<MapResponse>() {
            @Override
-           public void write(JsonWriter out, MapResponse200Response value) throws IOException {
+           public void write(JsonWriter out, MapResponse value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
              elementAdapter.write(out, obj);
            }
 
            @Override
-           public MapResponse200Response read(JsonReader in) throws IOException {
+           public MapResponse read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
              return thisAdapter.fromJsonTree(jsonObj);
@@ -13702,18 +13702,18 @@ public class MapResponse200Response {
   }
 
  /**
-  * Create an instance of MapResponse200Response given an JSON string
+  * Create an instance of MapResponse given an JSON string
   *
   * @param jsonString JSON string
-  * @return An instance of MapResponse200Response
-  * @throws IOException if the JSON string is invalid with respect to MapResponse200Response
+  * @return An instance of MapResponse
+  * @throws IOException if the JSON string is invalid with respect to MapResponse
   */
-  public static MapResponse200Response fromJson(String jsonString) throws IOException {
-    return JSON.getGson().fromJson(jsonString, MapResponse200Response.class);
+  public static MapResponse fromJson(String jsonString) throws IOException {
+    return JSON.getGson().fromJson(jsonString, MapResponse.class);
   }
 
  /**
-  * Convert an instance of MapResponse200Response to an JSON string
+  * Convert an instance of MapResponse to an JSON string
   *
   * @return JSON string
   */
@@ -13723,7 +13723,7 @@ public class MapResponse200Response {
 }
 
 ",
-  "src/main/java/test/test/runtime/model/MapResponse200ResponseMapPropertyValue.java": "/*
+  "src/main/java/test/test/runtime/model/MapResponseMapPropertyValue.java": "/*
  * Example API
  * No description provided (generated by Openapi Generator https://github.com/openapitools/openapi-generator)
  *
@@ -13769,11 +13769,11 @@ import java.util.Set;
 import test.test.runtime.JSON;
 
 /**
- * MapResponse200ResponseMapPropertyValue
+ * MapResponseMapPropertyValue
  */
 @lombok.AllArgsConstructor @lombok.experimental.SuperBuilder
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
-public class MapResponse200ResponseMapPropertyValue {
+public class MapResponseMapPropertyValue {
   public static final String SERIALIZED_NAME_A = "a";
   @SerializedName(SERIALIZED_NAME_A)
   private String a;
@@ -13782,10 +13782,10 @@ public class MapResponse200ResponseMapPropertyValue {
   @SerializedName(SERIALIZED_NAME_B)
   private String b;
 
-  public MapResponse200ResponseMapPropertyValue() {
+  public MapResponseMapPropertyValue() {
   }
 
-  public MapResponse200ResponseMapPropertyValue a(String a) {
+  public MapResponseMapPropertyValue a(String a) {
     
     this.a = a;
     return this;
@@ -13807,7 +13807,7 @@ public class MapResponse200ResponseMapPropertyValue {
   }
 
 
-  public MapResponse200ResponseMapPropertyValue b(String b) {
+  public MapResponseMapPropertyValue b(String b) {
     
     this.b = b;
     return this;
@@ -13838,9 +13838,9 @@ public class MapResponse200ResponseMapPropertyValue {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    MapResponse200ResponseMapPropertyValue mapResponse200ResponseMapPropertyValue = (MapResponse200ResponseMapPropertyValue) o;
-    return Objects.equals(this.a, mapResponse200ResponseMapPropertyValue.a) &&
-        Objects.equals(this.b, mapResponse200ResponseMapPropertyValue.b);
+    MapResponseMapPropertyValue mapResponseMapPropertyValue = (MapResponseMapPropertyValue) o;
+    return Objects.equals(this.a, mapResponseMapPropertyValue.a) &&
+        Objects.equals(this.b, mapResponseMapPropertyValue.b);
   }
 
   @Override
@@ -13851,7 +13851,7 @@ public class MapResponse200ResponseMapPropertyValue {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class MapResponse200ResponseMapPropertyValue {\\n");
+    sb.append("class MapResponseMapPropertyValue {\\n");
     sb.append("    a: ").append(toIndentedString(a)).append("\\n");
     sb.append("    b: ").append(toIndentedString(b)).append("\\n");
     sb.append("}");
@@ -13888,25 +13888,25 @@ public class MapResponse200ResponseMapPropertyValue {
   * Validates the JSON Object and throws an exception if issues found
   *
   * @param jsonObj JSON Object
-  * @throws IOException if the JSON Object is invalid with respect to MapResponse200ResponseMapPropertyValue
+  * @throws IOException if the JSON Object is invalid with respect to MapResponseMapPropertyValue
   */
   public static void validateJsonObject(JsonObject jsonObj) throws IOException {
       if (jsonObj == null) {
-        if (!MapResponse200ResponseMapPropertyValue.openapiRequiredFields.isEmpty()) { // has required fields but JSON object is null
-          throw new IllegalArgumentException(String.format("The required field(s) %s in MapResponse200ResponseMapPropertyValue is not found in the empty JSON string", MapResponse200ResponseMapPropertyValue.openapiRequiredFields.toString()));
+        if (!MapResponseMapPropertyValue.openapiRequiredFields.isEmpty()) { // has required fields but JSON object is null
+          throw new IllegalArgumentException(String.format("The required field(s) %s in MapResponseMapPropertyValue is not found in the empty JSON string", MapResponseMapPropertyValue.openapiRequiredFields.toString()));
         }
       }
 
       Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
       // check to see if the JSON string contains additional fields
       for (Entry<String, JsonElement> entry : entries) {
-        if (!MapResponse200ResponseMapPropertyValue.openapiFields.contains(entry.getKey())) {
-          throw new IllegalArgumentException(String.format("The field \`%s\` in the JSON string is not defined in the \`MapResponse200ResponseMapPropertyValue\` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
+        if (!MapResponseMapPropertyValue.openapiFields.contains(entry.getKey())) {
+          throw new IllegalArgumentException(String.format("The field \`%s\` in the JSON string is not defined in the \`MapResponseMapPropertyValue\` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
         }
       }
 
       // check to make sure all required properties/fields are present in the JSON string
-      for (String requiredField : MapResponse200ResponseMapPropertyValue.openapiRequiredFields) {
+      for (String requiredField : MapResponseMapPropertyValue.openapiRequiredFields) {
         if (jsonObj.get(requiredField) == null) {
           throw new IllegalArgumentException(String.format("The required field \`%s\` is not found in the JSON string: %s", requiredField, jsonObj.toString()));
         }
@@ -13923,22 +13923,22 @@ public class MapResponse200ResponseMapPropertyValue {
     @SuppressWarnings("unchecked")
     @Override
     public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-       if (!MapResponse200ResponseMapPropertyValue.class.isAssignableFrom(type.getRawType())) {
-         return null; // this class only serializes 'MapResponse200ResponseMapPropertyValue' and its subtypes
+       if (!MapResponseMapPropertyValue.class.isAssignableFrom(type.getRawType())) {
+         return null; // this class only serializes 'MapResponseMapPropertyValue' and its subtypes
        }
        final TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
-       final TypeAdapter<MapResponse200ResponseMapPropertyValue> thisAdapter
-                        = gson.getDelegateAdapter(this, TypeToken.get(MapResponse200ResponseMapPropertyValue.class));
+       final TypeAdapter<MapResponseMapPropertyValue> thisAdapter
+                        = gson.getDelegateAdapter(this, TypeToken.get(MapResponseMapPropertyValue.class));
 
-       return (TypeAdapter<T>) new TypeAdapter<MapResponse200ResponseMapPropertyValue>() {
+       return (TypeAdapter<T>) new TypeAdapter<MapResponseMapPropertyValue>() {
            @Override
-           public void write(JsonWriter out, MapResponse200ResponseMapPropertyValue value) throws IOException {
+           public void write(JsonWriter out, MapResponseMapPropertyValue value) throws IOException {
              JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
              elementAdapter.write(out, obj);
            }
 
            @Override
-           public MapResponse200ResponseMapPropertyValue read(JsonReader in) throws IOException {
+           public MapResponseMapPropertyValue read(JsonReader in) throws IOException {
              JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
              validateJsonObject(jsonObj);
              return thisAdapter.fromJsonTree(jsonObj);
@@ -13949,18 +13949,18 @@ public class MapResponse200ResponseMapPropertyValue {
   }
 
  /**
-  * Create an instance of MapResponse200ResponseMapPropertyValue given an JSON string
+  * Create an instance of MapResponseMapPropertyValue given an JSON string
   *
   * @param jsonString JSON string
-  * @return An instance of MapResponse200ResponseMapPropertyValue
-  * @throws IOException if the JSON string is invalid with respect to MapResponse200ResponseMapPropertyValue
+  * @return An instance of MapResponseMapPropertyValue
+  * @throws IOException if the JSON string is invalid with respect to MapResponseMapPropertyValue
   */
-  public static MapResponse200ResponseMapPropertyValue fromJson(String jsonString) throws IOException {
-    return JSON.getGson().fromJson(jsonString, MapResponse200ResponseMapPropertyValue.class);
+  public static MapResponseMapPropertyValue fromJson(String jsonString) throws IOException {
+    return JSON.getGson().fromJson(jsonString, MapResponseMapPropertyValue.class);
   }
 
  /**
-  * Convert an instance of MapResponse200ResponseMapPropertyValue to an JSON string
+  * Convert an instance of MapResponseMapPropertyValue to an JSON string
   *
   * @return JSON string
   */

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/python-cdk-infrastructure.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/python-cdk-infrastructure.test.ts.snap
@@ -61,13 +61,20 @@ class MockIntegrations:
         )
 
     @staticmethod
-    def map_response_200(body: str) -> MockIntegration:
+    def map_response_200(body: MapResponse = None) -> MockIntegration:
         """
         Mock integration to return a 200 response from the map_response operation
+        Call this with no arguments to use a generated mock response
         """
+        response_body = None
+        if body is None:
+            with open(path.join(MOCK_DATA_PATH, "get{}-200.json".format("/map-response".replace("/", "-"))), "r") as f:
+                response_body = f.read()
+        else:
+            response_body = json.dumps(JSONEncoder().default(body))
         return Integrations.mock(
             status_code=200,
-            body=body,
+            body=response_body,
         )
 
     @staticmethod
@@ -156,6 +163,9 @@ class MockIntegrations:
         """
         return OperationConfig(**{
             **{
+                "map_response": TypeSafeApiIntegration(
+                    integration=MockIntegrations.map_response_200(),
+                ),
                 "operation_one": TypeSafeApiIntegration(
                     integration=MockIntegrations.operation_one_200(),
                 ),

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
@@ -7826,6 +7826,7 @@ target/
 README.md
 docs/apis/tags/DefaultApi.md
 docs/models/ApiError.md
+docs/models/MapResponse.md
 docs/models/TestRequest.md
 docs/models/TestResponse.md
 git_push.sh
@@ -7836,6 +7837,7 @@ test-requirements.txt
 test/__init__.py
 test/test_models/__init__.py
 test/test_models/test_api_error.py
+test/test_models/test_map_response.py
 test/test_models/test_test_request.py
 test/test_models/test_test_response.py
 test_project/__init__.py
@@ -7848,6 +7850,8 @@ test_project/exceptions.py
 test_project/model/__init__.py
 test_project/model/api_error.py
 test_project/model/api_error.pyi
+test_project/model/map_response.py
+test_project/model/map_response.pyi
 test_project/model/test_request.py
 test_project/model/test_request.pyi
 test_project/model/test_response.py
@@ -8002,6 +8006,7 @@ import test_project
 from pprint import pprint
 from test_project.apis.tags import default_api
 from test_project.model.api_error import ApiError
+from test_project.model.map_response import MapResponse
 from test_project.model.test_request import TestRequest
 from test_project.model.test_response import TestResponse
 # Defining the host is optional and defaults to http://localhost
@@ -8041,6 +8046,7 @@ Class | Method | HTTP request | Description
 ## Documentation For Models
 
  - [ApiError](docs/models/ApiError.md)
+ - [MapResponse](docs/models/MapResponse.md)
  - [TestRequest](docs/models/TestRequest.md)
  - [TestResponse](docs/models/TestResponse.md)
 
@@ -8220,7 +8226,7 @@ No authorization required
 
 # **map_response**
 <a name="map_response"></a>
-> {str: (bool, date, datetime, dict, float, int, list, str, none_type)} map_response()
+> MapResponse map_response()
 
 
 
@@ -8229,6 +8235,7 @@ No authorization required
 \`\`\`python
 import test_project
 from test_project.apis.tags import default_api
+from test_project.model.map_response import MapResponse
 from pprint import pprint
 # Defining the host is optional and defaults to http://localhost
 # See configuration.py for a list of all supported configuration parameters.
@@ -8266,43 +8273,10 @@ body | typing.Union[SchemaFor200ResponseBodyApplicationJson, ] |  |
 headers | Unset | headers were not defined |
 
 # SchemaFor200ResponseBodyApplicationJson
+Type | Description  | Notes
+------------- | ------------- | -------------
+[**MapResponse**](../../models/MapResponse.md) |  | 
 
-## Model Type Info
-Input Type | Accessed Type | Description | Notes
------------- | ------------- | ------------- | -------------
-dict, frozendict.frozendict,  | frozendict.frozendict,  |  | 
-
-### Dictionary Keys
-Key | Input Type | Accessed Type | Description | Notes
------------- | ------------- | ------------- | ------------- | -------------
-**[mapProperty](#mapProperty)** | dict, frozendict.frozendict,  | frozendict.frozendict,  |  | 
-**any_string_name** | dict, frozendict.frozendict, str, date, datetime, int, float, bool, decimal.Decimal, None, list, tuple, bytes, io.FileIO, io.BufferedReader | frozendict.frozendict, str, BoolClass, decimal.Decimal, NoneClass, tuple, bytes, FileIO | any string name can be used but the value must be the correct type | [optional]
-
-# mapProperty
-
-## Model Type Info
-Input Type | Accessed Type | Description | Notes
------------- | ------------- | ------------- | -------------
-dict, frozendict.frozendict,  | frozendict.frozendict,  |  | 
-
-### Dictionary Keys
-Key | Input Type | Accessed Type | Description | Notes
------------- | ------------- | ------------- | ------------- | -------------
-**[any_string_name](#any_string_name)** | dict, frozendict.frozendict,  | frozendict.frozendict,  | any string name can be used but the value must be the correct type | [optional] 
-
-# any_string_name
-
-## Model Type Info
-Input Type | Accessed Type | Description | Notes
------------- | ------------- | ------------- | -------------
-dict, frozendict.frozendict,  | frozendict.frozendict,  |  | 
-
-### Dictionary Keys
-Key | Input Type | Accessed Type | Description | Notes
------------- | ------------- | ------------- | ------------- | -------------
-**a** | str,  | str,  |  | 
-**b** | str,  | str,  |  | [optional] 
-**any_string_name** | dict, frozendict.frozendict, str, date, datetime, int, float, bool, decimal.Decimal, None, list, tuple, bytes, io.FileIO, io.BufferedReader | frozendict.frozendict, str, BoolClass, decimal.Decimal, NoneClass, tuple, bytes, FileIO | any string name can be used but the value must be the correct type | [optional]
 
 ### Authorization
 
@@ -8745,6 +8719,48 @@ dict, frozendict.frozendict,  | frozendict.frozendict,  |  |
 Key | Input Type | Accessed Type | Description | Notes
 ------------ | ------------- | ------------- | ------------- | -------------
 **errorMessage** | str,  | str,  |  | 
+**any_string_name** | dict, frozendict.frozendict, str, date, datetime, int, float, bool, decimal.Decimal, None, list, tuple, bytes, io.FileIO, io.BufferedReader | frozendict.frozendict, str, BoolClass, decimal.Decimal, NoneClass, tuple, bytes, FileIO | any string name can be used but the value must be the correct type | [optional]
+
+[[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
+
+",
+  "docs/models/MapResponse.md": "# test_project.model.map_response.MapResponse
+
+## Model Type Info
+Input Type | Accessed Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+dict, frozendict.frozendict,  | frozendict.frozendict,  |  | 
+
+### Dictionary Keys
+Key | Input Type | Accessed Type | Description | Notes
+------------ | ------------- | ------------- | ------------- | -------------
+**[mapProperty](#mapProperty)** | dict, frozendict.frozendict,  | frozendict.frozendict,  |  | 
+**any_string_name** | dict, frozendict.frozendict, str, date, datetime, int, float, bool, decimal.Decimal, None, list, tuple, bytes, io.FileIO, io.BufferedReader | frozendict.frozendict, str, BoolClass, decimal.Decimal, NoneClass, tuple, bytes, FileIO | any string name can be used but the value must be the correct type | [optional]
+
+# mapProperty
+
+## Model Type Info
+Input Type | Accessed Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+dict, frozendict.frozendict,  | frozendict.frozendict,  |  | 
+
+### Dictionary Keys
+Key | Input Type | Accessed Type | Description | Notes
+------------ | ------------- | ------------- | ------------- | -------------
+**[any_string_name](#any_string_name)** | dict, frozendict.frozendict,  | frozendict.frozendict,  | any string name can be used but the value must be the correct type | [optional] 
+
+# any_string_name
+
+## Model Type Info
+Input Type | Accessed Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+dict, frozendict.frozendict,  | frozendict.frozendict,  |  | 
+
+### Dictionary Keys
+Key | Input Type | Accessed Type | Description | Notes
+------------ | ------------- | ------------- | ------------- | -------------
+**a** | str,  | str,  |  | 
+**b** | str,  | str,  |  | [optional] 
 **any_string_name** | dict, frozendict.frozendict, str, date, datetime, int, float, bool, decimal.Decimal, None, list, tuple, bytes, io.FileIO, io.BufferedReader | frozendict.frozendict, str, BoolClass, decimal.Decimal, NoneClass, tuple, bytes, FileIO | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../../README.md#documentation-for-models) [[Back to API list]](../../README.md#documentation-for-api-endpoints) [[Back to README]](../../README.md)
@@ -10515,6 +10531,7 @@ from functools import wraps
 from dataclasses import dataclass, fields
 
 from test_project.model.api_error import ApiError
+from test_project.model.map_response import MapResponse
 from test_project.model.test_request import TestRequest
 from test_project.model.test_response import TestResponse
 
@@ -10822,7 +10839,7 @@ class MapResponseRequestArrayParameters(TypedDict):
 # Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 MapResponseRequestBody = Any
 
-MapResponse200OperationResponse = ApiResponse[Literal[200], str]
+MapResponse200OperationResponse = ApiResponse[Literal[200], MapResponse]
 MapResponseOperationResponses = Union[MapResponse200OperationResponse, ]
 
 # Request type for map_response
@@ -10866,7 +10883,7 @@ def map_response_handler(_handler: MapResponseHandlerFunction = None, intercepto
             if response.body is None:
                 pass
             elif response.status_code == 200:
-                response_body = response.body
+                response_body = json.dumps(JSONEncoder().default(response.body))
 
             return {
                 'statusCode': response.status_code,
@@ -11956,6 +11973,358 @@ class ApiError(
             **kwargs,
         )
 ",
+  "test_project/model/map_response.py": "# coding: utf-8
+
+"""
+    Example API
+
+    No description provided (generated by Openapi Generator https://github.com/openapitools/openapi-generator)  # noqa: E501
+
+    The version of the OpenAPI document: 1.0.0
+    Generated by: https://openapi-generator.tech
+"""
+
+from datetime import date, datetime  # noqa: F401
+import decimal  # noqa: F401
+import functools  # noqa: F401
+import io  # noqa: F401
+import re  # noqa: F401
+import typing  # noqa: F401
+import typing_extensions  # noqa: F401
+import uuid  # noqa: F401
+
+import frozendict  # noqa: F401
+
+from test_project import schemas  # noqa: F401
+
+
+class MapResponse(
+    schemas.DictSchema
+):
+    """NOTE: This class is auto generated by OpenAPI Generator.
+    Ref: https://openapi-generator.tech
+
+    Do not edit the class manually.
+    """
+
+
+    class MetaOapg:
+        required = {
+            "mapProperty",
+        }
+        
+        class properties:
+            
+            
+            class mapProperty(
+                schemas.DictSchema
+            ):
+            
+            
+                class MetaOapg:
+                    
+                    
+                    class additional_properties(
+                        schemas.DictSchema
+                    ):
+                    
+                    
+                        class MetaOapg:
+                            required = {
+                                "a",
+                            }
+                            
+                            class properties:
+                                a = schemas.StrSchema
+                                b = schemas.StrSchema
+                                __annotations__ = {
+                                    "a": a,
+                                    "b": b,
+                                }
+                        
+                        a: MetaOapg.properties.a
+                        
+                        @typing.overload
+                        def __getitem__(self, name: typing_extensions.Literal["a"]) -> MetaOapg.properties.a: ...
+                        
+                        @typing.overload
+                        def __getitem__(self, name: typing_extensions.Literal["b"]) -> MetaOapg.properties.b: ...
+                        
+                        @typing.overload
+                        def __getitem__(self, name: str) -> schemas.UnsetAnyTypeSchema: ...
+                        
+                        def __getitem__(self, name: typing.Union[typing_extensions.Literal["a", "b", ], str]):
+                            # dict_instance[name] accessor
+                            return super().__getitem__(name)
+                        
+                        
+                        @typing.overload
+                        def get_item_oapg(self, name: typing_extensions.Literal["a"]) -> MetaOapg.properties.a: ...
+                        
+                        @typing.overload
+                        def get_item_oapg(self, name: typing_extensions.Literal["b"]) -> typing.Union[MetaOapg.properties.b, schemas.Unset]: ...
+                        
+                        @typing.overload
+                        def get_item_oapg(self, name: str) -> typing.Union[schemas.UnsetAnyTypeSchema, schemas.Unset]: ...
+                        
+                        def get_item_oapg(self, name: typing.Union[typing_extensions.Literal["a", "b", ], str]):
+                            return super().get_item_oapg(name)
+                        
+                    
+                        def __new__(
+                            cls,
+                            *_args: typing.Union[dict, frozendict.frozendict, ],
+                            a: typing.Union[MetaOapg.properties.a, str, ],
+                            b: typing.Union[MetaOapg.properties.b, str, schemas.Unset] = schemas.unset,
+                            _configuration: typing.Optional[schemas.Configuration] = None,
+                            **kwargs: typing.Union[schemas.AnyTypeSchema, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, None, list, tuple, bytes],
+                        ) -> 'additional_properties':
+                            return super().__new__(
+                                cls,
+                                *_args,
+                                a=a,
+                                b=b,
+                                _configuration=_configuration,
+                                **kwargs,
+                            )
+                
+                def __getitem__(self, name: typing.Union[str, ]) -> MetaOapg.additional_properties:
+                    # dict_instance[name] accessor
+                    return super().__getitem__(name)
+                
+                def get_item_oapg(self, name: typing.Union[str, ]) -> MetaOapg.additional_properties:
+                    return super().get_item_oapg(name)
+            
+                def __new__(
+                    cls,
+                    *_args: typing.Union[dict, frozendict.frozendict, ],
+                    _configuration: typing.Optional[schemas.Configuration] = None,
+                    **kwargs: typing.Union[MetaOapg.additional_properties, dict, frozendict.frozendict, ],
+                ) -> 'mapProperty':
+                    return super().__new__(
+                        cls,
+                        *_args,
+                        _configuration=_configuration,
+                        **kwargs,
+                    )
+            __annotations__ = {
+                "mapProperty": mapProperty,
+            }
+    
+    mapProperty: MetaOapg.properties.mapProperty
+    
+    @typing.overload
+    def __getitem__(self, name: typing_extensions.Literal["mapProperty"]) -> MetaOapg.properties.mapProperty: ...
+    
+    @typing.overload
+    def __getitem__(self, name: str) -> schemas.UnsetAnyTypeSchema: ...
+    
+    def __getitem__(self, name: typing.Union[typing_extensions.Literal["mapProperty", ], str]):
+        # dict_instance[name] accessor
+        return super().__getitem__(name)
+    
+    
+    @typing.overload
+    def get_item_oapg(self, name: typing_extensions.Literal["mapProperty"]) -> MetaOapg.properties.mapProperty: ...
+    
+    @typing.overload
+    def get_item_oapg(self, name: str) -> typing.Union[schemas.UnsetAnyTypeSchema, schemas.Unset]: ...
+    
+    def get_item_oapg(self, name: typing.Union[typing_extensions.Literal["mapProperty", ], str]):
+        return super().get_item_oapg(name)
+    
+
+    def __new__(
+        cls,
+        *_args: typing.Union[dict, frozendict.frozendict, ],
+        mapProperty: typing.Union[MetaOapg.properties.mapProperty, dict, frozendict.frozendict, ],
+        _configuration: typing.Optional[schemas.Configuration] = None,
+        **kwargs: typing.Union[schemas.AnyTypeSchema, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, None, list, tuple, bytes],
+    ) -> 'MapResponse':
+        return super().__new__(
+            cls,
+            *_args,
+            mapProperty=mapProperty,
+            _configuration=_configuration,
+            **kwargs,
+        )
+",
+  "test_project/model/map_response.pyi": "# coding: utf-8
+
+"""
+    Example API
+
+    No description provided (generated by Openapi Generator https://github.com/openapitools/openapi-generator)  # noqa: E501
+
+    The version of the OpenAPI document: 1.0.0
+    Generated by: https://openapi-generator.tech
+"""
+
+from datetime import date, datetime  # noqa: F401
+import decimal  # noqa: F401
+import functools  # noqa: F401
+import io  # noqa: F401
+import re  # noqa: F401
+import typing  # noqa: F401
+import typing_extensions  # noqa: F401
+import uuid  # noqa: F401
+
+import frozendict  # noqa: F401
+
+from test_project import schemas  # noqa: F401
+
+
+class MapResponse(
+    schemas.DictSchema
+):
+    """NOTE: This class is auto generated by OpenAPI Generator.
+    Ref: https://openapi-generator.tech
+
+    Do not edit the class manually.
+    """
+
+
+    class MetaOapg:
+        required = {
+            "mapProperty",
+        }
+        
+        class properties:
+            
+            
+            class mapProperty(
+                schemas.DictSchema
+            ):
+            
+            
+                class MetaOapg:
+                    
+                    
+                    class additional_properties(
+                        schemas.DictSchema
+                    ):
+                    
+                    
+                        class MetaOapg:
+                            required = {
+                                "a",
+                            }
+                            
+                            class properties:
+                                a = schemas.StrSchema
+                                b = schemas.StrSchema
+                                __annotations__ = {
+                                    "a": a,
+                                    "b": b,
+                                }
+                        
+                        a: MetaOapg.properties.a
+                        
+                        @typing.overload
+                        def __getitem__(self, name: typing_extensions.Literal["a"]) -> MetaOapg.properties.a: ...
+                        
+                        @typing.overload
+                        def __getitem__(self, name: typing_extensions.Literal["b"]) -> MetaOapg.properties.b: ...
+                        
+                        @typing.overload
+                        def __getitem__(self, name: str) -> schemas.UnsetAnyTypeSchema: ...
+                        
+                        def __getitem__(self, name: typing.Union[typing_extensions.Literal["a", "b", ], str]):
+                            # dict_instance[name] accessor
+                            return super().__getitem__(name)
+                        
+                        
+                        @typing.overload
+                        def get_item_oapg(self, name: typing_extensions.Literal["a"]) -> MetaOapg.properties.a: ...
+                        
+                        @typing.overload
+                        def get_item_oapg(self, name: typing_extensions.Literal["b"]) -> typing.Union[MetaOapg.properties.b, schemas.Unset]: ...
+                        
+                        @typing.overload
+                        def get_item_oapg(self, name: str) -> typing.Union[schemas.UnsetAnyTypeSchema, schemas.Unset]: ...
+                        
+                        def get_item_oapg(self, name: typing.Union[typing_extensions.Literal["a", "b", ], str]):
+                            return super().get_item_oapg(name)
+                        
+                    
+                        def __new__(
+                            cls,
+                            *_args: typing.Union[dict, frozendict.frozendict, ],
+                            a: typing.Union[MetaOapg.properties.a, str, ],
+                            b: typing.Union[MetaOapg.properties.b, str, schemas.Unset] = schemas.unset,
+                            _configuration: typing.Optional[schemas.Configuration] = None,
+                            **kwargs: typing.Union[schemas.AnyTypeSchema, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, None, list, tuple, bytes],
+                        ) -> 'additional_properties':
+                            return super().__new__(
+                                cls,
+                                *_args,
+                                a=a,
+                                b=b,
+                                _configuration=_configuration,
+                                **kwargs,
+                            )
+                
+                def __getitem__(self, name: typing.Union[str, ]) -> MetaOapg.additional_properties:
+                    # dict_instance[name] accessor
+                    return super().__getitem__(name)
+                
+                def get_item_oapg(self, name: typing.Union[str, ]) -> MetaOapg.additional_properties:
+                    return super().get_item_oapg(name)
+            
+                def __new__(
+                    cls,
+                    *_args: typing.Union[dict, frozendict.frozendict, ],
+                    _configuration: typing.Optional[schemas.Configuration] = None,
+                    **kwargs: typing.Union[MetaOapg.additional_properties, dict, frozendict.frozendict, ],
+                ) -> 'mapProperty':
+                    return super().__new__(
+                        cls,
+                        *_args,
+                        _configuration=_configuration,
+                        **kwargs,
+                    )
+            __annotations__ = {
+                "mapProperty": mapProperty,
+            }
+    
+    mapProperty: MetaOapg.properties.mapProperty
+    
+    @typing.overload
+    def __getitem__(self, name: typing_extensions.Literal["mapProperty"]) -> MetaOapg.properties.mapProperty: ...
+    
+    @typing.overload
+    def __getitem__(self, name: str) -> schemas.UnsetAnyTypeSchema: ...
+    
+    def __getitem__(self, name: typing.Union[typing_extensions.Literal["mapProperty", ], str]):
+        # dict_instance[name] accessor
+        return super().__getitem__(name)
+    
+    
+    @typing.overload
+    def get_item_oapg(self, name: typing_extensions.Literal["mapProperty"]) -> MetaOapg.properties.mapProperty: ...
+    
+    @typing.overload
+    def get_item_oapg(self, name: str) -> typing.Union[schemas.UnsetAnyTypeSchema, schemas.Unset]: ...
+    
+    def get_item_oapg(self, name: typing.Union[typing_extensions.Literal["mapProperty", ], str]):
+        return super().get_item_oapg(name)
+    
+
+    def __new__(
+        cls,
+        *_args: typing.Union[dict, frozendict.frozendict, ],
+        mapProperty: typing.Union[MetaOapg.properties.mapProperty, dict, frozendict.frozendict, ],
+        _configuration: typing.Optional[schemas.Configuration] = None,
+        **kwargs: typing.Union[schemas.AnyTypeSchema, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, None, list, tuple, bytes],
+    ) -> 'MapResponse':
+        return super().__new__(
+            cls,
+            *_args,
+            mapProperty=mapProperty,
+            _configuration=_configuration,
+            **kwargs,
+        )
+",
   "test_project/model/test_request.py": "# coding: utf-8
 
 """
@@ -12468,6 +12837,7 @@ class TestResponse(
 # sys.setrecursionlimit(n)
 
 from test_project.model.api_error import ApiError
+from test_project.model.map_response import MapResponse
 from test_project.model.test_request import TestRequest
 from test_project.model.test_response import TestResponse
 ",
@@ -14257,155 +14627,11 @@ import frozendict  # noqa: F401
 
 from test_project import schemas  # noqa: F401
 
+from test_project.model.map_response import MapResponse
+
 from . import path
 
-
-
-class SchemaFor200ResponseBodyApplicationJson(
-    schemas.DictSchema
-):
-
-
-    class MetaOapg:
-        required = {
-            "mapProperty",
-        }
-        
-        class properties:
-            
-            
-            class mapProperty(
-                schemas.DictSchema
-            ):
-            
-            
-                class MetaOapg:
-                    
-                    
-                    class additional_properties(
-                        schemas.DictSchema
-                    ):
-                    
-                    
-                        class MetaOapg:
-                            required = {
-                                "a",
-                            }
-                            
-                            class properties:
-                                a = schemas.StrSchema
-                                b = schemas.StrSchema
-                                __annotations__ = {
-                                    "a": a,
-                                    "b": b,
-                                }
-                        
-                        a: MetaOapg.properties.a
-                        
-                        @typing.overload
-                        def __getitem__(self, name: typing_extensions.Literal["a"]) -> MetaOapg.properties.a: ...
-                        
-                        @typing.overload
-                        def __getitem__(self, name: typing_extensions.Literal["b"]) -> MetaOapg.properties.b: ...
-                        
-                        @typing.overload
-                        def __getitem__(self, name: str) -> schemas.UnsetAnyTypeSchema: ...
-                        
-                        def __getitem__(self, name: typing.Union[typing_extensions.Literal["a", "b", ], str]):
-                            # dict_instance[name] accessor
-                            return super().__getitem__(name)
-                        
-                        
-                        @typing.overload
-                        def get_item_oapg(self, name: typing_extensions.Literal["a"]) -> MetaOapg.properties.a: ...
-                        
-                        @typing.overload
-                        def get_item_oapg(self, name: typing_extensions.Literal["b"]) -> typing.Union[MetaOapg.properties.b, schemas.Unset]: ...
-                        
-                        @typing.overload
-                        def get_item_oapg(self, name: str) -> typing.Union[schemas.UnsetAnyTypeSchema, schemas.Unset]: ...
-                        
-                        def get_item_oapg(self, name: typing.Union[typing_extensions.Literal["a", "b", ], str]):
-                            return super().get_item_oapg(name)
-                        
-                    
-                        def __new__(
-                            cls,
-                            *_args: typing.Union[dict, frozendict.frozendict, ],
-                            a: typing.Union[MetaOapg.properties.a, str, ],
-                            b: typing.Union[MetaOapg.properties.b, str, schemas.Unset] = schemas.unset,
-                            _configuration: typing.Optional[schemas.Configuration] = None,
-                            **kwargs: typing.Union[schemas.AnyTypeSchema, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, None, list, tuple, bytes],
-                        ) -> 'additional_properties':
-                            return super().__new__(
-                                cls,
-                                *_args,
-                                a=a,
-                                b=b,
-                                _configuration=_configuration,
-                                **kwargs,
-                            )
-                
-                def __getitem__(self, name: typing.Union[str, ]) -> MetaOapg.additional_properties:
-                    # dict_instance[name] accessor
-                    return super().__getitem__(name)
-                
-                def get_item_oapg(self, name: typing.Union[str, ]) -> MetaOapg.additional_properties:
-                    return super().get_item_oapg(name)
-            
-                def __new__(
-                    cls,
-                    *_args: typing.Union[dict, frozendict.frozendict, ],
-                    _configuration: typing.Optional[schemas.Configuration] = None,
-                    **kwargs: typing.Union[MetaOapg.additional_properties, dict, frozendict.frozendict, ],
-                ) -> 'mapProperty':
-                    return super().__new__(
-                        cls,
-                        *_args,
-                        _configuration=_configuration,
-                        **kwargs,
-                    )
-            __annotations__ = {
-                "mapProperty": mapProperty,
-            }
-    
-    mapProperty: MetaOapg.properties.mapProperty
-    
-    @typing.overload
-    def __getitem__(self, name: typing_extensions.Literal["mapProperty"]) -> MetaOapg.properties.mapProperty: ...
-    
-    @typing.overload
-    def __getitem__(self, name: str) -> schemas.UnsetAnyTypeSchema: ...
-    
-    def __getitem__(self, name: typing.Union[typing_extensions.Literal["mapProperty", ], str]):
-        # dict_instance[name] accessor
-        return super().__getitem__(name)
-    
-    
-    @typing.overload
-    def get_item_oapg(self, name: typing_extensions.Literal["mapProperty"]) -> MetaOapg.properties.mapProperty: ...
-    
-    @typing.overload
-    def get_item_oapg(self, name: str) -> typing.Union[schemas.UnsetAnyTypeSchema, schemas.Unset]: ...
-    
-    def get_item_oapg(self, name: typing.Union[typing_extensions.Literal["mapProperty", ], str]):
-        return super().get_item_oapg(name)
-    
-
-    def __new__(
-        cls,
-        *_args: typing.Union[dict, frozendict.frozendict, ],
-        mapProperty: typing.Union[MetaOapg.properties.mapProperty, dict, frozendict.frozendict, ],
-        _configuration: typing.Optional[schemas.Configuration] = None,
-        **kwargs: typing.Union[schemas.AnyTypeSchema, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, None, list, tuple, bytes],
-    ) -> 'SchemaFor200ResponseBodyApplicationJson':
-        return super().__new__(
-            cls,
-            *_args,
-            mapProperty=mapProperty,
-            _configuration=_configuration,
-            **kwargs,
-        )
+SchemaFor200ResponseBodyApplicationJson = MapResponse
 
 
 @dataclass
@@ -14640,153 +14866,9 @@ import frozendict  # noqa: F401
 
 from test_project import schemas  # noqa: F401
 
+from test_project.model.map_response import MapResponse
 
-
-class SchemaFor200ResponseBodyApplicationJson(
-    schemas.DictSchema
-):
-
-
-    class MetaOapg:
-        required = {
-            "mapProperty",
-        }
-        
-        class properties:
-            
-            
-            class mapProperty(
-                schemas.DictSchema
-            ):
-            
-            
-                class MetaOapg:
-                    
-                    
-                    class additional_properties(
-                        schemas.DictSchema
-                    ):
-                    
-                    
-                        class MetaOapg:
-                            required = {
-                                "a",
-                            }
-                            
-                            class properties:
-                                a = schemas.StrSchema
-                                b = schemas.StrSchema
-                                __annotations__ = {
-                                    "a": a,
-                                    "b": b,
-                                }
-                        
-                        a: MetaOapg.properties.a
-                        
-                        @typing.overload
-                        def __getitem__(self, name: typing_extensions.Literal["a"]) -> MetaOapg.properties.a: ...
-                        
-                        @typing.overload
-                        def __getitem__(self, name: typing_extensions.Literal["b"]) -> MetaOapg.properties.b: ...
-                        
-                        @typing.overload
-                        def __getitem__(self, name: str) -> schemas.UnsetAnyTypeSchema: ...
-                        
-                        def __getitem__(self, name: typing.Union[typing_extensions.Literal["a", "b", ], str]):
-                            # dict_instance[name] accessor
-                            return super().__getitem__(name)
-                        
-                        
-                        @typing.overload
-                        def get_item_oapg(self, name: typing_extensions.Literal["a"]) -> MetaOapg.properties.a: ...
-                        
-                        @typing.overload
-                        def get_item_oapg(self, name: typing_extensions.Literal["b"]) -> typing.Union[MetaOapg.properties.b, schemas.Unset]: ...
-                        
-                        @typing.overload
-                        def get_item_oapg(self, name: str) -> typing.Union[schemas.UnsetAnyTypeSchema, schemas.Unset]: ...
-                        
-                        def get_item_oapg(self, name: typing.Union[typing_extensions.Literal["a", "b", ], str]):
-                            return super().get_item_oapg(name)
-                        
-                    
-                        def __new__(
-                            cls,
-                            *_args: typing.Union[dict, frozendict.frozendict, ],
-                            a: typing.Union[MetaOapg.properties.a, str, ],
-                            b: typing.Union[MetaOapg.properties.b, str, schemas.Unset] = schemas.unset,
-                            _configuration: typing.Optional[schemas.Configuration] = None,
-                            **kwargs: typing.Union[schemas.AnyTypeSchema, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, None, list, tuple, bytes],
-                        ) -> 'additional_properties':
-                            return super().__new__(
-                                cls,
-                                *_args,
-                                a=a,
-                                b=b,
-                                _configuration=_configuration,
-                                **kwargs,
-                            )
-                
-                def __getitem__(self, name: typing.Union[str, ]) -> MetaOapg.additional_properties:
-                    # dict_instance[name] accessor
-                    return super().__getitem__(name)
-                
-                def get_item_oapg(self, name: typing.Union[str, ]) -> MetaOapg.additional_properties:
-                    return super().get_item_oapg(name)
-            
-                def __new__(
-                    cls,
-                    *_args: typing.Union[dict, frozendict.frozendict, ],
-                    _configuration: typing.Optional[schemas.Configuration] = None,
-                    **kwargs: typing.Union[MetaOapg.additional_properties, dict, frozendict.frozendict, ],
-                ) -> 'mapProperty':
-                    return super().__new__(
-                        cls,
-                        *_args,
-                        _configuration=_configuration,
-                        **kwargs,
-                    )
-            __annotations__ = {
-                "mapProperty": mapProperty,
-            }
-    
-    mapProperty: MetaOapg.properties.mapProperty
-    
-    @typing.overload
-    def __getitem__(self, name: typing_extensions.Literal["mapProperty"]) -> MetaOapg.properties.mapProperty: ...
-    
-    @typing.overload
-    def __getitem__(self, name: str) -> schemas.UnsetAnyTypeSchema: ...
-    
-    def __getitem__(self, name: typing.Union[typing_extensions.Literal["mapProperty", ], str]):
-        # dict_instance[name] accessor
-        return super().__getitem__(name)
-    
-    
-    @typing.overload
-    def get_item_oapg(self, name: typing_extensions.Literal["mapProperty"]) -> MetaOapg.properties.mapProperty: ...
-    
-    @typing.overload
-    def get_item_oapg(self, name: str) -> typing.Union[schemas.UnsetAnyTypeSchema, schemas.Unset]: ...
-    
-    def get_item_oapg(self, name: typing.Union[typing_extensions.Literal["mapProperty", ], str]):
-        return super().get_item_oapg(name)
-    
-
-    def __new__(
-        cls,
-        *_args: typing.Union[dict, frozendict.frozendict, ],
-        mapProperty: typing.Union[MetaOapg.properties.mapProperty, dict, frozendict.frozendict, ],
-        _configuration: typing.Optional[schemas.Configuration] = None,
-        **kwargs: typing.Union[schemas.AnyTypeSchema, dict, frozendict.frozendict, str, date, datetime, uuid.UUID, int, float, decimal.Decimal, None, list, tuple, bytes],
-    ) -> 'SchemaFor200ResponseBodyApplicationJson':
-        return super().__new__(
-            cls,
-            *_args,
-            mapProperty=mapProperty,
-            _configuration=_configuration,
-            **kwargs,
-        )
+SchemaFor200ResponseBodyApplicationJson = MapResponse
 
 
 @dataclass

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript-cdk-infrastructure.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript-cdk-infrastructure.test.ts.snap
@@ -33,10 +33,10 @@ exports[`Typescript Infrastructure Code Generation Script Unit Tests Generates W
 "import {
   ApiError,
   ApiErrorToJSON,
-  MapResponse200Response,
-  MapResponse200ResponseToJSON,
-  MapResponse200ResponseMapPropertyValue,
-  MapResponse200ResponseMapPropertyValueToJSON,
+  MapResponse,
+  MapResponseToJSON,
+  MapResponseMapPropertyValue,
+  MapResponseMapPropertyValueToJSON,
   TestRequest,
   TestRequestToJSON,
   TestResponse,
@@ -75,12 +75,12 @@ export class MockIntegrations {
    * Mock integration to return a 200 response from the mapResponse operation
    * Call this with no arguments to use a generated mock response
    */
-  public static mapResponse200(body?: MapResponse200Response): MockIntegration {
+  public static mapResponse200(body?: MapResponse): MockIntegration {
     return Integrations.mock({
       statusCode: 200,
       body: body === undefined
         ? fs.readFileSync(path.join(__dirname, "..", "mocks", \`get\${"/map-response".replace(/\\//g, "-")}-200.json\`), "utf-8")
-        : JSON.stringify(MapResponse200ResponseToJSON(body)),
+        : JSON.stringify(MapResponseToJSON(body)),
     });
   }
 

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript.test.ts.snap
@@ -1239,12 +1239,12 @@ src/index.ts
 src/models/ApiError.ts
 src/models/ApiError.ts
 src/models/ApiError.ts
-src/models/MapResponse200Response.ts
-src/models/MapResponse200Response.ts
-src/models/MapResponse200Response.ts
-src/models/MapResponse200ResponseMapPropertyValue.ts
-src/models/MapResponse200ResponseMapPropertyValue.ts
-src/models/MapResponse200ResponseMapPropertyValue.ts
+src/models/MapResponse.ts
+src/models/MapResponse.ts
+src/models/MapResponse.ts
+src/models/MapResponseMapPropertyValue.ts
+src/models/MapResponseMapPropertyValue.ts
+src/models/MapResponseMapPropertyValue.ts
 src/models/TestRequest.ts
 src/models/TestRequest.ts
 src/models/TestRequest.ts
@@ -1333,15 +1333,15 @@ npm install PATH_TO_GENERATED_PACKAGE --save
 import * as runtime from '../runtime';
 import type {
   ApiError,
-  MapResponse200Response,
+  MapResponse,
   TestRequest,
   TestResponse,
 } from '../models';
 import {
     ApiErrorFromJSON,
     ApiErrorToJSON,
-    MapResponse200ResponseFromJSON,
-    MapResponse200ResponseToJSON,
+    MapResponseFromJSON,
+    MapResponseToJSON,
     TestRequestFromJSON,
     TestRequestToJSON,
     TestResponseFromJSON,
@@ -1426,7 +1426,7 @@ export class DefaultApi extends runtime.BaseAPI {
 
     /**
      */
-    async mapResponseRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<MapResponse200Response>> {
+    async mapResponseRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<MapResponse>> {
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
@@ -1438,12 +1438,12 @@ export class DefaultApi extends runtime.BaseAPI {
             query: queryParameters,
         }, initOverrides);
 
-        return new runtime.JSONApiResponse(response, (jsonValue) => MapResponse200ResponseFromJSON(jsonValue));
+        return new runtime.JSONApiResponse(response, (jsonValue) => MapResponseFromJSON(jsonValue));
     }
 
     /**
      */
-    async mapResponse(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<MapResponse200Response> {
+    async mapResponse(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<MapResponse> {
         const response = await this.mapResponseRaw(initOverrides);
         return await response.value();
     }
@@ -1604,12 +1604,12 @@ import {
     ApiError,
     ApiErrorFromJSON,
     ApiErrorToJSON,
-    MapResponse200Response,
-    MapResponse200ResponseFromJSON,
-    MapResponse200ResponseToJSON,
-    MapResponse200ResponseMapPropertyValue,
-    MapResponse200ResponseMapPropertyValueFromJSON,
-    MapResponse200ResponseMapPropertyValueToJSON,
+    MapResponse,
+    MapResponseFromJSON,
+    MapResponseToJSON,
+    MapResponseMapPropertyValue,
+    MapResponseMapPropertyValueFromJSON,
+    MapResponseMapPropertyValueToJSON,
     TestRequest,
     TestRequestFromJSON,
     TestRequestToJSON,
@@ -1959,7 +1959,7 @@ export interface MapResponseRequestArrayParameters {
  */
 export type MapResponseRequestBody = never;
 
-export type MapResponse200OperationResponse = OperationResponse<200, MapResponse200Response>;
+export type MapResponse200OperationResponse = OperationResponse<200, MapResponse>;
 export type MapResponseOperationResponses = | MapResponse200OperationResponse ;
 
 // Type that the handler function provided to the wrapper must conform to
@@ -2003,7 +2003,7 @@ export const mapResponseHandler = (
         let marshalledBody = responseBody;
         switch(statusCode) {
             case 200:
-                marshalledBody = JSON.stringify(MapResponse200ResponseToJSON(marshalledBody));
+                marshalledBody = JSON.stringify(MapResponseToJSON(marshalledBody));
                 break;
             default:
                 break;
@@ -2460,7 +2460,7 @@ export function ApiErrorToJSON(value?: ApiError | null): any {
 }
 
 ",
-  "src/models/MapResponse200Response.ts": "/* tslint:disable */
+  "src/models/MapResponse.ts": "/* tslint:disable */
 /* eslint-disable */
 /**
  * Example API
@@ -2475,53 +2475,53 @@ export function ApiErrorToJSON(value?: ApiError | null): any {
  */
 
 import { exists, mapValues } from '../runtime';
-import type { MapResponse200ResponseMapPropertyValue } from './MapResponse200ResponseMapPropertyValue';
+import type { MapResponseMapPropertyValue } from './MapResponseMapPropertyValue';
 import {
-    MapResponse200ResponseMapPropertyValueFromJSON,
-    MapResponse200ResponseMapPropertyValueFromJSONTyped,
-    MapResponse200ResponseMapPropertyValueToJSON,
-} from './MapResponse200ResponseMapPropertyValue';
+    MapResponseMapPropertyValueFromJSON,
+    MapResponseMapPropertyValueFromJSONTyped,
+    MapResponseMapPropertyValueToJSON,
+} from './MapResponseMapPropertyValue';
 
 /**
  * 
  * @export
- * @interface MapResponse200Response
+ * @interface MapResponse
  */
-export interface MapResponse200Response {
+export interface MapResponse {
     /**
      * 
-     * @type {{ [key: string]: MapResponse200ResponseMapPropertyValue; }}
-     * @memberof MapResponse200Response
+     * @type {{ [key: string]: MapResponseMapPropertyValue; }}
+     * @memberof MapResponse
      */
-    mapProperty: { [key: string]: MapResponse200ResponseMapPropertyValue; };
+    mapProperty: { [key: string]: MapResponseMapPropertyValue; };
 }
 
 
 /**
- * Check if a given object implements the MapResponse200Response interface.
+ * Check if a given object implements the MapResponse interface.
  */
-export function instanceOfMapResponse200Response(value: object): boolean {
+export function instanceOfMapResponse(value: object): boolean {
     let isInstance = true;
     isInstance = isInstance && "mapProperty" in value;
 
     return isInstance;
 }
 
-export function MapResponse200ResponseFromJSON(json: any): MapResponse200Response {
-    return MapResponse200ResponseFromJSONTyped(json, false);
+export function MapResponseFromJSON(json: any): MapResponse {
+    return MapResponseFromJSONTyped(json, false);
 }
 
-export function MapResponse200ResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): MapResponse200Response {
+export function MapResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): MapResponse {
     if ((json === undefined) || (json === null)) {
         return json;
     }
     return {
         
-        'mapProperty': (mapValues(json['mapProperty'], MapResponse200ResponseMapPropertyValueFromJSON)),
+        'mapProperty': (mapValues(json['mapProperty'], MapResponseMapPropertyValueFromJSON)),
     };
 }
 
-export function MapResponse200ResponseToJSON(value?: MapResponse200Response | null): any {
+export function MapResponseToJSON(value?: MapResponse | null): any {
     if (value === undefined) {
         return undefined;
     }
@@ -2530,12 +2530,12 @@ export function MapResponse200ResponseToJSON(value?: MapResponse200Response | nu
     }
     return {
         
-        'mapProperty': (mapValues(value.mapProperty, MapResponse200ResponseMapPropertyValueToJSON)),
+        'mapProperty': (mapValues(value.mapProperty, MapResponseMapPropertyValueToJSON)),
     };
 }
 
 ",
-  "src/models/MapResponse200ResponseMapPropertyValue.ts": "/* tslint:disable */
+  "src/models/MapResponseMapPropertyValue.ts": "/* tslint:disable */
 /* eslint-disable */
 /**
  * Example API
@@ -2553,39 +2553,39 @@ import { exists, mapValues } from '../runtime';
 /**
  * 
  * @export
- * @interface MapResponse200ResponseMapPropertyValue
+ * @interface MapResponseMapPropertyValue
  */
-export interface MapResponse200ResponseMapPropertyValue {
+export interface MapResponseMapPropertyValue {
     /**
      * 
      * @type {string}
-     * @memberof MapResponse200ResponseMapPropertyValue
+     * @memberof MapResponseMapPropertyValue
      */
     a: string;
     /**
      * 
      * @type {string}
-     * @memberof MapResponse200ResponseMapPropertyValue
+     * @memberof MapResponseMapPropertyValue
      */
     b?: string;
 }
 
 
 /**
- * Check if a given object implements the MapResponse200ResponseMapPropertyValue interface.
+ * Check if a given object implements the MapResponseMapPropertyValue interface.
  */
-export function instanceOfMapResponse200ResponseMapPropertyValue(value: object): boolean {
+export function instanceOfMapResponseMapPropertyValue(value: object): boolean {
     let isInstance = true;
     isInstance = isInstance && "a" in value;
 
     return isInstance;
 }
 
-export function MapResponse200ResponseMapPropertyValueFromJSON(json: any): MapResponse200ResponseMapPropertyValue {
-    return MapResponse200ResponseMapPropertyValueFromJSONTyped(json, false);
+export function MapResponseMapPropertyValueFromJSON(json: any): MapResponseMapPropertyValue {
+    return MapResponseMapPropertyValueFromJSONTyped(json, false);
 }
 
-export function MapResponse200ResponseMapPropertyValueFromJSONTyped(json: any, ignoreDiscriminator: boolean): MapResponse200ResponseMapPropertyValue {
+export function MapResponseMapPropertyValueFromJSONTyped(json: any, ignoreDiscriminator: boolean): MapResponseMapPropertyValue {
     if ((json === undefined) || (json === null)) {
         return json;
     }
@@ -2596,7 +2596,7 @@ export function MapResponse200ResponseMapPropertyValueFromJSONTyped(json: any, i
     };
 }
 
-export function MapResponse200ResponseMapPropertyValueToJSON(value?: MapResponse200ResponseMapPropertyValue | null): any {
+export function MapResponseMapPropertyValueToJSON(value?: MapResponseMapPropertyValue | null): any {
     if (value === undefined) {
         return undefined;
     }
@@ -2832,8 +2832,8 @@ export function TestResponseMessagesInnerToJSON(value?: TestResponseMessagesInne
   "src/models/index.ts": "/* tslint:disable */
 /* eslint-disable */
 export * from './ApiError';
-export * from './MapResponse200Response';
-export * from './MapResponse200ResponseMapPropertyValue';
+export * from './MapResponse';
+export * from './MapResponseMapPropertyValue';
 export * from './TestRequest';
 export * from './TestResponse';
 export * from './TestResponseMessagesInner';


### PR DESCRIPTION
Some docs/test fixes:

* Add missing usage plan to api stage mapping for api keys in docs - you get a 403 if you miss this step
* Add note re python inline schemas in OpenAPI and update test schema to match
