### PR TITLE
fix(nx-monorepo): don't include roto java node in NX graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ jspm_packages/
 *.tgz
 .yarn-integrity
 .cache
-.nx/cache
 !/.projenrc.js
 !/.prettierignore
 !/.prettierrc.json
@@ -41,6 +40,7 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json

--- a/packages/nx-monorepo/.projen/deps.json
+++ b/packages/nx-monorepo/.projen/deps.json
@@ -1,6 +1,10 @@
 {
   "dependencies": [
     {
+      "name": "@nx/devkit",
+      "type": "build"
+    },
+    {
       "name": "@types/fs-extra",
       "type": "build"
     },

--- a/packages/nx-monorepo/package.json
+++ b/packages/nx-monorepo/package.json
@@ -37,6 +37,7 @@
     "organization": false
   },
   "devDependencies": {
+    "@nx/devkit": "^16.3.1",
     "@types/fs-extra": "^11.0.1",
     "@types/jest": "^29.5.2",
     "@types/node": "^16",

--- a/packages/nx-monorepo/src/components/nx-configurator.ts
+++ b/packages/nx-monorepo/src/components/nx-configurator.ts
@@ -105,6 +105,7 @@ export class NxConfigurator extends Component implements INxProjectCore {
   constructor(project: Project, options?: NxConfiguratorOptions) {
     super(project);
 
+    project.addGitIgnore(".nx/cache");
     project.addTask("run-many", {
       receiveArgs: true,
       exec: NodePackageUtils.command.exec(

--- a/packages/nx-monorepo/src/projects/java/nx-monorepo-java.ts
+++ b/packages/nx-monorepo/src/projects/java/nx-monorepo-java.ts
@@ -1,6 +1,8 @@
 /*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0 */
-import { Project, Task, TaskRuntime } from "projen";
+import * as fs from "fs";
+import * as path from "path";
+import { Project, Task, TaskRuntime, TextFile } from "projen";
 import { JavaProject, JavaProjectOptions } from "projen/lib/java";
 import { PythonProject } from "projen/lib/python";
 import {
@@ -9,6 +11,8 @@ import {
 } from "../../components/nx-configurator";
 import { NxWorkspace } from "../../components/nx-workspace";
 import { Nx } from "../../nx-types";
+
+const MVN_PLUGIN_PATH = "./.nx/plugins/nx_plugin.js";
 
 /**
  * Configuration options for the NxMonorepoJavaProject.
@@ -44,7 +48,14 @@ export class NxMonorepoJavaProject
     });
 
     // Setup maven nx plugin
-    this.nx.plugins.push("@jnxplus/nx-maven");
+    new TextFile(this, MVN_PLUGIN_PATH, {
+      readonly: true,
+      lines: fs
+        .readFileSync(path.join(__dirname, "plugin/mvn_plugin.js"))
+        .toString("utf-8")
+        .split("\n"),
+    });
+    this.nx.plugins.push("@jnxplus/nx-maven", MVN_PLUGIN_PATH);
     this.installTask = this.nxConfigurator.ensureNxInstallTask({
       "@jnxplus/nx-maven": "^0.x",
     });

--- a/packages/nx-monorepo/src/projects/java/plugin/mvn_plugin.ts
+++ b/packages/nx-monorepo/src/projects/java/plugin/mvn_plugin.ts
@@ -1,0 +1,18 @@
+/*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0 */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { ProjectGraphBuilder, ProjectGraph } from "@nx/devkit";
+
+export function processProjectGraph(graph: ProjectGraph): ProjectGraph {
+  const builder = new ProjectGraphBuilder(graph);
+  const rootNode = Object.keys(graph.nodes).reduce(
+    (_: string | undefined, k: string) =>
+      graph.nodes[k].data.root === "" ? graph.nodes[k].name : undefined,
+    undefined
+  );
+
+  rootNode && builder.removeNode(rootNode);
+
+  // We will see how this is used below.
+  return builder.getUpdatedProjectGraph();
+}

--- a/packages/nx-monorepo/src/projects/typescript/nx-monorepo.ts
+++ b/packages/nx-monorepo/src/projects/typescript/nx-monorepo.ts
@@ -153,7 +153,7 @@ export class NxMonorepoProject
       jest: options.jest ?? false,
       defaultReleaseBranch,
       sampleCode: false, // root should never have sample code,
-      gitignore: [".tmp", ".nx/cache", ...(options.gitignore ?? [])],
+      gitignore: [".tmp", ...(options.gitignore ?? [])],
       eslintOptions: options.eslintOptions ?? {
         dirs: ["."],
         ignorePatterns: ["packages/**/*.*"],

--- a/packages/nx-monorepo/test/__snapshots__/nx-monorepo.test.ts.snap
+++ b/packages/nx-monorepo/test/__snapshots__/nx-monorepo.test.ts.snap
@@ -197,7 +197,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 .tmp
-.nx/cache
 !/.projenrc.js
 !/.prettierignore
 !/.prettierrc.json
@@ -209,6 +208,7 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -2248,7 +2248,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 .tmp
-.nx/cache
 !/.projenrc.js
 !/.prettierignore
 !/.prettierrc.json
@@ -2260,6 +2259,7 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -4282,7 +4282,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 .tmp
-.nx/cache
 !/.projenrc.js
 !/.prettierignore
 !/.prettierrc.json
@@ -4294,6 +4293,7 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 .yarn/*
@@ -6319,7 +6319,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 .tmp
-.nx/cache
 !/.projenrc.js
 !/.prettierignore
 !/.prettierrc.json
@@ -6331,6 +6330,7 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -8168,7 +8168,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 .tmp
-.nx/cache
 !/.projenrc.js
 !/.prettierignore
 !/.prettierrc.json
@@ -8180,6 +8179,7 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -9913,7 +9913,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 .tmp
-.nx/cache
 !/.projenrc.js
 !/.prettierignore
 !/.prettierrc.json
@@ -9925,6 +9924,7 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -10943,7 +10943,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 .tmp
-.nx/cache
 !/.projenrc.js
 !/.prettierignore
 !/.prettierrc.json
@@ -10955,6 +10954,7 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -14290,7 +14290,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 .tmp
-.nx/cache
 !/.projenrc.js
 !/.prettierignore
 !/.prettierrc.json
@@ -14302,6 +14301,7 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -15320,7 +15320,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 .tmp
-.nx/cache
 !/.projenrc.js
 !/.prettierignore
 !/.prettierrc.json
@@ -15332,6 +15331,7 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -16349,7 +16349,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 .tmp
-.nx/cache
 another
 !/.projenrc.js
 !/.prettierignore
@@ -16362,6 +16361,7 @@ another
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -17383,7 +17383,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 .tmp
-.nx/cache
 !/.projenrc.js
 !/.prettierignore
 !/.prettierrc.json
@@ -17395,6 +17394,7 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -19427,7 +19427,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 .tmp
-.nx/cache
 !/.projenrc.js
 !/.prettierignore
 !/.prettierrc.json
@@ -19439,6 +19438,7 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -20470,7 +20470,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 .tmp
-.nx/cache
 !/.projenrc.js
 !/.prettierignore
 !/.prettierrc.json
@@ -20482,6 +20481,7 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json

--- a/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
@@ -3073,7 +3073,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 .tmp
-.nx/cache
 !/.projenrc.js
 !/.prettierignore
 !/.prettierrc.json
@@ -3085,6 +3084,7 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -10173,7 +10173,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 .tmp
-.nx/cache
 !/.projenrc.js
 !/.prettierignore
 !/.prettierrc.json
@@ -10185,6 +10184,7 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -17486,7 +17486,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 .tmp
-.nx/cache
 !/.projenrc.js
 !/.prettierignore
 !/.prettierrc.json
@@ -17498,6 +17497,7 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -27412,7 +27412,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 .tmp
-.nx/cache
 !/.projenrc.js
 !/.prettierignore
 !/.prettierrc.json
@@ -27424,6 +27423,7 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -34115,7 +34115,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 .tmp
-.nx/cache
 !/.projenrc.js
 !/.prettierignore
 !/.prettierrc.json
@@ -34127,6 +34126,7 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -40029,7 +40029,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 .tmp
-.nx/cache
 !/.projenrc.js
 !/.prettierignore
 !/.prettierrc.json
@@ -40041,6 +40040,7 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -46491,7 +46491,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 .tmp
-.nx/cache
 !/.projenrc.js
 !/.prettierignore
 !/.prettierrc.json
@@ -46503,6 +46502,7 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -53938,7 +53938,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 .tmp
-.nx/cache
 !/.projenrc.js
 !/.prettierignore
 !/.prettierrc.json
@@ -53950,6 +53949,7 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -60845,7 +60845,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 .tmp
-.nx/cache
 !/.projenrc.js
 !/.prettierignore
 !/.prettierrc.json
@@ -60857,6 +60856,7 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -66754,7 +66754,6 @@ jspm_packages/
 .yarn-integrity
 .cache
 .tmp
-.nx/cache
 !/.projenrc.js
 !/.prettierignore
 !/.prettierrc.json
@@ -66766,6 +66765,7 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
+.nx/cache
 !/nx.json
 !/.nxignore
 .yarn/*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   '@types/babel__traverse': 7.18.2
   '@types/prettier': 2.6.0
@@ -753,6 +757,9 @@ importers:
         specifier: ^7.5.1
         version: 7.5.1
     devDependencies:
+      '@nx/devkit':
+        specifier: ^16.3.1
+        version: 16.3.1(nx@16.3.1)
       '@types/fs-extra':
         specifier: ^11.0.1
         version: 11.0.1
@@ -3683,10 +3690,24 @@ packages:
       tslib: 2.5.0
     dev: true
 
+  /@nrwl/devkit@16.3.1:
+    resolution: {integrity: sha512-05WYGkjDjnzUDfA2MYyltTHYrGr4LqUF95Xxp/sOpXhhjklSAqK5wSwN+5S4pasNZhlPJ9DK+OJarkLAE08rkA==}
+    dependencies:
+      '@nx/devkit': 16.3.1(nx@16.0.0)
+    dev: true
+
   /@nrwl/devkit@16.3.1(nx@16.0.0):
     resolution: {integrity: sha512-05WYGkjDjnzUDfA2MYyltTHYrGr4LqUF95Xxp/sOpXhhjklSAqK5wSwN+5S4pasNZhlPJ9DK+OJarkLAE08rkA==}
     dependencies:
       '@nx/devkit': 16.3.1(nx@16.0.0)
+    transitivePeerDependencies:
+      - nx
+    dev: true
+
+  /@nrwl/devkit@16.3.1(nx@16.3.1):
+    resolution: {integrity: sha512-05WYGkjDjnzUDfA2MYyltTHYrGr4LqUF95Xxp/sOpXhhjklSAqK5wSwN+5S4pasNZhlPJ9DK+OJarkLAE08rkA==}
+    dependencies:
+      '@nx/devkit': 16.3.1(nx@16.3.1)
     transitivePeerDependencies:
       - nx
     dev: true
@@ -3818,10 +3839,24 @@ packages:
     peerDependencies:
       nx: '>= 15 <= 17'
     dependencies:
-      '@nrwl/devkit': 16.3.1(nx@16.0.0)
+      '@nrwl/devkit': 16.3.1
       ejs: 3.1.9
       ignore: 5.2.4
       nx: 16.0.0
+      semver: 7.3.4
+      tmp: 0.2.1
+      tslib: 2.5.0
+    dev: true
+
+  /@nx/devkit@16.3.1(nx@16.3.1):
+    resolution: {integrity: sha512-L0p4aIvR8dB2qjVF3vR1fkKNsm8/MeV9sLTMNCKWBWcyXzHTS48nUZMhizq59FNMlYn3Bz6yqfntXv6QKiYyvw==}
+    peerDependencies:
+      nx: '>= 15 <= 17'
+    dependencies:
+      '@nrwl/devkit': 16.3.1(nx@16.3.1)
+      ejs: 3.1.9
+      ignore: 5.2.4
+      nx: 16.3.1
       semver: 7.3.4
       tmp: 0.2.1
       tslib: 2.5.0
@@ -6596,7 +6631,7 @@ packages:
     dependencies:
       semver: 7.5.0
       shelljs: 0.8.5
-      typescript: 5.2.0-dev.20230725
+      typescript: 5.2.0-dev.20230731
     dev: true
 
   /duplexer2@0.0.2:
@@ -13306,8 +13341,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript@5.2.0-dev.20230725:
-    resolution: {integrity: sha512-ckVbPpSTdPA/Fxnrq1/mzO+LgzA64VPjm6YvV/axwZKgxviVHiUy0VvKS5EGBOpgFBwCNuN+ir24KIBGYWQCgQ==}
+  /typescript@5.2.0-dev.20230731:
+    resolution: {integrity: sha512-RJVLgnDgu67ZrohYy0aBea+5TICfRod36+24zw0bR/KJDQJO9mlIjTC0k+/PKw87fXP5JuUHqepEk15PvFya7A==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
@@ -13901,7 +13936,3 @@ packages:
   /zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/private/projects/nx-monorepo-project.ts
+++ b/private/projects/nx-monorepo-project.ts
@@ -17,7 +17,13 @@ export class NXMonorepoProject extends PDKProject {
       name: "nx-monorepo",
       keywords: ["aws", "pdk", "jsii", "projen"],
       repositoryUrl: "https://github.com/aws/aws-prototyping-sdk",
-      devDeps: ["projen", "nx", "@types/fs-extra", "@types/semver"],
+      devDeps: [
+        "projen",
+        "nx",
+        "@types/fs-extra",
+        "@types/semver",
+        "@nx/devkit",
+      ],
       peerDeps: ["projen"],
       bundledDeps: [
         "fs-extra",


### PR DESCRIPTION
Currently the Java NXMonorepo is broken as the @jnxplus/nx-maven plugin automatically includes the root node as part of the NX graph. This is problematic as we don't actually want to build the root node.

This PR includes an nx plugin which is added for JAVA projects which prunes the root  node from the NX graph.