### PR TITLE
fix(type-safe-api): fix documentation and ensure java resources dir exists

### DIFF
--- a/packages/type-safe-api/src/project/codegen/infrastructure/cdk/generated-java-cdk-infrastructure-project.ts
+++ b/packages/type-safe-api/src/project/codegen/infrastructure/cdk/generated-java-cdk-infrastructure-project.ts
@@ -133,6 +133,7 @@ export class GeneratedJavaCdkInfrastructureProject extends JavaProject {
       cwd: path.relative(this.outdir, generateInfraCommand.workingDir),
     });
     // Copy the parsed spec into the resources directory so that it's included in the jar
+    generateTask.exec("mkdir -p src/main/resources");
     generateTask.exec(`cp -f ${this.specPath} src/main/resources/.api.json`);
     generateTask.exec(mockDataCommand.command, {
       cwd: path.relative(this.outdir, mockDataCommand.workingDir),

--- a/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
@@ -893,6 +893,9 @@ src
             "exec": "./generate --generator java --spec-path ../../test/project/openapi-java/model/.api.json --output-path ../../test/project/openapi-java/infrastructure/java --generator-dir java-cdk-infrastructure --src-dir src/main/java/com/generated/api/openapijavajavainfra/infra --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-infrastructure-package":"com.generated.api.openapijavajavainfra.infra","x-runtime-package":"com.generated.api.openapijavajavaruntime.runtime"}'",
           },
           {
+            "exec": "mkdir -p src/main/resources",
+          },
+          {
             "exec": "cp -f ../../model/.api.json src/main/resources/.api.json",
           },
           {
@@ -4801,6 +4804,9 @@ src
           {
             "cwd": "../../../../../../../scripts/generators",
             "exec": "./generate --generator java --spec-path ../../test/project/monorepo-openapi-java/packages/api/model/.api.json --output-path ../../test/project/monorepo-openapi-java/packages/api/infrastructure/java --generator-dir java-cdk-infrastructure --src-dir src/main/java/com/generated/api/openapijavajavainfra/infra --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-infrastructure-package":"com.generated.api.openapijavajavainfra.infra","x-runtime-package":"com.generated.api.openapijavajavaruntime.runtime"}'",
+          },
+          {
+            "exec": "mkdir -p src/main/resources",
           },
           {
             "exec": "cp -f ../../model/.api.json src/main/resources/.api.json",
@@ -24756,6 +24762,9 @@ src
             "exec": "./generate --generator java --spec-path ../../test/project/smithy-java/model/.api.json --output-path ../../test/project/smithy-java/infrastructure/java --generator-dir java-cdk-infrastructure --src-dir src/main/java/com/generated/api/smithyjavajavainfra/infra --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-infrastructure-package":"com.generated.api.smithyjavajavainfra.infra","x-runtime-package":"com.generated.api.smithyjavajavaruntime.runtime"}'",
           },
           {
+            "exec": "mkdir -p src/main/resources",
+          },
+          {
             "exec": "cp -f ../../model/.api.json src/main/resources/.api.json",
           },
           {
@@ -28702,6 +28711,9 @@ src
           {
             "cwd": "../../../../../../../scripts/generators",
             "exec": "./generate --generator java --spec-path ../../test/project/monorepo-smithy-java/packages/api/model/.api.json --output-path ../../test/project/monorepo-smithy-java/packages/api/infrastructure/java --generator-dir java-cdk-infrastructure --src-dir src/main/java/com/generated/api/smithyjavajavainfra/infra --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-infrastructure-package":"com.generated.api.smithyjavajavainfra.infra","x-runtime-package":"com.generated.api.smithyjavajavaruntime.runtime"}'",
+          },
+          {
+            "exec": "mkdir -p src/main/resources",
           },
           {
             "exec": "cp -f ../../model/.api.json src/main/resources/.api.json",

--- a/packages/type-safe-api/test/project/codegen/infrastructure/cdk/__snapshots__/generated-java-cdk-infrastructure-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/codegen/infrastructure/cdk/__snapshots__/generated-java-cdk-infrastructure-project.test.ts.snap
@@ -332,6 +332,9 @@ src
             "exec": "./generate --generator java --spec-path ../../test/project/codegen/infrastructure/cdk/java-infra/my-spec.json --output-path ../../test/project/codegen/infrastructure/cdk/java-infra --generator-dir java-cdk-infrastructure --src-dir src/main/java/test/test-java-infra/infra --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-infrastructure-package":"test.test-java-infra.infra","x-runtime-package":"test.test-java-client.runtime"}'",
           },
           {
+            "exec": "mkdir -p src/main/resources",
+          },
+          {
             "exec": "cp -f my-spec.json src/main/resources/.api.json",
           },
           {


### PR DESCRIPTION

* fix(type-safe-api): ensure generated java infrastructure resources dir exists during first build
    
    Fixes an issue where `.api.json` couldn't be copied into the resources directory during first build
    since the directory didn't exist.

*  docs(type-safe-api): update java and python projenrc examples to use typescript
    
    Given that nx-monorepo currently only supports writing your .projenrc in TypeScript, we update the
    docs accordingly. The examples still show how to set up projects for writing CDK and lambdas in the
    respective languages.
    
    Fix #457
