### PR TITLE
fix: enable yarn workspaces for non-node nx monorepos

### DIFF
--- a/packages/cloudscape-react-ts-website/src/cloudscape-react-ts-website-project.ts
+++ b/packages/cloudscape-react-ts-website/src/cloudscape-react-ts-website-project.ts
@@ -81,12 +81,7 @@ export class CloudscapeReactTsWebsiteProject extends ReactTypeScriptProject {
           "Cannot pass in a Type Safe Api without React Hooks Library configured!"
         );
       }
-      this.addDeps(
-        `${libraryHooksPackage}@file:${path.relative(
-          this.outdir,
-          hooks.outdir
-        )}`
-      );
+      this.addDeps(libraryHooksPackage);
     }
 
     const mustacheConfig = {

--- a/packages/cloudscape-react-ts-website/test/__snapshots__/cloudscape-react-ts-website-project.test.ts.snap
+++ b/packages/cloudscape-react-ts-website/test/__snapshots__/cloudscape-react-ts-website-project.test.ts.snap
@@ -3567,7 +3567,6 @@ tsconfig.tsbuildinfo
       {
         "name": "testapi-typescript-react-query-hooks",
         "type": "runtime",
-        "version": "file:../api/libraries/typescript-react-query-hooks",
       },
       {
         "name": "web-vitals",
@@ -3713,19 +3712,19 @@ tsconfig.tsbuildinfo
             "exec": "yarn upgrade npm-check-updates",
           },
           {
-            "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='testapi-typescript-react-query-hooks'",
+            "exec": "npm-check-updates --dep dev --upgrade --target=minor",
           },
           {
-            "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='testapi-typescript-react-query-hooks'",
+            "exec": "npm-check-updates --dep optional --upgrade --target=minor",
           },
           {
-            "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='testapi-typescript-react-query-hooks'",
+            "exec": "npm-check-updates --dep peer --upgrade --target=minor",
           },
           {
-            "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='testapi-typescript-react-query-hooks'",
+            "exec": "npm-check-updates --dep prod --upgrade --target=minor",
           },
           {
-            "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='testapi-typescript-react-query-hooks'",
+            "exec": "npm-check-updates --dep bundle --upgrade --target=minor",
           },
           {
             "exec": "yarn install --check-files",
@@ -4037,7 +4036,7 @@ curl https://dxxxxxxxxxx.cloudfront.net/runtime-config.json > public/runtime-con
       "react-dom": "*",
       "react-router-dom": "*",
       "react-scripts": "^5",
-      "testapi-typescript-react-query-hooks": "file:../api/libraries/typescript-react-query-hooks",
+      "testapi-typescript-react-query-hooks": "*",
       "web-vitals": "*",
     },
     "devDependencies": {

--- a/packages/nx-monorepo/src/projects/java/nx-monorepo-java.ts
+++ b/packages/nx-monorepo/src/projects/java/nx-monorepo-java.ts
@@ -45,9 +45,9 @@ export class NxMonorepoJavaProject
 
     // Setup maven nx plugin
     this.nx.plugins.push("@jnxplus/nx-maven");
-    this.installTask = this.nxConfigurator.ensureNxInstallTask(
-      "@jnxplus/nx-maven@^0.x"
-    );
+    this.installTask = this.nxConfigurator.ensureNxInstallTask({
+      "@jnxplus/nx-maven": "^0.x",
+    });
 
     // Map tasks to nx run-many
     this.nxConfigurator._overrideNxBuildTask(

--- a/packages/nx-monorepo/src/projects/python/nx-monorepo-py.ts
+++ b/packages/nx-monorepo/src/projects/python/nx-monorepo-py.ts
@@ -49,8 +49,9 @@ export class NxMonorepoPythonProject
 
     // Setup python NX plugin
     this.nx.plugins.push("@nxlv/python");
-    this.installTask =
-      this.nxConfigurator.ensureNxInstallTask("@nxlv/python@^16");
+    this.installTask = this.nxConfigurator.ensureNxInstallTask({
+      "@nxlv/python": "^16",
+    });
 
     // Map tasks to nx run-many
     this.nxConfigurator._overrideNxBuildTask(

--- a/packages/type-safe-api/src/project/type-safe-api-project.ts
+++ b/packages/type-safe-api/src/project/type-safe-api-project.ts
@@ -2,7 +2,9 @@
 SPDX-License-Identifier: Apache-2.0 */
 import * as path from "path";
 import {
+  NxMonorepoJavaProject,
   NxMonorepoProject,
+  NxMonorepoPythonProject,
   NxProject,
   NxWorkspace,
   ProjectUtils,
@@ -168,9 +170,11 @@ export class TypeSafeApiProject extends Project {
 
     const nxWorkspace = this.getNxWorkspace(options);
 
-    const isNxTsWorkspace =
+    const isNxWorkspace =
       this.parent &&
-      ProjectUtils.isNamedInstanceOf(this.parent, NxMonorepoProject);
+      (ProjectUtils.isNamedInstanceOf(this.parent, NxMonorepoProject) ||
+        ProjectUtils.isNamedInstanceOf(this.parent, NxMonorepoJavaProject) ||
+        ProjectUtils.isNamedInstanceOf(this.parent, NxMonorepoPythonProject));
 
     // API Definition project containing the model
     const modelDir = "model";
@@ -205,7 +209,7 @@ export class TypeSafeApiProject extends Project {
       parent: nxWorkspace ? this.parent! : this,
       parentPackageName: this.name,
       generatedCodeDir: runtimeDirRelativeToParent,
-      isWithinMonorepo: isNxTsWorkspace,
+      isWithinMonorepo: isNxWorkspace,
       // Spec path relative to each generated client dir
       parsedSpecPath: path.join(
         "..",
@@ -275,7 +279,7 @@ export class TypeSafeApiProject extends Project {
       parent: nxWorkspace ? this.parent! : this,
       parentPackageName: this.name,
       generatedCodeDir: libraryDirRelativeToParent,
-      isWithinMonorepo: isNxTsWorkspace,
+      isWithinMonorepo: isNxWorkspace,
       // Spec path relative to each generated client dir
       parsedSpecPath: path.join(
         "..",
@@ -337,7 +341,7 @@ export class TypeSafeApiProject extends Project {
       parent: nxWorkspace ? this.parent! : this,
       parentPackageName: this.name,
       generatedCodeDir: infraDirRelativeToParent,
-      isWithinMonorepo: isNxTsWorkspace,
+      isWithinMonorepo: isNxWorkspace,
       // Spec path relative to each generated infra package dir
       parsedSpecPath: path.join(
         "..",


### PR DESCRIPTION
**nx-monorepo**
- Make any non-node NX projects have a yarn workspace configured which will allow node->node links.

**type-safe-api**
- Also check for parents of any NX language variant.

**cloudscape-react-ts-website**
- Use workspace link instead of file link.