### PR TITLE
fix(cloudscape-react-ts-website): pin Swagger UI

### DIFF
--- a/packages/cloudscape-react-ts-website/src/cloudscape-react-ts-website-project.ts
+++ b/packages/cloudscape-react-ts-website/src/cloudscape-react-ts-website-project.ts
@@ -131,7 +131,7 @@ export class CloudscapeReactTsWebsiteProject extends ReactTypeScriptProject {
 
   private setupSwaggerUi(tsApi: TypeSafeApiProject) {
     this.addDevDeps("@types/swagger-ui-react");
-    this.addDeps("swagger-ui-react", "aws4fetch");
+    this.addDeps("swagger-ui-react@5.5.0", "aws4fetch");
 
     const targetApiSpecPath = `${path.relative(
       tsApi.model.outdir,

--- a/packages/cloudscape-react-ts-website/test/__snapshots__/cloudscape-react-ts-website-project.test.ts.snap
+++ b/packages/cloudscape-react-ts-website/test/__snapshots__/cloudscape-react-ts-website-project.test.ts.snap
@@ -3423,6 +3423,7 @@ tsconfig.tsbuildinfo
       {
         "name": "swagger-ui-react",
         "type": "runtime",
+        "version": "5.5.0",
       },
       {
         "name": "testapi-typescript-react-query-hooks",
@@ -3578,13 +3579,13 @@ tsconfig.tsbuildinfo
             "exec": "yarn upgrade npm-check-updates",
           },
           {
-            "exec": "npm-check-updates --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@testing-library/jest-dom,@testing-library/react,@testing-library/user-event,@types/jest,@types/node,@types/react,@types/react-dom,@types/swagger-ui-react,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,eslint-config-prettier,eslint-import-resolver-node,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,eslint,npm-check-updates,prettier,projen,typescript,@aws-northstar/ui,@cloudscape-design/board-components,@cloudscape-design/components,aws4fetch,react,react-dom,react-router-dom,react-scripts,swagger-ui-react,testapi-typescript-react-query-hooks,web-vitals",
+            "exec": "npm-check-updates --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@testing-library/jest-dom,@testing-library/react,@testing-library/user-event,@types/jest,@types/node,@types/react,@types/react-dom,@types/swagger-ui-react,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,eslint-config-prettier,eslint-import-resolver-node,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,eslint,npm-check-updates,prettier,projen,typescript,@aws-northstar/ui,@cloudscape-design/board-components,@cloudscape-design/components,aws4fetch,react,react-dom,react-router-dom,react-scripts,testapi-typescript-react-query-hooks,web-vitals",
           },
           {
             "exec": "yarn install --check-files",
           },
           {
-            "exec": "yarn upgrade @testing-library/jest-dom @testing-library/react @testing-library/user-event @types/jest @types/node @types/react @types/react-dom @types/swagger-ui-react @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint npm-check-updates prettier projen typescript @aws-northstar/ui @cloudscape-design/board-components @cloudscape-design/components aws4fetch react react-dom react-router-dom react-scripts swagger-ui-react testapi-typescript-react-query-hooks web-vitals",
+            "exec": "yarn upgrade @testing-library/jest-dom @testing-library/react @testing-library/user-event @types/jest @types/node @types/react @types/react-dom @types/swagger-ui-react @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint npm-check-updates prettier projen typescript @aws-northstar/ui @cloudscape-design/board-components @cloudscape-design/components aws4fetch react react-dom react-router-dom react-scripts testapi-typescript-react-query-hooks web-vitals",
           },
           {
             "exec": "npx projen",
@@ -3834,7 +3835,7 @@ Refer to [Developer Guide](https://aws.github.io/aws-pdk/developer_guides/clouds
       "react-dom": "*",
       "react-router-dom": "*",
       "react-scripts": "^5",
-      "swagger-ui-react": "*",
+      "swagger-ui-react": "5.5.0",
       "testapi-typescript-react-query-hooks": "*",
       "web-vitals": "*",
     },


### PR DESCRIPTION
Swagger recently bumped to [5.6.1](https://github.com/swagger-api/swagger-ui/releases/tag/v5.6.1) and as such introduced a breaking change to consumers without proper semver or docs :(

```
SyntaxError: /Users/dimecha/Projects/workshop/node_modules/.pnpm/swagger-ui-react@5.6.1_@types+react-dom@18.2.7_@types+react@18.2.21_react-dom@18.2.0_react@18.2.0/node_modules/swagger-ui-react/index.mjs: Support for the experimental syntax 'decorators' isn't currently enabled (1:1):
> 1 | @babel/preset-env: `DEBUG` option
    | ^
  2 |
  3 | Using targets:
  4 | {

Add @babel/plugin-proposal-decorators (https://github.com/babel/babel/tree/main/packages/babel-plugin-proposal-decorators) to the 'plugins' section of your Babel config to enable transformation.
If you want to leave it as-is, add @babel/plugin-syntax-decorators (https://github.com/babel/babel/tree/main/packages/babel-plugin-syntax-decorators) to the 'plugins' section to enable parsing.
    at parser.next (<anonymous>)
    at normalizeFile.next (<anonymous>)
    at run.next (<anonymous>)
    at transform.next (<anonymous>)
```