### PR TITLE
fix(monorepo): fix issues with monorepo-ts peer deps

### DIFF
--- a/packages/monorepo/src/projects/typescript/monorepo-ts.ts
+++ b/packages/monorepo/src/projects/typescript/monorepo-ts.ts
@@ -171,6 +171,9 @@ export class MonorepoTsProject
         },
         include: ["**/*.ts", ".projenrc.ts"],
       },
+      peerDeps: ["nx@^16", ...(options.peerDeps || [])],
+      devDeps: ["nx@^16", "@aws/pdk@^0", ...(options.devDeps || [])],
+      deps: ["aws-cdk-lib", "constructs", "cdk-nag", ...(options.deps || [])],
     });
 
     this.nxConfigurator = new NxConfigurator(this, {
@@ -199,6 +202,12 @@ export class MonorepoTsProject
           "!.yarn/releases",
           "!.yarn/plugins"
         );
+        break;
+      }
+      case NodePackageManager.NPM: {
+        // Allow older versions of peer deps to resolv compatibility issues
+        this.tasks.tryFind("install")?.reset("npm install --legacy-peer-deps");
+        this.tasks.tryFind("install:ci")?.reset("npm ci --legacy-peer-deps");
         break;
       }
     }
@@ -272,10 +281,6 @@ export class MonorepoTsProject
       });
     }
 
-    // Add dependency on nx 16
-    this.addPeerDeps("nx@^16");
-    this.addDevDeps("nx@^16", "@aws/pdk@^0");
-    this.addDeps("aws-cdk-lib", "constructs", "cdk-nag"); // Needed as this can be bundled in @aws/pdk
     this.package.addPackageResolutions(
       "@types/babel__traverse@7.18.2",
       "wrap-ansi@^7.0.0",

--- a/packages/pdk/_scripts/exec-command.js
+++ b/packages/pdk/_scripts/exec-command.js
@@ -27,8 +27,8 @@ const engines = JSON.parse(
 ).engines;
 
 if (engines) {
-  const pkgMgr = engines.pnpm ? "pnpm" : engines.yarn ? "yarn" : "npm";
-  execa.commandSync(`${pkgMgr}${isSynth ? " projen" : ""} ${process.argv.join(" ")}`, { stdio: "inherit" });
+  const pkgMgrCmd = engines.pnpm ? "pnpm" : engines.yarn ? "yarn" : "npm run";
+  execa.commandSync(`${pkgMgrCmd}${isSynth ? " default" : ""} ${process.argv.join(" ")}`, { stdio: "inherit" });
 } else {
   execa.commandSync(`npx projen ${process.argv.join(" ")}`, { stdio: "inherit"});
 }

--- a/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
@@ -39615,7 +39615,7 @@ tsconfig.tsbuildinfo
         "name": "install",
         "steps": [
           {
-            "exec": "npm install",
+            "exec": "npm install --legacy-peer-deps",
           },
         ],
       },
@@ -39624,7 +39624,7 @@ tsconfig.tsbuildinfo
         "name": "install:ci",
         "steps": [
           {
-            "exec": "npm ci",
+            "exec": "npm ci --legacy-peer-deps",
           },
         ],
       },


### PR DESCRIPTION
Resolves the following issues related to peer deps:

- #586 : Add deps to monorepo constructor to allow customers to override versions
- #601: Enable --legacy-peer-deps flag for npm install to prevent compatibility issues and fix an issue in the pdk script related to npm script execution.

Fixes #601, #586 