### PR TITLE
feat(type-safe-api): include error header expected by smithy generated client in handler wrappers

### DIFF
--- a/packages/type-safe-api/scripts/generators/java/templates/handlers.mustache
+++ b/packages/type-safe-api/scripts/generators/java/templates/handlers.mustache
@@ -257,6 +257,11 @@ public class Handlers {
         private {{operationIdCamelCase}}{{code}}Response({{#dataType}}final {{#isPrimitiveType}}String{{/isPrimitiveType}}{{^isPrimitiveType}}{{.}}{{/isPrimitiveType}} body, {{/dataType}}final Map<String, String> headers) {
             this.body = {{#dataType}}{{#isPrimitiveType}}body{{/isPrimitiveType}}{{^isPrimitiveType}}body.toJson(){{/isPrimitiveType}}{{/dataType}}{{^dataType}}""{{/dataType}};
             this.headers = headers;
+            {{^is2xx}}
+            if ("{{dataType}}".endsWith("ResponseContent")) {
+                this.headers.put("x-amzn-errortype", "{{dataType}}".substring(0, "{{dataType}}".length() - "ResponseContent".length()));
+            }
+            {{/is2xx}}
         }
 
         @Override

--- a/packages/type-safe-api/scripts/generators/python/templates/operationConfig.mustache
+++ b/packages/type-safe-api/scripts/generators/python/templates/operationConfig.mustache
@@ -229,6 +229,7 @@ def {{operationId}}_handler(_handler: {{operationIdCamelCase}}HandlerFunction = 
                 interceptor_context,
             ), **kwargs)
 
+            response_headers = response.headers or {}
             response_body = ''
             if response.body is None:
                 pass
@@ -236,6 +237,10 @@ def {{operationId}}_handler(_handler: {{operationIdCamelCase}}HandlerFunction = 
             elif response.status_code == {{code}}:
                 {{^isPrimitiveType}}
                 response_body = json.dumps(JSONEncoder().default(response.body))
+                {{^is2xx}}
+                if "{{dataType}}".endswith("ResponseContent"):
+                    response_headers["x-amzn-errortype"] = "{{dataType}}"[:-len("ResponseContent")]
+                {{/is2xx}}
                 {{/isPrimitiveType}}
                 {{#isPrimitiveType}}
                 response_body = response.body
@@ -244,7 +249,7 @@ def {{operationId}}_handler(_handler: {{operationIdCamelCase}}HandlerFunction = 
 
             return {
                 'statusCode': response.status_code,
-                'headers': response.headers,
+                'headers': response_headers,
                 'body': response_body,
             }
         return wrapper

--- a/packages/type-safe-api/scripts/generators/typescript/templates/operationConfig.mustache
+++ b/packages/type-safe-api/scripts/generators/typescript/templates/operationConfig.mustache
@@ -270,8 +270,33 @@ export const {{nickname}}Handler = (
         return marshalledBody;
     };
 
+    const errorHeaders = (statusCode: number): { [key: string]: string } => {
+        let headers = {};
+
+        switch(statusCode) {
+        {{#responses}}
+        {{^is2xx}}
+            case {{code}}: {
+                if ("{{dataType}}".endsWith("ResponseContent")) {
+                    headers["x-amzn-errortype"] = "{{dataType}}".slice(0, -"ResponseContent".length);
+                }
+                break;
+            }
+        {{/is2xx}}
+        {{/responses}}
+            default:
+                break;
+        }
+
+        return headers;
+    };
+
     return {
         ...response,
+        headers: {
+          ...errorHeaders(response.statusCode),
+          ...response.headers,
+        },
         body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/java.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/java.test.ts.snap
@@ -12172,6 +12172,9 @@ public class Handlers {
         private OperationOne400Response(final ApiError body, final Map<String, String> headers) {
             this.body = body.toJson();
             this.headers = headers;
+            if ("ApiError".endsWith("ResponseContent")) {
+                this.headers.put("x-amzn-errortype", "ApiError".substring(0, "ApiError".length() - "ResponseContent".length()));
+            }
         }
 
         @Override

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
@@ -2419,6 +2419,7 @@ def neither_handler(_handler: NeitherHandlerFunction = None, interceptors: List[
                 interceptor_context,
             ), **kwargs)
 
+            response_headers = response.headers or {}
             response_body = ''
             if response.body is None:
                 pass
@@ -2427,7 +2428,7 @@ def neither_handler(_handler: NeitherHandlerFunction = None, interceptors: List[
 
             return {
                 'statusCode': response.status_code,
-                'headers': response.headers,
+                'headers': response_headers,
                 'body': response_body,
             }
         return wrapper
@@ -2491,6 +2492,7 @@ def both_handler(_handler: BothHandlerFunction = None, interceptors: List[BothIn
                 interceptor_context,
             ), **kwargs)
 
+            response_headers = response.headers or {}
             response_body = ''
             if response.body is None:
                 pass
@@ -2499,7 +2501,7 @@ def both_handler(_handler: BothHandlerFunction = None, interceptors: List[BothIn
 
             return {
                 'statusCode': response.status_code,
-                'headers': response.headers,
+                'headers': response_headers,
                 'body': response_body,
             }
         return wrapper
@@ -2563,6 +2565,7 @@ def tag1_handler(_handler: Tag1HandlerFunction = None, interceptors: List[Tag1In
                 interceptor_context,
             ), **kwargs)
 
+            response_headers = response.headers or {}
             response_body = ''
             if response.body is None:
                 pass
@@ -2571,7 +2574,7 @@ def tag1_handler(_handler: Tag1HandlerFunction = None, interceptors: List[Tag1In
 
             return {
                 'statusCode': response.status_code,
-                'headers': response.headers,
+                'headers': response_headers,
                 'body': response_body,
             }
         return wrapper
@@ -2635,6 +2638,7 @@ def tag2_handler(_handler: Tag2HandlerFunction = None, interceptors: List[Tag2In
                 interceptor_context,
             ), **kwargs)
 
+            response_headers = response.headers or {}
             response_body = ''
             if response.body is None:
                 pass
@@ -2643,7 +2647,7 @@ def tag2_handler(_handler: Tag2HandlerFunction = None, interceptors: List[Tag2In
 
             return {
                 'statusCode': response.status_code,
-                'headers': response.headers,
+                'headers': response_headers,
                 'body': response_body,
             }
         return wrapper
@@ -10735,6 +10739,7 @@ def any_request_response_handler(_handler: AnyRequestResponseHandlerFunction = N
                 interceptor_context,
             ), **kwargs)
 
+            response_headers = response.headers or {}
             response_body = ''
             if response.body is None:
                 pass
@@ -10743,7 +10748,7 @@ def any_request_response_handler(_handler: AnyRequestResponseHandlerFunction = N
 
             return {
                 'statusCode': response.status_code,
-                'headers': response.headers,
+                'headers': response_headers,
                 'body': response_body,
             }
         return wrapper
@@ -10807,6 +10812,7 @@ def empty_handler(_handler: EmptyHandlerFunction = None, interceptors: List[Empt
                 interceptor_context,
             ), **kwargs)
 
+            response_headers = response.headers or {}
             response_body = ''
             if response.body is None:
                 pass
@@ -10815,7 +10821,7 @@ def empty_handler(_handler: EmptyHandlerFunction = None, interceptors: List[Empt
 
             return {
                 'statusCode': response.status_code,
-                'headers': response.headers,
+                'headers': response_headers,
                 'body': response_body,
             }
         return wrapper
@@ -10879,6 +10885,7 @@ def map_response_handler(_handler: MapResponseHandlerFunction = None, intercepto
                 interceptor_context,
             ), **kwargs)
 
+            response_headers = response.headers or {}
             response_body = ''
             if response.body is None:
                 pass
@@ -10887,7 +10894,7 @@ def map_response_handler(_handler: MapResponseHandlerFunction = None, intercepto
 
             return {
                 'statusCode': response.status_code,
-                'headers': response.headers,
+                'headers': response_headers,
                 'body': response_body,
             }
         return wrapper
@@ -10952,6 +10959,7 @@ def media_types_handler(_handler: MediaTypesHandlerFunction = None, interceptors
                 interceptor_context,
             ), **kwargs)
 
+            response_headers = response.headers or {}
             response_body = ''
             if response.body is None:
                 pass
@@ -10960,7 +10968,7 @@ def media_types_handler(_handler: MediaTypesHandlerFunction = None, interceptors
 
             return {
                 'statusCode': response.status_code,
-                'headers': response.headers,
+                'headers': response_headers,
                 'body': response_body,
             }
         return wrapper
@@ -11025,6 +11033,7 @@ def multiple_content_types_handler(_handler: MultipleContentTypesHandlerFunction
                 interceptor_context,
             ), **kwargs)
 
+            response_headers = response.headers or {}
             response_body = ''
             if response.body is None:
                 pass
@@ -11033,7 +11042,7 @@ def multiple_content_types_handler(_handler: MultipleContentTypesHandlerFunction
 
             return {
                 'statusCode': response.status_code,
-                'headers': response.headers,
+                'headers': response_headers,
                 'body': response_body,
             }
         return wrapper
@@ -11104,6 +11113,7 @@ def operation_one_handler(_handler: OperationOneHandlerFunction = None, intercep
                 interceptor_context,
             ), **kwargs)
 
+            response_headers = response.headers or {}
             response_body = ''
             if response.body is None:
                 pass
@@ -11111,10 +11121,12 @@ def operation_one_handler(_handler: OperationOneHandlerFunction = None, intercep
                 response_body = json.dumps(JSONEncoder().default(response.body))
             elif response.status_code == 400:
                 response_body = json.dumps(JSONEncoder().default(response.body))
+                if "ApiError".endswith("ResponseContent"):
+                    response_headers["x-amzn-errortype"] = "ApiError"[:-len("ResponseContent")]
 
             return {
                 'statusCode': response.status_code,
-                'headers': response.headers,
+                'headers': response_headers,
                 'body': response_body,
             }
         return wrapper
@@ -11178,6 +11190,7 @@ def without_operation_id_delete_handler(_handler: WithoutOperationIdDeleteHandle
                 interceptor_context,
             ), **kwargs)
 
+            response_headers = response.headers or {}
             response_body = ''
             if response.body is None:
                 pass
@@ -11186,7 +11199,7 @@ def without_operation_id_delete_handler(_handler: WithoutOperationIdDeleteHandle
 
             return {
                 'statusCode': response.status_code,
-                'headers': response.headers,
+                'headers': response_headers,
                 'body': response_body,
             }
         return wrapper

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript.test.ts.snap
@@ -374,8 +374,23 @@ export const neitherHandler = (
         return marshalledBody;
     };
 
+    const errorHeaders = (statusCode: number): { [key: string]: string } => {
+        let headers = {};
+
+        switch(statusCode) {
+            default:
+                break;
+        }
+
+        return headers;
+    };
+
     return {
         ...response,
+        headers: {
+          ...errorHeaders(response.statusCode),
+          ...response.headers,
+        },
         body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
@@ -448,8 +463,23 @@ export const bothHandler = (
         return marshalledBody;
     };
 
+    const errorHeaders = (statusCode: number): { [key: string]: string } => {
+        let headers = {};
+
+        switch(statusCode) {
+            default:
+                break;
+        }
+
+        return headers;
+    };
+
     return {
         ...response,
+        headers: {
+          ...errorHeaders(response.statusCode),
+          ...response.headers,
+        },
         body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
@@ -522,8 +552,23 @@ export const tag1Handler = (
         return marshalledBody;
     };
 
+    const errorHeaders = (statusCode: number): { [key: string]: string } => {
+        let headers = {};
+
+        switch(statusCode) {
+            default:
+                break;
+        }
+
+        return headers;
+    };
+
     return {
         ...response,
+        headers: {
+          ...errorHeaders(response.statusCode),
+          ...response.headers,
+        },
         body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
@@ -596,8 +641,23 @@ export const tag2Handler = (
         return marshalledBody;
     };
 
+    const errorHeaders = (statusCode: number): { [key: string]: string } => {
+        let headers = {};
+
+        switch(statusCode) {
+            default:
+                break;
+        }
+
+        return headers;
+    };
+
     return {
         ...response,
+        headers: {
+          ...errorHeaders(response.statusCode),
+          ...response.headers,
+        },
         body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
@@ -1863,8 +1923,23 @@ export const anyRequestResponseHandler = (
         return marshalledBody;
     };
 
+    const errorHeaders = (statusCode: number): { [key: string]: string } => {
+        let headers = {};
+
+        switch(statusCode) {
+            default:
+                break;
+        }
+
+        return headers;
+    };
+
     return {
         ...response,
+        headers: {
+          ...errorHeaders(response.statusCode),
+          ...response.headers,
+        },
         body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
@@ -1937,8 +2012,23 @@ export const emptyHandler = (
         return marshalledBody;
     };
 
+    const errorHeaders = (statusCode: number): { [key: string]: string } => {
+        let headers = {};
+
+        switch(statusCode) {
+            default:
+                break;
+        }
+
+        return headers;
+    };
+
     return {
         ...response,
+        headers: {
+          ...errorHeaders(response.statusCode),
+          ...response.headers,
+        },
         body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
@@ -2012,8 +2102,23 @@ export const mapResponseHandler = (
         return marshalledBody;
     };
 
+    const errorHeaders = (statusCode: number): { [key: string]: string } => {
+        let headers = {};
+
+        switch(statusCode) {
+            default:
+                break;
+        }
+
+        return headers;
+    };
+
     return {
         ...response,
+        headers: {
+          ...errorHeaders(response.statusCode),
+          ...response.headers,
+        },
         body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
@@ -2086,8 +2191,23 @@ export const mediaTypesHandler = (
         return marshalledBody;
     };
 
+    const errorHeaders = (statusCode: number): { [key: string]: string } => {
+        let headers = {};
+
+        switch(statusCode) {
+            default:
+                break;
+        }
+
+        return headers;
+    };
+
     return {
         ...response,
+        headers: {
+          ...errorHeaders(response.statusCode),
+          ...response.headers,
+        },
         body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
@@ -2160,8 +2280,23 @@ export const multipleContentTypesHandler = (
         return marshalledBody;
     };
 
+    const errorHeaders = (statusCode: number): { [key: string]: string } => {
+        let headers = {};
+
+        switch(statusCode) {
+            default:
+                break;
+        }
+
+        return headers;
+    };
+
     return {
         ...response,
+        headers: {
+          ...errorHeaders(response.statusCode),
+          ...response.headers,
+        },
         body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
@@ -2244,8 +2379,29 @@ export const operationOneHandler = (
         return marshalledBody;
     };
 
+    const errorHeaders = (statusCode: number): { [key: string]: string } => {
+        let headers = {};
+
+        switch(statusCode) {
+            case 400: {
+                if ("ApiError".endsWith("ResponseContent")) {
+                    headers["x-amzn-errortype"] = "ApiError".slice(0, -"ResponseContent".length);
+                }
+                break;
+            }
+            default:
+                break;
+        }
+
+        return headers;
+    };
+
     return {
         ...response,
+        headers: {
+          ...errorHeaders(response.statusCode),
+          ...response.headers,
+        },
         body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };
@@ -2319,8 +2475,23 @@ export const withoutOperationIdDeleteHandler = (
         return marshalledBody;
     };
 
+    const errorHeaders = (statusCode: number): { [key: string]: string } => {
+        let headers = {};
+
+        switch(statusCode) {
+            default:
+                break;
+        }
+
+        return headers;
+    };
+
     return {
         ...response,
+        headers: {
+          ...errorHeaders(response.statusCode),
+          ...response.headers,
+        },
         body: response.body ? marshal(response.statusCode, response.body) : '',
     };
 };


### PR DESCRIPTION
Clients generated directly from Smithy (using the [`typescript-codegen` plugin](https://smithy.io/2.0/guides/using-code-generation/generating-a-client.html)) can deserialise error responses into the appropriate generated model classes, but they do this by checking for a special `x-amzn-errortype` header.

This change updates the generated handler wrappers to include the appropriate value for this header for error responses. Note that OpenAPI specs generated from Smithy [add "ResponseContent" as a suffix to all response data types](https://github.com/awslabs/smithy/blob/32b70c7066685340c0985e75bcb2428d3fb37f37/smithy-openapi/src/main/java/software/amazon/smithy/openapi/fromsmithy/protocols/AbstractRestProtocol.java#L808), so we remove this in order to match the appropriate error structure ID. If the response data type doesn't end with ResponseContent, it didn't come from Smithy so there's no need to return this header anyway.

re #460
