### PR TITLE
feat(type-safe-api): support header parameters in handler wrappers

### DIFF
--- a/packages/type-safe-api/scripts/generators/java/templates/handlers.mustache
+++ b/packages/type-safe-api/scripts/generators/java/templates/handlers.mustache
@@ -296,13 +296,13 @@ public class Handlers {
 
     {{/responses}}
     /**
-     * Single-value query and path parameters for the {{nickname}} operation
+     * Single-value query, path and header parameters for the {{nickname}} operation
      */
     public static class {{operationIdCamelCase}}RequestParameters {
         {{#allParams}}
         {{^isBodyParam}}
         {{^isArray}}
-        private {{^required}}Optional<{{/required}}String{{^required}}>{{/required}} {{baseName}};
+        private {{^required}}Optional<{{/required}}String{{^required}}>{{/required}} {{paramName}};
         {{/isArray}}
         {{/isBodyParam}}
         {{/allParams}}
@@ -311,12 +311,13 @@ public class Handlers {
             Map<String, String> parameters = new HashMap<>();
             putAllFromNullableMap(event.getPathParameters(), parameters);
             putAllFromNullableMap(event.getQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getHeaders(), parameters);
             Map<String, String> decodedParameters = decodeRequestParameters(parameters);
 
             {{#allParams}}
             {{^isBodyParam}}
             {{^isArray}}
-            this.{{baseName}} = {{^required}}Optional.ofNullable({{/required}}decodedParameters.get("{{baseName}}"){{^required}}){{/required}};
+            this.{{paramName}} = {{^required}}Optional.ofNullable({{/required}}decodedParameters.get("{{baseName}}"){{^required}}){{/required}};
             {{/isArray}}
             {{/isBodyParam}}
             {{/allParams}}
@@ -326,7 +327,7 @@ public class Handlers {
         {{^isBodyParam}}
         {{^isArray}}
         public {{^required}}Optional<{{/required}}String{{^required}}>{{/required}} {{#schema}}{{getter}}{{/schema}}() {
-            return this.{{baseName}};
+            return this.{{paramName}};
         }
         {{/isArray}}
         {{/isBodyParam}}
@@ -334,13 +335,13 @@ public class Handlers {
     }
 
     /**
-     * Multi-value query parameters for the {{nickname}} operation
+     * Multi-value query and header parameters for the {{nickname}} operation
      */
     public static class {{operationIdCamelCase}}RequestArrayParameters {
         {{#allParams}}
         {{^isBodyParam}}
         {{#isArray}}
-        private {{^required}}Optional<{{/required}}List<String>{{^required}}>{{/required}} {{baseName}};
+        private {{^required}}Optional<{{/required}}List<String>{{^required}}>{{/required}} {{paramName}};
         {{/isArray}}
         {{/isBodyParam}}
         {{/allParams}}
@@ -348,12 +349,13 @@ public class Handlers {
         public {{operationIdCamelCase}}RequestArrayParameters(final APIGatewayProxyRequestEvent event) {
             Map<String, List<String>> parameters = new HashMap<>();
             putAllFromNullableMap(event.getMultiValueQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getMultiValueHeaders(), parameters);
             Map<String, List<String>> decodedParameters = decodeRequestArrayParameters(parameters);
 
             {{#allParams}}
             {{^isBodyParam}}
             {{#isArray}}
-            this.{{baseName}} = {{^required}}Optional.ofNullable({{/required}}decodedParameters.get("{{baseName}}"){{^required}}){{/required}};
+            this.{{paramName}} = {{^required}}Optional.ofNullable({{/required}}decodedParameters.get("{{baseName}}"){{^required}}){{/required}};
             {{/isArray}}
             {{/isBodyParam}}
             {{/allParams}}
@@ -363,7 +365,7 @@ public class Handlers {
         {{^isBodyParam}}
         {{#isArray}}
         public {{^required}}Optional<{{/required}}List<String>{{^required}}>{{/required}} {{#schema}}{{getter}}{{/schema}}() {
-            return this.{{baseName}};
+            return this.{{paramName}};
         }
         {{/isArray}}
         {{/isBodyParam}}

--- a/packages/type-safe-api/scripts/generators/python/templates/operationConfig.mustache
+++ b/packages/type-safe-api/scripts/generators/python/templates/operationConfig.mustache
@@ -148,27 +148,31 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
 {{#operations}}
 {{#operation}}
 
-# Request parameters are single value query params or path params
-class {{operationIdCamelCase}}RequestParameters(TypedDict):
-{{#allParams}}
-{{^isBodyParam}}
-{{^isArray}}
-    {{baseName}}: str
-{{/isArray}}
-{{/isBodyParam}}
-{{/allParams}}
-    ...
+# Request parameters are single value query params, path params or header params
+{{operationIdCamelCase}}RequestParameters = TypedDict(
+    "{{operationIdCamelCase}}RequestParameters", {
+    {{#allParams}}
+    {{^isBodyParam}}
+    {{^isArray}}
+        "{{baseName}}": str,
+    {{/isArray}}
+    {{/isBodyParam}}
+    {{/allParams}}
+    }
+)
 
-# Request array parameters are multi-value query params
-class {{operationIdCamelCase}}RequestArrayParameters(TypedDict):
-{{#allParams}}
-{{^isBodyParam}}
-{{#isArray}}
-    {{baseName}}: List[str]
-{{/isArray}}
-{{/isBodyParam}}
-{{/allParams}}
-    ...
+# Request array parameters are multi-value query params or header params
+{{operationIdCamelCase}}RequestArrayParameters = TypedDict(
+    "{{operationIdCamelCase}}RequestArrayParameters", {
+    {{#allParams}}
+    {{^isBodyParam}}
+    {{#isArray}}
+        "{{baseName}}": List[str],
+    {{/isArray}}
+    {{/isBodyParam}}
+    {{/allParams}}
+    }
+)
 
 # Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 {{operationIdCamelCase}}RequestBody = {{^bodyParams.isEmpty}}{{#bodyParams.0}}{{^isPrimitiveType}}{{dataType}}{{/isPrimitiveType}}{{#isPrimitiveType}}str{{/isPrimitiveType}}{{/bodyParams.0}}{{/bodyParams.isEmpty}}{{#bodyParams.isEmpty}}Any{{/bodyParams.isEmpty}}
@@ -198,9 +202,11 @@ def {{operationId}}_handler(_handler: {{operationIdCamelCase}}HandlerFunction = 
             request_parameters = decode_request_parameters({
                 **(event['pathParameters'] or {}),
                 **(event['queryStringParameters'] or {}),
+                **(event['headers'] or {}),
             })
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
+                **(event['multiValueHeaders'] or {}),
             })
             {{^bodyParams.isEmpty}}
             {{#bodyParams.0}}

--- a/packages/type-safe-api/scripts/generators/typescript/templates/operationConfig.mustache
+++ b/packages/type-safe-api/scripts/generators/typescript/templates/operationConfig.mustache
@@ -171,26 +171,26 @@ const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBod
 {{#operations}}
 {{#operation}}
 /**
- * Single-value path/query parameters for {{operationIdCamelCase}}
+ * Single-value path/query/header parameters for {{operationIdCamelCase}}
  */
 export interface {{operationIdCamelCase}}RequestParameters {
 {{#allParams}}
 {{^isBodyParam}}
 {{^isArray}}
-    readonly {{baseName}}{{^required}}?{{/required}}: string;
+    readonly {{#isHeaderParam}}"{{/isHeaderParam}}{{baseName}}{{#isHeaderParam}}"{{/isHeaderParam}}{{^required}}?{{/required}}: string;
 {{/isArray}}
 {{/isBodyParam}}
 {{/allParams}}
 }
 
 /**
- * Multi-value query parameters for {{operationIdCamelCase}}
+ * Multi-value query or header parameters for {{operationIdCamelCase}}
  */
 export interface {{operationIdCamelCase}}RequestArrayParameters {
 {{#allParams}}
 {{^isBodyParam}}
 {{#isArray}}
-    readonly {{baseName}}{{^required}}?{{/required}}: string[];
+    readonly {{#isHeaderParam}}"{{/isHeaderParam}}{{baseName}}{{#isHeaderParam}}"{{/isHeaderParam}}{{^required}}?{{/required}}: string[];
 {{/isArray}}
 {{/isBodyParam}}
 {{/allParams}}
@@ -220,10 +220,12 @@ export const {{nickname}}Handler = (
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
+        ...(event.headers || {}),
     }) as unknown as {{operationIdCamelCase}}RequestParameters;
 
     const requestArrayParameters = decodeRequestParameters({
         ...(event.multiValueQueryStringParameters || {}),
+        ...(event.multiValueHeaders || {}),
     }) as unknown as {{operationIdCamelCase}}RequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {

--- a/packages/type-safe-api/test/resources/specs/single.yaml
+++ b/packages/type-safe-api/test/resources/specs/single.yaml
@@ -34,6 +34,17 @@ paths:
           schema:
             type: string
           required: true
+        - in: header
+          name: x-header-param
+          schema:
+            type: string
+          required: true
+        - in: header
+          name: x-multi-value-header-param
+          schema:
+            type: array
+            items:
+              type: string
       requestBody:
         required: true
         content:

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/docs.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/docs.test.ts.snap
@@ -2660,11 +2660,13 @@ public class DefaultApiExample {
         array[String] param2 = ; // array[String] | 
         BigDecimal param3 = 8.14; // BigDecimal | 
         String pathParam = pathParam_example; // String | 
+        String xHeaderParam = xHeaderParam_example; // String | 
         TestRequest testRequest = ; // TestRequest | 
         String param4 = param4_example; // String | 
+        array[String] xMultiValueHeaderParam = ; // array[String] | 
 
         try {
-            TestResponse result = apiInstance.operationOne(param1, param2, param3, pathParam, testRequest, param4);
+            TestResponse result = apiInstance.operationOne(param1, param2, param3, pathParam, xHeaderParam, testRequest, param4, xMultiValueHeaderParam);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#operationOne");
@@ -2685,11 +2687,13 @@ public class DefaultApiExample {
         array[String] param2 = ; // array[String] | 
         BigDecimal param3 = 8.14; // BigDecimal | 
         String pathParam = pathParam_example; // String | 
+        String xHeaderParam = xHeaderParam_example; // String | 
         TestRequest testRequest = ; // TestRequest | 
         String param4 = param4_example; // String | 
+        array[String] xMultiValueHeaderParam = ; // array[String] | 
 
         try {
-            TestResponse result = apiInstance.operationOne(param1, param2, param3, pathParam, testRequest, param4);
+            TestResponse result = apiInstance.operationOne(param1, param2, param3, pathParam, xHeaderParam, testRequest, param4, xMultiValueHeaderParam);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling DefaultApi#operationOne");
@@ -2711,15 +2715,19 @@ String *param1 = param1_example; //  (default to null)
 array[String] *param2 = ; //  (default to null)
 BigDecimal *param3 = 8.14; //  (default to null)
 String *pathParam = pathParam_example; //  (default to null)
+String *xHeaderParam = xHeaderParam_example; //  (default to null)
 TestRequest *testRequest = ; // 
 String *param4 = param4_example; //  (optional) (default to null)
+array[String] *xMultiValueHeaderParam = ; //  (optional) (default to null)
 
 [apiInstance operationOneWith:param1
     param2:param2
     param3:param3
     pathParam:pathParam
+    xHeaderParam:xHeaderParam
     testRequest:testRequest
     param4:param4
+    xMultiValueHeaderParam:xMultiValueHeaderParam
               completionHandler: ^(TestResponse output, NSError* error) {
     if (output) {
         NSLog(@"%@", output);
@@ -2740,9 +2748,11 @@ var param1 = param1_example; // {String}
 var param2 = ; // {array[String]} 
 var param3 = 8.14; // {BigDecimal} 
 var pathParam = pathParam_example; // {String} 
+var xHeaderParam = xHeaderParam_example; // {String} 
 var testRequest = ; // {TestRequest} 
 var opts = {
-  'param4': param4_example // {String} 
+  'param4': param4_example, // {String} 
+  'xMultiValueHeaderParam':  // {array[String]} 
 };
 
 var callback = function(error, data, response) {
@@ -2752,7 +2762,7 @@ var callback = function(error, data, response) {
     console.log('API called successfully. Returned data: ' + data);
   }
 };
-api.operationOne(param1, param2, param3, pathParam, testRequest, opts, callback);
+api.operationOne(param1, param2, param3, pathParam, xHeaderParam, testRequest, opts, callback);
 </code></pre>
                             </div>
 
@@ -2779,11 +2789,13 @@ namespace Example
             var param2 = new array[String](); // array[String] |  (default to null)
             var param3 = 8.14;  // BigDecimal |  (default to null)
             var pathParam = pathParam_example;  // String |  (default to null)
+            var xHeaderParam = xHeaderParam_example;  // String |  (default to null)
             var testRequest = new TestRequest(); // TestRequest | 
             var param4 = param4_example;  // String |  (optional)  (default to null)
+            var xMultiValueHeaderParam = new array[String](); // array[String] |  (optional)  (default to null)
 
             try {
-                TestResponse result = apiInstance.operationOne(param1, param2, param3, pathParam, testRequest, param4);
+                TestResponse result = apiInstance.operationOne(param1, param2, param3, pathParam, xHeaderParam, testRequest, param4, xMultiValueHeaderParam);
                 Debug.WriteLine(result);
             } catch (Exception e) {
                 Debug.Print("Exception when calling DefaultApi.operationOne: " + e.Message );
@@ -2804,11 +2816,13 @@ $param1 = param1_example; // String |
 $param2 = ; // array[String] | 
 $param3 = 8.14; // BigDecimal | 
 $pathParam = pathParam_example; // String | 
+$xHeaderParam = xHeaderParam_example; // String | 
 $testRequest = ; // TestRequest | 
 $param4 = param4_example; // String | 
+$xMultiValueHeaderParam = ; // array[String] | 
 
 try {
-    $result = $api_instance->operationOne($param1, $param2, $param3, $pathParam, $testRequest, $param4);
+    $result = $api_instance->operationOne($param1, $param2, $param3, $pathParam, $xHeaderParam, $testRequest, $param4, $xMultiValueHeaderParam);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling DefaultApi->operationOne: ', $e->getMessage(), PHP_EOL;
@@ -2827,11 +2841,13 @@ my $param1 = param1_example; # String |
 my $param2 = []; # array[String] | 
 my $param3 = 8.14; # BigDecimal | 
 my $pathParam = pathParam_example; # String | 
+my $xHeaderParam = xHeaderParam_example; # String | 
 my $testRequest = WWW::OPenAPIClient::Object::TestRequest->new(); # TestRequest | 
 my $param4 = param4_example; # String | 
+my $xMultiValueHeaderParam = []; # array[String] | 
 
 eval {
-    my $result = $api_instance->operationOne(param1 => $param1, param2 => $param2, param3 => $param3, pathParam => $pathParam, testRequest => $testRequest, param4 => $param4);
+    my $result = $api_instance->operationOne(param1 => $param1, param2 => $param2, param3 => $param3, pathParam => $pathParam, xHeaderParam => $xHeaderParam, testRequest => $testRequest, param4 => $param4, xMultiValueHeaderParam => $xMultiValueHeaderParam);
     print Dumper($result);
 };
 if ($@) {
@@ -2852,11 +2868,13 @@ param1 = param1_example # String |  (default to null)
 param2 =  # array[String] |  (default to null)
 param3 = 8.14 # BigDecimal |  (default to null)
 pathParam = pathParam_example # String |  (default to null)
+xHeaderParam = xHeaderParam_example # String |  (default to null)
 testRequest =  # TestRequest | 
 param4 = param4_example # String |  (optional) (default to null)
+xMultiValueHeaderParam =  # array[String] |  (optional) (default to null)
 
 try:
-    api_response = api_instance.operation_one(param1, param2, param3, pathParam, testRequest, param4=param4)
+    api_response = api_instance.operation_one(param1, param2, param3, pathParam, xHeaderParam, testRequest, param4=param4, xMultiValueHeaderParam=xMultiValueHeaderParam)
     pprint(api_response)
 except ApiException as e:
     print("Exception when calling DefaultApi->operationOne: %s\\n" % e)</code></pre>
@@ -2870,11 +2888,13 @@ pub fn main() {
     let param2 = ; // array[String]
     let param3 = 8.14; // BigDecimal
     let pathParam = pathParam_example; // String
+    let xHeaderParam = xHeaderParam_example; // String
     let testRequest = ; // TestRequest
     let param4 = param4_example; // String
+    let xMultiValueHeaderParam = ; // array[String]
 
     let mut context = DefaultApi::Context::default();
-    let result = client.operationOne(param1, param2, param3, pathParam, testRequest, param4, &context).wait();
+    let result = client.operationOne(param1, param2, param3, pathParam, xHeaderParam, testRequest, param4, xMultiValueHeaderParam, &context).wait();
 
     println!("{:?}", result);
 }
@@ -2917,6 +2937,50 @@ pub fn main() {
 
                             </table>
 
+                            <div class="methodsubtabletitle">Header parameters</div>
+                            <table id="methodsubtable">
+                              <tr>
+                                <th width="150px">Name</th>
+                                <th>Description</th>
+                              </tr>
+                                  <tr><td style="width:150px;">x-header-param*</td>
+<td>
+
+
+    <div id="d2e199_operationOne_xHeaderParam">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    String
+                </span>
+
+            </div>
+                <div class="inner required">
+                    Required
+                </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                                  <tr><td style="width:150px;">x-multi-value-header-param</td>
+<td>
+
+
+    <div id="d2e199_operationOne_xMultiValueHeaderParam">
+        <div class="json-schema-view">
+            <div class="primitive">
+                <span class="type">
+                    array[String]
+                </span>
+
+            </div>
+        </div>
+    </div>
+</td>
+</tr>
+
+                            </table>
 
                             <div class="methodsubtabletitle">Body parameters</div>
                             <table id="methodsubtable">
@@ -5414,7 +5478,7 @@ No authorization required
 
 <a name="operationOne"></a>
 # **operationOne**
-> TestResponse operationOne(param1, param2, param3, pathParam, TestRequest, param4)
+> TestResponse operationOne(param1, param2, param3, pathParam, x-header-param, TestRequest, param4, x-multi-value-header-param)
 
 
 
@@ -5426,8 +5490,10 @@ No authorization required
 | **param2** | [**List**](../Models/String.md)|  | [default to null] |
 | **param3** | **BigDecimal**|  | [default to null] |
 | **pathParam** | **String**|  | [default to null] |
+| **x-header-param** | **String**|  | [default to null] |
 | **TestRequest** | [**TestRequest**](../Models/TestRequest.md)|  | |
 | **param4** | **String**|  | [optional] [default to null] |
+| **x-multi-value-header-param** | [**List**](../Models/String.md)|  | [optional] [default to null] |
 
 ### Return type
 

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/java.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/java.test.ts.snap
@@ -3811,7 +3811,7 @@ public class Handlers {
     }
 
     /**
-     * Single-value query and path parameters for the neither operation
+     * Single-value query, path and header parameters for the neither operation
      */
     public static class NeitherRequestParameters {
 
@@ -3819,6 +3819,7 @@ public class Handlers {
             Map<String, String> parameters = new HashMap<>();
             putAllFromNullableMap(event.getPathParameters(), parameters);
             putAllFromNullableMap(event.getQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getHeaders(), parameters);
             Map<String, String> decodedParameters = decodeRequestParameters(parameters);
 
         }
@@ -3826,13 +3827,14 @@ public class Handlers {
     }
 
     /**
-     * Multi-value query parameters for the neither operation
+     * Multi-value query and header parameters for the neither operation
      */
     public static class NeitherRequestArrayParameters {
 
         public NeitherRequestArrayParameters(final APIGatewayProxyRequestEvent event) {
             Map<String, List<String>> parameters = new HashMap<>();
             putAllFromNullableMap(event.getMultiValueQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getMultiValueHeaders(), parameters);
             Map<String, List<String>> decodedParameters = decodeRequestArrayParameters(parameters);
 
         }
@@ -4031,7 +4033,7 @@ public class Handlers {
     }
 
     /**
-     * Single-value query and path parameters for the both operation
+     * Single-value query, path and header parameters for the both operation
      */
     public static class BothRequestParameters {
 
@@ -4039,6 +4041,7 @@ public class Handlers {
             Map<String, String> parameters = new HashMap<>();
             putAllFromNullableMap(event.getPathParameters(), parameters);
             putAllFromNullableMap(event.getQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getHeaders(), parameters);
             Map<String, String> decodedParameters = decodeRequestParameters(parameters);
 
         }
@@ -4046,13 +4049,14 @@ public class Handlers {
     }
 
     /**
-     * Multi-value query parameters for the both operation
+     * Multi-value query and header parameters for the both operation
      */
     public static class BothRequestArrayParameters {
 
         public BothRequestArrayParameters(final APIGatewayProxyRequestEvent event) {
             Map<String, List<String>> parameters = new HashMap<>();
             putAllFromNullableMap(event.getMultiValueQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getMultiValueHeaders(), parameters);
             Map<String, List<String>> decodedParameters = decodeRequestArrayParameters(parameters);
 
         }
@@ -4251,7 +4255,7 @@ public class Handlers {
     }
 
     /**
-     * Single-value query and path parameters for the tag1 operation
+     * Single-value query, path and header parameters for the tag1 operation
      */
     public static class Tag1RequestParameters {
 
@@ -4259,6 +4263,7 @@ public class Handlers {
             Map<String, String> parameters = new HashMap<>();
             putAllFromNullableMap(event.getPathParameters(), parameters);
             putAllFromNullableMap(event.getQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getHeaders(), parameters);
             Map<String, String> decodedParameters = decodeRequestParameters(parameters);
 
         }
@@ -4266,13 +4271,14 @@ public class Handlers {
     }
 
     /**
-     * Multi-value query parameters for the tag1 operation
+     * Multi-value query and header parameters for the tag1 operation
      */
     public static class Tag1RequestArrayParameters {
 
         public Tag1RequestArrayParameters(final APIGatewayProxyRequestEvent event) {
             Map<String, List<String>> parameters = new HashMap<>();
             putAllFromNullableMap(event.getMultiValueQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getMultiValueHeaders(), parameters);
             Map<String, List<String>> decodedParameters = decodeRequestArrayParameters(parameters);
 
         }
@@ -4471,7 +4477,7 @@ public class Handlers {
     }
 
     /**
-     * Single-value query and path parameters for the tag2 operation
+     * Single-value query, path and header parameters for the tag2 operation
      */
     public static class Tag2RequestParameters {
 
@@ -4479,6 +4485,7 @@ public class Handlers {
             Map<String, String> parameters = new HashMap<>();
             putAllFromNullableMap(event.getPathParameters(), parameters);
             putAllFromNullableMap(event.getQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getHeaders(), parameters);
             Map<String, String> decodedParameters = decodeRequestParameters(parameters);
 
         }
@@ -4486,13 +4493,14 @@ public class Handlers {
     }
 
     /**
-     * Multi-value query parameters for the tag2 operation
+     * Multi-value query and header parameters for the tag2 operation
      */
     public static class Tag2RequestArrayParameters {
 
         public Tag2RequestArrayParameters(final APIGatewayProxyRequestEvent event) {
             Map<String, List<String>> parameters = new HashMap<>();
             putAllFromNullableMap(event.getMultiValueQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getMultiValueHeaders(), parameters);
             Map<String, List<String>> decodedParameters = decodeRequestArrayParameters(parameters);
 
         }
@@ -6133,6 +6141,22 @@ paths:
         schema:
           type: string
         style: simple
+      - explode: false
+        in: header
+        name: x-header-param
+        required: true
+        schema:
+          type: string
+        style: simple
+      - explode: false
+        in: header
+        name: x-multi-value-header-param
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+        style: simple
       requestBody:
         content:
           application/json:
@@ -6618,7 +6642,7 @@ No authorization required
 
 <a name="operationOne"></a>
 # **operationOne**
-> TestResponse operationOne(param1, param2, param3, pathParam, testRequest).param4(param4).execute();
+> TestResponse operationOne(param1, param2, param3, pathParam, xHeaderParam, testRequest).param4(param4).xMultiValueHeaderParam(xMultiValueHeaderParam).execute();
 
 
 
@@ -6641,11 +6665,14 @@ public class Example {
     List<String> param2 = Arrays.asList(); // List<String> | 
     BigDecimal param3 = new BigDecimal(78); // BigDecimal | 
     String pathParam = "pathParam_example"; // String | 
+    String xHeaderParam = "xHeaderParam_example"; // String | 
     TestRequest testRequest = new TestRequest(); // TestRequest | 
     String param4 = "param4_example"; // String | 
+    List<String> xMultiValueHeaderParam = Arrays.asList(); // List<String> | 
     try {
-      TestResponse result = apiInstance.operationOne(param1, param2, param3, pathParam, testRequest)
+      TestResponse result = apiInstance.operationOne(param1, param2, param3, pathParam, xHeaderParam, testRequest)
             .param4(param4)
+            .xMultiValueHeaderParam(xMultiValueHeaderParam)
             .execute();
       System.out.println(result);
     } catch (ApiException e) {
@@ -6667,8 +6694,10 @@ public class Example {
 | **param2** | [**List&lt;String&gt;**](String.md)|  | |
 | **param3** | **BigDecimal**|  | |
 | **pathParam** | **String**|  | |
+| **xHeaderParam** | **String**|  | |
 | **testRequest** | [**TestRequest**](TestRequest.md)|  | |
 | **param4** | **String**|  | [optional] |
+| **xMultiValueHeaderParam** | [**List&lt;String&gt;**](String.md)|  | [optional] |
 
 ### Return type
 
@@ -10407,7 +10436,7 @@ public class DefaultApi {
     public APImultipleContentTypesRequest multipleContentTypes(TestRequest testRequest) {
         return new APImultipleContentTypesRequest(testRequest);
     }
-    private okhttp3.Call operationOneCall(String param1, List<String> param2, BigDecimal param3, String pathParam, TestRequest testRequest, String param4, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call operationOneCall(String param1, List<String> param2, BigDecimal param3, String pathParam, String xHeaderParam, TestRequest testRequest, String param4, List<String> xMultiValueHeaderParam, final ApiCallback _callback) throws ApiException {
         String basePath = null;
         // Operation Servers
         String[] localBasePaths = new String[] {  };
@@ -10449,6 +10478,14 @@ public class DefaultApi {
             localVarQueryParams.addAll(localVarApiClient.parameterToPair("param4", param4));
         }
 
+        if (xHeaderParam != null) {
+            localVarHeaderParams.put("x-header-param", localVarApiClient.parameterToString(xHeaderParam));
+        }
+
+        if (xMultiValueHeaderParam != null) {
+            localVarHeaderParams.put("x-multi-value-header-param", localVarApiClient.parameterToString(xMultiValueHeaderParam));
+        }
+
         final String[] localVarAccepts = {
             "application/json"
         };
@@ -10470,7 +10507,7 @@ public class DefaultApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call operationOneValidateBeforeCall(String param1, List<String> param2, BigDecimal param3, String pathParam, TestRequest testRequest, String param4, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call operationOneValidateBeforeCall(String param1, List<String> param2, BigDecimal param3, String pathParam, String xHeaderParam, TestRequest testRequest, String param4, List<String> xMultiValueHeaderParam, final ApiCallback _callback) throws ApiException {
         // verify the required parameter 'param1' is set
         if (param1 == null) {
             throw new ApiException("Missing the required parameter 'param1' when calling operationOne(Async)");
@@ -10491,25 +10528,30 @@ public class DefaultApi {
             throw new ApiException("Missing the required parameter 'pathParam' when calling operationOne(Async)");
         }
 
+        // verify the required parameter 'xHeaderParam' is set
+        if (xHeaderParam == null) {
+            throw new ApiException("Missing the required parameter 'xHeaderParam' when calling operationOne(Async)");
+        }
+
         // verify the required parameter 'testRequest' is set
         if (testRequest == null) {
             throw new ApiException("Missing the required parameter 'testRequest' when calling operationOne(Async)");
         }
 
-        return operationOneCall(param1, param2, param3, pathParam, testRequest, param4, _callback);
+        return operationOneCall(param1, param2, param3, pathParam, xHeaderParam, testRequest, param4, xMultiValueHeaderParam, _callback);
 
     }
 
 
-    private ApiResponse<TestResponse> operationOneWithHttpInfo(String param1, List<String> param2, BigDecimal param3, String pathParam, TestRequest testRequest, String param4) throws ApiException {
-        okhttp3.Call localVarCall = operationOneValidateBeforeCall(param1, param2, param3, pathParam, testRequest, param4, null);
+    private ApiResponse<TestResponse> operationOneWithHttpInfo(String param1, List<String> param2, BigDecimal param3, String pathParam, String xHeaderParam, TestRequest testRequest, String param4, List<String> xMultiValueHeaderParam) throws ApiException {
+        okhttp3.Call localVarCall = operationOneValidateBeforeCall(param1, param2, param3, pathParam, xHeaderParam, testRequest, param4, xMultiValueHeaderParam, null);
         Type localVarReturnType = new TypeToken<TestResponse>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
-    private okhttp3.Call operationOneAsync(String param1, List<String> param2, BigDecimal param3, String pathParam, TestRequest testRequest, String param4, final ApiCallback<TestResponse> _callback) throws ApiException {
+    private okhttp3.Call operationOneAsync(String param1, List<String> param2, BigDecimal param3, String pathParam, String xHeaderParam, TestRequest testRequest, String param4, List<String> xMultiValueHeaderParam, final ApiCallback<TestResponse> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = operationOneValidateBeforeCall(param1, param2, param3, pathParam, testRequest, param4, _callback);
+        okhttp3.Call localVarCall = operationOneValidateBeforeCall(param1, param2, param3, pathParam, xHeaderParam, testRequest, param4, xMultiValueHeaderParam, _callback);
         Type localVarReturnType = new TypeToken<TestResponse>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
@@ -10520,14 +10562,17 @@ public class DefaultApi {
         private final List<String> param2;
         private final BigDecimal param3;
         private final String pathParam;
+        private final String xHeaderParam;
         private final TestRequest testRequest;
         private String param4;
+        private List<String> xMultiValueHeaderParam;
 
-        private APIoperationOneRequest(String param1, List<String> param2, BigDecimal param3, String pathParam, TestRequest testRequest) {
+        private APIoperationOneRequest(String param1, List<String> param2, BigDecimal param3, String pathParam, String xHeaderParam, TestRequest testRequest) {
             this.param1 = param1;
             this.param2 = param2;
             this.param3 = param3;
             this.pathParam = pathParam;
+            this.xHeaderParam = xHeaderParam;
             this.testRequest = testRequest;
         }
 
@@ -10538,6 +10583,16 @@ public class DefaultApi {
          */
         public APIoperationOneRequest param4(String param4) {
             this.param4 = param4;
+            return this;
+        }
+
+        /**
+         * Set xMultiValueHeaderParam
+         * @param xMultiValueHeaderParam  (optional)
+         * @return APIoperationOneRequest
+         */
+        public APIoperationOneRequest xMultiValueHeaderParam(List<String> xMultiValueHeaderParam) {
+            this.xMultiValueHeaderParam = xMultiValueHeaderParam;
             return this;
         }
 
@@ -10554,7 +10609,7 @@ public class DefaultApi {
          </table>
          */
         public okhttp3.Call buildCall(final ApiCallback _callback) throws ApiException {
-            return operationOneCall(param1, param2, param3, pathParam, testRequest, param4, _callback);
+            return operationOneCall(param1, param2, param3, pathParam, xHeaderParam, testRequest, param4, xMultiValueHeaderParam, _callback);
         }
 
         /**
@@ -10569,7 +10624,7 @@ public class DefaultApi {
          </table>
          */
         public TestResponse execute() throws ApiException {
-            ApiResponse<TestResponse> localVarResp = operationOneWithHttpInfo(param1, param2, param3, pathParam, testRequest, param4);
+            ApiResponse<TestResponse> localVarResp = operationOneWithHttpInfo(param1, param2, param3, pathParam, xHeaderParam, testRequest, param4, xMultiValueHeaderParam);
             return localVarResp.getData();
         }
 
@@ -10585,7 +10640,7 @@ public class DefaultApi {
          </table>
          */
         public ApiResponse<TestResponse> executeWithHttpInfo() throws ApiException {
-            return operationOneWithHttpInfo(param1, param2, param3, pathParam, testRequest, param4);
+            return operationOneWithHttpInfo(param1, param2, param3, pathParam, xHeaderParam, testRequest, param4, xMultiValueHeaderParam);
         }
 
         /**
@@ -10601,7 +10656,7 @@ public class DefaultApi {
          </table>
          */
         public okhttp3.Call executeAsync(final ApiCallback<TestResponse> _callback) throws ApiException {
-            return operationOneAsync(param1, param2, param3, pathParam, testRequest, param4, _callback);
+            return operationOneAsync(param1, param2, param3, pathParam, xHeaderParam, testRequest, param4, xMultiValueHeaderParam, _callback);
         }
     }
 
@@ -10612,6 +10667,7 @@ public class DefaultApi {
      * @param param2  (required)
      * @param param3  (required)
      * @param pathParam  (required)
+     * @param xHeaderParam  (required)
      * @param testRequest  (required)
      * @return APIoperationOneRequest
      * @http.response.details
@@ -10621,8 +10677,8 @@ public class DefaultApi {
         <tr><td> 400 </td><td> Error response </td><td>  -  </td></tr>
      </table>
      */
-    public APIoperationOneRequest operationOne(String param1, List<String> param2, BigDecimal param3, String pathParam, TestRequest testRequest) {
-        return new APIoperationOneRequest(param1, param2, param3, pathParam, testRequest);
+    public APIoperationOneRequest operationOne(String param1, List<String> param2, BigDecimal param3, String pathParam, String xHeaderParam, TestRequest testRequest) {
+        return new APIoperationOneRequest(param1, param2, param3, pathParam, xHeaderParam, testRequest);
     }
     private okhttp3.Call withoutOperationIdDeleteCall(final ApiCallback _callback) throws ApiException {
         String basePath = null;
@@ -11044,7 +11100,7 @@ public class Handlers {
     }
 
     /**
-     * Single-value query and path parameters for the anyRequestResponse operation
+     * Single-value query, path and header parameters for the anyRequestResponse operation
      */
     public static class AnyRequestResponseRequestParameters {
 
@@ -11052,6 +11108,7 @@ public class Handlers {
             Map<String, String> parameters = new HashMap<>();
             putAllFromNullableMap(event.getPathParameters(), parameters);
             putAllFromNullableMap(event.getQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getHeaders(), parameters);
             Map<String, String> decodedParameters = decodeRequestParameters(parameters);
 
         }
@@ -11059,13 +11116,14 @@ public class Handlers {
     }
 
     /**
-     * Multi-value query parameters for the anyRequestResponse operation
+     * Multi-value query and header parameters for the anyRequestResponse operation
      */
     public static class AnyRequestResponseRequestArrayParameters {
 
         public AnyRequestResponseRequestArrayParameters(final APIGatewayProxyRequestEvent event) {
             Map<String, List<String>> parameters = new HashMap<>();
             putAllFromNullableMap(event.getMultiValueQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getMultiValueHeaders(), parameters);
             Map<String, List<String>> decodedParameters = decodeRequestArrayParameters(parameters);
 
         }
@@ -11269,7 +11327,7 @@ public class Handlers {
     }
 
     /**
-     * Single-value query and path parameters for the empty operation
+     * Single-value query, path and header parameters for the empty operation
      */
     public static class EmptyRequestParameters {
 
@@ -11277,6 +11335,7 @@ public class Handlers {
             Map<String, String> parameters = new HashMap<>();
             putAllFromNullableMap(event.getPathParameters(), parameters);
             putAllFromNullableMap(event.getQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getHeaders(), parameters);
             Map<String, String> decodedParameters = decodeRequestParameters(parameters);
 
         }
@@ -11284,13 +11343,14 @@ public class Handlers {
     }
 
     /**
-     * Multi-value query parameters for the empty operation
+     * Multi-value query and header parameters for the empty operation
      */
     public static class EmptyRequestArrayParameters {
 
         public EmptyRequestArrayParameters(final APIGatewayProxyRequestEvent event) {
             Map<String, List<String>> parameters = new HashMap<>();
             putAllFromNullableMap(event.getMultiValueQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getMultiValueHeaders(), parameters);
             Map<String, List<String>> decodedParameters = decodeRequestArrayParameters(parameters);
 
         }
@@ -11489,7 +11549,7 @@ public class Handlers {
     }
 
     /**
-     * Single-value query and path parameters for the mapResponse operation
+     * Single-value query, path and header parameters for the mapResponse operation
      */
     public static class MapResponseRequestParameters {
 
@@ -11497,6 +11557,7 @@ public class Handlers {
             Map<String, String> parameters = new HashMap<>();
             putAllFromNullableMap(event.getPathParameters(), parameters);
             putAllFromNullableMap(event.getQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getHeaders(), parameters);
             Map<String, String> decodedParameters = decodeRequestParameters(parameters);
 
         }
@@ -11504,13 +11565,14 @@ public class Handlers {
     }
 
     /**
-     * Multi-value query parameters for the mapResponse operation
+     * Multi-value query and header parameters for the mapResponse operation
      */
     public static class MapResponseRequestArrayParameters {
 
         public MapResponseRequestArrayParameters(final APIGatewayProxyRequestEvent event) {
             Map<String, List<String>> parameters = new HashMap<>();
             putAllFromNullableMap(event.getMultiValueQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getMultiValueHeaders(), parameters);
             Map<String, List<String>> decodedParameters = decodeRequestArrayParameters(parameters);
 
         }
@@ -11709,7 +11771,7 @@ public class Handlers {
     }
 
     /**
-     * Single-value query and path parameters for the mediaTypes operation
+     * Single-value query, path and header parameters for the mediaTypes operation
      */
     public static class MediaTypesRequestParameters {
 
@@ -11717,6 +11779,7 @@ public class Handlers {
             Map<String, String> parameters = new HashMap<>();
             putAllFromNullableMap(event.getPathParameters(), parameters);
             putAllFromNullableMap(event.getQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getHeaders(), parameters);
             Map<String, String> decodedParameters = decodeRequestParameters(parameters);
 
         }
@@ -11724,13 +11787,14 @@ public class Handlers {
     }
 
     /**
-     * Multi-value query parameters for the mediaTypes operation
+     * Multi-value query and header parameters for the mediaTypes operation
      */
     public static class MediaTypesRequestArrayParameters {
 
         public MediaTypesRequestArrayParameters(final APIGatewayProxyRequestEvent event) {
             Map<String, List<String>> parameters = new HashMap<>();
             putAllFromNullableMap(event.getMultiValueQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getMultiValueHeaders(), parameters);
             Map<String, List<String>> decodedParameters = decodeRequestArrayParameters(parameters);
 
         }
@@ -11934,7 +11998,7 @@ public class Handlers {
     }
 
     /**
-     * Single-value query and path parameters for the multipleContentTypes operation
+     * Single-value query, path and header parameters for the multipleContentTypes operation
      */
     public static class MultipleContentTypesRequestParameters {
 
@@ -11942,6 +12006,7 @@ public class Handlers {
             Map<String, String> parameters = new HashMap<>();
             putAllFromNullableMap(event.getPathParameters(), parameters);
             putAllFromNullableMap(event.getQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getHeaders(), parameters);
             Map<String, String> decodedParameters = decodeRequestParameters(parameters);
 
         }
@@ -11949,13 +12014,14 @@ public class Handlers {
     }
 
     /**
-     * Multi-value query parameters for the multipleContentTypes operation
+     * Multi-value query and header parameters for the multipleContentTypes operation
      */
     public static class MultipleContentTypesRequestArrayParameters {
 
         public MultipleContentTypesRequestArrayParameters(final APIGatewayProxyRequestEvent event) {
             Map<String, List<String>> parameters = new HashMap<>();
             putAllFromNullableMap(event.getMultiValueQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getMultiValueHeaders(), parameters);
             Map<String, List<String>> decodedParameters = decodeRequestArrayParameters(parameters);
 
         }
@@ -12208,23 +12274,26 @@ public class Handlers {
     }
 
     /**
-     * Single-value query and path parameters for the operationOne operation
+     * Single-value query, path and header parameters for the operationOne operation
      */
     public static class OperationOneRequestParameters {
         private String param1;
         private String param3;
         private String pathParam;
+        private String xHeaderParam;
         private Optional<String> param4;
 
         public OperationOneRequestParameters(final APIGatewayProxyRequestEvent event) {
             Map<String, String> parameters = new HashMap<>();
             putAllFromNullableMap(event.getPathParameters(), parameters);
             putAllFromNullableMap(event.getQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getHeaders(), parameters);
             Map<String, String> decodedParameters = decodeRequestParameters(parameters);
 
             this.param1 = decodedParameters.get("param1");
             this.param3 = decodedParameters.get("param3");
             this.pathParam = decodedParameters.get("pathParam");
+            this.xHeaderParam = decodedParameters.get("x-header-param");
             this.param4 = Optional.ofNullable(decodedParameters.get("param4"));
         }
 
@@ -12237,27 +12306,36 @@ public class Handlers {
         public String getPathParam() {
             return this.pathParam;
         }
+        public String getxHeaderParam() {
+            return this.xHeaderParam;
+        }
         public Optional<String> getParam4() {
             return this.param4;
         }
     }
 
     /**
-     * Multi-value query parameters for the operationOne operation
+     * Multi-value query and header parameters for the operationOne operation
      */
     public static class OperationOneRequestArrayParameters {
         private List<String> param2;
+        private Optional<List<String>> xMultiValueHeaderParam;
 
         public OperationOneRequestArrayParameters(final APIGatewayProxyRequestEvent event) {
             Map<String, List<String>> parameters = new HashMap<>();
             putAllFromNullableMap(event.getMultiValueQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getMultiValueHeaders(), parameters);
             Map<String, List<String>> decodedParameters = decodeRequestArrayParameters(parameters);
 
             this.param2 = decodedParameters.get("param2");
+            this.xMultiValueHeaderParam = Optional.ofNullable(decodedParameters.get("x-multi-value-header-param"));
         }
 
         public List<String> getParam2() {
             return this.param2;
+        }
+        public Optional<List<String>> getxMultiValueHeaderParam() {
+            return this.xMultiValueHeaderParam;
         }
     }
 
@@ -12462,7 +12540,7 @@ public class Handlers {
     }
 
     /**
-     * Single-value query and path parameters for the withoutOperationIdDelete operation
+     * Single-value query, path and header parameters for the withoutOperationIdDelete operation
      */
     public static class WithoutOperationIdDeleteRequestParameters {
 
@@ -12470,6 +12548,7 @@ public class Handlers {
             Map<String, String> parameters = new HashMap<>();
             putAllFromNullableMap(event.getPathParameters(), parameters);
             putAllFromNullableMap(event.getQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getHeaders(), parameters);
             Map<String, String> decodedParameters = decodeRequestParameters(parameters);
 
         }
@@ -12477,13 +12556,14 @@ public class Handlers {
     }
 
     /**
-     * Multi-value query parameters for the withoutOperationIdDelete operation
+     * Multi-value query and header parameters for the withoutOperationIdDelete operation
      */
     public static class WithoutOperationIdDeleteRequestArrayParameters {
 
         public WithoutOperationIdDeleteRequestArrayParameters(final APIGatewayProxyRequestEvent event) {
             Map<String, List<String>> parameters = new HashMap<>();
             putAllFromNullableMap(event.getMultiValueQueryStringParameters(), parameters);
+            putAllFromNullableMap(event.getMultiValueHeaders(), parameters);
             Map<String, List<String>> decodedParameters = decodeRequestArrayParameters(parameters);
 
         }

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
@@ -2368,13 +2368,17 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
         return RemainingHandlerChain()
 
 
-# Request parameters are single value query params or path params
-class NeitherRequestParameters(TypedDict):
-    ...
+# Request parameters are single value query params, path params or header params
+NeitherRequestParameters = TypedDict(
+    "NeitherRequestParameters", {
+    }
+)
 
-# Request array parameters are multi-value query params
-class NeitherRequestArrayParameters(TypedDict):
-    ...
+# Request array parameters are multi-value query params or header params
+NeitherRequestArrayParameters = TypedDict(
+    "NeitherRequestArrayParameters", {
+    }
+)
 
 # Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 NeitherRequestBody = Any
@@ -2402,9 +2406,11 @@ def neither_handler(_handler: NeitherHandlerFunction = None, interceptors: List[
             request_parameters = decode_request_parameters({
                 **(event['pathParameters'] or {}),
                 **(event['queryStringParameters'] or {}),
+                **(event['headers'] or {}),
             })
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
+                **(event['multiValueHeaders'] or {}),
             })
             body = {}
             interceptor_context = {}
@@ -2441,13 +2447,17 @@ def neither_handler(_handler: NeitherHandlerFunction = None, interceptors: List[
     else:
         raise Exception("Positional arguments are not supported by neither_handler.")
 
-# Request parameters are single value query params or path params
-class BothRequestParameters(TypedDict):
-    ...
+# Request parameters are single value query params, path params or header params
+BothRequestParameters = TypedDict(
+    "BothRequestParameters", {
+    }
+)
 
-# Request array parameters are multi-value query params
-class BothRequestArrayParameters(TypedDict):
-    ...
+# Request array parameters are multi-value query params or header params
+BothRequestArrayParameters = TypedDict(
+    "BothRequestArrayParameters", {
+    }
+)
 
 # Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 BothRequestBody = Any
@@ -2475,9 +2485,11 @@ def both_handler(_handler: BothHandlerFunction = None, interceptors: List[BothIn
             request_parameters = decode_request_parameters({
                 **(event['pathParameters'] or {}),
                 **(event['queryStringParameters'] or {}),
+                **(event['headers'] or {}),
             })
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
+                **(event['multiValueHeaders'] or {}),
             })
             body = {}
             interceptor_context = {}
@@ -2514,13 +2526,17 @@ def both_handler(_handler: BothHandlerFunction = None, interceptors: List[BothIn
     else:
         raise Exception("Positional arguments are not supported by both_handler.")
 
-# Request parameters are single value query params or path params
-class Tag1RequestParameters(TypedDict):
-    ...
+# Request parameters are single value query params, path params or header params
+Tag1RequestParameters = TypedDict(
+    "Tag1RequestParameters", {
+    }
+)
 
-# Request array parameters are multi-value query params
-class Tag1RequestArrayParameters(TypedDict):
-    ...
+# Request array parameters are multi-value query params or header params
+Tag1RequestArrayParameters = TypedDict(
+    "Tag1RequestArrayParameters", {
+    }
+)
 
 # Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 Tag1RequestBody = Any
@@ -2548,9 +2564,11 @@ def tag1_handler(_handler: Tag1HandlerFunction = None, interceptors: List[Tag1In
             request_parameters = decode_request_parameters({
                 **(event['pathParameters'] or {}),
                 **(event['queryStringParameters'] or {}),
+                **(event['headers'] or {}),
             })
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
+                **(event['multiValueHeaders'] or {}),
             })
             body = {}
             interceptor_context = {}
@@ -2587,13 +2605,17 @@ def tag1_handler(_handler: Tag1HandlerFunction = None, interceptors: List[Tag1In
     else:
         raise Exception("Positional arguments are not supported by tag1_handler.")
 
-# Request parameters are single value query params or path params
-class Tag2RequestParameters(TypedDict):
-    ...
+# Request parameters are single value query params, path params or header params
+Tag2RequestParameters = TypedDict(
+    "Tag2RequestParameters", {
+    }
+)
 
-# Request array parameters are multi-value query params
-class Tag2RequestArrayParameters(TypedDict):
-    ...
+# Request array parameters are multi-value query params or header params
+Tag2RequestArrayParameters = TypedDict(
+    "Tag2RequestArrayParameters", {
+    }
+)
 
 # Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 Tag2RequestBody = Any
@@ -2621,9 +2643,11 @@ def tag2_handler(_handler: Tag2HandlerFunction = None, interceptors: List[Tag2In
             request_parameters = decode_request_parameters({
                 **(event['pathParameters'] or {}),
                 **(event['queryStringParameters'] or {}),
+                **(event['headers'] or {}),
             })
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
+                **(event['multiValueHeaders'] or {}),
             })
             body = {}
             interceptor_context = {}
@@ -8459,7 +8483,7 @@ No authorization required
 
 # **operation_one**
 <a name="operation_one"></a>
-> TestResponse operation_one(param1param2param3path_paramtest_request)
+> TestResponse operation_one(param1param2param3path_paramx_header_paramtest_request)
 
 
 
@@ -8494,6 +8518,9 @@ with test_project.ApiClient(configuration) as api_client:
     ],
         'param3': 3.14,
     }
+    header_params = {
+        'x-header-param': "x-header-param_example",
+    }
     body = TestRequest(
         my_input=3.14,
     )
@@ -8501,6 +8528,7 @@ with test_project.ApiClient(configuration) as api_client:
         api_response = api_instance.operation_one(
             path_params=path_params,
             query_params=query_params,
+            header_params=header_params,
             body=body,
         )
         pprint(api_response)
@@ -8519,6 +8547,12 @@ with test_project.ApiClient(configuration) as api_client:
         'param3': 3.14,
         'param4': "param4_example",
     }
+    header_params = {
+        'x-header-param': "x-header-param_example",
+        'x-multi-value-header-param': [
+        "x-multi-value-header-param_example"
+    ],
+    }
     body = TestRequest(
         my_input=3.14,
     )
@@ -8526,6 +8560,7 @@ with test_project.ApiClient(configuration) as api_client:
         api_response = api_instance.operation_one(
             path_params=path_params,
             query_params=query_params,
+            header_params=header_params,
             body=body,
         )
         pprint(api_response)
@@ -8538,6 +8573,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 body | typing.Union[SchemaForRequestBodyApplicationJson] | required |
 query_params | RequestQueryParams | |
+header_params | RequestHeaderParams | |
 path_params | RequestPathParams | |
 content_type | str | optional, default is 'application/json' | Selects the schema and serialization of the request body
 accept_content_types | typing.Tuple[str] | default is ('application/json', ) | Tells the server the content type(s) that are accepted by the client
@@ -8596,6 +8632,33 @@ decimal.Decimal, int, float,  | decimal.Decimal,  |  |
 Input Type | Accessed Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 str,  | str,  |  | 
+
+### header_params
+#### RequestHeaderParams
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+x-header-param | XHeaderParamSchema | | 
+x-multi-value-header-param | XMultiValueHeaderParamSchema | | optional
+
+# XHeaderParamSchema
+
+## Model Type Info
+Input Type | Accessed Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+str,  | str,  |  | 
+
+# XMultiValueHeaderParamSchema
+
+## Model Type Info
+Input Type | Accessed Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+list, tuple,  | tuple,  |  | 
+
+### Tuple Items
+Class Name | Input Type | Accessed Type | Description | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+items | str,  | str,  |  | 
 
 ### path_params
 #### RequestPathParams
@@ -10687,13 +10750,17 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
         return RemainingHandlerChain()
 
 
-# Request parameters are single value query params or path params
-class AnyRequestResponseRequestParameters(TypedDict):
-    ...
+# Request parameters are single value query params, path params or header params
+AnyRequestResponseRequestParameters = TypedDict(
+    "AnyRequestResponseRequestParameters", {
+    }
+)
 
-# Request array parameters are multi-value query params
-class AnyRequestResponseRequestArrayParameters(TypedDict):
-    ...
+# Request array parameters are multi-value query params or header params
+AnyRequestResponseRequestArrayParameters = TypedDict(
+    "AnyRequestResponseRequestArrayParameters", {
+    }
+)
 
 # Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 AnyRequestResponseRequestBody = str
@@ -10721,9 +10788,11 @@ def any_request_response_handler(_handler: AnyRequestResponseHandlerFunction = N
             request_parameters = decode_request_parameters({
                 **(event['pathParameters'] or {}),
                 **(event['queryStringParameters'] or {}),
+                **(event['headers'] or {}),
             })
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
+                **(event['multiValueHeaders'] or {}),
             })
             # Primitive type so body is passed as the original string
             body = event['body']
@@ -10761,13 +10830,17 @@ def any_request_response_handler(_handler: AnyRequestResponseHandlerFunction = N
     else:
         raise Exception("Positional arguments are not supported by any_request_response_handler.")
 
-# Request parameters are single value query params or path params
-class EmptyRequestParameters(TypedDict):
-    ...
+# Request parameters are single value query params, path params or header params
+EmptyRequestParameters = TypedDict(
+    "EmptyRequestParameters", {
+    }
+)
 
-# Request array parameters are multi-value query params
-class EmptyRequestArrayParameters(TypedDict):
-    ...
+# Request array parameters are multi-value query params or header params
+EmptyRequestArrayParameters = TypedDict(
+    "EmptyRequestArrayParameters", {
+    }
+)
 
 # Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 EmptyRequestBody = Any
@@ -10795,9 +10868,11 @@ def empty_handler(_handler: EmptyHandlerFunction = None, interceptors: List[Empt
             request_parameters = decode_request_parameters({
                 **(event['pathParameters'] or {}),
                 **(event['queryStringParameters'] or {}),
+                **(event['headers'] or {}),
             })
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
+                **(event['multiValueHeaders'] or {}),
             })
             body = {}
             interceptor_context = {}
@@ -10834,13 +10909,17 @@ def empty_handler(_handler: EmptyHandlerFunction = None, interceptors: List[Empt
     else:
         raise Exception("Positional arguments are not supported by empty_handler.")
 
-# Request parameters are single value query params or path params
-class MapResponseRequestParameters(TypedDict):
-    ...
+# Request parameters are single value query params, path params or header params
+MapResponseRequestParameters = TypedDict(
+    "MapResponseRequestParameters", {
+    }
+)
 
-# Request array parameters are multi-value query params
-class MapResponseRequestArrayParameters(TypedDict):
-    ...
+# Request array parameters are multi-value query params or header params
+MapResponseRequestArrayParameters = TypedDict(
+    "MapResponseRequestArrayParameters", {
+    }
+)
 
 # Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 MapResponseRequestBody = Any
@@ -10868,9 +10947,11 @@ def map_response_handler(_handler: MapResponseHandlerFunction = None, intercepto
             request_parameters = decode_request_parameters({
                 **(event['pathParameters'] or {}),
                 **(event['queryStringParameters'] or {}),
+                **(event['headers'] or {}),
             })
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
+                **(event['multiValueHeaders'] or {}),
             })
             body = {}
             interceptor_context = {}
@@ -10907,13 +10988,17 @@ def map_response_handler(_handler: MapResponseHandlerFunction = None, intercepto
     else:
         raise Exception("Positional arguments are not supported by map_response_handler.")
 
-# Request parameters are single value query params or path params
-class MediaTypesRequestParameters(TypedDict):
-    ...
+# Request parameters are single value query params, path params or header params
+MediaTypesRequestParameters = TypedDict(
+    "MediaTypesRequestParameters", {
+    }
+)
 
-# Request array parameters are multi-value query params
-class MediaTypesRequestArrayParameters(TypedDict):
-    ...
+# Request array parameters are multi-value query params or header params
+MediaTypesRequestArrayParameters = TypedDict(
+    "MediaTypesRequestArrayParameters", {
+    }
+)
 
 # Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 MediaTypesRequestBody = str
@@ -10941,9 +11026,11 @@ def media_types_handler(_handler: MediaTypesHandlerFunction = None, interceptors
             request_parameters = decode_request_parameters({
                 **(event['pathParameters'] or {}),
                 **(event['queryStringParameters'] or {}),
+                **(event['headers'] or {}),
             })
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
+                **(event['multiValueHeaders'] or {}),
             })
             # Primitive type so body is passed as the original string
             body = event['body']
@@ -10981,13 +11068,17 @@ def media_types_handler(_handler: MediaTypesHandlerFunction = None, interceptors
     else:
         raise Exception("Positional arguments are not supported by media_types_handler.")
 
-# Request parameters are single value query params or path params
-class MultipleContentTypesRequestParameters(TypedDict):
-    ...
+# Request parameters are single value query params, path params or header params
+MultipleContentTypesRequestParameters = TypedDict(
+    "MultipleContentTypesRequestParameters", {
+    }
+)
 
-# Request array parameters are multi-value query params
-class MultipleContentTypesRequestArrayParameters(TypedDict):
-    ...
+# Request array parameters are multi-value query params or header params
+MultipleContentTypesRequestArrayParameters = TypedDict(
+    "MultipleContentTypesRequestArrayParameters", {
+    }
+)
 
 # Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 MultipleContentTypesRequestBody = TestRequest
@@ -11015,9 +11106,11 @@ def multiple_content_types_handler(_handler: MultipleContentTypesHandlerFunction
             request_parameters = decode_request_parameters({
                 **(event['pathParameters'] or {}),
                 **(event['queryStringParameters'] or {}),
+                **(event['headers'] or {}),
             })
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
+                **(event['multiValueHeaders'] or {}),
             })
             # Non-primitive type so parse the body into the appropriate model
             body = parse_body(event['body'], ['application/json','application/pdf',], MultipleContentTypesRequestBody)
@@ -11055,18 +11148,24 @@ def multiple_content_types_handler(_handler: MultipleContentTypesHandlerFunction
     else:
         raise Exception("Positional arguments are not supported by multiple_content_types_handler.")
 
-# Request parameters are single value query params or path params
-class OperationOneRequestParameters(TypedDict):
-    param1: str
-    param3: str
-    pathParam: str
-    param4: str
-    ...
+# Request parameters are single value query params, path params or header params
+OperationOneRequestParameters = TypedDict(
+    "OperationOneRequestParameters", {
+        "param1": str,
+        "param3": str,
+        "pathParam": str,
+        "x-header-param": str,
+        "param4": str,
+    }
+)
 
-# Request array parameters are multi-value query params
-class OperationOneRequestArrayParameters(TypedDict):
-    param2: List[str]
-    ...
+# Request array parameters are multi-value query params or header params
+OperationOneRequestArrayParameters = TypedDict(
+    "OperationOneRequestArrayParameters", {
+        "param2": List[str],
+        "x-multi-value-header-param": List[str],
+    }
+)
 
 # Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 OperationOneRequestBody = TestRequest
@@ -11095,9 +11194,11 @@ def operation_one_handler(_handler: OperationOneHandlerFunction = None, intercep
             request_parameters = decode_request_parameters({
                 **(event['pathParameters'] or {}),
                 **(event['queryStringParameters'] or {}),
+                **(event['headers'] or {}),
             })
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
+                **(event['multiValueHeaders'] or {}),
             })
             # Non-primitive type so parse the body into the appropriate model
             body = parse_body(event['body'], ['application/json',], OperationOneRequestBody)
@@ -11139,13 +11240,17 @@ def operation_one_handler(_handler: OperationOneHandlerFunction = None, intercep
     else:
         raise Exception("Positional arguments are not supported by operation_one_handler.")
 
-# Request parameters are single value query params or path params
-class WithoutOperationIdDeleteRequestParameters(TypedDict):
-    ...
+# Request parameters are single value query params, path params or header params
+WithoutOperationIdDeleteRequestParameters = TypedDict(
+    "WithoutOperationIdDeleteRequestParameters", {
+    }
+)
 
-# Request array parameters are multi-value query params
-class WithoutOperationIdDeleteRequestArrayParameters(TypedDict):
-    ...
+# Request array parameters are multi-value query params or header params
+WithoutOperationIdDeleteRequestArrayParameters = TypedDict(
+    "WithoutOperationIdDeleteRequestArrayParameters", {
+    }
+)
 
 # Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
 WithoutOperationIdDeleteRequestBody = Any
@@ -11173,9 +11278,11 @@ def without_operation_id_delete_handler(_handler: WithoutOperationIdDeleteHandle
             request_parameters = decode_request_parameters({
                 **(event['pathParameters'] or {}),
                 **(event['queryStringParameters'] or {}),
+                **(event['headers'] or {}),
             })
             request_array_parameters = decode_request_parameters({
                 **(event['multiValueQueryStringParameters'] or {}),
+                **(event['multiValueHeaders'] or {}),
             })
             body = {}
             interceptor_context = {}
@@ -15953,6 +16060,61 @@ request_query_param4 = api_client.QueryParameter(
     schema=Param4Schema,
     explode=True,
 )
+# Header params
+XHeaderParamSchema = schemas.StrSchema
+
+
+class XMultiValueHeaderParamSchema(
+    schemas.ListSchema
+):
+
+
+    class MetaOapg:
+        items = schemas.StrSchema
+
+    def __new__(
+        cls,
+        _arg: typing.Union[typing.Tuple[typing.Union[MetaOapg.items, str, ]], typing.List[typing.Union[MetaOapg.items, str, ]]],
+        _configuration: typing.Optional[schemas.Configuration] = None,
+    ) -> 'XMultiValueHeaderParamSchema':
+        return super().__new__(
+            cls,
+            _arg,
+            _configuration=_configuration,
+        )
+
+    def __getitem__(self, i: int) -> MetaOapg.items:
+        return super().__getitem__(i)
+RequestRequiredHeaderParams = typing_extensions.TypedDict(
+    'RequestRequiredHeaderParams',
+    {
+        'x-header-param': typing.Union[XHeaderParamSchema, str, ],
+    }
+)
+RequestOptionalHeaderParams = typing_extensions.TypedDict(
+    'RequestOptionalHeaderParams',
+    {
+        'x-multi-value-header-param': typing.Union[XMultiValueHeaderParamSchema, list, tuple, ],
+    },
+    total=False
+)
+
+
+class RequestHeaderParams(RequestRequiredHeaderParams, RequestOptionalHeaderParams):
+    pass
+
+
+request_header_x_header_param = api_client.HeaderParameter(
+    name="x-header-param",
+    style=api_client.ParameterStyle.SIMPLE,
+    schema=XHeaderParamSchema,
+    required=True,
+)
+request_header_x_multi_value_header_param = api_client.HeaderParameter(
+    name="x-multi-value-header-param",
+    style=api_client.ParameterStyle.SIMPLE,
+    schema=XMultiValueHeaderParamSchema,
+)
 # Path params
 PathParamSchema = schemas.StrSchema
 RequestRequiredPathParams = typing_extensions.TypedDict(
@@ -16044,6 +16206,7 @@ class BaseApi(api_client.Api):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: typing_extensions.Literal["application/json"] = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16059,6 +16222,7 @@ class BaseApi(api_client.Api):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: str = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16076,6 +16240,7 @@ class BaseApi(api_client.Api):
         skip_deserialization: typing_extensions.Literal[True],
         content_type: str = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16088,6 +16253,7 @@ class BaseApi(api_client.Api):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: str = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16103,6 +16269,7 @@ class BaseApi(api_client.Api):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: str = 'application/json',
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16115,6 +16282,7 @@ class BaseApi(api_client.Api):
             class instances
         """
         self._verify_typed_dict_inputs_oapg(RequestQueryParams, query_params)
+        self._verify_typed_dict_inputs_oapg(RequestHeaderParams, header_params)
         self._verify_typed_dict_inputs_oapg(RequestPathParams, path_params)
         used_path = path.value
 
@@ -16148,6 +16316,15 @@ class BaseApi(api_client.Api):
                 used_path += serialized_value
 
         _headers = HTTPHeaderDict()
+        for parameter in (
+            request_header_x_header_param,
+            request_header_x_multi_value_header_param,
+        ):
+            parameter_data = header_params.get(parameter.name, schemas.unset)
+            if parameter_data is schemas.unset:
+                continue
+            serialized_data = parameter.serialize(parameter_data)
+            _headers.extend(serialized_data)
         # TODO add cookie handling
         if accept_content_types:
             for accept_content_type in accept_content_types:
@@ -16202,6 +16379,7 @@ class OperationOne(BaseApi):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: typing_extensions.Literal["application/json"] = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16217,6 +16395,7 @@ class OperationOne(BaseApi):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: str = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16234,6 +16413,7 @@ class OperationOne(BaseApi):
         skip_deserialization: typing_extensions.Literal[True],
         content_type: str = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16246,6 +16426,7 @@ class OperationOne(BaseApi):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: str = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16261,6 +16442,7 @@ class OperationOne(BaseApi):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: str = 'application/json',
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16270,6 +16452,7 @@ class OperationOne(BaseApi):
         return self._operation_one_oapg(
             body=body,
             query_params=query_params,
+            header_params=header_params,
             path_params=path_params,
             content_type=content_type,
             accept_content_types=accept_content_types,
@@ -16288,6 +16471,7 @@ class ApiForpost(BaseApi):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: typing_extensions.Literal["application/json"] = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16303,6 +16487,7 @@ class ApiForpost(BaseApi):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: str = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16320,6 +16505,7 @@ class ApiForpost(BaseApi):
         skip_deserialization: typing_extensions.Literal[True],
         content_type: str = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16332,6 +16518,7 @@ class ApiForpost(BaseApi):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: str = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16347,6 +16534,7 @@ class ApiForpost(BaseApi):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: str = 'application/json',
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16356,6 +16544,7 @@ class ApiForpost(BaseApi):
         return self._operation_one_oapg(
             body=body,
             query_params=query_params,
+            header_params=header_params,
             path_params=path_params,
             content_type=content_type,
             accept_content_types=accept_content_types,
@@ -16472,6 +16661,61 @@ request_query_param4 = api_client.QueryParameter(
     schema=Param4Schema,
     explode=True,
 )
+# Header params
+XHeaderParamSchema = schemas.StrSchema
+
+
+class XMultiValueHeaderParamSchema(
+    schemas.ListSchema
+):
+
+
+    class MetaOapg:
+        items = schemas.StrSchema
+
+    def __new__(
+        cls,
+        _arg: typing.Union[typing.Tuple[typing.Union[MetaOapg.items, str, ]], typing.List[typing.Union[MetaOapg.items, str, ]]],
+        _configuration: typing.Optional[schemas.Configuration] = None,
+    ) -> 'XMultiValueHeaderParamSchema':
+        return super().__new__(
+            cls,
+            _arg,
+            _configuration=_configuration,
+        )
+
+    def __getitem__(self, i: int) -> MetaOapg.items:
+        return super().__getitem__(i)
+RequestRequiredHeaderParams = typing_extensions.TypedDict(
+    'RequestRequiredHeaderParams',
+    {
+        'x-header-param': typing.Union[XHeaderParamSchema, str, ],
+    }
+)
+RequestOptionalHeaderParams = typing_extensions.TypedDict(
+    'RequestOptionalHeaderParams',
+    {
+        'x-multi-value-header-param': typing.Union[XMultiValueHeaderParamSchema, list, tuple, ],
+    },
+    total=False
+)
+
+
+class RequestHeaderParams(RequestRequiredHeaderParams, RequestOptionalHeaderParams):
+    pass
+
+
+request_header_x_header_param = api_client.HeaderParameter(
+    name="x-header-param",
+    style=api_client.ParameterStyle.SIMPLE,
+    schema=XHeaderParamSchema,
+    required=True,
+)
+request_header_x_multi_value_header_param = api_client.HeaderParameter(
+    name="x-multi-value-header-param",
+    style=api_client.ParameterStyle.SIMPLE,
+    schema=XMultiValueHeaderParamSchema,
+)
 # Path params
 PathParamSchema = schemas.StrSchema
 RequestRequiredPathParams = typing_extensions.TypedDict(
@@ -16559,6 +16803,7 @@ class BaseApi(api_client.Api):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: typing_extensions.Literal["application/json"] = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16574,6 +16819,7 @@ class BaseApi(api_client.Api):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: str = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16591,6 +16837,7 @@ class BaseApi(api_client.Api):
         skip_deserialization: typing_extensions.Literal[True],
         content_type: str = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16603,6 +16850,7 @@ class BaseApi(api_client.Api):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: str = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16618,6 +16866,7 @@ class BaseApi(api_client.Api):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: str = 'application/json',
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16630,6 +16879,7 @@ class BaseApi(api_client.Api):
             class instances
         """
         self._verify_typed_dict_inputs_oapg(RequestQueryParams, query_params)
+        self._verify_typed_dict_inputs_oapg(RequestHeaderParams, header_params)
         self._verify_typed_dict_inputs_oapg(RequestPathParams, path_params)
         used_path = path.value
 
@@ -16663,6 +16913,15 @@ class BaseApi(api_client.Api):
                 used_path += serialized_value
 
         _headers = HTTPHeaderDict()
+        for parameter in (
+            request_header_x_header_param,
+            request_header_x_multi_value_header_param,
+        ):
+            parameter_data = header_params.get(parameter.name, schemas.unset)
+            if parameter_data is schemas.unset:
+                continue
+            serialized_data = parameter.serialize(parameter_data)
+            _headers.extend(serialized_data)
         # TODO add cookie handling
         if accept_content_types:
             for accept_content_type in accept_content_types:
@@ -16717,6 +16976,7 @@ class OperationOne(BaseApi):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: typing_extensions.Literal["application/json"] = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16732,6 +16992,7 @@ class OperationOne(BaseApi):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: str = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16749,6 +17010,7 @@ class OperationOne(BaseApi):
         skip_deserialization: typing_extensions.Literal[True],
         content_type: str = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16761,6 +17023,7 @@ class OperationOne(BaseApi):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: str = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16776,6 +17039,7 @@ class OperationOne(BaseApi):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: str = 'application/json',
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16785,6 +17049,7 @@ class OperationOne(BaseApi):
         return self._operation_one_oapg(
             body=body,
             query_params=query_params,
+            header_params=header_params,
             path_params=path_params,
             content_type=content_type,
             accept_content_types=accept_content_types,
@@ -16803,6 +17068,7 @@ class ApiForpost(BaseApi):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: typing_extensions.Literal["application/json"] = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16818,6 +17084,7 @@ class ApiForpost(BaseApi):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: str = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16835,6 +17102,7 @@ class ApiForpost(BaseApi):
         skip_deserialization: typing_extensions.Literal[True],
         content_type: str = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16847,6 +17115,7 @@ class ApiForpost(BaseApi):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: str = ...,
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16862,6 +17131,7 @@ class ApiForpost(BaseApi):
         body: typing.Union[SchemaForRequestBodyApplicationJson,],
         content_type: str = 'application/json',
         query_params: RequestQueryParams = frozendict.frozendict(),
+        header_params: RequestHeaderParams = frozendict.frozendict(),
         path_params: RequestPathParams = frozendict.frozendict(),
         accept_content_types: typing.Tuple[str] = _all_accept_content_types,
         stream: bool = False,
@@ -16871,6 +17141,7 @@ class ApiForpost(BaseApi):
         return self._operation_one_oapg(
             body=body,
             query_params=query_params,
+            header_params=header_params,
             path_params=path_params,
             content_type=content_type,
             accept_content_types=accept_content_types,

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript.test.ts.snap
@@ -306,13 +306,13 @@ const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBod
 };
 
 /**
- * Single-value path/query parameters for Neither
+ * Single-value path/query/header parameters for Neither
  */
 export interface NeitherRequestParameters {
 }
 
 /**
- * Multi-value query parameters for Neither
+ * Multi-value query or header parameters for Neither
  */
 export interface NeitherRequestArrayParameters {
 }
@@ -339,10 +339,12 @@ export const neitherHandler = (
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
+        ...(event.headers || {}),
     }) as unknown as NeitherRequestParameters;
 
     const requestArrayParameters = decodeRequestParameters({
         ...(event.multiValueQueryStringParameters || {}),
+        ...(event.multiValueHeaders || {}),
     }) as unknown as NeitherRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
@@ -395,13 +397,13 @@ export const neitherHandler = (
     };
 };
 /**
- * Single-value path/query parameters for Both
+ * Single-value path/query/header parameters for Both
  */
 export interface BothRequestParameters {
 }
 
 /**
- * Multi-value query parameters for Both
+ * Multi-value query or header parameters for Both
  */
 export interface BothRequestArrayParameters {
 }
@@ -428,10 +430,12 @@ export const bothHandler = (
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
+        ...(event.headers || {}),
     }) as unknown as BothRequestParameters;
 
     const requestArrayParameters = decodeRequestParameters({
         ...(event.multiValueQueryStringParameters || {}),
+        ...(event.multiValueHeaders || {}),
     }) as unknown as BothRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
@@ -484,13 +488,13 @@ export const bothHandler = (
     };
 };
 /**
- * Single-value path/query parameters for Tag1
+ * Single-value path/query/header parameters for Tag1
  */
 export interface Tag1RequestParameters {
 }
 
 /**
- * Multi-value query parameters for Tag1
+ * Multi-value query or header parameters for Tag1
  */
 export interface Tag1RequestArrayParameters {
 }
@@ -517,10 +521,12 @@ export const tag1Handler = (
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
+        ...(event.headers || {}),
     }) as unknown as Tag1RequestParameters;
 
     const requestArrayParameters = decodeRequestParameters({
         ...(event.multiValueQueryStringParameters || {}),
+        ...(event.multiValueHeaders || {}),
     }) as unknown as Tag1RequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
@@ -573,13 +579,13 @@ export const tag1Handler = (
     };
 };
 /**
- * Single-value path/query parameters for Tag2
+ * Single-value path/query/header parameters for Tag2
  */
 export interface Tag2RequestParameters {
 }
 
 /**
- * Multi-value query parameters for Tag2
+ * Multi-value query or header parameters for Tag2
  */
 export interface Tag2RequestArrayParameters {
 }
@@ -606,10 +612,12 @@ export const tag2Handler = (
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
+        ...(event.headers || {}),
     }) as unknown as Tag2RequestParameters;
 
     const requestArrayParameters = decodeRequestParameters({
         ...(event.multiValueQueryStringParameters || {}),
+        ...(event.multiValueHeaders || {}),
     }) as unknown as Tag2RequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
@@ -1425,8 +1433,10 @@ export interface OperationOneRequest {
     param2: Array<string>;
     param3: number;
     pathParam: string;
+    xHeaderParam: string;
     testRequest: TestRequest;
     param4?: string;
+    xMultiValueHeaderParam?: Array<string>;
 }
 
 /**
@@ -1589,6 +1599,10 @@ export class DefaultApi extends runtime.BaseAPI {
             throw new runtime.RequiredError('pathParam','Required parameter requestParameters.pathParam was null or undefined when calling operationOne.');
         }
 
+        if (requestParameters.xHeaderParam === null || requestParameters.xHeaderParam === undefined) {
+            throw new runtime.RequiredError('xHeaderParam','Required parameter requestParameters.xHeaderParam was null or undefined when calling operationOne.');
+        }
+
         if (requestParameters.testRequest === null || requestParameters.testRequest === undefined) {
             throw new runtime.RequiredError('testRequest','Required parameter requestParameters.testRequest was null or undefined when calling operationOne.');
         }
@@ -1614,6 +1628,14 @@ export class DefaultApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
         headerParameters['Content-Type'] = 'application/json';
+
+        if (requestParameters.xHeaderParam !== undefined && requestParameters.xHeaderParam !== null) {
+            headerParameters['x-header-param'] = String(requestParameters.xHeaderParam);
+        }
+
+        if (requestParameters.xMultiValueHeaderParam) {
+            headerParameters['x-multi-value-header-param'] = requestParameters.xMultiValueHeaderParam.join(runtime.COLLECTION_FORMATS["csv"]);
+        }
 
         const response = await this.request({
             path: \`/path/{pathParam}\`.replace(\`{\${"pathParam"}}\`, encodeURIComponent(String(requestParameters.pathParam))),
@@ -1855,13 +1877,13 @@ const buildHandlerChain = <RequestParameters, RequestArrayParameters, RequestBod
 };
 
 /**
- * Single-value path/query parameters for AnyRequestResponse
+ * Single-value path/query/header parameters for AnyRequestResponse
  */
 export interface AnyRequestResponseRequestParameters {
 }
 
 /**
- * Multi-value query parameters for AnyRequestResponse
+ * Multi-value query or header parameters for AnyRequestResponse
  */
 export interface AnyRequestResponseRequestArrayParameters {
 }
@@ -1888,10 +1910,12 @@ export const anyRequestResponseHandler = (
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
+        ...(event.headers || {}),
     }) as unknown as AnyRequestResponseRequestParameters;
 
     const requestArrayParameters = decodeRequestParameters({
         ...(event.multiValueQueryStringParameters || {}),
+        ...(event.multiValueHeaders || {}),
     }) as unknown as AnyRequestResponseRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
@@ -1944,13 +1968,13 @@ export const anyRequestResponseHandler = (
     };
 };
 /**
- * Single-value path/query parameters for Empty
+ * Single-value path/query/header parameters for Empty
  */
 export interface EmptyRequestParameters {
 }
 
 /**
- * Multi-value query parameters for Empty
+ * Multi-value query or header parameters for Empty
  */
 export interface EmptyRequestArrayParameters {
 }
@@ -1977,10 +2001,12 @@ export const emptyHandler = (
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
+        ...(event.headers || {}),
     }) as unknown as EmptyRequestParameters;
 
     const requestArrayParameters = decodeRequestParameters({
         ...(event.multiValueQueryStringParameters || {}),
+        ...(event.multiValueHeaders || {}),
     }) as unknown as EmptyRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
@@ -2033,13 +2059,13 @@ export const emptyHandler = (
     };
 };
 /**
- * Single-value path/query parameters for MapResponse
+ * Single-value path/query/header parameters for MapResponse
  */
 export interface MapResponseRequestParameters {
 }
 
 /**
- * Multi-value query parameters for MapResponse
+ * Multi-value query or header parameters for MapResponse
  */
 export interface MapResponseRequestArrayParameters {
 }
@@ -2066,10 +2092,12 @@ export const mapResponseHandler = (
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
+        ...(event.headers || {}),
     }) as unknown as MapResponseRequestParameters;
 
     const requestArrayParameters = decodeRequestParameters({
         ...(event.multiValueQueryStringParameters || {}),
+        ...(event.multiValueHeaders || {}),
     }) as unknown as MapResponseRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
@@ -2123,13 +2151,13 @@ export const mapResponseHandler = (
     };
 };
 /**
- * Single-value path/query parameters for MediaTypes
+ * Single-value path/query/header parameters for MediaTypes
  */
 export interface MediaTypesRequestParameters {
 }
 
 /**
- * Multi-value query parameters for MediaTypes
+ * Multi-value query or header parameters for MediaTypes
  */
 export interface MediaTypesRequestArrayParameters {
 }
@@ -2156,10 +2184,12 @@ export const mediaTypesHandler = (
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
+        ...(event.headers || {}),
     }) as unknown as MediaTypesRequestParameters;
 
     const requestArrayParameters = decodeRequestParameters({
         ...(event.multiValueQueryStringParameters || {}),
+        ...(event.multiValueHeaders || {}),
     }) as unknown as MediaTypesRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
@@ -2212,13 +2242,13 @@ export const mediaTypesHandler = (
     };
 };
 /**
- * Single-value path/query parameters for MultipleContentTypes
+ * Single-value path/query/header parameters for MultipleContentTypes
  */
 export interface MultipleContentTypesRequestParameters {
 }
 
 /**
- * Multi-value query parameters for MultipleContentTypes
+ * Multi-value query or header parameters for MultipleContentTypes
  */
 export interface MultipleContentTypesRequestArrayParameters {
 }
@@ -2245,10 +2275,12 @@ export const multipleContentTypesHandler = (
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
+        ...(event.headers || {}),
     }) as unknown as MultipleContentTypesRequestParameters;
 
     const requestArrayParameters = decodeRequestParameters({
         ...(event.multiValueQueryStringParameters || {}),
+        ...(event.multiValueHeaders || {}),
     }) as unknown as MultipleContentTypesRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
@@ -2301,20 +2333,22 @@ export const multipleContentTypesHandler = (
     };
 };
 /**
- * Single-value path/query parameters for OperationOne
+ * Single-value path/query/header parameters for OperationOne
  */
 export interface OperationOneRequestParameters {
     readonly param1: string;
     readonly param3: string;
     readonly pathParam: string;
+    readonly "x-header-param": string;
     readonly param4?: string;
 }
 
 /**
- * Multi-value query parameters for OperationOne
+ * Multi-value query or header parameters for OperationOne
  */
 export interface OperationOneRequestArrayParameters {
     readonly param2: string[];
+    readonly "x-multi-value-header-param"?: string[];
 }
 
 /**
@@ -2340,10 +2374,12 @@ export const operationOneHandler = (
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
+        ...(event.headers || {}),
     }) as unknown as OperationOneRequestParameters;
 
     const requestArrayParameters = decodeRequestParameters({
         ...(event.multiValueQueryStringParameters || {}),
+        ...(event.multiValueHeaders || {}),
     }) as unknown as OperationOneRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {
@@ -2406,13 +2442,13 @@ export const operationOneHandler = (
     };
 };
 /**
- * Single-value path/query parameters for WithoutOperationIdDelete
+ * Single-value path/query/header parameters for WithoutOperationIdDelete
  */
 export interface WithoutOperationIdDeleteRequestParameters {
 }
 
 /**
- * Multi-value query parameters for WithoutOperationIdDelete
+ * Multi-value query or header parameters for WithoutOperationIdDelete
  */
 export interface WithoutOperationIdDeleteRequestArrayParameters {
 }
@@ -2439,10 +2475,12 @@ export const withoutOperationIdDeleteHandler = (
     const requestParameters = decodeRequestParameters({
         ...(event.pathParameters || {}),
         ...(event.queryStringParameters || {}),
+        ...(event.headers || {}),
     }) as unknown as WithoutOperationIdDeleteRequestParameters;
 
     const requestArrayParameters = decodeRequestParameters({
         ...(event.multiValueQueryStringParameters || {}),
+        ...(event.multiValueHeaders || {}),
     }) as unknown as WithoutOperationIdDeleteRequestArrayParameters;
 
     const demarshal = (bodyString: string): any => {


### PR DESCRIPTION
Include header parameters in the request parameters in the lambda handler wrappers. Previously headers would appear in the `RequestParameters` or `RequestArrayParameters` type but would not be populated from the API gateway event. 

Additionally, we support dashes in header parameters by wrapping the name in quotes (or using a camelCase variant for java). Previously, dashes in header parameters would cause syntax errors in the generated TypeScript, Python and Java runtime packages!
