### PR TITLE
feat(type-safe-api): enable snapstart for java handlers by default and optimise java interceptors

### DIFF
--- a/packages/type-safe-api/scripts/type-safe-api/generators/java-cdk-infrastructure/templates/functions.handlebars
+++ b/packages/type-safe-api/scripts/type-safe-api/generators/java-cdk-infrastructure/templates/functions.handlebars
@@ -15,12 +15,13 @@
 
 import org.jetbrains.annotations.NotNull;
 import software.amazon.awscdk.services.lambda.Function;
+import software.aws.pdk.type_safe_api.SnapStartFunction;
 import software.constructs.Construct;
 
 /**
  * Lambda function construct which points to the {{vendorExtensions.x-handler.language}} implementation of {{operationIdCamelCase}}
  */
-public class {{operationIdCamelCase}}Function extends Function {
+public class {{operationIdCamelCase}}Function extends {{#startsWith vendorExtensions.x-handler.language 'java' ~}}SnapStart{{~/startsWith}}Function {
     public {{operationIdCamelCase}}Function(@NotNull Construct scope, @NotNull String id, @NotNull {{operationIdCamelCase}}FunctionProps props) {
         super(scope, id, props);
     }
@@ -67,6 +68,7 @@ import software.amazon.awscdk.services.lambda.VersionOptions;
 import software.amazon.awscdk.services.logs.RetentionDays;
 import software.amazon.awscdk.services.sns.ITopic;
 import software.amazon.awscdk.services.sqs.IQueue;
+import software.aws.pdk.type_safe_api.SnapStartFunctionProps;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -77,7 +79,7 @@ import java.util.List;
 import java.util.Map;
 
 @lombok.Builder @lombok.Getter
-public class {{operationIdCamelCase}}FunctionProps implements FunctionProps {
+public class {{operationIdCamelCase}}FunctionProps implements {{#startsWith vendorExtensions.x-handler.language 'java' ~}}SnapStart{{~/startsWith}}FunctionProps {
     private static String infraProjectAbsolutePath;
 
     static {

--- a/packages/type-safe-api/scripts/type-safe-api/generators/java-lambda-handlers/templates/handlers.handlebars
+++ b/packages/type-safe-api/scripts/type-safe-api/generators/java-lambda-handlers/templates/handlers.handlebars
@@ -32,12 +32,17 @@ import java.util.List;
  */
 public class {{operationIdCamelCase}}Handler extends {{operationIdCamelCase}} {
     /**
+     * Interceptors are initialised once during the lambda "init" phase
+     */
+    private final List<Interceptor<{{operationIdCamelCase}}Input>> interceptors = DefaultInterceptors.all();
+
+    /**
      * Return the interceptors for this handler.
      * You can also use the @Interceptors annotation on the class to add interceptors
      */
     @Override
     public List<Interceptor<{{operationIdCamelCase}}Input>> getInterceptors() {
-        return DefaultInterceptors.all();
+        return this.interceptors;
     }
 
     /**

--- a/packages/type-safe-api/scripts/type-safe-api/generators/java/templates/handlers.mustache
+++ b/packages/type-safe-api/scripts/type-safe-api/generators/java/templates/handlers.mustache
@@ -1024,6 +1024,11 @@ public abstract class {{operationIdCamelCase}} implements RequestHandler<APIGate
     public abstract {{operationIdCamelCase}}Response handle(final {{operationIdCamelCase}}RequestInput request);
 
     /**
+     * Interceptors that the handler class has been decorated with
+     */
+    private List<Interceptor<{{operationIdCamelCase}}Input>> annotationInterceptors = Handlers.getAnnotationInterceptors({{operationIdCamelCase}}.class);
+
+    /**
      * For more complex interceptors that require instantiation with parameters, you may override this method to
      * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
      * prefer the @Interceptors annotation.
@@ -1055,9 +1060,6 @@ public abstract class {{operationIdCamelCase}} implements RequestHandler<APIGate
 
         List<Interceptor<{{operationIdCamelCase}}Input>> interceptors = new ArrayList<>();
         interceptors.addAll(additionalInterceptors);
-
-        List<Interceptor<{{operationIdCamelCase}}Input>> annotationInterceptors = Handlers.getAnnotationInterceptors(this.getClass());
-
         interceptors.addAll(annotationInterceptors);
         interceptors.addAll(this.getInterceptors());
 

--- a/packages/type-safe-api/scripts/type-safe-api/generators/java/templates/interceptors.mustache
+++ b/packages/type-safe-api/scripts/type-safe-api/generators/java/templates/interceptors.mustache
@@ -123,6 +123,7 @@ import software.amazon.lambda.powertools.logging.LoggingUtils;
  * See https://docs.powertools.aws.dev/lambda/java/latest/core/logging/
  */
 public class LoggingInterceptor<Input> implements Interceptor<Input> {
+    private Logger logger = LogManager.getLogger(LoggingInterceptor.class);
 
     /**
      * Return the instance of the logger from the interceptor context
@@ -161,7 +162,6 @@ public class LoggingInterceptor<Input> implements Interceptor<Input> {
         LoggingUtils.appendKey("operationId", operationId);
 
         // Add the logger to the interceptor context
-        Logger logger = LogManager.getLogger(operationId);
         input.getInterceptorContext().put("logger", logger);
 
         Response response = input.getChain().next(input);
@@ -201,6 +201,13 @@ import software.amazon.lambda.powertools.tracing.TracingUtils;
  * See: https://docs.powertools.aws.dev/lambda/java/latest/core/tracing/
  */
 public class TracingInterceptor<Input> implements Interceptor<Input> {
+
+    {
+        // Create a segment during the lambda init phase to ensure xray emitter
+        // is warmed up prior to invocation phase
+        AWSXRay.beginSubsegment("Tracing Interceptor - Init");
+        AWSXRay.endSubsegment();
+    }
 
     private final boolean captureResponse;
 
@@ -284,6 +291,7 @@ import software.amazon.lambda.powertools.metrics.MetricsUtils;
  * See: https://docs.powertools.aws.dev/lambda/typescript/latest/core/metrics
  */
 public class MetricsInterceptor<Input> implements Interceptor<Input> {
+    private MetricsLogger metrics = MetricsUtils.metricsLogger();
 
     /**
      * Return the instance of the metrics logger from the interceptor context
@@ -298,7 +306,6 @@ public class MetricsInterceptor<Input> implements Interceptor<Input> {
 
     @Override
     public Response handle(final ChainedRequestInput<Input> input) {
-        MetricsLogger metrics = MetricsUtils.metricsLogger();
         metrics.putDimensions(DimensionSet.of("operationId", (String) input.getInterceptorContext().get("operationId")));
 
         input.getInterceptorContext().put("metrics", metrics);

--- a/packages/type-safe-api/scripts/type-safe-api/generators/python-cdk-infrastructure/templates/functions.handlebars
+++ b/packages/type-safe-api/scripts/type-safe-api/generators/python-cdk-infrastructure/templates/functions.handlebars
@@ -10,6 +10,7 @@
 from aws_cdk.aws_lambda import (
     Function, Runtime, Tracing, Code
 )
+from aws_pdk.type_safe_api import SnapStartFunction
 from os import path
 from pathlib import Path
 
@@ -19,7 +20,7 @@ from pathlib import Path
 {{#operation ~}}
 {{#if vendorExtensions.x-handler}}
 
-class {{operationIdCamelCase}}Function(Function):
+class {{operationIdCamelCase}}Function({{#startsWith vendorExtensions.x-handler.language 'java' ~}}SnapStart{{~/startsWith}}Function):
     """
     Lambda function construct which points to the {{vendorExtensions.x-handler.language}} implementation of {{operationIdCamelCase}}
     """

--- a/packages/type-safe-api/scripts/type-safe-api/generators/typescript-cdk-infrastructure/templates/functions.handlebars
+++ b/packages/type-safe-api/scripts/type-safe-api/generators/typescript-cdk-infrastructure/templates/functions.handlebars
@@ -9,6 +9,7 @@
 }
 ###/TSAPI_WRITE_FILE###import { Construct } from "constructs";
 import { Duration } from "aws-cdk-lib";
+import { SnapStartFunction, SnapStartFunctionProps } from "@aws/pdk/type-safe-api";
 import { Code, Function, Runtime, Tracing, FunctionProps } from "aws-cdk-lib/aws-lambda";
 import * as path from "path";
 {{#apiInfo ~}}
@@ -20,12 +21,12 @@ import * as path from "path";
 /**
  * Options for the {{operationIdCamelCase}}Function construct
  */
-export interface {{operationIdCamelCase}}FunctionProps extends Omit<FunctionProps, 'code' | 'handler' | 'runtime'> {}
+export interface {{operationIdCamelCase}}FunctionProps extends Omit<{{#startsWith vendorExtensions.x-handler.language 'java' ~}}SnapStart{{~/startsWith}}FunctionProps, 'code' | 'handler' | 'runtime'> {}
 
 /**
  * Lambda function construct which points to the {{vendorExtensions.x-handler.language}} implementation of {{operationIdCamelCase}}
  */
-export class {{operationIdCamelCase}}Function extends Function {
+export class {{operationIdCamelCase}}Function extends {{#startsWith vendorExtensions.x-handler.language 'java' ~}}SnapStart{{~/startsWith}}Function {
   constructor(scope: Construct, id: string, props?: {{operationIdCamelCase}}FunctionProps) {
     super(scope, id, {
       {{#startsWith vendorExtensions.x-handler.language 'typescript' ~}}

--- a/packages/type-safe-api/src/construct/functions/index.ts
+++ b/packages/type-safe-api/src/construct/functions/index.ts
@@ -1,0 +1,3 @@
+/*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0 */
+export * from "./snap-start-java-function";

--- a/packages/type-safe-api/src/construct/functions/snap-start-java-function.ts
+++ b/packages/type-safe-api/src/construct/functions/snap-start-java-function.ts
@@ -1,0 +1,30 @@
+/*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0 */
+import { CfnFunction, Function, FunctionProps } from "aws-cdk-lib/aws-lambda";
+import { Construct } from "constructs";
+
+/**
+ * Options for the SnapStartFunction construct
+ */
+export interface SnapStartFunctionProps extends FunctionProps {
+  /**
+   * When true, disable snap start
+   * @default false
+   */
+  readonly disableSnapStart?: boolean;
+}
+
+/**
+ * A lambda function which enables SnapStart on published versions by default
+ */
+export class SnapStartFunction extends Function {
+  constructor(scope: Construct, id: string, props: SnapStartFunctionProps) {
+    super(scope, id, props);
+
+    if (!props.disableSnapStart) {
+      (this.node.defaultChild as CfnFunction).addPropertyOverride("SnapStart", {
+        ApplyOn: "PublishedVersions",
+      });
+    }
+  }
+}

--- a/packages/type-safe-api/src/construct/index.ts
+++ b/packages/type-safe-api/src/construct/index.ts
@@ -5,3 +5,4 @@ export * from "./waf/types";
 export * from "./authorizers";
 export * from "./integrations";
 export * from "./spec";
+export * from "./functions";

--- a/packages/type-safe-api/src/construct/integrations/lambda.ts
+++ b/packages/type-safe-api/src/construct/integrations/lambda.ts
@@ -8,6 +8,7 @@ import {
   IntegrationGrantProps,
   IntegrationRenderProps,
 } from "./integration";
+import { SnapStartFunction } from "../functions/snap-start-java-function";
 import { functionInvocationUri } from "../spec/utils";
 
 /**
@@ -18,7 +19,12 @@ export class LambdaIntegration extends Integration {
 
   constructor(lambdaFunction: IFunction) {
     super();
-    this.lambdaFunction = lambdaFunction;
+    // Snap Start applies only to versions, so if the function is a SnapStartFunction, we'll reference the current version
+    if (lambdaFunction instanceof SnapStartFunction) {
+      this.lambdaFunction = lambdaFunction.currentVersion;
+    } else {
+      this.lambdaFunction = lambdaFunction;
+    }
   }
 
   /**

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/java-cdk-infrastructure.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/java-cdk-infrastructure.test.ts.snap
@@ -8,12 +8,13 @@ exports[`Java Infrastructure Code Generation Script Unit Tests Generates Functio
 
 import org.jetbrains.annotations.NotNull;
 import software.amazon.awscdk.services.lambda.Function;
+import software.aws.pdk.type_safe_api.SnapStartFunction;
 import software.constructs.Construct;
 
 /**
  * Lambda function construct which points to the java implementation of JavaOne
  */
-public class JavaOneFunction extends Function {
+public class JavaOneFunction extends SnapStartFunction {
     public JavaOneFunction(@NotNull Construct scope, @NotNull String id, @NotNull JavaOneFunctionProps props) {
         super(scope, id, props);
     }
@@ -57,6 +58,7 @@ import software.amazon.awscdk.services.lambda.VersionOptions;
 import software.amazon.awscdk.services.logs.RetentionDays;
 import software.amazon.awscdk.services.sns.ITopic;
 import software.amazon.awscdk.services.sqs.IQueue;
+import software.aws.pdk.type_safe_api.SnapStartFunctionProps;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -67,7 +69,7 @@ import java.util.List;
 import java.util.Map;
 
 @lombok.Builder @lombok.Getter
-public class JavaOneFunctionProps implements FunctionProps {
+public class JavaOneFunctionProps implements SnapStartFunctionProps {
     private static String infraProjectAbsolutePath;
 
     static {
@@ -144,12 +146,13 @@ public class JavaOneFunctionProps implements FunctionProps {
 
 import org.jetbrains.annotations.NotNull;
 import software.amazon.awscdk.services.lambda.Function;
+import software.aws.pdk.type_safe_api.SnapStartFunction;
 import software.constructs.Construct;
 
 /**
  * Lambda function construct which points to the java implementation of JavaTwo
  */
-public class JavaTwoFunction extends Function {
+public class JavaTwoFunction extends SnapStartFunction {
     public JavaTwoFunction(@NotNull Construct scope, @NotNull String id, @NotNull JavaTwoFunctionProps props) {
         super(scope, id, props);
     }
@@ -193,6 +196,7 @@ import software.amazon.awscdk.services.lambda.VersionOptions;
 import software.amazon.awscdk.services.logs.RetentionDays;
 import software.amazon.awscdk.services.sns.ITopic;
 import software.amazon.awscdk.services.sqs.IQueue;
+import software.aws.pdk.type_safe_api.SnapStartFunctionProps;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -203,7 +207,7 @@ import java.util.List;
 import java.util.Map;
 
 @lombok.Builder @lombok.Getter
-public class JavaTwoFunctionProps implements FunctionProps {
+public class JavaTwoFunctionProps implements SnapStartFunctionProps {
     private static String infraProjectAbsolutePath;
 
     static {
@@ -280,6 +284,7 @@ public class JavaTwoFunctionProps implements FunctionProps {
 
 import org.jetbrains.annotations.NotNull;
 import software.amazon.awscdk.services.lambda.Function;
+import software.aws.pdk.type_safe_api.SnapStartFunction;
 import software.constructs.Construct;
 
 /**
@@ -329,6 +334,7 @@ import software.amazon.awscdk.services.lambda.VersionOptions;
 import software.amazon.awscdk.services.logs.RetentionDays;
 import software.amazon.awscdk.services.sns.ITopic;
 import software.amazon.awscdk.services.sqs.IQueue;
+import software.aws.pdk.type_safe_api.SnapStartFunctionProps;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -416,6 +422,7 @@ public class PythonOneFunctionProps implements FunctionProps {
 
 import org.jetbrains.annotations.NotNull;
 import software.amazon.awscdk.services.lambda.Function;
+import software.aws.pdk.type_safe_api.SnapStartFunction;
 import software.constructs.Construct;
 
 /**
@@ -465,6 +472,7 @@ import software.amazon.awscdk.services.lambda.VersionOptions;
 import software.amazon.awscdk.services.logs.RetentionDays;
 import software.amazon.awscdk.services.sns.ITopic;
 import software.amazon.awscdk.services.sqs.IQueue;
+import software.aws.pdk.type_safe_api.SnapStartFunctionProps;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -552,6 +560,7 @@ public class PythonTwoFunctionProps implements FunctionProps {
 
 import org.jetbrains.annotations.NotNull;
 import software.amazon.awscdk.services.lambda.Function;
+import software.aws.pdk.type_safe_api.SnapStartFunction;
 import software.constructs.Construct;
 
 /**
@@ -601,6 +610,7 @@ import software.amazon.awscdk.services.lambda.VersionOptions;
 import software.amazon.awscdk.services.logs.RetentionDays;
 import software.amazon.awscdk.services.sns.ITopic;
 import software.amazon.awscdk.services.sqs.IQueue;
+import software.aws.pdk.type_safe_api.SnapStartFunctionProps;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -688,6 +698,7 @@ public class TypescriptOneFunctionProps implements FunctionProps {
 
 import org.jetbrains.annotations.NotNull;
 import software.amazon.awscdk.services.lambda.Function;
+import software.aws.pdk.type_safe_api.SnapStartFunction;
 import software.constructs.Construct;
 
 /**
@@ -737,6 +748,7 @@ import software.amazon.awscdk.services.lambda.VersionOptions;
 import software.amazon.awscdk.services.logs.RetentionDays;
 import software.amazon.awscdk.services.sns.ITopic;
 import software.amazon.awscdk.services.sqs.IQueue;
+import software.aws.pdk.type_safe_api.SnapStartFunctionProps;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/java-lambda-handlers.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/java-lambda-handlers.test.ts.snap
@@ -21,12 +21,17 @@ import java.util.List;
  */
 public class JavaOneHandler extends JavaOne {
     /**
+     * Interceptors are initialised once during the lambda "init" phase
+     */
+    private final List<Interceptor<JavaOneInput>> interceptors = DefaultInterceptors.all();
+
+    /**
      * Return the interceptors for this handler.
      * You can also use the @Interceptors annotation on the class to add interceptors
      */
     @Override
     public List<Interceptor<JavaOneInput>> getInterceptors() {
-        return DefaultInterceptors.all();
+        return this.interceptors;
     }
 
     /**
@@ -69,12 +74,17 @@ import java.util.List;
  */
 public class JavaTwoHandler extends JavaTwo {
     /**
+     * Interceptors are initialised once during the lambda "init" phase
+     */
+    private final List<Interceptor<JavaTwoInput>> interceptors = DefaultInterceptors.all();
+
+    /**
      * Return the interceptors for this handler.
      * You can also use the @Interceptors annotation on the class to add interceptors
      */
     @Override
     public List<Interceptor<JavaTwoInput>> getInterceptors() {
-        return DefaultInterceptors.all();
+        return this.interceptors;
     }
 
     /**

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/java.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/java.test.ts.snap
@@ -4825,6 +4825,11 @@ public abstract class Both implements RequestHandler<APIGatewayProxyRequestEvent
     public abstract BothResponse handle(final BothRequestInput request);
 
     /**
+     * Interceptors that the handler class has been decorated with
+     */
+    private List<Interceptor<BothInput>> annotationInterceptors = Handlers.getAnnotationInterceptors(Both.class);
+
+    /**
      * For more complex interceptors that require instantiation with parameters, you may override this method to
      * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
      * prefer the @Interceptors annotation.
@@ -4849,9 +4854,6 @@ public abstract class Both implements RequestHandler<APIGatewayProxyRequestEvent
 
         List<Interceptor<BothInput>> interceptors = new ArrayList<>();
         interceptors.addAll(additionalInterceptors);
-
-        List<Interceptor<BothInput>> annotationInterceptors = Handlers.getAnnotationInterceptors(this.getClass());
-
         interceptors.addAll(annotationInterceptors);
         interceptors.addAll(this.getInterceptors());
 
@@ -5145,6 +5147,11 @@ public abstract class Neither implements RequestHandler<APIGatewayProxyRequestEv
     public abstract NeitherResponse handle(final NeitherRequestInput request);
 
     /**
+     * Interceptors that the handler class has been decorated with
+     */
+    private List<Interceptor<NeitherInput>> annotationInterceptors = Handlers.getAnnotationInterceptors(Neither.class);
+
+    /**
      * For more complex interceptors that require instantiation with parameters, you may override this method to
      * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
      * prefer the @Interceptors annotation.
@@ -5169,9 +5176,6 @@ public abstract class Neither implements RequestHandler<APIGatewayProxyRequestEv
 
         List<Interceptor<NeitherInput>> interceptors = new ArrayList<>();
         interceptors.addAll(additionalInterceptors);
-
-        List<Interceptor<NeitherInput>> annotationInterceptors = Handlers.getAnnotationInterceptors(this.getClass());
-
         interceptors.addAll(annotationInterceptors);
         interceptors.addAll(this.getInterceptors());
 
@@ -5465,6 +5469,11 @@ public abstract class Tag1 implements RequestHandler<APIGatewayProxyRequestEvent
     public abstract Tag1Response handle(final Tag1RequestInput request);
 
     /**
+     * Interceptors that the handler class has been decorated with
+     */
+    private List<Interceptor<Tag1Input>> annotationInterceptors = Handlers.getAnnotationInterceptors(Tag1.class);
+
+    /**
      * For more complex interceptors that require instantiation with parameters, you may override this method to
      * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
      * prefer the @Interceptors annotation.
@@ -5489,9 +5498,6 @@ public abstract class Tag1 implements RequestHandler<APIGatewayProxyRequestEvent
 
         List<Interceptor<Tag1Input>> interceptors = new ArrayList<>();
         interceptors.addAll(additionalInterceptors);
-
-        List<Interceptor<Tag1Input>> annotationInterceptors = Handlers.getAnnotationInterceptors(this.getClass());
-
         interceptors.addAll(annotationInterceptors);
         interceptors.addAll(this.getInterceptors());
 
@@ -5785,6 +5791,11 @@ public abstract class Tag2 implements RequestHandler<APIGatewayProxyRequestEvent
     public abstract Tag2Response handle(final Tag2RequestInput request);
 
     /**
+     * Interceptors that the handler class has been decorated with
+     */
+    private List<Interceptor<Tag2Input>> annotationInterceptors = Handlers.getAnnotationInterceptors(Tag2.class);
+
+    /**
      * For more complex interceptors that require instantiation with parameters, you may override this method to
      * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
      * prefer the @Interceptors annotation.
@@ -5809,9 +5820,6 @@ public abstract class Tag2 implements RequestHandler<APIGatewayProxyRequestEvent
 
         List<Interceptor<Tag2Input>> interceptors = new ArrayList<>();
         interceptors.addAll(additionalInterceptors);
-
-        List<Interceptor<Tag2Input>> annotationInterceptors = Handlers.getAnnotationInterceptors(this.getClass());
-
         interceptors.addAll(annotationInterceptors);
         interceptors.addAll(this.getInterceptors());
 
@@ -6199,6 +6207,7 @@ import software.amazon.lambda.powertools.logging.LoggingUtils;
  * See https://docs.powertools.aws.dev/lambda/java/latest/core/logging/
  */
 public class LoggingInterceptor<Input> implements Interceptor<Input> {
+    private Logger logger = LogManager.getLogger(LoggingInterceptor.class);
 
     /**
      * Return the instance of the logger from the interceptor context
@@ -6237,7 +6246,6 @@ public class LoggingInterceptor<Input> implements Interceptor<Input> {
         LoggingUtils.appendKey("operationId", operationId);
 
         // Add the logger to the interceptor context
-        Logger logger = LogManager.getLogger(operationId);
         input.getInterceptorContext().put("logger", logger);
 
         Response response = input.getChain().next(input);
@@ -6269,6 +6277,7 @@ import software.amazon.lambda.powertools.metrics.MetricsUtils;
  * See: https://docs.powertools.aws.dev/lambda/typescript/latest/core/metrics
  */
 public class MetricsInterceptor<Input> implements Interceptor<Input> {
+    private MetricsLogger metrics = MetricsUtils.metricsLogger();
 
     /**
      * Return the instance of the metrics logger from the interceptor context
@@ -6283,7 +6292,6 @@ public class MetricsInterceptor<Input> implements Interceptor<Input> {
 
     @Override
     public Response handle(final ChainedRequestInput<Input> input) {
-        MetricsLogger metrics = MetricsUtils.metricsLogger();
         metrics.putDimensions(DimensionSet.of("operationId", (String) input.getInterceptorContext().get("operationId")));
 
         input.getInterceptorContext().put("metrics", metrics);
@@ -6325,6 +6333,13 @@ import software.amazon.lambda.powertools.tracing.TracingUtils;
  * See: https://docs.powertools.aws.dev/lambda/java/latest/core/tracing/
  */
 public class TracingInterceptor<Input> implements Interceptor<Input> {
+
+    {
+        // Create a segment during the lambda init phase to ensure xray emitter
+        // is warmed up prior to invocation phase
+        AWSXRay.beginSubsegment("Tracing Interceptor - Init");
+        AWSXRay.endSubsegment();
+    }
 
     private final boolean captureResponse;
 
@@ -12684,6 +12699,11 @@ public abstract class AnyRequestResponse implements RequestHandler<APIGatewayPro
     public abstract AnyRequestResponseResponse handle(final AnyRequestResponseRequestInput request);
 
     /**
+     * Interceptors that the handler class has been decorated with
+     */
+    private List<Interceptor<AnyRequestResponseInput>> annotationInterceptors = Handlers.getAnnotationInterceptors(AnyRequestResponse.class);
+
+    /**
      * For more complex interceptors that require instantiation with parameters, you may override this method to
      * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
      * prefer the @Interceptors annotation.
@@ -12708,9 +12728,6 @@ public abstract class AnyRequestResponse implements RequestHandler<APIGatewayPro
 
         List<Interceptor<AnyRequestResponseInput>> interceptors = new ArrayList<>();
         interceptors.addAll(additionalInterceptors);
-
-        List<Interceptor<AnyRequestResponseInput>> annotationInterceptors = Handlers.getAnnotationInterceptors(this.getClass());
-
         interceptors.addAll(annotationInterceptors);
         interceptors.addAll(this.getInterceptors());
 
@@ -13012,6 +13029,11 @@ public abstract class Empty implements RequestHandler<APIGatewayProxyRequestEven
     public abstract EmptyResponse handle(final EmptyRequestInput request);
 
     /**
+     * Interceptors that the handler class has been decorated with
+     */
+    private List<Interceptor<EmptyInput>> annotationInterceptors = Handlers.getAnnotationInterceptors(Empty.class);
+
+    /**
      * For more complex interceptors that require instantiation with parameters, you may override this method to
      * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
      * prefer the @Interceptors annotation.
@@ -13036,9 +13058,6 @@ public abstract class Empty implements RequestHandler<APIGatewayProxyRequestEven
 
         List<Interceptor<EmptyInput>> interceptors = new ArrayList<>();
         interceptors.addAll(additionalInterceptors);
-
-        List<Interceptor<EmptyInput>> annotationInterceptors = Handlers.getAnnotationInterceptors(this.getClass());
-
         interceptors.addAll(annotationInterceptors);
         interceptors.addAll(this.getInterceptors());
 
@@ -13332,6 +13351,11 @@ public abstract class MapResponse implements RequestHandler<APIGatewayProxyReque
     public abstract MapResponseResponse handle(final MapResponseRequestInput request);
 
     /**
+     * Interceptors that the handler class has been decorated with
+     */
+    private List<Interceptor<MapResponseInput>> annotationInterceptors = Handlers.getAnnotationInterceptors(MapResponse.class);
+
+    /**
      * For more complex interceptors that require instantiation with parameters, you may override this method to
      * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
      * prefer the @Interceptors annotation.
@@ -13356,9 +13380,6 @@ public abstract class MapResponse implements RequestHandler<APIGatewayProxyReque
 
         List<Interceptor<MapResponseInput>> interceptors = new ArrayList<>();
         interceptors.addAll(additionalInterceptors);
-
-        List<Interceptor<MapResponseInput>> annotationInterceptors = Handlers.getAnnotationInterceptors(this.getClass());
-
         interceptors.addAll(annotationInterceptors);
         interceptors.addAll(this.getInterceptors());
 
@@ -13655,6 +13676,11 @@ public abstract class MediaTypes implements RequestHandler<APIGatewayProxyReques
     public abstract MediaTypesResponse handle(final MediaTypesRequestInput request);
 
     /**
+     * Interceptors that the handler class has been decorated with
+     */
+    private List<Interceptor<MediaTypesInput>> annotationInterceptors = Handlers.getAnnotationInterceptors(MediaTypes.class);
+
+    /**
      * For more complex interceptors that require instantiation with parameters, you may override this method to
      * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
      * prefer the @Interceptors annotation.
@@ -13679,9 +13705,6 @@ public abstract class MediaTypes implements RequestHandler<APIGatewayProxyReques
 
         List<Interceptor<MediaTypesInput>> interceptors = new ArrayList<>();
         interceptors.addAll(additionalInterceptors);
-
-        List<Interceptor<MediaTypesInput>> annotationInterceptors = Handlers.getAnnotationInterceptors(this.getClass());
-
         interceptors.addAll(annotationInterceptors);
         interceptors.addAll(this.getInterceptors());
 
@@ -13983,6 +14006,11 @@ public abstract class MultipleContentTypes implements RequestHandler<APIGatewayP
     public abstract MultipleContentTypesResponse handle(final MultipleContentTypesRequestInput request);
 
     /**
+     * Interceptors that the handler class has been decorated with
+     */
+    private List<Interceptor<MultipleContentTypesInput>> annotationInterceptors = Handlers.getAnnotationInterceptors(MultipleContentTypes.class);
+
+    /**
      * For more complex interceptors that require instantiation with parameters, you may override this method to
      * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
      * prefer the @Interceptors annotation.
@@ -14007,9 +14035,6 @@ public abstract class MultipleContentTypes implements RequestHandler<APIGatewayP
 
         List<Interceptor<MultipleContentTypesInput>> interceptors = new ArrayList<>();
         interceptors.addAll(additionalInterceptors);
-
-        List<Interceptor<MultipleContentTypesInput>> annotationInterceptors = Handlers.getAnnotationInterceptors(this.getClass());
-
         interceptors.addAll(annotationInterceptors);
         interceptors.addAll(this.getInterceptors());
 
@@ -14315,6 +14340,11 @@ public abstract class OperationOne implements RequestHandler<APIGatewayProxyRequ
     public abstract OperationOneResponse handle(final OperationOneRequestInput request);
 
     /**
+     * Interceptors that the handler class has been decorated with
+     */
+    private List<Interceptor<OperationOneInput>> annotationInterceptors = Handlers.getAnnotationInterceptors(OperationOne.class);
+
+    /**
      * For more complex interceptors that require instantiation with parameters, you may override this method to
      * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
      * prefer the @Interceptors annotation.
@@ -14342,9 +14372,6 @@ public abstract class OperationOne implements RequestHandler<APIGatewayProxyRequ
 
         List<Interceptor<OperationOneInput>> interceptors = new ArrayList<>();
         interceptors.addAll(additionalInterceptors);
-
-        List<Interceptor<OperationOneInput>> annotationInterceptors = Handlers.getAnnotationInterceptors(this.getClass());
-
         interceptors.addAll(annotationInterceptors);
         interceptors.addAll(this.getInterceptors());
 
@@ -14747,6 +14774,11 @@ public abstract class WithoutOperationIdDelete implements RequestHandler<APIGate
     public abstract WithoutOperationIdDeleteResponse handle(final WithoutOperationIdDeleteRequestInput request);
 
     /**
+     * Interceptors that the handler class has been decorated with
+     */
+    private List<Interceptor<WithoutOperationIdDeleteInput>> annotationInterceptors = Handlers.getAnnotationInterceptors(WithoutOperationIdDelete.class);
+
+    /**
      * For more complex interceptors that require instantiation with parameters, you may override this method to
      * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
      * prefer the @Interceptors annotation.
@@ -14771,9 +14803,6 @@ public abstract class WithoutOperationIdDelete implements RequestHandler<APIGate
 
         List<Interceptor<WithoutOperationIdDeleteInput>> interceptors = new ArrayList<>();
         interceptors.addAll(additionalInterceptors);
-
-        List<Interceptor<WithoutOperationIdDeleteInput>> annotationInterceptors = Handlers.getAnnotationInterceptors(this.getClass());
-
         interceptors.addAll(annotationInterceptors);
         interceptors.addAll(this.getInterceptors());
 
@@ -15164,6 +15193,7 @@ import software.amazon.lambda.powertools.logging.LoggingUtils;
  * See https://docs.powertools.aws.dev/lambda/java/latest/core/logging/
  */
 public class LoggingInterceptor<Input> implements Interceptor<Input> {
+    private Logger logger = LogManager.getLogger(LoggingInterceptor.class);
 
     /**
      * Return the instance of the logger from the interceptor context
@@ -15202,7 +15232,6 @@ public class LoggingInterceptor<Input> implements Interceptor<Input> {
         LoggingUtils.appendKey("operationId", operationId);
 
         // Add the logger to the interceptor context
-        Logger logger = LogManager.getLogger(operationId);
         input.getInterceptorContext().put("logger", logger);
 
         Response response = input.getChain().next(input);
@@ -15234,6 +15263,7 @@ import software.amazon.lambda.powertools.metrics.MetricsUtils;
  * See: https://docs.powertools.aws.dev/lambda/typescript/latest/core/metrics
  */
 public class MetricsInterceptor<Input> implements Interceptor<Input> {
+    private MetricsLogger metrics = MetricsUtils.metricsLogger();
 
     /**
      * Return the instance of the metrics logger from the interceptor context
@@ -15248,7 +15278,6 @@ public class MetricsInterceptor<Input> implements Interceptor<Input> {
 
     @Override
     public Response handle(final ChainedRequestInput<Input> input) {
-        MetricsLogger metrics = MetricsUtils.metricsLogger();
         metrics.putDimensions(DimensionSet.of("operationId", (String) input.getInterceptorContext().get("operationId")));
 
         input.getInterceptorContext().put("metrics", metrics);
@@ -15290,6 +15319,13 @@ import software.amazon.lambda.powertools.tracing.TracingUtils;
  * See: https://docs.powertools.aws.dev/lambda/java/latest/core/tracing/
  */
 public class TracingInterceptor<Input> implements Interceptor<Input> {
+
+    {
+        // Create a segment during the lambda init phase to ensure xray emitter
+        // is warmed up prior to invocation phase
+        AWSXRay.beginSubsegment("Tracing Interceptor - Init");
+        AWSXRay.endSubsegment();
+    }
 
     private final boolean captureResponse;
 

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/python-cdk-infrastructure.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/python-cdk-infrastructure.test.ts.snap
@@ -5,12 +5,13 @@ exports[`Python Infrastructure Code Generation Script Unit Tests Generates Funct
 from aws_cdk.aws_lambda import (
     Function, Runtime, Tracing, Code
 )
+from aws_pdk.type_safe_api import SnapStartFunction
 from os import path
 from pathlib import Path
 
 
 
-class JavaOneFunction(Function):
+class JavaOneFunction(SnapStartFunction):
     """
     Lambda function construct which points to the java implementation of JavaOne
     """
@@ -26,7 +27,7 @@ class JavaOneFunction(Function):
             **kwargs,
         )
 
-class JavaTwoFunction(Function):
+class JavaTwoFunction(SnapStartFunction):
     """
     Lambda function construct which points to the java implementation of JavaTwo
     """

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript-cdk-infrastructure.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript-cdk-infrastructure.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`Typescript Infrastructure Code Generation Script Unit Tests Generates Functions 1`] = `
 "import { Construct } from "constructs";
 import { Duration } from "aws-cdk-lib";
+import { SnapStartFunction, SnapStartFunctionProps } from "@aws/pdk/type-safe-api";
 import { Code, Function, Runtime, Tracing, FunctionProps } from "aws-cdk-lib/aws-lambda";
 import * as path from "path";
 
@@ -10,12 +11,12 @@ import * as path from "path";
 /**
  * Options for the JavaOneFunction construct
  */
-export interface JavaOneFunctionProps extends Omit<FunctionProps, 'code' | 'handler' | 'runtime'> {}
+export interface JavaOneFunctionProps extends Omit<SnapStartFunctionProps, 'code' | 'handler' | 'runtime'> {}
 
 /**
  * Lambda function construct which points to the java implementation of JavaOne
  */
-export class JavaOneFunction extends Function {
+export class JavaOneFunction extends SnapStartFunction {
   constructor(scope: Construct, id: string, props?: JavaOneFunctionProps) {
     super(scope, id, {
       runtime: Runtime.JAVA_17,
@@ -33,12 +34,12 @@ export class JavaOneFunction extends Function {
 /**
  * Options for the JavaTwoFunction construct
  */
-export interface JavaTwoFunctionProps extends Omit<FunctionProps, 'code' | 'handler' | 'runtime'> {}
+export interface JavaTwoFunctionProps extends Omit<SnapStartFunctionProps, 'code' | 'handler' | 'runtime'> {}
 
 /**
  * Lambda function construct which points to the java implementation of JavaTwo
  */
-export class JavaTwoFunction extends Function {
+export class JavaTwoFunction extends SnapStartFunction {
   constructor(scope: Construct, id: string, props?: JavaTwoFunctionProps) {
     super(scope, id, {
       runtime: Runtime.JAVA_17,


### PR DESCRIPTION
Java handlers now have snapstart enabled by default to improve cold start times.

Ensure logging, metrics and tracing interceptors perform as much initialisation as possible during the init phase which can therefore be saved from snapstart invocations.

Also move the annotation processing to the init phase since this takes approximately a second.

This reduces cold start times from ~25s down to ~4s. Warm invocations remain the same at <100ms.

On a cold start it seems as though the logger takes about 500ms per log, and the tracer takes about 1500ms to end the subsegment - so there may be an opportunity to reduce the 4s cold start even further if we can figure out why :)

Fixes #572
