### PR TITLE
fix(static-website): rename webacl since custom resource will create new one before delete

### DIFF
--- a/packages/static-website/src/cloudfront-web-acl.ts
+++ b/packages/static-website/src/cloudfront-web-acl.ts
@@ -95,7 +95,7 @@ export class CloudfrontWebAcl extends Construct {
     super(scope, id);
 
     const stack = Stack.of(this);
-    const aclName = `${stack.stackName}-${id}`; // Unique per stack
+    const aclName = `${stack.stackName}-${id}-${this.node.addr.slice(-4)}`;
     const onEventHandler = this.createOnEventHandler(stack, aclName);
     const customResource = this.createAclCustomResource(
       stack,

--- a/packages/static-website/test/__snapshots__/static-website.test.ts.snap
+++ b/packages/static-website/test/__snapshots__/static-website.test.ts.snap
@@ -1361,7 +1361,7 @@ exports[`Static Website Unit Tests Defaults - Nested 1`] = `
               {
                 "Ref": "AWS::StackName",
               },
-              "-WebsiteAcl",
+              "-WebsiteAcl-313c",
             ],
           ],
         },
@@ -2039,7 +2039,7 @@ exports[`Static Website Unit Tests Defaults - Nested 1`] = `
                           {
                             "Ref": "AWS::StackName",
                           },
-                          "-WebsiteAcl-IPSet/*",
+                          "-WebsiteAcl-313c-IPSet/*",
                         ],
                       ],
                     },
@@ -2055,7 +2055,7 @@ exports[`Static Website Unit Tests Defaults - Nested 1`] = `
                           {
                             "Ref": "AWS::StackName",
                           },
-                          "-WebsiteAcl/*",
+                          "-WebsiteAcl-313c/*",
                         ],
                       ],
                     },
@@ -2093,7 +2093,7 @@ exports[`Static Website Unit Tests Defaults - Nested 1`] = `
                         {
                           "Ref": "AWS::StackName",
                         },
-                        "-WebsiteAcl-IPSet/*",
+                        "-WebsiteAcl-313c-IPSet/*",
                       ],
                     ],
                   },
@@ -4028,7 +4028,7 @@ exports[`Static Website Unit Tests Defaults - using AwsPrototyping NagPack 1`] =
         },
       },
       "Properties": {
-        "ID": "Default-WebsiteAcl",
+        "ID": "Default-WebsiteAcl-d248",
         "MANAGED_RULES": [
           {
             "name": "AWSManagedRulesCommonRuleSet",
@@ -4699,7 +4699,7 @@ exports[`Static Website Unit Tests Defaults - using AwsPrototyping NagPack 1`] =
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":global/ipset/Default-WebsiteAcl-IPSet/*",
+                          ":global/ipset/Default-WebsiteAcl-d248-IPSet/*",
                         ],
                       ],
                     },
@@ -4711,7 +4711,7 @@ exports[`Static Website Unit Tests Defaults - using AwsPrototyping NagPack 1`] =
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":global/webacl/Default-WebsiteAcl/*",
+                          ":global/webacl/Default-WebsiteAcl-d248/*",
                         ],
                       ],
                     },
@@ -4745,7 +4745,7 @@ exports[`Static Website Unit Tests Defaults - using AwsPrototyping NagPack 1`] =
                         {
                           "Ref": "AWS::AccountId",
                         },
-                        ":global/ipset/Default-WebsiteAcl-IPSet/*",
+                        ":global/ipset/Default-WebsiteAcl-d248-IPSet/*",
                       ],
                     ],
                   },
@@ -6707,7 +6707,7 @@ exports[`Static Website Unit Tests Defaults 1`] = `
         },
       },
       "Properties": {
-        "ID": "Default-WebsiteAcl",
+        "ID": "Default-WebsiteAcl-d248",
         "MANAGED_RULES": [
           {
             "name": "AWSManagedRulesCommonRuleSet",
@@ -7378,7 +7378,7 @@ exports[`Static Website Unit Tests Defaults 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":global/ipset/Default-WebsiteAcl-IPSet/*",
+                          ":global/ipset/Default-WebsiteAcl-d248-IPSet/*",
                         ],
                       ],
                     },
@@ -7390,7 +7390,7 @@ exports[`Static Website Unit Tests Defaults 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":global/webacl/Default-WebsiteAcl/*",
+                          ":global/webacl/Default-WebsiteAcl-d248/*",
                         ],
                       ],
                     },
@@ -7424,7 +7424,7 @@ exports[`Static Website Unit Tests Defaults 1`] = `
                         {
                           "Ref": "AWS::AccountId",
                         },
-                        ":global/ipset/Default-WebsiteAcl-IPSet/*",
+                        ":global/ipset/Default-WebsiteAcl-d248-IPSet/*",
                       ],
                     ],
                   },
@@ -9395,7 +9395,7 @@ exports[`Static Website Unit Tests Defaults and Geoblocking - using AwsPrototypi
         },
       },
       "Properties": {
-        "ID": "Default-WebsiteAcl",
+        "ID": "Default-WebsiteAcl-d248",
         "MANAGED_RULES": [
           {
             "name": "AWSManagedRulesCommonRuleSet",
@@ -10066,7 +10066,7 @@ exports[`Static Website Unit Tests Defaults and Geoblocking - using AwsPrototypi
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":global/ipset/Default-WebsiteAcl-IPSet/*",
+                          ":global/ipset/Default-WebsiteAcl-d248-IPSet/*",
                         ],
                       ],
                     },
@@ -10078,7 +10078,7 @@ exports[`Static Website Unit Tests Defaults and Geoblocking - using AwsPrototypi
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":global/webacl/Default-WebsiteAcl/*",
+                          ":global/webacl/Default-WebsiteAcl-d248/*",
                         ],
                       ],
                     },
@@ -10112,7 +10112,7 @@ exports[`Static Website Unit Tests Defaults and Geoblocking - using AwsPrototypi
                         {
                           "Ref": "AWS::AccountId",
                         },
-                        ":global/ipset/Default-WebsiteAcl-IPSet/*",
+                        ":global/ipset/Default-WebsiteAcl-d248-IPSet/*",
                       ],
                     ],
                   },
@@ -12160,7 +12160,7 @@ exports[`Static Website Unit Tests Defaults with suppression rule - using AwsPro
         },
       },
       "Properties": {
-        "ID": "Default-WebsiteAcl",
+        "ID": "Default-WebsiteAcl-d248",
         "MANAGED_RULES": [
           {
             "name": "AWSManagedRulesCommonRuleSet",
@@ -12851,7 +12851,7 @@ exports[`Static Website Unit Tests Defaults with suppression rule - using AwsPro
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":global/ipset/Default-WebsiteAcl-IPSet/*",
+                          ":global/ipset/Default-WebsiteAcl-d248-IPSet/*",
                         ],
                       ],
                     },
@@ -12863,7 +12863,7 @@ exports[`Static Website Unit Tests Defaults with suppression rule - using AwsPro
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":global/webacl/Default-WebsiteAcl/*",
+                          ":global/webacl/Default-WebsiteAcl-d248/*",
                         ],
                       ],
                     },
@@ -12897,7 +12897,7 @@ exports[`Static Website Unit Tests Defaults with suppression rule - using AwsPro
                         {
                           "Ref": "AWS::AccountId",
                         },
-                        ":global/ipset/Default-WebsiteAcl-IPSet/*",
+                        ":global/ipset/Default-WebsiteAcl-d248-IPSet/*",
                       ],
                     ],
                   },
@@ -16529,7 +16529,7 @@ exports[`Static Website Unit Tests With custom bucket deployment props 1`] = `
         },
       },
       "Properties": {
-        "ID": "Default-WebsiteAcl",
+        "ID": "Default-WebsiteAcl-ebea",
         "MANAGED_RULES": [
           {
             "name": "AWSManagedRulesCommonRuleSet",
@@ -17200,7 +17200,7 @@ exports[`Static Website Unit Tests With custom bucket deployment props 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":global/ipset/Default-WebsiteAcl-IPSet/*",
+                          ":global/ipset/Default-WebsiteAcl-ebea-IPSet/*",
                         ],
                       ],
                     },
@@ -17212,7 +17212,7 @@ exports[`Static Website Unit Tests With custom bucket deployment props 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":global/webacl/Default-WebsiteAcl/*",
+                          ":global/webacl/Default-WebsiteAcl-ebea/*",
                         ],
                       ],
                     },
@@ -17246,7 +17246,7 @@ exports[`Static Website Unit Tests With custom bucket deployment props 1`] = `
                         {
                           "Ref": "AWS::AccountId",
                         },
-                        ":global/ipset/Default-WebsiteAcl-IPSet/*",
+                        ":global/ipset/Default-WebsiteAcl-ebea-IPSet/*",
                       ],
                     ],
                   },


### PR DESCRIPTION
Also add a unique suffix to the name to avoid potential naming conflicts when multiple acls are used within the same stack
