### PR TITLE
fix(pipeline): change default install/commands to use generic projen cmds

### DIFF
--- a/packages/pipeline/src/pdk-pipeline.ts
+++ b/packages/pipeline/src/pdk-pipeline.ts
@@ -304,14 +304,9 @@ export class PDKPipeline extends Construct {
               BRANCH: branch,
             }
           : undefined,
-      installCommands: [
-        "npm install -g aws-cdk",
-        "yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile",
-      ],
+      installCommands: ["npm install -g aws-cdk", "npx projen install"],
       commands:
-        commands && commands.length > 0
-          ? commands
-          : ["npx nx run-many --target=build --all"],
+        commands && commands.length > 0 ? commands : ["npx projen build"],
       primaryOutputDirectory: props.primarySynthDirectory,
       ...(synthShellStepPartialProps || {}),
     });

--- a/packages/pipeline/test/__snapshots__/pdk-pipeline-ts-project.test.ts.snap
+++ b/packages/pipeline/test/__snapshots__/pdk-pipeline-ts-project.test.ts.snap
@@ -1694,7 +1694,7 @@ exports[\`Snapshot 1\`] = \`
                   "Version": "1",
                 },
                 "Configuration": {
-                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"13fb1f6f3f0a665500d00a30e46cf5c67342362be94a9d79d179c2ea7436a504"}]",
+                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"649231761b2be685631c779ce7c6eec0a56054e9a146dce9d92b0108e597de4f"}]",
                   "ProjectName": {
                     "Ref": "ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A",
                   },
@@ -1795,12 +1795,12 @@ exports[\`Snapshot 1\`] = \`
     "install": {
       "commands": [
         "npm install -g aws-cdk",
-        "yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile"
+        "npx projen install"
       ]
     },
     "build": {
       "commands": [
-        "npx nx run-many --target=build --all"
+        "npx projen build"
       ]
     }
   },
@@ -4512,7 +4512,7 @@ exports[\`Snapshot 1\`] = \`
                   "Version": "1",
                 },
                 "Configuration": {
-                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"13fb1f6f3f0a665500d00a30e46cf5c67342362be94a9d79d179c2ea7436a504"}]",
+                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"649231761b2be685631c779ce7c6eec0a56054e9a146dce9d92b0108e597de4f"}]",
                   "ProjectName": {
                     "Ref": "ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A",
                   },
@@ -4613,12 +4613,12 @@ exports[\`Snapshot 1\`] = \`
     "install": {
       "commands": [
         "npm install -g aws-cdk",
-        "yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile"
+        "npx projen install"
       ]
     },
     "build": {
       "commands": [
-        "npx nx run-many --target=build --all"
+        "npx projen build"
       ]
     }
   },
@@ -7345,7 +7345,7 @@ exports[\`Snapshot 1\`] = \`
                   "Version": "1",
                 },
                 "Configuration": {
-                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"13fb1f6f3f0a665500d00a30e46cf5c67342362be94a9d79d179c2ea7436a504"}]",
+                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"649231761b2be685631c779ce7c6eec0a56054e9a146dce9d92b0108e597de4f"}]",
                   "ProjectName": {
                     "Ref": "ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A",
                   },
@@ -7446,12 +7446,12 @@ exports[\`Snapshot 1\`] = \`
     "install": {
       "commands": [
         "npm install -g aws-cdk",
-        "yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile"
+        "npx projen install"
       ]
     },
     "build": {
       "commands": [
-        "npx nx run-many --target=build --all"
+        "npx projen build"
       ]
     }
   },

--- a/packages/pipeline/test/__snapshots__/pdk-pipeline.test.ts.snap
+++ b/packages/pipeline/test/__snapshots__/pdk-pipeline.test.ts.snap
@@ -1316,12 +1316,12 @@ exports[`PDK Pipeline Unit Tests CrossAccount - using AwsPrototyping NagPack 1`]
     "install": {
       "commands": [
         "npm install -g aws-cdk",
-        "yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile"
+        "npx projen install"
       ]
     },
     "build": {
       "commands": [
-        "npx nx run-many --target=build --all"
+        "npx projen build"
       ]
     }
   },
@@ -1825,7 +1825,7 @@ exports[`PDK Pipeline Unit Tests CrossAccount - using AwsPrototyping NagPack 1`]
                   "Version": "1",
                 },
                 "Configuration": {
-                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"9b6cac2596443c465eb42c0d0d84de22a8632cbeb9388a40d13889341f9b20c5"}]",
+                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"e88b8ad7ebd645201ade2dc2947c0fe9bcd7337245ef0e37f1eef6df040290ea"}]",
                   "ProjectName": {
                     "Ref": "CrossAccountCodePipelineBuildSynthCdkBuildProject938B55FC",
                   },
@@ -4972,12 +4972,12 @@ exports[`PDK Pipeline Unit Tests CrossAccount 1`] = `
     "install": {
       "commands": [
         "npm install -g aws-cdk",
-        "yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile"
+        "npx projen install"
       ]
     },
     "build": {
       "commands": [
-        "npx nx run-many --target=build --all"
+        "npx projen build"
       ]
     }
   },
@@ -5481,7 +5481,7 @@ exports[`PDK Pipeline Unit Tests CrossAccount 1`] = `
                   "Version": "1",
                 },
                 "Configuration": {
-                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"9b6cac2596443c465eb42c0d0d84de22a8632cbeb9388a40d13889341f9b20c5"}]",
+                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"e88b8ad7ebd645201ade2dc2947c0fe9bcd7337245ef0e37f1eef6df040290ea"}]",
                   "ProjectName": {
                     "Ref": "CrossAccountCodePipelineBuildSynthCdkBuildProject938B55FC",
                   },
@@ -8558,12 +8558,12 @@ exports[`PDK Pipeline Unit Tests Defaults - using AwsPrototyping NagPack 1`] = `
     "install": {
       "commands": [
         "npm install -g aws-cdk",
-        "yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile"
+        "npx projen install"
       ]
     },
     "build": {
       "commands": [
-        "npx nx run-many --target=build --all"
+        "npx projen build"
       ]
     }
   },
@@ -8907,7 +8907,7 @@ exports[`PDK Pipeline Unit Tests Defaults - using AwsPrototyping NagPack 1`] = `
                   "Version": "1",
                 },
                 "Configuration": {
-                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"9b6cac2596443c465eb42c0d0d84de22a8632cbeb9388a40d13889341f9b20c5"}]",
+                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"e88b8ad7ebd645201ade2dc2947c0fe9bcd7337245ef0e37f1eef6df040290ea"}]",
                   "ProjectName": {
                     "Ref": "DefaultsCodePipelineBuildSynthCdkBuildProject81772484",
                   },
@@ -11968,12 +11968,12 @@ exports[`PDK Pipeline Unit Tests Defaults 1`] = `
     "install": {
       "commands": [
         "npm install -g aws-cdk",
-        "yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile"
+        "npx projen install"
       ]
     },
     "build": {
       "commands": [
-        "npx nx run-many --target=build --all"
+        "npx projen build"
       ]
     }
   },
@@ -12317,7 +12317,7 @@ exports[`PDK Pipeline Unit Tests Defaults 1`] = `
                   "Version": "1",
                 },
                 "Configuration": {
-                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"9b6cac2596443c465eb42c0d0d84de22a8632cbeb9388a40d13889341f9b20c5"}]",
+                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"e88b8ad7ebd645201ade2dc2947c0fe9bcd7337245ef0e37f1eef6df040290ea"}]",
                   "ProjectName": {
                     "Ref": "DefaultsCodePipelineBuildSynthCdkBuildProject81772484",
                   },
@@ -15523,7 +15523,7 @@ exports[`PDK Pipeline Unit Tests Feature Branches - feature/new-feature_branch -
                   "Version": "1",
                 },
                 "Configuration": {
-                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"7bf3917a8bbdb63d144a12066dfcb5d5ec707592fcca5d3671715100cd08d871"}]",
+                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"67db69532fbc589de8543a6422f1f87774eec58c6fcb5ac12f96cf82a5cc3a7d"}]",
                   "ProjectName": {
                     "Ref": "featurenewfeaturebranchFeatureBranchesCodePipelineBuildSynthCdkBuildProjectF14755B5",
                   },
@@ -15809,12 +15809,12 @@ exports[`PDK Pipeline Unit Tests Feature Branches - feature/new-feature_branch -
     "install": {
       "commands": [
         "npm install -g aws-cdk",
-        "yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile"
+        "npx projen install"
       ]
     },
     "build": {
       "commands": [
-        "npx nx run-many --target=build --all"
+        "npx projen build"
       ]
     }
   },
@@ -18344,7 +18344,7 @@ exports[`PDK Pipeline Unit Tests Feature Branches - feature/new-feature_branch 1
                   "Version": "1",
                 },
                 "Configuration": {
-                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"7bf3917a8bbdb63d144a12066dfcb5d5ec707592fcca5d3671715100cd08d871"}]",
+                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"67db69532fbc589de8543a6422f1f87774eec58c6fcb5ac12f96cf82a5cc3a7d"}]",
                   "ProjectName": {
                     "Ref": "featurenewfeaturebranchFeatureBranchesCodePipelineBuildSynthCdkBuildProjectF14755B5",
                   },
@@ -18630,12 +18630,12 @@ exports[`PDK Pipeline Unit Tests Feature Branches - feature/new-feature_branch 1
     "install": {
       "commands": [
         "npm install -g aws-cdk",
-        "yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile"
+        "npx projen install"
       ]
     },
     "build": {
       "commands": [
-        "npx nx run-many --target=build --all"
+        "npx projen build"
       ]
     }
   },
@@ -21022,12 +21022,12 @@ exports[`PDK Pipeline Unit Tests Feature Branches - mainline - using AwsPrototyp
     "install": {
       "commands": [
         "npm install -g aws-cdk",
-        "yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile"
+        "npx projen install"
       ]
     },
     "build": {
       "commands": [
-        "npx nx run-many --target=build --all"
+        "npx projen build"
       ]
     }
   },
@@ -21371,7 +21371,7 @@ exports[`PDK Pipeline Unit Tests Feature Branches - mainline - using AwsPrototyp
                   "Version": "1",
                 },
                 "Configuration": {
-                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"7cb930276e2c624899dadc5cd557500f267ff825956ffae5529d532ebc7f659d"}]",
+                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"386b84c05e4930470ddd333fcce8fab4d248aacc11677015b29524355082c584"}]",
                   "ProjectName": {
                     "Ref": "FeatureBranchesCodePipelineBuildSynthCdkBuildProject09632D29",
                   },
@@ -25022,12 +25022,12 @@ exports[`PDK Pipeline Unit Tests Feature Branches - mainline 1`] = `
     "install": {
       "commands": [
         "npm install -g aws-cdk",
-        "yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile"
+        "npx projen install"
       ]
     },
     "build": {
       "commands": [
-        "npx nx run-many --target=build --all"
+        "npx projen build"
       ]
     }
   },
@@ -25371,7 +25371,7 @@ exports[`PDK Pipeline Unit Tests Feature Branches - mainline 1`] = `
                   "Version": "1",
                 },
                 "Configuration": {
-                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"7cb930276e2c624899dadc5cd557500f267ff825956ffae5529d532ebc7f659d"}]",
+                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"386b84c05e4930470ddd333fcce8fab4d248aacc11677015b29524355082c584"}]",
                   "ProjectName": {
                     "Ref": "FeatureBranchesCodePipelineBuildSynthCdkBuildProject09632D29",
                   },
@@ -29022,12 +29022,12 @@ exports[`PDK Pipeline Unit Tests Feature Branches - using AwsPrototyping NagPack
     "install": {
       "commands": [
         "npm install -g aws-cdk",
-        "yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile"
+        "npx projen install"
       ]
     },
     "build": {
       "commands": [
-        "npx nx run-many --target=build --all"
+        "npx projen build"
       ]
     }
   },
@@ -29371,7 +29371,7 @@ exports[`PDK Pipeline Unit Tests Feature Branches - using AwsPrototyping NagPack
                   "Version": "1",
                 },
                 "Configuration": {
-                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"7cb930276e2c624899dadc5cd557500f267ff825956ffae5529d532ebc7f659d"}]",
+                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"386b84c05e4930470ddd333fcce8fab4d248aacc11677015b29524355082c584"}]",
                   "ProjectName": {
                     "Ref": "FeatureBranchesCodePipelineBuildSynthCdkBuildProject09632D29",
                   },
@@ -33022,12 +33022,12 @@ exports[`PDK Pipeline Unit Tests Feature Branches 1`] = `
     "install": {
       "commands": [
         "npm install -g aws-cdk",
-        "yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile"
+        "npx projen install"
       ]
     },
     "build": {
       "commands": [
-        "npx nx run-many --target=build --all"
+        "npx projen build"
       ]
     }
   },
@@ -33371,7 +33371,7 @@ exports[`PDK Pipeline Unit Tests Feature Branches 1`] = `
                   "Version": "1",
                 },
                 "Configuration": {
-                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"7cb930276e2c624899dadc5cd557500f267ff825956ffae5529d532ebc7f659d"}]",
+                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"386b84c05e4930470ddd333fcce8fab4d248aacc11677015b29524355082c584"}]",
                   "ProjectName": {
                     "Ref": "FeatureBranchesCodePipelineBuildSynthCdkBuildProject09632D29",
                   },

--- a/samples/pipeline/typescript/test/__snapshots__/pipeline.test.ts.snap
+++ b/samples/pipeline/typescript/test/__snapshots__/pipeline.test.ts.snap
@@ -643,7 +643,7 @@ exports[`Snapshot 1`] = `
                   "Version": "1",
                 },
                 "Configuration": {
-                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"13fb1f6f3f0a665500d00a30e46cf5c67342362be94a9d79d179c2ea7436a504"}]",
+                  "EnvironmentVariables": "[{"name":"_PROJECT_CONFIG_HASH","type":"PLAINTEXT","value":"649231761b2be685631c779ce7c6eec0a56054e9a146dce9d92b0108e597de4f"}]",
                   "ProjectName": {
                     "Ref": "ApplicationPipelineCodePipelineBuildSynthCdkBuildProjectEE7ED66A",
                   },
@@ -744,12 +744,12 @@ exports[`Snapshot 1`] = `
     "install": {
       "commands": [
         "npm install -g aws-cdk",
-        "yarn install --frozen-lockfile || npx projen && yarn install --frozen-lockfile"
+        "npx projen install"
       ]
     },
     "build": {
       "commands": [
-        "npx nx run-many --target=build --all"
+        "npx projen build"
       ]
     }
   },


### PR DESCRIPTION
This change will ensure that any nx-monorepo project (or pure projen), regardless of language will work in the pipeline.