### PR TITLE
fix(type-safe-api): unique prepare spec lambda name for multiple apis in same stack

### DIFF
--- a/packages/type-safe-api/src/construct/type-safe-rest-api.ts
+++ b/packages/type-safe-api/src/construct/type-safe-rest-api.ts
@@ -115,7 +115,7 @@ export class TypeSafeRestApi extends Construct {
 
     const prepareSpecLambdaName = `${PDKNag.getStackPrefix(stack)
       .split("/")
-      .join("-")}PrepareSpec`;
+      .join("-")}PrepareSpec${this.node.addr.slice(-8).toUpperCase()}`;
     const prepareSpecRole = new Role(this, "PrepareSpecRole", {
       assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
       inlinePolicies: {

--- a/packages/type-safe-api/test/construct/__snapshots__/type-safe-rest-api.test.ts.snap
+++ b/packages/type-safe-api/test/construct/__snapshots__/type-safe-rest-api.test.ts.snap
@@ -723,7 +723,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
           },
           "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
-        "FunctionName": "Default-PrepareSpec",
+        "FunctionName": "Default-PrepareSpec85532C36",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -814,7 +814,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider",
+                          ":log-group:/aws/lambda/Default-PrepareSpec85532C36-Provider",
                         ],
                       ],
                     },
@@ -830,7 +830,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec85532C36-Provider:*",
                         ],
                       ],
                     },
@@ -990,7 +990,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec-Provider",
+        "FunctionName": "Default-PrepareSpec85532C36-Provider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -1010,7 +1010,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec85532C36:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -1028,7 +1028,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec85532C36:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -1109,7 +1109,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec",
+                          ":log-group:/aws/lambda/Default-PrepareSpec85532C36",
                         ],
                       ],
                     },
@@ -1125,7 +1125,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec85532C36:*",
                         ],
                       ],
                     },
@@ -1751,7 +1751,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
           },
           "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
-        "FunctionName": "Default-PrepareSpec",
+        "FunctionName": "Default-PrepareSpec300D0E5F",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -1938,7 +1938,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider",
+                          ":log-group:/aws/lambda/Default-PrepareSpec300D0E5F-Provider",
                         ],
                       ],
                     },
@@ -1954,7 +1954,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec300D0E5F-Provider:*",
                         ],
                       ],
                     },
@@ -2114,7 +2114,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec-Provider",
+        "FunctionName": "Default-PrepareSpec300D0E5F-Provider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -2134,7 +2134,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec300D0E5F:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -2152,7 +2152,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec300D0E5F:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -2233,7 +2233,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec",
+                          ":log-group:/aws/lambda/Default-PrepareSpec300D0E5F",
                         ],
                       ],
                     },
@@ -2249,7 +2249,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec300D0E5F:*",
                         ],
                       ],
                     },
@@ -3089,7 +3089,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
           },
           "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
-        "FunctionName": "Default-PrepareSpec",
+        "FunctionName": "Default-PrepareSpec3E755E54",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -3358,7 +3358,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
                         ],
                       ],
                     },
@@ -3374,7 +3374,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
                         ],
                       ],
                     },
@@ -3452,7 +3452,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec-Provider",
+        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -3472,7 +3472,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -3490,7 +3490,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -3571,7 +3571,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
                         ],
                       ],
                     },
@@ -3587,7 +3587,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
                         ],
                       ],
                     },
@@ -4332,7 +4332,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
           },
           "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
-        "FunctionName": "Default-PrepareSpec",
+        "FunctionName": "Default-PrepareSpec3E755E54",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -4604,7 +4604,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
                         ],
                       ],
                     },
@@ -4620,7 +4620,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
                         ],
                       ],
                     },
@@ -4698,7 +4698,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec-Provider",
+        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -4718,7 +4718,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -4736,7 +4736,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -4817,7 +4817,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
                         ],
                       ],
                     },
@@ -4833,7 +4833,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
                         ],
                       ],
                     },
@@ -5578,7 +5578,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
           },
           "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
-        "FunctionName": "Default-PrepareSpec",
+        "FunctionName": "Default-PrepareSpec3E755E54",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -5847,7 +5847,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
                         ],
                       ],
                     },
@@ -5863,7 +5863,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
                         ],
                       ],
                     },
@@ -5941,7 +5941,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec-Provider",
+        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -5961,7 +5961,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -5979,7 +5979,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -6060,7 +6060,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
                         ],
                       ],
                     },
@@ -6076,7 +6076,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
                         ],
                       ],
                     },
@@ -7920,7 +7920,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
           },
           "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
-        "FunctionName": "Default-PrepareSpec",
+        "FunctionName": "Default-PrepareSpec3E755E54",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -8210,7 +8210,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
                         ],
                       ],
                     },
@@ -8226,7 +8226,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
                         ],
                       ],
                     },
@@ -8304,7 +8304,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec-Provider",
+        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -8324,7 +8324,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -8342,7 +8342,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -8423,7 +8423,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
                         ],
                       ],
                     },
@@ -8439,7 +8439,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
                         ],
                       ],
                     },
@@ -9361,7 +9361,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
           },
           "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
-        "FunctionName": "Default-PrepareSpec",
+        "FunctionName": "Default-PrepareSpec3E755E54",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -9668,7 +9668,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
                         ],
                       ],
                     },
@@ -9684,7 +9684,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
                         ],
                       ],
                     },
@@ -9762,7 +9762,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec-Provider",
+        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -9782,7 +9782,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -9800,7 +9800,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -9881,7 +9881,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
                         ],
                       ],
                     },
@@ -9897,7 +9897,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
                         ],
                       ],
                     },
@@ -10787,7 +10787,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
           },
           "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
-        "FunctionName": "Default-PrepareSpec",
+        "FunctionName": "Default-PrepareSpec3E755E54",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -11056,7 +11056,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
                         ],
                       ],
                     },
@@ -11072,7 +11072,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
                         ],
                       ],
                     },
@@ -11150,7 +11150,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec-Provider",
+        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -11170,7 +11170,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -11188,7 +11188,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -11269,7 +11269,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
                         ],
                       ],
                     },
@@ -11285,7 +11285,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
                         ],
                       ],
                     },
@@ -12030,7 +12030,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
           },
           "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
-        "FunctionName": "Default-PrepareSpec",
+        "FunctionName": "Default-PrepareSpec3E755E54",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -12333,7 +12333,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
                         ],
                       ],
                     },
@@ -12349,7 +12349,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
                         ],
                       ],
                     },
@@ -12427,7 +12427,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec-Provider",
+        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -12447,7 +12447,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -12465,7 +12465,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -12546,7 +12546,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
                         ],
                       ],
                     },
@@ -12562,7 +12562,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
                         ],
                       ],
                     },
@@ -13725,7 +13725,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
           },
           "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
-        "FunctionName": "Default-PrepareSpec",
+        "FunctionName": "Default-PrepareSpec3E755E54",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -14172,7 +14172,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
                         ],
                       ],
                     },
@@ -14188,7 +14188,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
                         ],
                       ],
                     },
@@ -14266,7 +14266,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec-Provider",
+        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -14286,7 +14286,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -14304,7 +14304,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -14385,7 +14385,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
                         ],
                       ],
                     },
@@ -14401,7 +14401,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
                         ],
                       ],
                     },
@@ -15353,7 +15353,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
           },
           "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
-        "FunctionName": "Default-PrepareSpec",
+        "FunctionName": "Default-PrepareSpec3E755E54",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -15609,7 +15609,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
                         ],
                       ],
                     },
@@ -15625,7 +15625,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
                         ],
                       ],
                     },
@@ -15703,7 +15703,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec-Provider",
+        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -15723,7 +15723,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -15741,7 +15741,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -15822,7 +15822,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
                         ],
                       ],
                     },
@@ -15838,7 +15838,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
                         ],
                       ],
                     },
@@ -16532,7 +16532,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
           },
           "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
-        "FunctionName": "Default-PrepareSpec",
+        "FunctionName": "Default-PrepareSpec3E755E54",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -16816,7 +16816,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
                         ],
                       ],
                     },
@@ -16832,7 +16832,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
                         ],
                       ],
                     },
@@ -16910,7 +16910,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec-Provider",
+        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -16930,7 +16930,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -16948,7 +16948,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -17029,7 +17029,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
                         ],
                       ],
                     },
@@ -17045,7 +17045,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
                         ],
                       ],
                     },
@@ -17883,7 +17883,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
           },
           "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
-        "FunctionName": "Default-PrepareSpec",
+        "FunctionName": "Default-PrepareSpec3E755E54",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -18152,7 +18152,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
                         ],
                       ],
                     },
@@ -18168,7 +18168,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
                         ],
                       ],
                     },
@@ -18246,7 +18246,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec-Provider",
+        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -18266,7 +18266,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -18284,7 +18284,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -18365,7 +18365,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
                         ],
                       ],
                     },
@@ -18381,7 +18381,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
                         ],
                       ],
                     },
@@ -19254,7 +19254,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
           },
           "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
-        "FunctionName": "Default-PrepareSpec",
+        "FunctionName": "Default-PrepareSpec3E755E54",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -19523,7 +19523,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
                         ],
                       ],
                     },
@@ -19539,7 +19539,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
                         ],
                       ],
                     },
@@ -19617,7 +19617,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec-Provider",
+        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -19637,7 +19637,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -19655,7 +19655,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -19736,7 +19736,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
                         ],
                       ],
                     },
@@ -19752,7 +19752,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
                         ],
                       ],
                     },
@@ -20364,7 +20364,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
           },
           "S3Key": "24eec97ce84445986321e2f17395e7827ad4500908e0a92d18d2bba7350329af.zip",
         },
-        "FunctionName": "Default-PrepareSpec",
+        "FunctionName": "Default-PrepareSpec3E755E54",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -20633,7 +20633,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
                         ],
                       ],
                     },
@@ -20649,7 +20649,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec-Provider:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
                         ],
                       ],
                     },
@@ -20727,7 +20727,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec-Provider",
+        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -20747,7 +20747,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -20765,7 +20765,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -20846,7 +20846,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
                         ],
                       ],
                     },
@@ -20862,7 +20862,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec:*",
+                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
                         ],
                       ],
                     },


### PR DESCRIPTION
Attempting to create multiple TypeSafeRestApi constructs in the same stack would clash due to the prepare spec lambda name. Include a suffix in the name which is unique to the full construct path.
