### PR TITLE
fix(nx-monorepo): ensure output targets are unique

### DIFF
--- a/packages/nx-monorepo/src/components/nx-project/index.ts
+++ b/packages/nx-monorepo/src/components/nx-project/index.ts
@@ -220,7 +220,15 @@ export class NxProject extends Component {
           this.targets[name] || {};
       }
     }
-    this.targets[name] = deepMerge([_default, target], { append: true });
+    const mergedTarget: Nx.IProjectTarget = deepMerge([_default, target], {
+      append: true,
+    });
+    this.targets[name] = {
+      ...mergedTarget,
+      outputs: mergedTarget.outputs
+        ? [...new Set(mergedTarget.outputs)]
+        : undefined,
+    };
   }
 
   /**


### PR DESCRIPTION
It is possible for users to define multiple duplicate outputs in their project.json. This is leading to fs related issues like ENOTEMPTY: directory not empty, rmdir. The reason this occurs is that the src will tried to be copied to the cached directory in parallel for all output paths (even duplicated ones) and is the reason why these errors are seen sporadically. By ensuring output paths are unique, we only ever copy one path which resolves this issue.

Note: There may still be an issue present if there is a glob that is overlapping another directory i.e: cdk.out/* and cdk.out, however have not been able to reproduce a fs error while testing.

This PR acts as a stopgap until the following PR is merged in NX [18207](https://github.com/nrwl/nx/pull/18207)

fix #488