### PR TITLE
chore(type-safe-api): more verbose scripts by default

### DIFF
--- a/packages/type-safe-api/scripts/common/common.sh
+++ b/packages/type-safe-api/scripts/common/common.sh
@@ -3,12 +3,9 @@
 set -e
 
 ##
-# log debug messages if TYPE_SAFE_API_DEBUG env var set to 1
-# this is a helper function for debugging our scripts
+# log messages
 log() {
-  if [ "$TYPE_SAFE_API_DEBUG" == 1 ]; then
-    echo "$@"
-  fi
+  echo "$@"
 }
 
 # Determine which package manager we're using
@@ -30,17 +27,9 @@ install_packages() {
   log "installing packages :: $@"
 
   if [ "$pkg_manager" == "pnpm" ]; then
-    reporter=silent
-    if [ "$TYPE_SAFE_API_DEBUG" == 1 ]; then
-      reporter=default
-    fi
-    $pkg_manager install --reporter=$reporter "$@"
+    $pkg_manager install --reporter=default "$@"
   else
-    silent_switch="--silent"
-    if [ "$TYPE_SAFE_API_DEBUG" == 1 ]; then
-      silent_switch=""
-    fi
-    $pkg_manager install $silent_switch "$@"
+    $pkg_manager install "$@"
   fi
 }
 
@@ -57,9 +46,5 @@ run_command() {
 
   log "running command $runner $cmd"
 
-  if [ "$TYPE_SAFE_API_DEBUG" == 1 ]; then
-    $runner $cmd
-  else
-    $runner $cmd >/dev/null 2>&1
-  fi
+  $runner $cmd
 }

--- a/packages/type-safe-api/test/scripts/custom/mock-data/generate-mock-data.test.ts
+++ b/packages/type-safe-api/test/scripts/custom/mock-data/generate-mock-data.test.ts
@@ -11,7 +11,7 @@ describe("Generate Mock Data Unit Tests", () => {
       withTmpDirSnapshot(os.tmpdir(), (tmpDir) => {
         const specPath = "../../../resources/specs/single.yaml";
         const outputPath = path.relative(path.resolve(__dirname), tmpDir);
-        const command = `TYPE_SAFE_API_DEBUG=1 ../../../../scripts/custom/mock-data/generate-mock-data --spec-path ${specPath} --output-path ${outputPath}`;
+        const command = `../../../../scripts/custom/mock-data/generate-mock-data --spec-path ${specPath} --output-path ${outputPath}`;
         exec(command, {
           cwd: path.resolve(__dirname),
         });

--- a/packages/type-safe-api/test/scripts/generators/docs.test.ts
+++ b/packages/type-safe-api/test/scripts/generators/docs.test.ts
@@ -34,7 +34,7 @@ describe("Docs Generation Script Unit Tests", () => {
             new Project({ name: "test-project", outdir })
           ).synthesize();
           exec(
-            `TYPE_SAFE_API_DEBUG=1 ${path.resolve(
+            `${path.resolve(
               __dirname,
               "../../../scripts/generators/generate"
             )} ${buildInvokeOpenApiGeneratorCommandArgs({

--- a/packages/type-safe-api/test/scripts/generators/java-cdk-infrastructure.test.ts
+++ b/packages/type-safe-api/test/scripts/generators/java-cdk-infrastructure.test.ts
@@ -40,7 +40,7 @@ describe("Java Infrastructure Code Generation Script Unit Tests", () => {
         // Synth the openapitools.json since it's used by the generate command
         OpenApiToolsJsonFile.of(project)!.synthesize();
         exec(
-          `TYPE_SAFE_API_DEBUG=1 ${path.resolve(
+          `${path.resolve(
             __dirname,
             "../../../scripts/generators/generate"
           )} ${project.buildGenerateCommandArgs()}`,

--- a/packages/type-safe-api/test/scripts/generators/java.test.ts
+++ b/packages/type-safe-api/test/scripts/generators/java.test.ts
@@ -31,7 +31,7 @@ describe("Java Client Code Generation Script Unit Tests", () => {
             // Synth the openapitools.json since it's used by the generate command
             OpenApiToolsJsonFile.of(project)!.synthesize();
             exec(
-              `TYPE_SAFE_API_DEBUG=1 ${path.resolve(
+              `${path.resolve(
                 __dirname,
                 "../../../scripts/generators/generate"
               )} ${project.buildGenerateCommandArgs()}`,

--- a/packages/type-safe-api/test/scripts/generators/python-cdk-infrastructure.test.ts
+++ b/packages/type-safe-api/test/scripts/generators/python-cdk-infrastructure.test.ts
@@ -40,7 +40,7 @@ describe("Python Infrastructure Code Generation Script Unit Tests", () => {
       // Synth the openapitools.json since it's used by the generate command
       OpenApiToolsJsonFile.of(project)!.synthesize();
       exec(
-        `TYPE_SAFE_API_DEBUG=1 ${path.resolve(
+        `${path.resolve(
           __dirname,
           "../../../scripts/generators/generate"
         )} ${project.buildGenerateCommandArgs()}`,

--- a/packages/type-safe-api/test/scripts/generators/python.test.ts
+++ b/packages/type-safe-api/test/scripts/generators/python.test.ts
@@ -32,7 +32,7 @@ describe("Python Client Code Generation Script Unit Tests", () => {
             // Synth the openapitools.json since it's used by the generate command
             OpenApiToolsJsonFile.of(project)!.synthesize();
             exec(
-              `TYPE_SAFE_API_DEBUG=1 ${path.resolve(
+              `${path.resolve(
                 __dirname,
                 "../../../scripts/generators/generate"
               )} ${project.buildGenerateCommandArgs()}`,

--- a/packages/type-safe-api/test/scripts/generators/typescript-cdk-infrastructure.test.ts
+++ b/packages/type-safe-api/test/scripts/generators/typescript-cdk-infrastructure.test.ts
@@ -34,7 +34,7 @@ describe("Typescript Infrastructure Code Generation Script Unit Tests", () => {
       // Synth the openapitools.json since it's used by the generate command
       OpenApiToolsJsonFile.of(project)!.synthesize();
       exec(
-        `TYPE_SAFE_API_DEBUG=1 ${path.resolve(
+        `${path.resolve(
           __dirname,
           "../../../scripts/generators/generate"
         )} ${project.buildGenerateCommandArgs()}`,

--- a/packages/type-safe-api/test/scripts/generators/typescript-react-query-hooks.test.ts
+++ b/packages/type-safe-api/test/scripts/generators/typescript-react-query-hooks.test.ts
@@ -28,7 +28,7 @@ describe("Typescript React Query Hooks Code Generation Script Unit Tests", () =>
             // Synth the project so that the generate command honours the .openapi-generator-ignore-handlebars file
             project.synth();
             exec(
-              `TYPE_SAFE_API_DEBUG=1 ${path.resolve(
+              `${path.resolve(
                 __dirname,
                 "../../../scripts/generators/generate"
               )} ${project.buildGenerateCommandArgs()}`,

--- a/packages/type-safe-api/test/scripts/generators/typescript.test.ts
+++ b/packages/type-safe-api/test/scripts/generators/typescript.test.ts
@@ -29,7 +29,7 @@ describe("Typescript Client Code Generation Script Unit Tests", () => {
             // Synth the openapitools.json since it's used by the generate command
             OpenApiToolsJsonFile.of(project)!.synthesize();
             exec(
-              `TYPE_SAFE_API_DEBUG=1 ${path.resolve(
+              `${path.resolve(
                 __dirname,
                 "../../../scripts/generators/generate"
               )} ${project.buildGenerateCommandArgs()}`,

--- a/packages/type-safe-api/test/scripts/parser/parse-openapi-spec.test.ts
+++ b/packages/type-safe-api/test/scripts/parser/parse-openapi-spec.test.ts
@@ -14,7 +14,7 @@ describe("Parse OpenAPI Spec Script Unit Tests", () => {
           path.relative(path.resolve(__dirname), tmpDir),
           ".api.json"
         );
-        const command = `TYPE_SAFE_API_DEBUG=1 ../../../scripts/parser/parse-openapi-spec --spec-path ${specPath} --output-path ${outputPath}`;
+        const command = `../../../scripts/parser/parse-openapi-spec --spec-path ${specPath} --output-path ${outputPath}`;
         exec(command, {
           cwd: path.resolve(__dirname),
         });


### PR DESCRIPTION
The `TYPE_SAFE_API_DEBUG=1` flag is now just used for the extra logs. Failures to run openapi-generator or other scripts are no longer suppressed by default, so that users can get more actionable error messages than "script exited with code 1".

A recent example was a customer found the `generate` command was failing due to not having Java installed, but could only discover that this was the root cause by adding the `TYPE_SAFE_API_DEBUG=1` flag.
