### PR TITLE
fix(type-safe-api): relax instanceof checks to allow for dependency version mismatches

### DIFF
--- a/packages/nx-monorepo/src/components/nx-configurator.ts
+++ b/packages/nx-monorepo/src/components/nx-configurator.ts
@@ -8,7 +8,7 @@ import { Poetry, PythonProject } from "projen/lib/python";
 import { NxProject } from "./nx-project";
 import { NxWorkspace } from "./nx-workspace";
 import { Nx } from "../nx-types";
-import { NodePackageUtils } from "../utils";
+import { NodePackageUtils, ProjectUtils } from "../utils";
 
 /**
  * Options for overriding nx build tasks
@@ -305,7 +305,7 @@ export class NxConfigurator extends Component implements INxProjectCore {
     dependee: PythonProject
   ) {
     // Check we're adding the dependency to a poetry python project
-    if (!(dependent.depsManager instanceof Poetry)) {
+    if (!ProjectUtils.isNamedInstanceOf(dependent.depsManager as any, Poetry)) {
       throw new Error(
         `${dependent.name} must be a PythonProject with Poetry enabled to add this dependency`
       );

--- a/packages/nx-monorepo/src/components/nx-project/index.ts
+++ b/packages/nx-monorepo/src/components/nx-project/index.ts
@@ -6,7 +6,7 @@ import { NodePackageManager } from "projen/lib/javascript";
 import { Obj } from "projen/lib/util";
 import { inferBuildTarget } from "./targets";
 import { Nx } from "../../nx-types";
-import { NodePackageUtils } from "../../utils";
+import { NodePackageUtils, ProjectUtils } from "../../utils";
 import { asUndefinedIfEmpty, deepMerge } from "../../utils/common";
 import { NxWorkspace } from "../nx-workspace";
 
@@ -31,9 +31,9 @@ export class NxProject extends Component {
    * @param project project instance.
    */
   static of(project: Project): NxProject | undefined {
-    return project.components.find((c) => c instanceof NxProject) as
-      | NxProject
-      | undefined;
+    return project.components.find((c) =>
+      ProjectUtils.isNamedInstanceOf(c, NxProject)
+    ) as NxProject | undefined;
   }
   /**
    * Retrieves an instance of NXProject if one is associated to the given project,
@@ -91,7 +91,10 @@ export class NxProject extends Component {
       );
 
     const _existingFile = project.tryFindObjectFile("project.json");
-    if (_existingFile && _existingFile instanceof JsonFile !== true) {
+    if (
+      _existingFile &&
+      !ProjectUtils.isNamedInstanceOf(_existingFile, JsonFile)
+    ) {
       throw new Error(
         `Project "${project.name}" contains a "project.json" file that is not a JsonFile instance. NxProject is unable to support this project.`
       );
@@ -189,7 +192,7 @@ export class NxProject extends Component {
    */
   public addImplicitDependency(...dependee: (Project | string)[]) {
     this.implicitDependencies.push(
-      ...dependee.map((_d) => (_d instanceof Project ? _d.name : _d))
+      ...dependee.map((_d) => (typeof _d === "string" ? _d : _d.name))
     );
   }
 

--- a/packages/nx-monorepo/src/components/nx-project/targets.ts
+++ b/packages/nx-monorepo/src/components/nx-project/targets.ts
@@ -6,6 +6,7 @@ import { JavaProject } from "projen/lib/java";
 import { Jest } from "projen/lib/javascript";
 import { PythonProject } from "projen/lib/python";
 import { Nx } from "../../nx-types";
+import { ProjectUtils } from "../../utils";
 
 /**
  * Defines a fileset for target inputs and outputs.
@@ -169,7 +170,7 @@ function _inferBuildTargetIO(project: Project): InferedTargetFilesets {
   const outputs: (TargetFileset | string)[] = [];
   let includeDefaultInputs = true;
 
-  if (project instanceof JsiiProject) {
+  if (ProjectUtils.isNamedInstanceOf(project, JsiiProject)) {
     outputs.push(
       TargetFileset.File(".jsii"),
       TargetFileset.Directory(project.libdir),
@@ -184,14 +185,14 @@ function _inferBuildTargetIO(project: Project): InferedTargetFilesets {
     );
   }
 
-  if (project instanceof PythonProject) {
+  if (ProjectUtils.isNamedInstanceOf(project, PythonProject)) {
     inputs.push(
       TargetFileset.Directory("!.env"),
       TargetFileset.Directory("!.pytest_cache")
     );
   }
 
-  if (project instanceof JavaProject) {
+  if (ProjectUtils.isNamedInstanceOf(project, JavaProject)) {
     inputs.push(
       TargetFileset.File("!.classpath"),
       TargetFileset.File("!.project"),

--- a/packages/nx-monorepo/src/components/nx-workspace.ts
+++ b/packages/nx-monorepo/src/components/nx-workspace.ts
@@ -9,6 +9,7 @@ import {
 } from "projen";
 import { Obj } from "projen/lib/util";
 import { Nx } from "../nx-types";
+import { ProjectUtils } from "../utils";
 import { asUndefinedIfEmpty, deepMerge } from "../utils/common";
 
 const ALWAYS_IGNORE: string[] = [".tmp", ".env", ".pytest_cache"];
@@ -37,9 +38,9 @@ export class NxWorkspace extends Component {
    * @param scope project instance.
    */
   static of(scope: Project): NxWorkspace | undefined {
-    return scope.root.components.find((c) => c instanceof NxWorkspace) as
-      | NxWorkspace
-      | undefined;
+    return scope.root.components.find((c) =>
+      ProjectUtils.isNamedInstanceOf(c, NxWorkspace)
+    ) as NxWorkspace | undefined;
   }
 
   /**

--- a/packages/nx-monorepo/src/projects/python/nx-monorepo-py.ts
+++ b/packages/nx-monorepo/src/projects/python/nx-monorepo-py.ts
@@ -11,7 +11,7 @@ import {
 import { NxProject } from "../../components/nx-project";
 import { NxWorkspace } from "../../components/nx-workspace";
 import { Nx } from "../../nx-types";
-import { NodePackageUtils } from "../../utils";
+import { NodePackageUtils, ProjectUtils } from "../../utils";
 
 /**
  * Configuration options for the NxMonorepoPythonProject.
@@ -226,7 +226,7 @@ export class NxMonorepoPythonProject
  * @returns true if the project instance is of type PythonProject.
  */
 function isPythonProject(project: any): boolean {
-  return project instanceof PythonProject;
+  return ProjectUtils.isNamedInstanceOf(project, PythonProject);
 }
 
 /**
@@ -236,5 +236,9 @@ function isPythonProject(project: any): boolean {
  * @returns true if the project uses Poetry.
  */
 function isPoetryConfigured(project: PythonProject): boolean {
-  return project.components.find((c) => c instanceof Poetry) !== undefined;
+  return (
+    project.components.find((c) =>
+      ProjectUtils.isNamedInstanceOf(c, Poetry)
+    ) !== undefined
+  );
 }

--- a/packages/nx-monorepo/src/utils/index.ts
+++ b/packages/nx-monorepo/src/utils/index.ts
@@ -1,3 +1,4 @@
 /*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0 */
 export * from "./node";
+export * from "./project";

--- a/packages/nx-monorepo/src/utils/node.ts
+++ b/packages/nx-monorepo/src/utils/node.ts
@@ -6,6 +6,7 @@ import {
   NodeProject,
   NodePackage,
 } from "projen/lib/javascript";
+import { ProjectUtils } from "./project";
 
 /**
  * Utility functions for working with different Node package managers.
@@ -25,11 +26,8 @@ export namespace NodePackageUtils {
   }
 
   /** Indicates if project is a node based project */
-  export function isNodeProject(project: Project): boolean {
-    return (
-      project instanceof NodeProject ||
-      tryFindNodePackage(project, false) != null
-    );
+  export function isNodeProject(project: Project): project is NodeProject {
+    return ProjectUtils.isNamedInstanceOf(project, NodeProject);
   }
 
   /**
@@ -93,8 +91,8 @@ export namespace NodePackageUtils {
   ): NodePackage | undefined {
     let _project: Project | undefined = scope;
     while (_project) {
-      const nodePackage = _project.components.find(
-        (c) => c instanceof NodePackage
+      const nodePackage = _project.components.find((c) =>
+        ProjectUtils.isNamedInstanceOf(c, NodePackage)
       ) as NodePackage | undefined;
       if (nodePackage) {
         return nodePackage;

--- a/packages/nx-monorepo/src/utils/project.ts
+++ b/packages/nx-monorepo/src/utils/project.ts
@@ -1,0 +1,39 @@
+/*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0 */
+import { Component, Project } from "projen";
+
+/**
+ * Utility for projen projects
+ * @experimental
+ */
+export namespace ProjectUtils {
+  /**
+   * List all parent class names of the given class (includes the given class's name as the last element)
+   * @internal
+   */
+  function listParentClassNames(clazz?: {
+    new (...args: any[]): any;
+  }): string[] {
+    if (!clazz?.name) {
+      return [];
+    }
+    return [...listParentClassNames(Object.getPrototypeOf(clazz)), clazz.name];
+  }
+
+  /**
+   * Returns whether the given project is an instance of the given project class.
+   * Uses the class name to perform this check, such that the check still passes for
+   * classes imported from mismatching package versions.
+   */
+  export function isNamedInstanceOf<
+    TParent extends Project | Component,
+    TChild extends TParent
+  >(
+    instance: TParent,
+    clazz: { new (...args: any[]): TChild }
+  ): instance is TChild {
+    return new Set(listParentClassNames(instance.constructor as any)).has(
+      clazz.name
+    );
+  }
+}

--- a/packages/nx-monorepo/test/utils/project.test.ts
+++ b/packages/nx-monorepo/test/utils/project.test.ts
@@ -1,0 +1,78 @@
+/*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0 */
+import { Project } from "projen";
+import { NodeProject } from "projen/lib/javascript";
+import { IPythonDeps, Poetry, PythonProject } from "projen/lib/python";
+import { NxMonorepoProject } from "../../lib";
+import { ProjectUtils } from "../../src";
+
+describe("ProjectUtils", () => {
+  it("should determine whether an object instance is an instance of a given parent class", () => {
+    // Project is a Project
+    expect(
+      ProjectUtils.isNamedInstanceOf(new Project({ name: "test" }), Project)
+    ).toBe(true);
+
+    // NodeProject is a Project
+    expect(
+      ProjectUtils.isNamedInstanceOf(
+        new NodeProject({ name: "test", defaultReleaseBranch: "test" }),
+        Project as any
+      )
+    ).toBe(true);
+
+    // NodeProject is a NodeProject
+    expect(
+      ProjectUtils.isNamedInstanceOf(
+        new NodeProject({ name: "test", defaultReleaseBranch: "test" }),
+        NodeProject
+      )
+    ).toBe(true);
+
+    // PythonProject is not a NodeProject
+    expect(
+      ProjectUtils.isNamedInstanceOf(
+        new PythonProject({
+          authorEmail: "test",
+          authorName: "test",
+          moduleName: "test",
+          name: "test",
+          version: "1.0.0",
+        }),
+        NodeProject as any
+      )
+    ).toBe(false);
+
+    // NxMonorepoProject is a NxMonorepoProject
+    expect(
+      ProjectUtils.isNamedInstanceOf(
+        new NxMonorepoProject({ name: "test", defaultReleaseBranch: "test" }),
+        NxMonorepoProject
+      )
+    ).toBe(true);
+
+    // Project (NxMonorepoProject) is a NxMonorepoProject
+    const pNx: Project = new NxMonorepoProject({
+      name: "test",
+      defaultReleaseBranch: "test",
+    });
+    expect(ProjectUtils.isNamedInstanceOf(pNx, NxMonorepoProject)).toBe(true);
+
+    // Project (NodeProject) is not a NxMonorepoProject
+    const pNode: Project = new NodeProject({
+      name: "test",
+      defaultReleaseBranch: "test",
+    });
+    expect(ProjectUtils.isNamedInstanceOf(pNode, NxMonorepoProject)).toBe(
+      false
+    );
+
+    // Component cast to interface, then any
+    const poetry: IPythonDeps = new Poetry(new Project({ name: "test" }), {
+      authorEmail: "test",
+      authorName: "test",
+      version: "1.0.0",
+    });
+    expect(ProjectUtils.isNamedInstanceOf(poetry as any, Poetry)).toBe(true);
+  });
+});

--- a/packages/type-safe-api/src/project/codegen/components/open-api-tools-json-file.ts
+++ b/packages/type-safe-api/src/project/codegen/components/open-api-tools-json-file.ts
@@ -1,5 +1,6 @@
 /*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0 */
+import { ProjectUtils } from "@aws-prototyping-sdk/nx-monorepo";
 import { JsonFile, Project } from "projen";
 import { OpenApiGeneratorCliConfig } from "../../types";
 
@@ -14,9 +15,9 @@ export class OpenApiToolsJsonFile extends JsonFile {
    * @param project project instance.
    */
   static of(project: Project): OpenApiToolsJsonFile | undefined {
-    return project.components.find((c) => c instanceof OpenApiToolsJsonFile) as
-      | OpenApiToolsJsonFile
-      | undefined;
+    return project.components.find((c) =>
+      ProjectUtils.isNamedInstanceOf(c, OpenApiToolsJsonFile)
+    ) as OpenApiToolsJsonFile | undefined;
   }
 
   /**

--- a/packages/type-safe-api/src/project/type-safe-api-project.ts
+++ b/packages/type-safe-api/src/project/type-safe-api-project.ts
@@ -5,6 +5,7 @@ import {
   NxMonorepoProject,
   NxProject,
   NxWorkspace,
+  ProjectUtils,
 } from "@aws-prototyping-sdk/nx-monorepo";
 import { Project, ProjectOptions, SampleFile } from "projen";
 import { JavaProject } from "projen/lib/java";
@@ -166,7 +167,10 @@ export class TypeSafeApiProject extends Project {
     super(options);
 
     const nxWorkspace = this.getNxWorkspace(options);
-    const isNxTsWorkspace = this.parent instanceof NxMonorepoProject;
+
+    const isNxTsWorkspace =
+      this.parent &&
+      ProjectUtils.isNamedInstanceOf(this.parent, NxMonorepoProject);
 
     // API Definition project containing the model
     const modelDir = "model";
@@ -212,7 +216,8 @@ export class TypeSafeApiProject extends Project {
         // Try to infer monorepo default release branch, otherwise default to mainline unless overridden
         defaultReleaseBranch: nxWorkspace?.affected?.defaultBase ?? "mainline",
         packageManager:
-          this.parent && this.parent instanceof NodeProject
+          this.parent &&
+          ProjectUtils.isNamedInstanceOf(this.parent, NodeProject)
             ? this.parent.package.packageManager
             : NodePackageManager.YARN,
         ...options.runtime.options?.typescript,
@@ -281,7 +286,8 @@ export class TypeSafeApiProject extends Project {
         // Try to infer monorepo default release branch, otherwise default to mainline unless overridden
         defaultReleaseBranch: nxWorkspace?.affected.defaultBase ?? "mainline",
         packageManager:
-          this.parent && this.parent instanceof NodeProject
+          this.parent &&
+          ProjectUtils.isNamedInstanceOf(this.parent, NodeProject)
             ? this.parent.package.packageManager
             : NodePackageManager.YARN,
         ...options.runtime.options?.typescript,
@@ -342,7 +348,8 @@ export class TypeSafeApiProject extends Project {
         // Try to infer monorepo default release branch, otherwise default to mainline unless overridden
         defaultReleaseBranch: nxWorkspace?.affected.defaultBase ?? "mainline",
         packageManager:
-          this.parent && this.parent instanceof NodeProject
+          this.parent &&
+          ProjectUtils.isNamedInstanceOf(this.parent, NodeProject)
             ? this.parent.package.packageManager
             : NodePackageManager.YARN,
         ...options.infrastructure.options?.typescript,


### PR DESCRIPTION
When the version of `nx-monorepo` a user used was not the same as the version `type-safe-api` depends on (for example a user upgrades `type-safe-api` without upgrading the monorepo or vice versa), the standard `instanceof` check would fail and `type-safe-api` would run link commands, assuming it is not part of a repo.

This addresses this issue by performing a check based on the class name of the instance rather than the built-in `instanceof` check. We follow the prototype chain in case the instance is a child of the class we are testing for.
