### PR TITLE
fix(type-safe-api): use lambda region in both parts of function integration uri

### DIFF
--- a/packages/type-safe-api/src/construct/integrations/lambda.ts
+++ b/packages/type-safe-api/src/construct/integrations/lambda.ts
@@ -24,11 +24,11 @@ export class LambdaIntegration extends Integration {
   /**
    * Render the lambda integration as a snippet of OpenAPI
    */
-  public render(props: IntegrationRenderProps): ApiGatewayIntegration {
+  public render(_props: IntegrationRenderProps): ApiGatewayIntegration {
     return {
       type: "AWS_PROXY",
       httpMethod: "POST",
-      uri: functionInvocationUri(props.scope, this.lambdaFunction),
+      uri: functionInvocationUri(this.lambdaFunction),
       passthroughBehavior: "WHEN_NO_MATCH",
     };
   }

--- a/packages/type-safe-api/src/construct/spec/api-gateway-auth.ts
+++ b/packages/type-safe-api/src/construct/spec/api-gateway-auth.ts
@@ -179,7 +179,7 @@ const cognitoSecurityScheme = (
  * @param authorizer custom authorizer
  */
 const customSecurityScheme = (
-  scope: Construct,
+  _scope: Construct,
   authorizer: CustomAuthorizer
 ): CustomSecurityScheme => {
   const singleHeaderMatch = authorizer.identitySource.match(
@@ -205,7 +205,7 @@ const customSecurityScheme = (
     "x-amazon-apigateway-authtype": authorizer.authorizationType,
     "x-amazon-apigateway-authorizer": {
       type: authorizer.type,
-      authorizerUri: functionInvocationUri(scope, authorizer.function),
+      authorizerUri: functionInvocationUri(authorizer.function),
       authorizerResultTtlInSeconds: authorizer.authorizerResultTtlInSeconds,
       identitySource: authorizer.identitySource,
     },

--- a/packages/type-safe-api/src/construct/spec/utils.ts
+++ b/packages/type-safe-api/src/construct/spec/utils.ts
@@ -2,17 +2,12 @@
 SPDX-License-Identifier: Apache-2.0 */
 import { Stack } from "aws-cdk-lib";
 import { IFunction } from "aws-cdk-lib/aws-lambda";
-import { Construct } from "constructs";
 
 /**
  * Generate the lambda function invocation uri for the given lambda within the given scope
- * @param scope scope in which the lambda is deployed
  * @param lambdaFunction the lambda function to be invoked
  */
-export const functionInvocationUri = (
-  scope: Construct,
-  lambdaFunction: IFunction
-): string => {
-  const stack = Stack.of(scope);
+export const functionInvocationUri = (lambdaFunction: IFunction): string => {
+  const stack = Stack.of(lambdaFunction);
   return `arn:${stack.partition}:apigateway:${stack.region}:lambda:path/2015-03-31/functions/${lambdaFunction.functionArn}/invocations`;
 };

--- a/packages/type-safe-api/test/construct/__snapshots__/type-safe-rest-api.test.ts.snap
+++ b/packages/type-safe-api/test/construct/__snapshots__/type-safe-rest-api.test.ts.snap
@@ -7045,6 +7045,65 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
 }
 `;
 
+exports[`Type Safe Rest Api Construct Unit Tests Should allow for lambdas in different regions 1`] = `
+{
+  "components": {
+    "securitySchemes": {},
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "testOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:\${<TOKEN>}:lambda:us-east-1:\${<TOKEN>}:function:Test/invocations",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
+    },
+  },
+}
+`;
+
 exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions for reused lambdas 1`] = `
 {
   "Outputs": {

--- a/packages/type-safe-api/test/construct/type-safe-rest-api.test.ts
+++ b/packages/type-safe-api/test/construct/type-safe-rest-api.test.ts
@@ -3,7 +3,7 @@ SPDX-License-Identifier: Apache-2.0 */
 import * as fs from "fs";
 import * as path from "path";
 import { PDKNag } from "@aws/pdk-nag";
-import { Size, Stack } from "aws-cdk-lib";
+import { App, Size, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 import { ApiKeySourceType, Cors } from "aws-cdk-lib/aws-apigateway";
 import { UserPool } from "aws-cdk-lib/aws-cognito";
@@ -1231,6 +1231,34 @@ describe("Type Safe Rest Api Construct Unit Tests", () => {
         },
       });
       expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
+      snapshotExtendedSpec(api);
+    });
+  });
+
+  it("Should allow for lambdas in different regions", () => {
+    const app = new App();
+    const usStack = new Stack(app, "USStack", {
+      env: {
+        region: "us-east-1",
+      },
+    });
+    const auStack = new Stack(app, "AUStack", {
+      env: {
+        region: "ap-southeast-2",
+      },
+    });
+    const func = Function.fromFunctionName(usStack, "Func", "Test");
+    withTempSpec(sampleSpec, (specPath) => {
+      const api = new TypeSafeRestApi(auStack, "ApiTest", {
+        specPath,
+        operationLookup,
+        integrations: {
+          testOperation: {
+            integration: Integrations.lambda(func),
+          },
+        },
+      });
+
       snapshotExtendedSpec(api);
     });
   });


### PR DESCRIPTION
The region in the first part of a function invocation uri is also the region of the lambda function itself, rather than the api gateway rest api

Thanks @valebedu 😄 

Fixes #594
