### PR TITLE
fix(type-safe-api): reduce strictness of ts nx monorepo parent check

### DIFF
--- a/packages/type-safe-api/src/project/type-safe-api-project.ts
+++ b/packages/type-safe-api/src/project/type-safe-api-project.ts
@@ -166,7 +166,9 @@ export class TypeSafeApiProject extends Project {
     super(options);
 
     const nxWorkspace = this.getNxWorkspace(options);
-    const isNxTsWorkspace = this.parent instanceof NxMonorepoProject;
+
+    const isNxTsWorkspace =
+      this.parent && this.parent.constructor.name === NxMonorepoProject.name;
 
     // API Definition project containing the model
     const modelDir = "model";


### PR DESCRIPTION
instanceof will return false if the version of nx-monorepo the user has installed does not exactly match the one type-safe-api depends on, so we fall back to check that the parent looks like the typescript nx-monorepo.