### PR TITLE
fix(typesafe-api): fix optional event params syntax

### DIFF
--- a/packages/type-safe-api/scripts/generators/python/templates/operationConfig.mustache
+++ b/packages/type-safe-api/scripts/generators/python/templates/operationConfig.mustache
@@ -200,13 +200,13 @@ def {{operationId}}_handler(_handler: {{operationIdCamelCase}}HandlerFunction = 
         @wraps(handler)
         def wrapper(event, context, additional_interceptors = [], **kwargs):
             request_parameters = decode_request_parameters({
-                **(event['pathParameters'] or {}),
-                **(event['queryStringParameters'] or {}),
-                **(event['headers'] or {}),
+                **(event.get('pathParameters', {})),
+                **(event.get('queryStringParameters', {})),
+                **(event.get('headers', {})),
             })
             request_array_parameters = decode_request_parameters({
-                **(event['multiValueQueryStringParameters'] or {}),
-                **(event['multiValueHeaders'] or {}),
+                **(event.get('multiValueQueryStringParameters', {})),
+                **(event.get('multiValueHeaders', {})),
             })
             {{^bodyParams.isEmpty}}
             {{#bodyParams.0}}

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
@@ -2404,13 +2404,13 @@ def neither_handler(_handler: NeitherHandlerFunction = None, interceptors: List[
         @wraps(handler)
         def wrapper(event, context, additional_interceptors = [], **kwargs):
             request_parameters = decode_request_parameters({
-                **(event['pathParameters'] or {}),
-                **(event['queryStringParameters'] or {}),
-                **(event['headers'] or {}),
+                **(event.get('pathParameters', {})),
+                **(event.get('queryStringParameters', {})),
+                **(event.get('headers', {})),
             })
             request_array_parameters = decode_request_parameters({
-                **(event['multiValueQueryStringParameters'] or {}),
-                **(event['multiValueHeaders'] or {}),
+                **(event.get('multiValueQueryStringParameters', {})),
+                **(event.get('multiValueHeaders', {})),
             })
             body = {}
             interceptor_context = {}
@@ -2483,13 +2483,13 @@ def both_handler(_handler: BothHandlerFunction = None, interceptors: List[BothIn
         @wraps(handler)
         def wrapper(event, context, additional_interceptors = [], **kwargs):
             request_parameters = decode_request_parameters({
-                **(event['pathParameters'] or {}),
-                **(event['queryStringParameters'] or {}),
-                **(event['headers'] or {}),
+                **(event.get('pathParameters', {})),
+                **(event.get('queryStringParameters', {})),
+                **(event.get('headers', {})),
             })
             request_array_parameters = decode_request_parameters({
-                **(event['multiValueQueryStringParameters'] or {}),
-                **(event['multiValueHeaders'] or {}),
+                **(event.get('multiValueQueryStringParameters', {})),
+                **(event.get('multiValueHeaders', {})),
             })
             body = {}
             interceptor_context = {}
@@ -2562,13 +2562,13 @@ def tag1_handler(_handler: Tag1HandlerFunction = None, interceptors: List[Tag1In
         @wraps(handler)
         def wrapper(event, context, additional_interceptors = [], **kwargs):
             request_parameters = decode_request_parameters({
-                **(event['pathParameters'] or {}),
-                **(event['queryStringParameters'] or {}),
-                **(event['headers'] or {}),
+                **(event.get('pathParameters', {})),
+                **(event.get('queryStringParameters', {})),
+                **(event.get('headers', {})),
             })
             request_array_parameters = decode_request_parameters({
-                **(event['multiValueQueryStringParameters'] or {}),
-                **(event['multiValueHeaders'] or {}),
+                **(event.get('multiValueQueryStringParameters', {})),
+                **(event.get('multiValueHeaders', {})),
             })
             body = {}
             interceptor_context = {}
@@ -2641,13 +2641,13 @@ def tag2_handler(_handler: Tag2HandlerFunction = None, interceptors: List[Tag2In
         @wraps(handler)
         def wrapper(event, context, additional_interceptors = [], **kwargs):
             request_parameters = decode_request_parameters({
-                **(event['pathParameters'] or {}),
-                **(event['queryStringParameters'] or {}),
-                **(event['headers'] or {}),
+                **(event.get('pathParameters', {})),
+                **(event.get('queryStringParameters', {})),
+                **(event.get('headers', {})),
             })
             request_array_parameters = decode_request_parameters({
-                **(event['multiValueQueryStringParameters'] or {}),
-                **(event['multiValueHeaders'] or {}),
+                **(event.get('multiValueQueryStringParameters', {})),
+                **(event.get('multiValueHeaders', {})),
             })
             body = {}
             interceptor_context = {}
@@ -10786,13 +10786,13 @@ def any_request_response_handler(_handler: AnyRequestResponseHandlerFunction = N
         @wraps(handler)
         def wrapper(event, context, additional_interceptors = [], **kwargs):
             request_parameters = decode_request_parameters({
-                **(event['pathParameters'] or {}),
-                **(event['queryStringParameters'] or {}),
-                **(event['headers'] or {}),
+                **(event.get('pathParameters', {})),
+                **(event.get('queryStringParameters', {})),
+                **(event.get('headers', {})),
             })
             request_array_parameters = decode_request_parameters({
-                **(event['multiValueQueryStringParameters'] or {}),
-                **(event['multiValueHeaders'] or {}),
+                **(event.get('multiValueQueryStringParameters', {})),
+                **(event.get('multiValueHeaders', {})),
             })
             # Primitive type so body is passed as the original string
             body = event['body']
@@ -10866,13 +10866,13 @@ def empty_handler(_handler: EmptyHandlerFunction = None, interceptors: List[Empt
         @wraps(handler)
         def wrapper(event, context, additional_interceptors = [], **kwargs):
             request_parameters = decode_request_parameters({
-                **(event['pathParameters'] or {}),
-                **(event['queryStringParameters'] or {}),
-                **(event['headers'] or {}),
+                **(event.get('pathParameters', {})),
+                **(event.get('queryStringParameters', {})),
+                **(event.get('headers', {})),
             })
             request_array_parameters = decode_request_parameters({
-                **(event['multiValueQueryStringParameters'] or {}),
-                **(event['multiValueHeaders'] or {}),
+                **(event.get('multiValueQueryStringParameters', {})),
+                **(event.get('multiValueHeaders', {})),
             })
             body = {}
             interceptor_context = {}
@@ -10945,13 +10945,13 @@ def map_response_handler(_handler: MapResponseHandlerFunction = None, intercepto
         @wraps(handler)
         def wrapper(event, context, additional_interceptors = [], **kwargs):
             request_parameters = decode_request_parameters({
-                **(event['pathParameters'] or {}),
-                **(event['queryStringParameters'] or {}),
-                **(event['headers'] or {}),
+                **(event.get('pathParameters', {})),
+                **(event.get('queryStringParameters', {})),
+                **(event.get('headers', {})),
             })
             request_array_parameters = decode_request_parameters({
-                **(event['multiValueQueryStringParameters'] or {}),
-                **(event['multiValueHeaders'] or {}),
+                **(event.get('multiValueQueryStringParameters', {})),
+                **(event.get('multiValueHeaders', {})),
             })
             body = {}
             interceptor_context = {}
@@ -11024,13 +11024,13 @@ def media_types_handler(_handler: MediaTypesHandlerFunction = None, interceptors
         @wraps(handler)
         def wrapper(event, context, additional_interceptors = [], **kwargs):
             request_parameters = decode_request_parameters({
-                **(event['pathParameters'] or {}),
-                **(event['queryStringParameters'] or {}),
-                **(event['headers'] or {}),
+                **(event.get('pathParameters', {})),
+                **(event.get('queryStringParameters', {})),
+                **(event.get('headers', {})),
             })
             request_array_parameters = decode_request_parameters({
-                **(event['multiValueQueryStringParameters'] or {}),
-                **(event['multiValueHeaders'] or {}),
+                **(event.get('multiValueQueryStringParameters', {})),
+                **(event.get('multiValueHeaders', {})),
             })
             # Primitive type so body is passed as the original string
             body = event['body']
@@ -11104,13 +11104,13 @@ def multiple_content_types_handler(_handler: MultipleContentTypesHandlerFunction
         @wraps(handler)
         def wrapper(event, context, additional_interceptors = [], **kwargs):
             request_parameters = decode_request_parameters({
-                **(event['pathParameters'] or {}),
-                **(event['queryStringParameters'] or {}),
-                **(event['headers'] or {}),
+                **(event.get('pathParameters', {})),
+                **(event.get('queryStringParameters', {})),
+                **(event.get('headers', {})),
             })
             request_array_parameters = decode_request_parameters({
-                **(event['multiValueQueryStringParameters'] or {}),
-                **(event['multiValueHeaders'] or {}),
+                **(event.get('multiValueQueryStringParameters', {})),
+                **(event.get('multiValueHeaders', {})),
             })
             # Non-primitive type so parse the body into the appropriate model
             body = parse_body(event['body'], ['application/json','application/pdf',], MultipleContentTypesRequestBody)
@@ -11192,13 +11192,13 @@ def operation_one_handler(_handler: OperationOneHandlerFunction = None, intercep
         @wraps(handler)
         def wrapper(event, context, additional_interceptors = [], **kwargs):
             request_parameters = decode_request_parameters({
-                **(event['pathParameters'] or {}),
-                **(event['queryStringParameters'] or {}),
-                **(event['headers'] or {}),
+                **(event.get('pathParameters', {})),
+                **(event.get('queryStringParameters', {})),
+                **(event.get('headers', {})),
             })
             request_array_parameters = decode_request_parameters({
-                **(event['multiValueQueryStringParameters'] or {}),
-                **(event['multiValueHeaders'] or {}),
+                **(event.get('multiValueQueryStringParameters', {})),
+                **(event.get('multiValueHeaders', {})),
             })
             # Non-primitive type so parse the body into the appropriate model
             body = parse_body(event['body'], ['application/json',], OperationOneRequestBody)
@@ -11276,13 +11276,13 @@ def without_operation_id_delete_handler(_handler: WithoutOperationIdDeleteHandle
         @wraps(handler)
         def wrapper(event, context, additional_interceptors = [], **kwargs):
             request_parameters = decode_request_parameters({
-                **(event['pathParameters'] or {}),
-                **(event['queryStringParameters'] or {}),
-                **(event['headers'] or {}),
+                **(event.get('pathParameters', {})),
+                **(event.get('queryStringParameters', {})),
+                **(event.get('headers', {})),
             })
             request_array_parameters = decode_request_parameters({
-                **(event['multiValueQueryStringParameters'] or {}),
-                **(event['multiValueHeaders'] or {}),
+                **(event.get('multiValueQueryStringParameters', {})),
+                **(event.get('multiValueHeaders', {})),
             })
             body = {}
             interceptor_context = {}


### PR DESCRIPTION
fix(typesafe-api): make `event['path|queryString|multipValueQueryString*Parameters'] optional

To suport Lambda Function Urls, which do not provide `pathParameters`, we need to make these optional. Which originally the source attempts to provide defaults, but sincing using [] notation which is required attribute lookup, it fails before returning the `or {}`.

By switching to `event.get('***', {})` we fix the intended usage.

See - https://docs.aws.amazon.com/lambda/latest/dg/urls-invocation.html#urls-payloads

Fixes #