### PR TITLE
fix(docs): fix migration dependency for @aws/pdk/monorepo (not nx-monorepo)

### DIFF
--- a/docs/content/getting_started/migration_guide.md
+++ b/docs/content/getting_started/migration_guide.md
@@ -143,7 +143,7 @@ Now that the new dependency is installed, we can perform the following modificat
 -
 -const monorepo = new NxMonorepoProject({
 +import { CloudscapeReactTsWebsiteProject } from "@aws/pdk/cloudscape-react-ts-website";
-+import { MonorepoTsProject } from "@aws/pdk/nx-monorepo";
++import { MonorepoTsProject } from "@aws/pdk/monorepo";
 +import {
 +    DocumentationFormat,
 +    Language,


### PR DESCRIPTION
Fixes #588

Update migration `diff` in step 2 of the migration to `@aws/pdk/monorepo`.  The existing diff still has the change as `@aws/pdk/nx-monorepo` which is incorrect.