### PR TITLE
fix(type-safe-api): update prepare spec provider logical id

### DIFF
--- a/packages/type-safe-api/src/construct/type-safe-rest-api.ts
+++ b/packages/type-safe-api/src/construct/type-safe-rest-api.ts
@@ -244,7 +244,7 @@ export class TypeSafeRestApi extends Construct {
       },
     });
 
-    const provider = new Provider(this, "PrepareSpecProvider", {
+    const provider = new Provider(this, "PrepareSpecResourceProvider", {
       onEventHandler: prepareSpec,
       role: providerRole,
       providerFunctionName,

--- a/packages/type-safe-api/test/construct/__snapshots__/type-safe-rest-api.test.ts.snap
+++ b/packages/type-safe-api/test/construct/__snapshots__/type-safe-rest-api.test.ts.snap
@@ -621,7 +621,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
-            "ApiTest1PrepareSpecProviderframeworkonEvent9E64448F",
+            "ApiTest1PrepareSpecResourceProviderframeworkonEventCE6393EE",
             "Arn",
           ],
         },
@@ -927,7 +927,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
       },
       "Type": "AWS::IAM::Policy",
     },
-    "ApiTest1PrepareSpecProviderframeworkonEvent9E64448F": {
+    "ApiTest1PrepareSpecResourceProviderframeworkonEventCE6393EE": {
       "DependsOn": [
         "ApiTest1PrepareSpecProviderRoleDefaultPolicyFCE97042",
         "ApiTest1PrepareSpecProviderRoleA1D8F665",
@@ -979,7 +979,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
           },
           "S3Key": "8e3d635893ea17fa3158623489cd42c680fad925b38de1ef51cb10d84f6e245e.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest1/PrepareSpecProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest1/PrepareSpecResourceProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
@@ -1801,7 +1801,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
-            "ApiTest2PrepareSpecProviderframeworkonEventC9470DD8",
+            "ApiTest2PrepareSpecResourceProviderframeworkonEventF2315413",
             "Arn",
           ],
         },
@@ -2051,7 +2051,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
       },
       "Type": "AWS::IAM::Policy",
     },
-    "ApiTest2PrepareSpecProviderframeworkonEventC9470DD8": {
+    "ApiTest2PrepareSpecResourceProviderframeworkonEventF2315413": {
       "DependsOn": [
         "ApiTest2PrepareSpecProviderRoleDefaultPolicyA41E659C",
         "ApiTest2PrepareSpecProviderRole59C44E6C",
@@ -2103,7 +2103,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
           },
           "S3Key": "8e3d635893ea17fa3158623489cd42c680fad925b38de1ef51cb10d84f6e245e.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest2/PrepareSpecProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest2/PrepareSpecResourceProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
@@ -3139,7 +3139,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
-            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
             "Arn",
           ],
         },
@@ -3389,7 +3389,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
+    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -3441,7 +3441,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
           },
           "S3Key": "8e3d635893ea17fa3158623489cd42c680fad925b38de1ef51cb10d84f6e245e.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
@@ -4382,7 +4382,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
-            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
             "Arn",
           ],
         },
@@ -4635,7 +4635,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
+    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -4687,7 +4687,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
           },
           "S3Key": "8e3d635893ea17fa3158623489cd42c680fad925b38de1ef51cb10d84f6e245e.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
@@ -5629,7 +5629,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
-            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
             "Arn",
           ],
         },
@@ -5879,7 +5879,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
+    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -5931,7 +5931,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
           },
           "S3Key": "8e3d635893ea17fa3158623489cd42c680fad925b38de1ef51cb10d84f6e245e.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
@@ -6872,7 +6872,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
-            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
             "Arn",
           ],
         },
@@ -7122,7 +7122,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
+    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -7174,7 +7174,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
           },
           "S3Key": "8e3d635893ea17fa3158623489cd42c680fad925b38de1ef51cb10d84f6e245e.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
@@ -9214,7 +9214,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
-            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
             "Arn",
           ],
         },
@@ -9485,7 +9485,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
+    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -9537,7 +9537,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
           },
           "S3Key": "8e3d635893ea17fa3158623489cd42c680fad925b38de1ef51cb10d84f6e245e.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
@@ -10655,7 +10655,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
-            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
             "Arn",
           ],
         },
@@ -10943,7 +10943,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
+    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -10995,7 +10995,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
           },
           "S3Key": "8e3d635893ea17fa3158623489cd42c680fad925b38de1ef51cb10d84f6e245e.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
@@ -12081,7 +12081,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
-            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
             "Arn",
           ],
         },
@@ -12331,7 +12331,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
+    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -12383,7 +12383,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
           },
           "S3Key": "8e3d635893ea17fa3158623489cd42c680fad925b38de1ef51cb10d84f6e245e.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
@@ -13324,7 +13324,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
-            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
             "Arn",
           ],
         },
@@ -13608,7 +13608,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
+    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -13660,7 +13660,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
           },
           "S3Key": "8e3d635893ea17fa3158623489cd42c680fad925b38de1ef51cb10d84f6e245e.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
@@ -15019,7 +15019,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
-            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
             "Arn",
           ],
         },
@@ -15447,7 +15447,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
+    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -15499,7 +15499,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
           },
           "S3Key": "8e3d635893ea17fa3158623489cd42c680fad925b38de1ef51cb10d84f6e245e.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
@@ -16647,7 +16647,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
-            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
             "Arn",
           ],
         },
@@ -16884,7 +16884,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
+    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -16936,7 +16936,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
           },
           "S3Key": "8e3d635893ea17fa3158623489cd42c680fad925b38de1ef51cb10d84f6e245e.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
@@ -17826,7 +17826,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
-            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
             "Arn",
           ],
         },
@@ -18091,7 +18091,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
+    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -18143,7 +18143,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
           },
           "S3Key": "8e3d635893ea17fa3158623489cd42c680fad925b38de1ef51cb10d84f6e245e.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
@@ -19177,7 +19177,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
-            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
             "Arn",
           ],
         },
@@ -19427,7 +19427,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
+    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -19479,7 +19479,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
           },
           "S3Key": "8e3d635893ea17fa3158623489cd42c680fad925b38de1ef51cb10d84f6e245e.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
@@ -20548,7 +20548,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
-            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
             "Arn",
           ],
         },
@@ -20798,7 +20798,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
+    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -20850,7 +20850,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
           },
           "S3Key": "8e3d635893ea17fa3158623489cd42c680fad925b38de1ef51cb10d84f6e245e.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
@@ -21658,7 +21658,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
-            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
             "Arn",
           ],
         },
@@ -21908,7 +21908,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
+    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -21960,7 +21960,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
           },
           "S3Key": "8e3d635893ea17fa3158623489cd42c680fad925b38de1ef51cb10d84f6e245e.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {


### PR DESCRIPTION
[Service Token updates aren't supported by cloudformation custom resources](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cfn-customresource.html#aws-resource-cfn-customresource-properties), so changing the logical id of the custom resource will ensure a smoother deployment of the new unique lambda name if upgrading from < `0.19.38`. Without this, customers would need to change the logical ID of the `TypeSafeRestApi` construct to do a full redeploy.
