### PR TITLE
feat(type-safe-api): match default smithy modelled 400 error with api gateway validator error

### DIFF
--- a/packages/type-safe-api/src/project/model/smithy/smithy-definition.ts
+++ b/packages/type-safe-api/src/project/model/smithy/smithy-definition.ts
@@ -156,7 +156,7 @@ string ErrorMessage
 structure InternalFailureError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error at the fault of the client sending invalid input
@@ -165,7 +165,7 @@ structure InternalFailureError {
 structure BadRequestError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client attempting to access a missing resource
@@ -174,7 +174,7 @@ structure BadRequestError {
 structure NotFoundError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client not being authorized to access the resource
@@ -183,7 +183,7 @@ structure NotFoundError {
 structure NotAuthorizedError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 `,
       },

--- a/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
@@ -23266,7 +23266,7 @@ string ErrorMessage
 structure InternalFailureError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error at the fault of the client sending invalid input
@@ -23275,7 +23275,7 @@ structure InternalFailureError {
 structure BadRequestError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client attempting to access a missing resource
@@ -23284,7 +23284,7 @@ structure BadRequestError {
 structure NotFoundError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client not being authorized to access the resource
@@ -23293,7 +23293,7 @@ structure NotFoundError {
 structure NotAuthorizedError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 ",
   "runtime/README.md": "## Generated Runtimes
@@ -25229,7 +25229,7 @@ string ErrorMessage
 structure InternalFailureError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error at the fault of the client sending invalid input
@@ -25238,7 +25238,7 @@ structure InternalFailureError {
 structure BadRequestError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client attempting to access a missing resource
@@ -25247,7 +25247,7 @@ structure BadRequestError {
 structure NotFoundError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client not being authorized to access the resource
@@ -25256,7 +25256,7 @@ structure NotFoundError {
 structure NotAuthorizedError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 ",
   "runtime/README.md": "## Generated Runtimes
@@ -29323,7 +29323,7 @@ string ErrorMessage
 structure InternalFailureError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error at the fault of the client sending invalid input
@@ -29332,7 +29332,7 @@ structure InternalFailureError {
 structure BadRequestError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client attempting to access a missing resource
@@ -29341,7 +29341,7 @@ structure BadRequestError {
 structure NotFoundError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client not being authorized to access the resource
@@ -29350,7 +29350,7 @@ structure NotFoundError {
 structure NotAuthorizedError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 ",
   "packages/api/project.json": {
@@ -32647,7 +32647,7 @@ string ErrorMessage
 structure InternalFailureError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error at the fault of the client sending invalid input
@@ -32656,7 +32656,7 @@ structure InternalFailureError {
 structure BadRequestError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client attempting to access a missing resource
@@ -32665,7 +32665,7 @@ structure BadRequestError {
 structure NotFoundError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client not being authorized to access the resource
@@ -32674,7 +32674,7 @@ structure NotFoundError {
 structure NotAuthorizedError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 ",
   "runtime/README.md": "## Generated Runtimes
@@ -36081,7 +36081,7 @@ string ErrorMessage
 structure InternalFailureError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error at the fault of the client sending invalid input
@@ -36090,7 +36090,7 @@ structure InternalFailureError {
 structure BadRequestError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client attempting to access a missing resource
@@ -36099,7 +36099,7 @@ structure BadRequestError {
 structure NotFoundError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client not being authorized to access the resource
@@ -36108,7 +36108,7 @@ structure NotFoundError {
 structure NotAuthorizedError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 ",
   "packages/api/project.json": {
@@ -38423,7 +38423,7 @@ string ErrorMessage
 structure InternalFailureError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error at the fault of the client sending invalid input
@@ -38432,7 +38432,7 @@ structure InternalFailureError {
 structure BadRequestError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client attempting to access a missing resource
@@ -38441,7 +38441,7 @@ structure BadRequestError {
 structure NotFoundError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client not being authorized to access the resource
@@ -38450,7 +38450,7 @@ structure NotFoundError {
 structure NotAuthorizedError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 ",
   "runtime/README.md": "## Generated Runtimes
@@ -41868,7 +41868,7 @@ string ErrorMessage
 structure InternalFailureError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error at the fault of the client sending invalid input
@@ -41877,7 +41877,7 @@ structure InternalFailureError {
 structure BadRequestError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client attempting to access a missing resource
@@ -41886,7 +41886,7 @@ structure BadRequestError {
 structure NotFoundError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client not being authorized to access the resource
@@ -41895,7 +41895,7 @@ structure NotFoundError {
 structure NotAuthorizedError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 ",
   "packages/api/project.json": {
@@ -43927,7 +43927,7 @@ string ErrorMessage
 structure InternalFailureError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error at the fault of the client sending invalid input
@@ -43936,7 +43936,7 @@ structure InternalFailureError {
 structure BadRequestError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client attempting to access a missing resource
@@ -43945,7 +43945,7 @@ structure BadRequestError {
 structure NotFoundError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client not being authorized to access the resource
@@ -43954,7 +43954,7 @@ structure NotFoundError {
 structure NotAuthorizedError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 ",
   "runtime/README.md": "## Generated Runtimes
@@ -47920,7 +47920,7 @@ string ErrorMessage
 structure InternalFailureError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error at the fault of the client sending invalid input
@@ -47929,7 +47929,7 @@ structure InternalFailureError {
 structure BadRequestError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client attempting to access a missing resource
@@ -47938,7 +47938,7 @@ structure BadRequestError {
 structure NotFoundError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client not being authorized to access the resource
@@ -47947,7 +47947,7 @@ structure NotFoundError {
 structure NotAuthorizedError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 ",
   "packages/api/project.json": {
@@ -51252,7 +51252,7 @@ string ErrorMessage
 structure InternalFailureError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error at the fault of the client sending invalid input
@@ -51261,7 +51261,7 @@ structure InternalFailureError {
 structure BadRequestError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client attempting to access a missing resource
@@ -51270,7 +51270,7 @@ structure BadRequestError {
 structure NotFoundError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client not being authorized to access the resource
@@ -51279,7 +51279,7 @@ structure NotFoundError {
 structure NotAuthorizedError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 ",
   "runtime/README.md": "## Generated Runtimes
@@ -55535,7 +55535,7 @@ string ErrorMessage
 structure InternalFailureError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error at the fault of the client sending invalid input
@@ -55544,7 +55544,7 @@ structure InternalFailureError {
 structure BadRequestError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client attempting to access a missing resource
@@ -55553,7 +55553,7 @@ structure BadRequestError {
 structure NotFoundError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client not being authorized to access the resource
@@ -55562,7 +55562,7 @@ structure NotFoundError {
 structure NotAuthorizedError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 ",
   "packages/api/project.json": {
@@ -58859,7 +58859,7 @@ string ErrorMessage
 structure InternalFailureError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error at the fault of the client sending invalid input
@@ -58868,7 +58868,7 @@ structure InternalFailureError {
 structure BadRequestError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client attempting to access a missing resource
@@ -58877,7 +58877,7 @@ structure BadRequestError {
 structure NotFoundError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client not being authorized to access the resource
@@ -58886,7 +58886,7 @@ structure NotFoundError {
 structure NotAuthorizedError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 ",
   "runtime/README.md": "## Generated Runtimes
@@ -62294,7 +62294,7 @@ string ErrorMessage
 structure InternalFailureError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error at the fault of the client sending invalid input
@@ -62303,7 +62303,7 @@ structure InternalFailureError {
 structure BadRequestError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client attempting to access a missing resource
@@ -62312,7 +62312,7 @@ structure BadRequestError {
 structure NotFoundError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client not being authorized to access the resource
@@ -62321,7 +62321,7 @@ structure NotFoundError {
 structure NotAuthorizedError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 ",
   "packages/api/project.json": {
@@ -64631,7 +64631,7 @@ string ErrorMessage
 structure InternalFailureError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error at the fault of the client sending invalid input
@@ -64640,7 +64640,7 @@ structure InternalFailureError {
 structure BadRequestError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client attempting to access a missing resource
@@ -64649,7 +64649,7 @@ structure BadRequestError {
 structure NotFoundError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client not being authorized to access the resource
@@ -64658,7 +64658,7 @@ structure NotFoundError {
 structure NotAuthorizedError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 ",
   "runtime/README.md": "## Generated Runtimes
@@ -68070,7 +68070,7 @@ string ErrorMessage
 structure InternalFailureError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error at the fault of the client sending invalid input
@@ -68079,7 +68079,7 @@ structure InternalFailureError {
 structure BadRequestError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client attempting to access a missing resource
@@ -68088,7 +68088,7 @@ structure BadRequestError {
 structure NotFoundError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client not being authorized to access the resource
@@ -68097,7 +68097,7 @@ structure NotFoundError {
 structure NotAuthorizedError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 ",
   "packages/api/project.json": {

--- a/packages/type-safe-api/test/project/model/__snapshots__/type-safe-api-model-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/model/__snapshots__/type-safe-api-model-project.test.ts.snap
@@ -622,7 +622,7 @@ string ErrorMessage
 structure InternalFailureError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error at the fault of the client sending invalid input
@@ -631,7 +631,7 @@ structure InternalFailureError {
 structure BadRequestError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client attempting to access a missing resource
@@ -640,7 +640,7 @@ structure BadRequestError {
 structure NotFoundError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client not being authorized to access the resource
@@ -649,7 +649,7 @@ structure NotFoundError {
 structure NotAuthorizedError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 ",
 }
@@ -989,7 +989,7 @@ string ErrorMessage
 structure InternalFailureError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error at the fault of the client sending invalid input
@@ -998,7 +998,7 @@ structure InternalFailureError {
 structure BadRequestError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client attempting to access a missing resource
@@ -1007,7 +1007,7 @@ structure BadRequestError {
 structure NotFoundError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client not being authorized to access the resource
@@ -1016,7 +1016,7 @@ structure NotFoundError {
 structure NotAuthorizedError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 ",
 }
@@ -1351,7 +1351,7 @@ string ErrorMessage
 structure InternalFailureError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error at the fault of the client sending invalid input
@@ -1360,7 +1360,7 @@ structure InternalFailureError {
 structure BadRequestError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client attempting to access a missing resource
@@ -1369,7 +1369,7 @@ structure BadRequestError {
 structure NotFoundError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 
 /// An error due to the client not being authorized to access the resource
@@ -1378,7 +1378,7 @@ structure NotFoundError {
 structure NotAuthorizedError {
     /// Message with details about the error
     @required
-    errorMessage: ErrorMessage
+    message: ErrorMessage
 }
 ",
 }


### PR DESCRIPTION
The API Gateway validator is configured to return a 400 for a validation error with a "message" property.

See: https://github.com/aws/aws-prototyping-sdk/blob/01c766a268b5076210e540bb96f56b64f937fd04/packages/type-safe-api/src/construct/prepare-spec-event-handler/prepare-spec.ts#L514-L518

Update the error structures so that they align with this pattern such that it's easier to handle API gateway validation errors in clients too
