### PR TITLE
feat(cdk-graph): publish cdk-graph to maven and pypi

### DIFF
--- a/packages/cdk-graph/.projen/tasks.json
+++ b/packages/cdk-graph/.projen/tasks.json
@@ -66,6 +66,12 @@
       "steps": [
         {
           "exec": "mkdir -p docs/api/typescript && jsii-docgen -r=false -o docs/api/typescript/index.md"
+        },
+        {
+          "exec": "mkdir -p docs/api/python && jsii-docgen -l python -r=false -o docs/api/python/index.md"
+        },
+        {
+          "exec": "mkdir -p docs/api/java && jsii-docgen -l java -r=false -o docs/api/java/index.md"
         }
       ]
     },
@@ -139,6 +145,24 @@
       "steps": [
         {
           "spawn": "package:js"
+        },
+        {
+          "spawn": "package:java"
+        },
+        {
+          "spawn": "package:python"
+        }
+      ]
+    },
+    "package:java": {
+      "name": "package:java",
+      "description": "Create java language bindings",
+      "steps": [
+        {
+          "exec": "[ -d ~/.m2/repository ] && [ ! -d \"../../node_modules/.cache/.m2/repository\" ] && mkdir -p ../../node_modules/.cache/.m2 && ln -s ~/.m2/repository ../../node_modules/.cache/.m2/repository || true"
+        },
+        {
+          "exec": "jsii-pacmak -v --target java --maven-local-repository=../../node_modules/.cache/.m2/repository --pack-command='pnpm pack'"
         }
       ]
     },
@@ -148,6 +172,15 @@
       "steps": [
         {
           "exec": "jsii-pacmak -v --target js --pack-command='pnpm pack'"
+        }
+      ]
+    },
+    "package:python": {
+      "name": "package:python",
+      "description": "Create python language bindings",
+      "steps": [
+        {
+          "exec": "jsii-pacmak -v --target python --pack-command='pnpm pack'"
         }
       ]
     },

--- a/packages/cdk-graph/package.json
+++ b/packages/cdk-graph/package.json
@@ -16,7 +16,9 @@
     "jest": "pnpm exec projen jest",
     "package": "pnpm exec projen package",
     "package-all": "pnpm exec projen package-all",
+    "package:java": "pnpm exec projen package:java",
     "package:js": "pnpm exec projen package:js",
+    "package:python": "pnpm exec projen package:python",
     "post-compile": "pnpm exec projen post-compile",
     "pre-compile": "pnpm exec projen pre-compile",
     "release:mainline": "pnpm exec projen release:mainline",
@@ -183,7 +185,19 @@
   "stability": "experimental",
   "jsii": {
     "outdir": "dist",
-    "targets": {},
+    "targets": {
+      "java": {
+        "package": "software.aws.awsprototypingsdk.cdkgraph",
+        "maven": {
+          "groupId": "software.aws.awsprototypingsdk",
+          "artifactId": "cdk-graph"
+        }
+      },
+      "python": {
+        "distName": "aws_prototyping_sdk.cdk_graph",
+        "module": "aws_prototyping_sdk.cdk_graph"
+      }
+    },
     "tsc": {
       "outDir": "lib",
       "rootDir": "src"

--- a/packages/cdk-graph/project.json
+++ b/packages/cdk-graph/project.json
@@ -116,6 +116,20 @@
         "cwd": "packages/cdk-graph"
       }
     },
+    "package:java": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen package:java",
+        "cwd": "packages/cdk-graph"
+      }
+    },
+    "package:python": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm exec projen package:python",
+        "cwd": "packages/cdk-graph"
+      }
+    },
     "jest": {
       "executor": "nx:run-commands",
       "options": {

--- a/private/projects/cdk-graph.ts
+++ b/private/projects/cdk-graph.ts
@@ -66,9 +66,6 @@ export class CdkGraphProject extends PDKProject {
           noUnusedParameters: false,
         },
       },
-      // Only publish to NPM until more stable - currently very experimental and need to test Typescript version more extensively
-      publishToPypiConfig: false,
-      publishToMavenConfig: false,
     });
 
     this.eslint?.addIgnorePattern("scripts/**");


### PR DESCRIPTION
PR 1/2

This is the first of two PR's that will enable publication of the `cdk-graph*` packages to Maven and PYPI.

This has to be split into two PR's as `cdk-graph` was previously published to Maven a while ago with an outdated version of Projen. When trying to build locally, `cdk-graph-plugin-diagram` has a dependency on `cdk-graph` using `^0.x`, however  unlike npm it picks up the latest entry from Maven which mismatches with the projen cersion declared locally. To remedy this, we publish cdk-graph first which will bump the dependency on Projen and then a follow up PR should then resolve the dependency issue.