### PR TITLE
fix(type-safe-api): resolve parameter refs prior to parameter validation

### DIFF
--- a/packages/type-safe-api/test/resources/specs/parameter-refs.yaml
+++ b/packages/type-safe-api/test/resources/specs/parameter-refs.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.3
+info:
+  version: 1.0.0
+  title: Example API
+paths:
+  /hello:
+    get:
+      operationId: sayHello
+      x-handler:
+        language: typescript
+      parameters:
+        - $ref: '#/components/parameters/HelloId'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/HelloResponse'
+components:
+  parameters:
+    HelloId:
+      in: query
+      name: id
+      schema:
+        $ref: '#/components/schemas/HelloId'
+      required: false
+  schemas:
+    HelloId:
+      type: string
+    HelloResponse:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/HelloId'
+        message:
+          $ref: '#/components/schemas/HelloResponse'
+      required:
+        - id

--- a/packages/type-safe-api/test/scripts/parser/__snapshots__/parse-openapi-spec.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/parser/__snapshots__/parse-openapi-spec.test.ts.snap
@@ -366,3 +366,73 @@ exports[`Parse OpenAPI Spec Script Unit Tests Injects @handler and @paginated tr
   },
 }
 `;
+
+exports[`Parse OpenAPI Spec Script Unit Tests Permits parameter references (and circular references) 1`] = `
+{
+  ".api.json": {
+    "components": {
+      "parameters": {
+        "HelloId": {
+          "in": "query",
+          "name": "id",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/HelloId",
+          },
+        },
+      },
+      "schemas": {
+        "HelloId": {
+          "type": "string",
+        },
+        "HelloResponse": {
+          "properties": {
+            "id": {
+              "$ref": "#/components/schemas/HelloId",
+            },
+            "message": {
+              "$ref": "#/components/schemas/HelloResponse",
+            },
+          },
+          "required": [
+            "id",
+          ],
+          "type": "object",
+        },
+      },
+    },
+    "info": {
+      "title": "Example API",
+      "version": "1.0.0",
+    },
+    "openapi": "3.0.3",
+    "paths": {
+      "/hello": {
+        "get": {
+          "operationId": "sayHello",
+          "parameters": [
+            {
+              "$ref": "#/components/parameters/HelloId",
+            },
+          ],
+          "responses": {
+            "200": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/HelloResponse",
+                  },
+                },
+              },
+              "description": "Successful response",
+            },
+          },
+          "x-handler": {
+            "language": "typescript",
+          },
+        },
+      },
+    },
+  },
+}
+`;

--- a/packages/type-safe-api/test/scripts/parser/parse-openapi-spec.test.ts
+++ b/packages/type-safe-api/test/scripts/parser/parse-openapi-spec.test.ts
@@ -58,4 +58,20 @@ describe("Parse OpenAPI Spec Script Unit Tests", () => {
       );
     });
   });
+
+  it("Permits parameter references (and circular references)", () => {
+    expect(
+      withTmpDirSnapshot(os.tmpdir(), (tmpDir) => {
+        const specPath = "../../resources/specs/parameter-refs.yaml";
+        const outputPath = path.join(
+          path.relative(path.resolve(__dirname), tmpDir),
+          ".api.json"
+        );
+        const command = `../../../scripts/type-safe-api/parser/parse-openapi-spec --spec-path ${specPath} --output-path ${outputPath}`;
+        exec(command, {
+          cwd: path.resolve(__dirname),
+        });
+      })
+    ).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
It is legal to use `$ref` in parameters in an OpenAPI spec, but the validation was assuming these were not present. Updated the validation to work on a dereferenced clone of the spec. Ensured that the final parsed spec retains references to ensure the code generator can consolidate models.

Fixes #590
