### PR TITLE
fix(type-safe-api): ensure lambda function names do not exceed max length

### DIFF
--- a/packages/type-safe-api/test/construct/__snapshots__/type-safe-rest-api.test.ts.snap
+++ b/packages/type-safe-api/test/construct/__snapshots__/type-safe-rest-api.test.ts.snap
@@ -108,7 +108,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
       "DeletionPolicy": "Retain",
       "DependsOn": [
         "ApiTest1E0FDBC81",
-        "ApiTest1PrepareSpecResource90D3F124",
+        "ApiTest1PrepareSpecCustomResource30CD03AA",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -289,7 +289,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
     "ApiTest1CloudWatchRole30B84AB0": {
       "DeletionPolicy": "Retain",
       "DependsOn": [
-        "ApiTest1PrepareSpecResource90D3F124",
+        "ApiTest1PrepareSpecCustomResource30CD03AA",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -354,9 +354,9 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTest1Deployment2E308FF829282c3ffceb3f752e192bfc30d947d6": {
+    "ApiTest1Deployment2E308FF82fc4f0a458a5f6de41661a6b62b5c224": {
       "DependsOn": [
-        "ApiTest1PrepareSpecResource90D3F124",
+        "ApiTest1PrepareSpecCustomResource30CD03AA",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -401,7 +401,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
     "ApiTest1DeploymentStageprod6B6E3F66": {
       "DependsOn": [
         "ApiTest1Account37F1A1C0",
-        "ApiTest1PrepareSpecResource90D3F124",
+        "ApiTest1PrepareSpecCustomResource30CD03AA",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -446,7 +446,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTest1Deployment2E308FF829282c3ffceb3f752e192bfc30d947d6",
+          "Ref": "ApiTest1Deployment2E308FF82fc4f0a458a5f6de41661a6b62b5c224",
         },
         "MethodSettings": [
           {
@@ -465,7 +465,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
     },
     "ApiTest1E0FDBC81": {
       "DependsOn": [
-        "ApiTest1PrepareSpecResource90D3F124",
+        "ApiTest1PrepareSpecCustomResource30CD03AA",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -506,7 +506,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
           },
           "Key": {
             "Fn::GetAtt": [
-              "ApiTest1PrepareSpecResource90D3F124",
+              "ApiTest1PrepareSpecCustomResource30CD03AA",
               "outputSpecKey",
             ],
           },
@@ -584,7 +584,103 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "ApiTest1PrepareSpecE7061D01": {
+    "ApiTest1PrepareSpecCustomResource30CD03AA": {
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "ApiTest1PrepareSpecProviderframeworkonEvent9E64448F",
+            "Arn",
+          ],
+        },
+        "inputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+        },
+        "integrations": {
+          "testOperation": {
+            "integration": {
+              "httpMethod": "POST",
+              "passthroughBehavior": "WHEN_NO_MATCH",
+              "type": "AWS_PROXY",
+              "uri": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":apigateway:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":lambda:path/2015-03-31/functions/",
+                    {
+                      "Fn::GetAtt": [
+                        "LambdaD247545B",
+                        "Arn",
+                      ],
+                    },
+                    "/invocations",
+                  ],
+                ],
+              },
+            },
+          },
+        },
+        "operationLookup": {
+          "testOperation": {
+            "method": "get",
+            "path": "/test",
+          },
+        },
+        "outputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+        },
+        "securitySchemes": {},
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ApiTest1PrepareSpecHandler41DBA69C": {
       "DependsOn": [
         "ApiTest1PrepareSpecRole6018776C",
       ],
@@ -627,7 +723,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
           },
           "S3Key": "7f5f734c4b1912c2e0519cc77c4a123953110c510f49ff2b58500ae796674fbf.zip",
         },
-        "FunctionName": "Default-PrepareSpec85532C36",
+        "FunctionName": "Default-85532C36PrepSpec",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -718,7 +814,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec85532C36-Provider",
+                          ":log-group:/aws/lambda/Default-85532C36PrepSpecProvider",
                         ],
                       ],
                     },
@@ -734,7 +830,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec85532C36-Provider:*",
+                          ":log-group:/aws/lambda/Default-85532C36PrepSpecProvider:*",
                         ],
                       ],
                     },
@@ -799,7 +895,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "ApiTest1PrepareSpecE7061D01",
+                    "ApiTest1PrepareSpecHandler41DBA69C",
                     "Arn",
                   ],
                 },
@@ -809,7 +905,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
                     [
                       {
                         "Fn::GetAtt": [
-                          "ApiTest1PrepareSpecE7061D01",
+                          "ApiTest1PrepareSpecHandler41DBA69C",
                           "Arn",
                         ],
                       },
@@ -831,103 +927,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
       },
       "Type": "AWS::IAM::Policy",
     },
-    "ApiTest1PrepareSpecResource90D3F124": {
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "ApiTest1PrepareSpecResourceProviderframeworkonEventCE6393EE",
-            "Arn",
-          ],
-        },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
-                ],
-              },
-            },
-          },
-        },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
-      },
-      "Type": "AWS::CloudFormation::CustomResource",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ApiTest1PrepareSpecResourceProviderframeworkonEventCE6393EE": {
+    "ApiTest1PrepareSpecProviderframeworkonEvent9E64448F": {
       "DependsOn": [
         "ApiTest1PrepareSpecProviderRoleDefaultPolicyFCE97042",
         "ApiTest1PrepareSpecProviderRoleA1D8F665",
@@ -979,18 +979,18 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
           },
           "S3Key": "f2d30cfc360482320a52a4fcde8a70f3569df79ab30be24650fda58eb60052cf.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest1/PrepareSpecResourceProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest1/PrepareSpecProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
               "Fn::GetAtt": [
-                "ApiTest1PrepareSpecE7061D01",
+                "ApiTest1PrepareSpecHandler41DBA69C",
                 "Arn",
               ],
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec85532C36-Provider",
+        "FunctionName": "Default-85532C36PrepSpecProvider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -1010,7 +1010,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec85532C36:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-85532C36PrepSpec:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -1028,7 +1028,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec85532C36:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-85532C36PrepSpec:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -1109,7 +1109,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec85532C36",
+                          ":log-group:/aws/lambda/Default-85532C36PrepSpec",
                         ],
                       ],
                     },
@@ -1125,7 +1125,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec85532C36:*",
+                          ":log-group:/aws/lambda/Default-85532C36PrepSpec:*",
                         ],
                       ],
                     },
@@ -1190,7 +1190,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
     },
     "ApiTest29D927A57": {
       "DependsOn": [
-        "ApiTest2PrepareSpecResourceD26A81CE",
+        "ApiTest2PrepareSpecCustomResource2182A9C5",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -1231,7 +1231,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
           },
           "Key": {
             "Fn::GetAtt": [
-              "ApiTest2PrepareSpecResourceD26A81CE",
+              "ApiTest2PrepareSpecCustomResource2182A9C5",
               "outputSpecKey",
             ],
           },
@@ -1284,7 +1284,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
       "DeletionPolicy": "Retain",
       "DependsOn": [
         "ApiTest29D927A57",
-        "ApiTest2PrepareSpecResourceD26A81CE",
+        "ApiTest2PrepareSpecCustomResource2182A9C5",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -1465,7 +1465,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
     "ApiTest2CloudWatchRole72C1A98D": {
       "DeletionPolicy": "Retain",
       "DependsOn": [
-        "ApiTest2PrepareSpecResourceD26A81CE",
+        "ApiTest2PrepareSpecCustomResource2182A9C5",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -1530,9 +1530,9 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTest2DeploymentF5547FBBf114e24fd32a3a02b1d1eb07572095f3": {
+    "ApiTest2DeploymentF5547FBB0628ff5b414eb67a464523f7ee50546d": {
       "DependsOn": [
-        "ApiTest2PrepareSpecResourceD26A81CE",
+        "ApiTest2PrepareSpecCustomResource2182A9C5",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -1577,7 +1577,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
     "ApiTest2DeploymentStageprodF3467DC1": {
       "DependsOn": [
         "ApiTest2Account685F675E",
-        "ApiTest2PrepareSpecResourceD26A81CE",
+        "ApiTest2PrepareSpecCustomResource2182A9C5",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -1622,7 +1622,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTest2DeploymentF5547FBBf114e24fd32a3a02b1d1eb07572095f3",
+          "Ref": "ApiTest2DeploymentF5547FBB0628ff5b414eb67a464523f7ee50546d",
         },
         "MethodSettings": [
           {
@@ -1708,7 +1708,103 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "ApiTest2PrepareSpec6015FD84": {
+    "ApiTest2PrepareSpecCustomResource2182A9C5": {
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "ApiTest2PrepareSpecProviderframeworkonEventC9470DD8",
+            "Arn",
+          ],
+        },
+        "inputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+        },
+        "integrations": {
+          "testOperation": {
+            "integration": {
+              "httpMethod": "POST",
+              "passthroughBehavior": "WHEN_NO_MATCH",
+              "type": "AWS_PROXY",
+              "uri": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":apigateway:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":lambda:path/2015-03-31/functions/",
+                    {
+                      "Fn::GetAtt": [
+                        "LambdaD247545B",
+                        "Arn",
+                      ],
+                    },
+                    "/invocations",
+                  ],
+                ],
+              },
+            },
+          },
+        },
+        "operationLookup": {
+          "testOperation": {
+            "method": "get",
+            "path": "/test",
+          },
+        },
+        "outputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+        },
+        "securitySchemes": {},
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ApiTest2PrepareSpecHandler8A43E4DB": {
       "DependsOn": [
         "ApiTest2PrepareSpecRoleE638C076",
       ],
@@ -1751,7 +1847,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
           },
           "S3Key": "7f5f734c4b1912c2e0519cc77c4a123953110c510f49ff2b58500ae796674fbf.zip",
         },
-        "FunctionName": "Default-PrepareSpec300D0E5F",
+        "FunctionName": "Default-300D0E5FPrepSpec",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -1842,7 +1938,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec300D0E5F-Provider",
+                          ":log-group:/aws/lambda/Default-300D0E5FPrepSpecProvider",
                         ],
                       ],
                     },
@@ -1858,7 +1954,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec300D0E5F-Provider:*",
+                          ":log-group:/aws/lambda/Default-300D0E5FPrepSpecProvider:*",
                         ],
                       ],
                     },
@@ -1923,7 +2019,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "ApiTest2PrepareSpec6015FD84",
+                    "ApiTest2PrepareSpecHandler8A43E4DB",
                     "Arn",
                   ],
                 },
@@ -1933,7 +2029,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
                     [
                       {
                         "Fn::GetAtt": [
-                          "ApiTest2PrepareSpec6015FD84",
+                          "ApiTest2PrepareSpecHandler8A43E4DB",
                           "Arn",
                         ],
                       },
@@ -1955,103 +2051,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
       },
       "Type": "AWS::IAM::Policy",
     },
-    "ApiTest2PrepareSpecResourceD26A81CE": {
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "ApiTest2PrepareSpecResourceProviderframeworkonEventF2315413",
-            "Arn",
-          ],
-        },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
-                ],
-              },
-            },
-          },
-        },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
-      },
-      "Type": "AWS::CloudFormation::CustomResource",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ApiTest2PrepareSpecResourceProviderframeworkonEventF2315413": {
+    "ApiTest2PrepareSpecProviderframeworkonEventC9470DD8": {
       "DependsOn": [
         "ApiTest2PrepareSpecProviderRoleDefaultPolicyA41E659C",
         "ApiTest2PrepareSpecProviderRole59C44E6C",
@@ -2103,18 +2103,18 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
           },
           "S3Key": "f2d30cfc360482320a52a4fcde8a70f3569df79ab30be24650fda58eb60052cf.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest2/PrepareSpecResourceProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest2/PrepareSpecProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
               "Fn::GetAtt": [
-                "ApiTest2PrepareSpec6015FD84",
+                "ApiTest2PrepareSpecHandler8A43E4DB",
                 "Arn",
               ],
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec300D0E5F-Provider",
+        "FunctionName": "Default-300D0E5FPrepSpecProvider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -2134,7 +2134,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec300D0E5F:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-300D0E5FPrepSpec:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -2152,7 +2152,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec300D0E5F:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-300D0E5FPrepSpec:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -2233,7 +2233,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec300D0E5F",
+                          ":log-group:/aws/lambda/Default-300D0E5FPrepSpec",
                         ],
                       ],
                     },
@@ -2249,7 +2249,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec300D0E5F:*",
+                          ":log-group:/aws/lambda/Default-300D0E5FPrepSpec:*",
                         ],
                       ],
                     },
@@ -2503,7 +2503,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
       "DeletionPolicy": "Retain",
       "DependsOn": [
         "ApiTestEE73F324",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -2684,7 +2684,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
     "ApiTestCloudWatchRole56ED0814": {
       "DeletionPolicy": "Retain",
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -2749,9 +2749,9 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC4789714f15d025ac32418baad3768f6c629": {
+    "ApiTestDeployment153EC4781c1d08559e5f0b03e31c4dcb542fe38a": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -2796,7 +2796,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
     "ApiTestDeploymentStageprod660267A6": {
       "DependsOn": [
         "ApiTestAccount272B5CDD",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -2841,7 +2841,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTestDeployment153EC4789714f15d025ac32418baad3768f6c629",
+          "Ref": "ApiTestDeployment153EC4781c1d08559e5f0b03e31c4dcb542fe38a",
         },
         "MethodSettings": [
           {
@@ -2860,7 +2860,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
     },
     "ApiTestEE73F324": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -3046,7 +3046,103 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "ApiTestPrepareSpecA3536D2B": {
+    "ApiTestPrepareSpecCustomResourceC9800EE6": {
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "Arn",
+          ],
+        },
+        "inputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+        },
+        "integrations": {
+          "testOperation": {
+            "integration": {
+              "httpMethod": "POST",
+              "passthroughBehavior": "WHEN_NO_MATCH",
+              "type": "AWS_PROXY",
+              "uri": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":apigateway:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":lambda:path/2015-03-31/functions/",
+                    {
+                      "Fn::GetAtt": [
+                        "LambdaD247545B",
+                        "Arn",
+                      ],
+                    },
+                    "/invocations",
+                  ],
+                ],
+              },
+            },
+          },
+        },
+        "operationLookup": {
+          "testOperation": {
+            "method": "get",
+            "path": "/test",
+          },
+        },
+        "outputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+        },
+        "securitySchemes": {},
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ApiTestPrepareSpecHandler46C6FEB5": {
       "DependsOn": [
         "ApiTestPrepareSpecRole44D562E5",
       ],
@@ -3089,7 +3185,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
           },
           "S3Key": "7f5f734c4b1912c2e0519cc77c4a123953110c510f49ff2b58500ae796674fbf.zip",
         },
-        "FunctionName": "Default-PrepareSpec3E755E54",
+        "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -3152,7 +3248,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "ApiTestPrepareSpecA3536D2B",
+                    "ApiTestPrepareSpecHandler46C6FEB5",
                     "Arn",
                   ],
                 },
@@ -3162,7 +3258,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "ApiTestPrepareSpecA3536D2B",
+                          "ApiTestPrepareSpecHandler46C6FEB5",
                           "Arn",
                         ],
                       },
@@ -3262,7 +3358,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider",
                         ],
                       ],
                     },
@@ -3278,7 +3374,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider:*",
                         ],
                       ],
                     },
@@ -3293,103 +3389,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecResource58706514": {
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
-            "Arn",
-          ],
-        },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
-                ],
-              },
-            },
-          },
-        },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
-      },
-      "Type": "AWS::CloudFormation::CustomResource",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
+    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -3441,18 +3441,18 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
           },
           "S3Key": "f2d30cfc360482320a52a4fcde8a70f3569df79ab30be24650fda58eb60052cf.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
               "Fn::GetAtt": [
-                "ApiTestPrepareSpecA3536D2B",
+                "ApiTestPrepareSpecHandler46C6FEB5",
                 "Arn",
               ],
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
+        "FunctionName": "Default-3E755E54PrepSpecProvider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -3472,7 +3472,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -3490,7 +3490,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -3571,7 +3571,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec",
                         ],
                       ],
                     },
@@ -3587,7 +3587,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec:*",
                         ],
                       ],
                     },
@@ -3813,7 +3813,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
       "DeletionPolicy": "Retain",
       "DependsOn": [
         "ApiTestEE73F324",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -3994,7 +3994,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
     "ApiTestCloudWatchRole56ED0814": {
       "DeletionPolicy": "Retain",
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -4059,9 +4059,9 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC478ea304cc67d1740dcd707f988306159b0": {
+    "ApiTestDeployment153EC47838079670259c24557112d51aa8c99f2d": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -4106,7 +4106,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
     "ApiTestDeploymentStageprod660267A6": {
       "DependsOn": [
         "ApiTestAccount272B5CDD",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -4151,7 +4151,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTestDeployment153EC478ea304cc67d1740dcd707f988306159b0",
+          "Ref": "ApiTestDeployment153EC47838079670259c24557112d51aa8c99f2d",
         },
         "MethodSettings": [
           {
@@ -4170,7 +4170,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
     },
     "ApiTestEE73F324": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -4211,7 +4211,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
           },
           "Key": {
             "Fn::GetAtt": [
-              "ApiTestPrepareSpecResource58706514",
+              "ApiTestPrepareSpecCustomResourceC9800EE6",
               "outputSpecKey",
             ],
           },
@@ -4289,7 +4289,106 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "ApiTestPrepareSpecA3536D2B": {
+    "ApiTestPrepareSpecCustomResourceC9800EE6": {
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "Arn",
+          ],
+        },
+        "defaultAuthorizerReference": {
+          "authorizerId": "none",
+        },
+        "inputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+        },
+        "integrations": {
+          "testOperation": {
+            "integration": {
+              "httpMethod": "POST",
+              "passthroughBehavior": "WHEN_NO_MATCH",
+              "type": "AWS_PROXY",
+              "uri": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":apigateway:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":lambda:path/2015-03-31/functions/",
+                    {
+                      "Fn::GetAtt": [
+                        "LambdaD247545B",
+                        "Arn",
+                      ],
+                    },
+                    "/invocations",
+                  ],
+                ],
+              },
+            },
+          },
+        },
+        "operationLookup": {
+          "testOperation": {
+            "method": "get",
+            "path": "/test",
+          },
+        },
+        "outputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+        },
+        "securitySchemes": {},
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ApiTestPrepareSpecHandler46C6FEB5": {
       "DependsOn": [
         "ApiTestPrepareSpecRole44D562E5",
       ],
@@ -4332,7 +4431,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
           },
           "S3Key": "7f5f734c4b1912c2e0519cc77c4a123953110c510f49ff2b58500ae796674fbf.zip",
         },
-        "FunctionName": "Default-PrepareSpec3E755E54",
+        "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -4395,7 +4494,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "ApiTestPrepareSpecA3536D2B",
+                    "ApiTestPrepareSpecHandler46C6FEB5",
                     "Arn",
                   ],
                 },
@@ -4405,7 +4504,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
                     [
                       {
                         "Fn::GetAtt": [
-                          "ApiTestPrepareSpecA3536D2B",
+                          "ApiTestPrepareSpecHandler46C6FEB5",
                           "Arn",
                         ],
                       },
@@ -4505,7 +4604,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider",
                         ],
                       ],
                     },
@@ -4521,7 +4620,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider:*",
                         ],
                       ],
                     },
@@ -4536,106 +4635,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecResource58706514": {
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
-            "Arn",
-          ],
-        },
-        "defaultAuthorizerReference": {
-          "authorizerId": "none",
-        },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
-                ],
-              },
-            },
-          },
-        },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
-      },
-      "Type": "AWS::CloudFormation::CustomResource",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
+    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -4687,18 +4687,18 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
           },
           "S3Key": "f2d30cfc360482320a52a4fcde8a70f3569df79ab30be24650fda58eb60052cf.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
               "Fn::GetAtt": [
-                "ApiTestPrepareSpecA3536D2B",
+                "ApiTestPrepareSpecHandler46C6FEB5",
                 "Arn",
               ],
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
+        "FunctionName": "Default-3E755E54PrepSpecProvider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -4718,7 +4718,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -4736,7 +4736,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -4817,7 +4817,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec",
                         ],
                       ],
                     },
@@ -4833,7 +4833,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec:*",
                         ],
                       ],
                     },
@@ -5059,7 +5059,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
       "DeletionPolicy": "Retain",
       "DependsOn": [
         "ApiTestEE73F324",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -5240,7 +5240,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
     "ApiTestCloudWatchRole56ED0814": {
       "DeletionPolicy": "Retain",
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -5305,9 +5305,9 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC47845bc057e867fdbb6199242334c8d117a": {
+    "ApiTestDeployment153EC47894f72739a02c7563be2a8cc00e09568e": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -5352,7 +5352,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
     "ApiTestDeploymentStageprod660267A6": {
       "DependsOn": [
         "ApiTestAccount272B5CDD",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -5397,7 +5397,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTestDeployment153EC47845bc057e867fdbb6199242334c8d117a",
+          "Ref": "ApiTestDeployment153EC47894f72739a02c7563be2a8cc00e09568e",
         },
         "MethodSettings": [
           {
@@ -5416,7 +5416,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
     },
     "ApiTestEE73F324": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -5457,7 +5457,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
           },
           "Key": {
             "Fn::GetAtt": [
-              "ApiTestPrepareSpecResource58706514",
+              "ApiTestPrepareSpecCustomResourceC9800EE6",
               "outputSpecKey",
             ],
           },
@@ -5742,254 +5742,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "ApiTestPrepareSpecA3536D2B": {
-      "DependsOn": [
-        "ApiTestPrepareSpecRole44D562E5",
-      ],
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "7f5f734c4b1912c2e0519cc77c4a123953110c510f49ff2b58500ae796674fbf.zip",
-        },
-        "FunctionName": "Default-PrepareSpec3E755E54",
-        "Handler": "index.handler",
-        "Role": {
-          "Fn::GetAtt": [
-            "ApiTestPrepareSpecRole44D562E5",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs18.x",
-        "Timeout": 30,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78": {
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "id": "AwsSolutions-IAM5",
-              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
-            },
-            {
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "lambda:InvokeFunction",
-              "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::GetAtt": [
-                    "ApiTestPrepareSpecA3536D2B",
-                    "Arn",
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Fn::GetAtt": [
-                          "ApiTestPrepareSpecA3536D2B",
-                          "Arn",
-                        ],
-                      },
-                      ":*",
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
-        "Roles": [
-          {
-            "Ref": "ApiTestPrepareSpecProviderRoleF47822B8",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "ApiTestPrepareSpecProviderRoleF47822B8": {
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "id": "AwsSolutions-IAM5",
-              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
-            },
-            {
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": [
-                    "logs:CreateLogGroup",
-                    "logs:CreateLogStream",
-                    "logs:PutLogEvents",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": [
-                    {
-                      "Fn::Join": [
-                        "",
-                        [
-                          "arn:aws:logs:",
-                          {
-                            "Ref": "AWS::Region",
-                          },
-                          ":",
-                          {
-                            "Ref": "AWS::AccountId",
-                          },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
-                        ],
-                      ],
-                    },
-                    {
-                      "Fn::Join": [
-                        "",
-                        [
-                          "arn:aws:logs:",
-                          {
-                            "Ref": "AWS::Region",
-                          },
-                          ":",
-                          {
-                            "Ref": "AWS::AccountId",
-                          },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
-                        ],
-                      ],
-                    },
-                  ],
-                },
-              ],
-              "Version": "2012-10-17",
-            },
-            "PolicyName": "logs",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "ApiTestPrepareSpecResource58706514": {
+    "ApiTestPrepareSpecCustomResourceC9800EE6": {
       "DeletionPolicy": "Delete",
       "Metadata": {
         "cdk_nag": {
@@ -6026,7 +5779,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
-            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
+            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
             "Arn",
           ],
         },
@@ -6221,7 +5974,254 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
     },
-    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
+    "ApiTestPrepareSpecHandler46C6FEB5": {
+      "DependsOn": [
+        "ApiTestPrepareSpecRole44D562E5",
+      ],
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "7f5f734c4b1912c2e0519cc77c4a123953110c510f49ff2b58500ae796674fbf.zip",
+        },
+        "FunctionName": "Default-3E755E54PrepSpec",
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiTestPrepareSpecRole44D562E5",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78": {
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "ApiTestPrepareSpecHandler46C6FEB5",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "ApiTestPrepareSpecHandler46C6FEB5",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
+        "Roles": [
+          {
+            "Ref": "ApiTestPrepareSpecProviderRoleF47822B8",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiTestPrepareSpecProviderRoleF47822B8": {
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:logs:",
+                          {
+                            "Ref": "AWS::Region",
+                          },
+                          ":",
+                          {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider",
+                        ],
+                      ],
+                    },
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:logs:",
+                          {
+                            "Ref": "AWS::Region",
+                          },
+                          ":",
+                          {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider:*",
+                        ],
+                      ],
+                    },
+                  ],
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "logs",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -6273,18 +6273,18 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
           },
           "S3Key": "f2d30cfc360482320a52a4fcde8a70f3569df79ab30be24650fda58eb60052cf.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
               "Fn::GetAtt": [
-                "ApiTestPrepareSpecA3536D2B",
+                "ApiTestPrepareSpecHandler46C6FEB5",
                 "Arn",
               ],
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
+        "FunctionName": "Default-3E755E54PrepSpecProvider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -6304,7 +6304,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -6322,7 +6322,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -6403,7 +6403,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec",
                         ],
                       ],
                     },
@@ -6419,7 +6419,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec:*",
                         ],
                       ],
                     },
@@ -7186,7 +7186,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
       "DeletionPolicy": "Retain",
       "DependsOn": [
         "ApiTestEE73F324",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -7367,7 +7367,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
     "ApiTestCloudWatchRole56ED0814": {
       "DeletionPolicy": "Retain",
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -7432,9 +7432,9 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC478dc93de2fef0f82ebbfb635f6bbddb176": {
+    "ApiTestDeployment153EC4783909f7c5ff6f3e4849abee9771dfb63a": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -7479,7 +7479,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
     "ApiTestDeploymentStageprod660267A6": {
       "DependsOn": [
         "ApiTestAccount272B5CDD",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -7524,7 +7524,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTestDeployment153EC478dc93de2fef0f82ebbfb635f6bbddb176",
+          "Ref": "ApiTestDeployment153EC4783909f7c5ff6f3e4849abee9771dfb63a",
         },
         "MethodSettings": [
           {
@@ -7543,7 +7543,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
     },
     "ApiTestEE73F324": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -7584,7 +7584,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
           },
           "Key": {
             "Fn::GetAtt": [
-              "ApiTestPrepareSpecResource58706514",
+              "ApiTestPrepareSpecCustomResourceC9800EE6",
               "outputSpecKey",
             ],
           },
@@ -7731,254 +7731,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "ApiTestPrepareSpecA3536D2B": {
-      "DependsOn": [
-        "ApiTestPrepareSpecRole44D562E5",
-      ],
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "7f5f734c4b1912c2e0519cc77c4a123953110c510f49ff2b58500ae796674fbf.zip",
-        },
-        "FunctionName": "Default-PrepareSpec3E755E54",
-        "Handler": "index.handler",
-        "Role": {
-          "Fn::GetAtt": [
-            "ApiTestPrepareSpecRole44D562E5",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs18.x",
-        "Timeout": 30,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78": {
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "id": "AwsSolutions-IAM5",
-              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
-            },
-            {
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "lambda:InvokeFunction",
-              "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::GetAtt": [
-                    "ApiTestPrepareSpecA3536D2B",
-                    "Arn",
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Fn::GetAtt": [
-                          "ApiTestPrepareSpecA3536D2B",
-                          "Arn",
-                        ],
-                      },
-                      ":*",
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
-        "Roles": [
-          {
-            "Ref": "ApiTestPrepareSpecProviderRoleF47822B8",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "ApiTestPrepareSpecProviderRoleF47822B8": {
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "id": "AwsSolutions-IAM5",
-              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
-            },
-            {
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": [
-                    "logs:CreateLogGroup",
-                    "logs:CreateLogStream",
-                    "logs:PutLogEvents",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": [
-                    {
-                      "Fn::Join": [
-                        "",
-                        [
-                          "arn:aws:logs:",
-                          {
-                            "Ref": "AWS::Region",
-                          },
-                          ":",
-                          {
-                            "Ref": "AWS::AccountId",
-                          },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
-                        ],
-                      ],
-                    },
-                    {
-                      "Fn::Join": [
-                        "",
-                        [
-                          "arn:aws:logs:",
-                          {
-                            "Ref": "AWS::Region",
-                          },
-                          ":",
-                          {
-                            "Ref": "AWS::AccountId",
-                          },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
-                        ],
-                      ],
-                    },
-                  ],
-                },
-              ],
-              "Version": "2012-10-17",
-            },
-            "PolicyName": "logs",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "ApiTestPrepareSpecResource58706514": {
+    "ApiTestPrepareSpecCustomResourceC9800EE6": {
       "DeletionPolicy": "Delete",
       "Metadata": {
         "cdk_nag": {
@@ -8015,7 +7768,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
-            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
+            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
             "Arn",
           ],
         },
@@ -8176,7 +7929,254 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
     },
-    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
+    "ApiTestPrepareSpecHandler46C6FEB5": {
+      "DependsOn": [
+        "ApiTestPrepareSpecRole44D562E5",
+      ],
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "7f5f734c4b1912c2e0519cc77c4a123953110c510f49ff2b58500ae796674fbf.zip",
+        },
+        "FunctionName": "Default-3E755E54PrepSpec",
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiTestPrepareSpecRole44D562E5",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78": {
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "ApiTestPrepareSpecHandler46C6FEB5",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "ApiTestPrepareSpecHandler46C6FEB5",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
+        "Roles": [
+          {
+            "Ref": "ApiTestPrepareSpecProviderRoleF47822B8",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiTestPrepareSpecProviderRoleF47822B8": {
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:logs:",
+                          {
+                            "Ref": "AWS::Region",
+                          },
+                          ":",
+                          {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider",
+                        ],
+                      ],
+                    },
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:logs:",
+                          {
+                            "Ref": "AWS::Region",
+                          },
+                          ":",
+                          {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider:*",
+                        ],
+                      ],
+                    },
+                  ],
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "logs",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -8228,18 +8228,18 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
           },
           "S3Key": "f2d30cfc360482320a52a4fcde8a70f3569df79ab30be24650fda58eb60052cf.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
               "Fn::GetAtt": [
-                "ApiTestPrepareSpecA3536D2B",
+                "ApiTestPrepareSpecHandler46C6FEB5",
                 "Arn",
               ],
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
+        "FunctionName": "Default-3E755E54PrepSpecProvider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -8259,7 +8259,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -8277,7 +8277,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -8358,7 +8358,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec",
                         ],
                       ],
                     },
@@ -8374,7 +8374,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec:*",
                         ],
                       ],
                     },
@@ -8650,7 +8650,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
       "DeletionPolicy": "Retain",
       "DependsOn": [
         "ApiTestEE73F324",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -8831,7 +8831,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
     "ApiTestCloudWatchRole56ED0814": {
       "DeletionPolicy": "Retain",
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -8896,9 +8896,9 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC478e7ffe1cfd3a74c45e7b50a4ea8ddf8e2": {
+    "ApiTestDeployment153EC478faa243d7b88abc45cdf0192565d77ac9": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -8943,7 +8943,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
     "ApiTestDeploymentStageprod660267A6": {
       "DependsOn": [
         "ApiTestAccount272B5CDD",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -8988,7 +8988,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTestDeployment153EC478e7ffe1cfd3a74c45e7b50a4ea8ddf8e2",
+          "Ref": "ApiTestDeployment153EC478faa243d7b88abc45cdf0192565d77ac9",
         },
         "MethodSettings": [
           {
@@ -9007,7 +9007,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
     },
     "ApiTestEE73F324": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -9048,7 +9048,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
           },
           "Key": {
             "Fn::GetAtt": [
-              "ApiTestPrepareSpecResource58706514",
+              "ApiTestPrepareSpecCustomResourceC9800EE6",
               "outputSpecKey",
             ],
           },
@@ -9127,7 +9127,103 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "ApiTestPrepareSpecA3536D2B": {
+    "ApiTestPrepareSpecCustomResourceC9800EE6": {
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "Arn",
+          ],
+        },
+        "inputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+        },
+        "integrations": {
+          "testOperation": {
+            "integration": {
+              "httpMethod": "POST",
+              "passthroughBehavior": "WHEN_NO_MATCH",
+              "type": "AWS_PROXY",
+              "uri": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":apigateway:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":lambda:path/2015-03-31/functions/",
+                    {
+                      "Fn::GetAtt": [
+                        "LambdaD247545B",
+                        "Arn",
+                      ],
+                    },
+                    "/invocations",
+                  ],
+                ],
+              },
+            },
+          },
+        },
+        "operationLookup": {
+          "testOperation": {
+            "method": "get",
+            "path": "/test",
+          },
+        },
+        "outputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+        },
+        "securitySchemes": {},
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ApiTestPrepareSpecHandler46C6FEB5": {
       "DependsOn": [
         "ApiTestPrepareSpecRole44D562E5",
       ],
@@ -9170,7 +9266,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
           },
           "S3Key": "7f5f734c4b1912c2e0519cc77c4a123953110c510f49ff2b58500ae796674fbf.zip",
         },
-        "FunctionName": "Default-PrepareSpec3E755E54",
+        "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -9233,7 +9329,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "ApiTestPrepareSpecA3536D2B",
+                    "ApiTestPrepareSpecHandler46C6FEB5",
                     "Arn",
                   ],
                 },
@@ -9243,7 +9339,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
                     [
                       {
                         "Fn::GetAtt": [
-                          "ApiTestPrepareSpecA3536D2B",
+                          "ApiTestPrepareSpecHandler46C6FEB5",
                           "Arn",
                         ],
                       },
@@ -9343,7 +9439,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider",
                         ],
                       ],
                     },
@@ -9359,7 +9455,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider:*",
                         ],
                       ],
                     },
@@ -9374,103 +9470,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecResource58706514": {
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
-            "Arn",
-          ],
-        },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
-                ],
-              },
-            },
-          },
-        },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
-      },
-      "Type": "AWS::CloudFormation::CustomResource",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
+    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -9522,18 +9522,18 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
           },
           "S3Key": "f2d30cfc360482320a52a4fcde8a70f3569df79ab30be24650fda58eb60052cf.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
               "Fn::GetAtt": [
-                "ApiTestPrepareSpecA3536D2B",
+                "ApiTestPrepareSpecHandler46C6FEB5",
                 "Arn",
               ],
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
+        "FunctionName": "Default-3E755E54PrepSpecProvider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -9553,7 +9553,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -9571,7 +9571,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -9652,7 +9652,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec",
                         ],
                       ],
                     },
@@ -9668,7 +9668,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec:*",
                         ],
                       ],
                     },
@@ -9894,7 +9894,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
       "DeletionPolicy": "Retain",
       "DependsOn": [
         "ApiTestEE73F324",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -10075,7 +10075,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
     "ApiTestCloudWatchRole56ED0814": {
       "DeletionPolicy": "Retain",
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -10140,9 +10140,9 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC478950afb915db24dc651450ed2227b1233": {
+    "ApiTestDeployment153EC478ba688c73ecd411d6bc46f33941546de6": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -10187,7 +10187,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
     "ApiTestDeploymentStageprod660267A6": {
       "DependsOn": [
         "ApiTestAccount272B5CDD",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -10232,7 +10232,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTestDeployment153EC478950afb915db24dc651450ed2227b1233",
+          "Ref": "ApiTestDeployment153EC478ba688c73ecd411d6bc46f33941546de6",
         },
         "MethodSettings": [
           {
@@ -10251,7 +10251,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
     },
     "ApiTestEE73F324": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -10292,7 +10292,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
           },
           "Key": {
             "Fn::GetAtt": [
-              "ApiTestPrepareSpecResource58706514",
+              "ApiTestPrepareSpecCustomResourceC9800EE6",
               "outputSpecKey",
             ],
           },
@@ -10370,7 +10370,103 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "ApiTestPrepareSpecA3536D2B": {
+    "ApiTestPrepareSpecCustomResourceC9800EE6": {
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "Arn",
+          ],
+        },
+        "inputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+        },
+        "integrations": {
+          "testOperation": {
+            "integration": {
+              "httpMethod": "POST",
+              "passthroughBehavior": "WHEN_NO_MATCH",
+              "type": "AWS_PROXY",
+              "uri": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":apigateway:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":lambda:path/2015-03-31/functions/",
+                    {
+                      "Fn::GetAtt": [
+                        "LambdaD247545B",
+                        "Arn",
+                      ],
+                    },
+                    "/invocations",
+                  ],
+                ],
+              },
+            },
+          },
+        },
+        "operationLookup": {
+          "testOperation": {
+            "method": "get",
+            "path": "/test",
+          },
+        },
+        "outputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+        },
+        "securitySchemes": {},
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ApiTestPrepareSpecHandler46C6FEB5": {
       "DependsOn": [
         "ApiTestPrepareSpecRole44D562E5",
       ],
@@ -10413,7 +10509,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
           },
           "S3Key": "7f5f734c4b1912c2e0519cc77c4a123953110c510f49ff2b58500ae796674fbf.zip",
         },
-        "FunctionName": "Default-PrepareSpec3E755E54",
+        "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -10476,7 +10572,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "ApiTestPrepareSpecA3536D2B",
+                    "ApiTestPrepareSpecHandler46C6FEB5",
                     "Arn",
                   ],
                 },
@@ -10486,7 +10582,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "ApiTestPrepareSpecA3536D2B",
+                          "ApiTestPrepareSpecHandler46C6FEB5",
                           "Arn",
                         ],
                       },
@@ -10586,7 +10682,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider",
                         ],
                       ],
                     },
@@ -10602,7 +10698,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider:*",
                         ],
                       ],
                     },
@@ -10617,103 +10713,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecResource58706514": {
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
-            "Arn",
-          ],
-        },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
-                ],
-              },
-            },
-          },
-        },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
-      },
-      "Type": "AWS::CloudFormation::CustomResource",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
+    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -10765,18 +10765,18 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
           },
           "S3Key": "f2d30cfc360482320a52a4fcde8a70f3569df79ab30be24650fda58eb60052cf.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
               "Fn::GetAtt": [
-                "ApiTestPrepareSpecA3536D2B",
+                "ApiTestPrepareSpecHandler46C6FEB5",
                 "Arn",
               ],
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
+        "FunctionName": "Default-3E755E54PrepSpecProvider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -10796,7 +10796,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -10814,7 +10814,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -10895,7 +10895,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec",
                         ],
                       ],
                     },
@@ -10911,7 +10911,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec:*",
                         ],
                       ],
                     },
@@ -12236,7 +12236,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
       "DeletionPolicy": "Retain",
       "DependsOn": [
         "ApiTestEE73F324",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -12417,7 +12417,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
     "ApiTestCloudWatchRole56ED0814": {
       "DeletionPolicy": "Retain",
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -12482,9 +12482,9 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC47838831ee40913844aca2242aa92d1dbc5": {
+    "ApiTestDeployment153EC4782f7f76b22669fc980f9f7456fe1deff4": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -12529,7 +12529,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
     "ApiTestDeploymentStageprod660267A6": {
       "DependsOn": [
         "ApiTestAccount272B5CDD",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -12574,7 +12574,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTestDeployment153EC47838831ee40913844aca2242aa92d1dbc5",
+          "Ref": "ApiTestDeployment153EC4782f7f76b22669fc980f9f7456fe1deff4",
         },
         "MethodSettings": [
           {
@@ -12593,7 +12593,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
     },
     "ApiTestEE73F324": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -12634,7 +12634,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
           },
           "Key": {
             "Fn::GetAtt": [
-              "ApiTestPrepareSpecResource58706514",
+              "ApiTestPrepareSpecCustomResourceC9800EE6",
               "outputSpecKey",
             ],
           },
@@ -12712,7 +12712,124 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "ApiTestPrepareSpecA3536D2B": {
+    "ApiTestPrepareSpecCustomResourceC9800EE6": {
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "Arn",
+          ],
+        },
+        "defaultAuthorizerReference": {
+          "authorizerId": "myCognitoAuthorizer",
+        },
+        "inputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+        },
+        "integrations": {
+          "testOperation": {
+            "integration": {
+              "httpMethod": "POST",
+              "passthroughBehavior": "WHEN_NO_MATCH",
+              "type": "AWS_PROXY",
+              "uri": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":apigateway:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":lambda:path/2015-03-31/functions/",
+                    {
+                      "Fn::GetAtt": [
+                        "LambdaD247545B",
+                        "Arn",
+                      ],
+                    },
+                    "/invocations",
+                  ],
+                ],
+              },
+            },
+          },
+        },
+        "operationLookup": {
+          "testOperation": {
+            "method": "get",
+            "path": "/test",
+          },
+        },
+        "outputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+        },
+        "securitySchemes": {
+          "myCognitoAuthorizer": {
+            "in": "header",
+            "name": "Authorization",
+            "type": "apiKey",
+            "x-amazon-apigateway-authorizer": {
+              "providerARNs": [
+                {
+                  "Fn::GetAtt": [
+                    "pool056F3F7E",
+                    "Arn",
+                  ],
+                },
+              ],
+              "type": "COGNITO_USER_POOLS",
+            },
+            "x-amazon-apigateway-authtype": "COGNITO_USER_POOLS",
+          },
+        },
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ApiTestPrepareSpecHandler46C6FEB5": {
       "DependsOn": [
         "ApiTestPrepareSpecRole44D562E5",
       ],
@@ -12755,7 +12872,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
           },
           "S3Key": "7f5f734c4b1912c2e0519cc77c4a123953110c510f49ff2b58500ae796674fbf.zip",
         },
-        "FunctionName": "Default-PrepareSpec3E755E54",
+        "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -12818,7 +12935,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "ApiTestPrepareSpecA3536D2B",
+                    "ApiTestPrepareSpecHandler46C6FEB5",
                     "Arn",
                   ],
                 },
@@ -12828,7 +12945,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "ApiTestPrepareSpecA3536D2B",
+                          "ApiTestPrepareSpecHandler46C6FEB5",
                           "Arn",
                         ],
                       },
@@ -12928,7 +13045,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider",
                         ],
                       ],
                     },
@@ -12944,7 +13061,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider:*",
                         ],
                       ],
                     },
@@ -12959,124 +13076,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecResource58706514": {
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
-            "Arn",
-          ],
-        },
-        "defaultAuthorizerReference": {
-          "authorizerId": "myCognitoAuthorizer",
-        },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
-                ],
-              },
-            },
-          },
-        },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {
-          "myCognitoAuthorizer": {
-            "in": "header",
-            "name": "Authorization",
-            "type": "apiKey",
-            "x-amazon-apigateway-authorizer": {
-              "providerARNs": [
-                {
-                  "Fn::GetAtt": [
-                    "pool056F3F7E",
-                    "Arn",
-                  ],
-                },
-              ],
-              "type": "COGNITO_USER_POOLS",
-            },
-            "x-amazon-apigateway-authtype": "COGNITO_USER_POOLS",
-          },
-        },
-      },
-      "Type": "AWS::CloudFormation::CustomResource",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
+    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -13128,18 +13128,18 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
           },
           "S3Key": "f2d30cfc360482320a52a4fcde8a70f3569df79ab30be24650fda58eb60052cf.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
               "Fn::GetAtt": [
-                "ApiTestPrepareSpecA3536D2B",
+                "ApiTestPrepareSpecHandler46C6FEB5",
                 "Arn",
               ],
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
+        "FunctionName": "Default-3E755E54PrepSpecProvider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -13159,7 +13159,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -13177,7 +13177,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -13258,7 +13258,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec",
                         ],
                       ],
                     },
@@ -13274,7 +13274,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec:*",
                         ],
                       ],
                     },
@@ -13608,7 +13608,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
       "DeletionPolicy": "Retain",
       "DependsOn": [
         "ApiTestEE73F324",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -13789,7 +13789,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
     "ApiTestCloudWatchRole56ED0814": {
       "DeletionPolicy": "Retain",
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -13854,9 +13854,9 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC4789abd2506c995fb1e3f8048cbc34a252c": {
+    "ApiTestDeployment153EC47803e8a90fd243402c01d0e16cbd6e0535": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -13901,7 +13901,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
     "ApiTestDeploymentStageprod660267A6": {
       "DependsOn": [
         "ApiTestAccount272B5CDD",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -13946,7 +13946,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTestDeployment153EC4789abd2506c995fb1e3f8048cbc34a252c",
+          "Ref": "ApiTestDeployment153EC47803e8a90fd243402c01d0e16cbd6e0535",
         },
         "MethodSettings": [
           {
@@ -13965,7 +13965,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
     },
     "ApiTestEE73F324": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -14006,7 +14006,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
           },
           "Key": {
             "Fn::GetAtt": [
-              "ApiTestPrepareSpecResource58706514",
+              "ApiTestPrepareSpecCustomResourceC9800EE6",
               "outputSpecKey",
             ],
           },
@@ -14153,7 +14153,141 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "ApiTestPrepareSpecA3536D2B": {
+    "ApiTestPrepareSpecCustomResourceC9800EE6": {
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "Arn",
+          ],
+        },
+        "defaultAuthorizerReference": {
+          "authorizerId": "myCustomAuthorizer",
+        },
+        "inputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+        },
+        "integrations": {
+          "testOperation": {
+            "integration": {
+              "httpMethod": "POST",
+              "passthroughBehavior": "WHEN_NO_MATCH",
+              "type": "AWS_PROXY",
+              "uri": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":apigateway:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":lambda:path/2015-03-31/functions/",
+                    {
+                      "Fn::GetAtt": [
+                        "LambdaD247545B",
+                        "Arn",
+                      ],
+                    },
+                    "/invocations",
+                  ],
+                ],
+              },
+            },
+          },
+        },
+        "operationLookup": {
+          "testOperation": {
+            "method": "get",
+            "path": "/test",
+          },
+        },
+        "outputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+        },
+        "securitySchemes": {
+          "myCustomAuthorizer": {
+            "in": "header",
+            "name": "Authorization",
+            "type": "apiKey",
+            "x-amazon-apigateway-authorizer": {
+              "authorizerResultTtlInSeconds": 300,
+              "authorizerUri": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":apigateway:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":lambda:path/2015-03-31/functions/",
+                    {
+                      "Fn::GetAtt": [
+                        "AuthorizerBD825682",
+                        "Arn",
+                      ],
+                    },
+                    "/invocations",
+                  ],
+                ],
+              },
+              "identitySource": "method.request.header.Authorization",
+              "type": "token",
+            },
+            "x-amazon-apigateway-authtype": "CUSTOM",
+          },
+        },
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ApiTestPrepareSpecHandler46C6FEB5": {
       "DependsOn": [
         "ApiTestPrepareSpecRole44D562E5",
       ],
@@ -14196,7 +14330,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
           },
           "S3Key": "7f5f734c4b1912c2e0519cc77c4a123953110c510f49ff2b58500ae796674fbf.zip",
         },
-        "FunctionName": "Default-PrepareSpec3E755E54",
+        "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -14259,7 +14393,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "ApiTestPrepareSpecA3536D2B",
+                    "ApiTestPrepareSpecHandler46C6FEB5",
                     "Arn",
                   ],
                 },
@@ -14269,7 +14403,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "ApiTestPrepareSpecA3536D2B",
+                          "ApiTestPrepareSpecHandler46C6FEB5",
                           "Arn",
                         ],
                       },
@@ -14369,7 +14503,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider",
                         ],
                       ],
                     },
@@ -14385,7 +14519,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider:*",
                         ],
                       ],
                     },
@@ -14400,141 +14534,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecResource58706514": {
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
-            "Arn",
-          ],
-        },
-        "defaultAuthorizerReference": {
-          "authorizerId": "myCustomAuthorizer",
-        },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
-                ],
-              },
-            },
-          },
-        },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {
-          "myCustomAuthorizer": {
-            "in": "header",
-            "name": "Authorization",
-            "type": "apiKey",
-            "x-amazon-apigateway-authorizer": {
-              "authorizerResultTtlInSeconds": 300,
-              "authorizerUri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "AuthorizerBD825682",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
-                ],
-              },
-              "identitySource": "method.request.header.Authorization",
-              "type": "token",
-            },
-            "x-amazon-apigateway-authtype": "CUSTOM",
-          },
-        },
-      },
-      "Type": "AWS::CloudFormation::CustomResource",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
+    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -14586,18 +14586,18 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
           },
           "S3Key": "f2d30cfc360482320a52a4fcde8a70f3569df79ab30be24650fda58eb60052cf.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
               "Fn::GetAtt": [
-                "ApiTestPrepareSpecA3536D2B",
+                "ApiTestPrepareSpecHandler46C6FEB5",
                 "Arn",
               ],
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
+        "FunctionName": "Default-3E755E54PrepSpecProvider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -14617,7 +14617,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -14635,7 +14635,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -14716,7 +14716,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec",
                         ],
                       ],
                     },
@@ -14732,7 +14732,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec:*",
                         ],
                       ],
                     },
@@ -15085,7 +15085,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
       "DeletionPolicy": "Retain",
       "DependsOn": [
         "ApiTestEE73F324",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -15284,7 +15284,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
     "ApiTestCloudWatchRole56ED0814": {
       "DeletionPolicy": "Retain",
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -15349,9 +15349,9 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC478950afb915db24dc651450ed2227b1233": {
+    "ApiTestDeployment153EC478ba688c73ecd411d6bc46f33941546de6": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -15396,7 +15396,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
     "ApiTestDeploymentStageprod660267A6": {
       "DependsOn": [
         "ApiTestAccount272B5CDD",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -15441,7 +15441,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTestDeployment153EC478950afb915db24dc651450ed2227b1233",
+          "Ref": "ApiTestDeployment153EC478ba688c73ecd411d6bc46f33941546de6",
         },
         "MethodSettings": [
           {
@@ -15460,7 +15460,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
     },
     "ApiTestEE73F324": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -15501,7 +15501,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
           },
           "Key": {
             "Fn::GetAtt": [
-              "ApiTestPrepareSpecResource58706514",
+              "ApiTestPrepareSpecCustomResourceC9800EE6",
               "outputSpecKey",
             ],
           },
@@ -15579,7 +15579,103 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "ApiTestPrepareSpecA3536D2B": {
+    "ApiTestPrepareSpecCustomResourceC9800EE6": {
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "Arn",
+          ],
+        },
+        "inputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+        },
+        "integrations": {
+          "testOperation": {
+            "integration": {
+              "httpMethod": "POST",
+              "passthroughBehavior": "WHEN_NO_MATCH",
+              "type": "AWS_PROXY",
+              "uri": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":apigateway:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":lambda:path/2015-03-31/functions/",
+                    {
+                      "Fn::GetAtt": [
+                        "LambdaD247545B",
+                        "Arn",
+                      ],
+                    },
+                    "/invocations",
+                  ],
+                ],
+              },
+            },
+          },
+        },
+        "operationLookup": {
+          "testOperation": {
+            "method": "get",
+            "path": "/test",
+          },
+        },
+        "outputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+        },
+        "securitySchemes": {},
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ApiTestPrepareSpecHandler46C6FEB5": {
       "DependsOn": [
         "ApiTestPrepareSpecRole44D562E5",
       ],
@@ -15622,7 +15718,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
           },
           "S3Key": "7f5f734c4b1912c2e0519cc77c4a123953110c510f49ff2b58500ae796674fbf.zip",
         },
-        "FunctionName": "Default-PrepareSpec3E755E54",
+        "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -15685,7 +15781,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "ApiTestPrepareSpecA3536D2B",
+                    "ApiTestPrepareSpecHandler46C6FEB5",
                     "Arn",
                   ],
                 },
@@ -15695,7 +15791,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
                     [
                       {
                         "Fn::GetAtt": [
-                          "ApiTestPrepareSpecA3536D2B",
+                          "ApiTestPrepareSpecHandler46C6FEB5",
                           "Arn",
                         ],
                       },
@@ -15795,7 +15891,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider",
                         ],
                       ],
                     },
@@ -15811,7 +15907,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider:*",
                         ],
                       ],
                     },
@@ -15826,103 +15922,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecResource58706514": {
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
-            "Arn",
-          ],
-        },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
-                ],
-              },
-            },
-          },
-        },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
-      },
-      "Type": "AWS::CloudFormation::CustomResource",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
+    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -15974,18 +15974,18 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
           },
           "S3Key": "f2d30cfc360482320a52a4fcde8a70f3569df79ab30be24650fda58eb60052cf.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
               "Fn::GetAtt": [
-                "ApiTestPrepareSpecA3536D2B",
+                "ApiTestPrepareSpecHandler46C6FEB5",
                 "Arn",
               ],
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
+        "FunctionName": "Default-3E755E54PrepSpecProvider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -16005,7 +16005,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -16023,7 +16023,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -16104,7 +16104,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec",
                         ],
                       ],
                     },
@@ -16120,7 +16120,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec:*",
                         ],
                       ],
                     },
@@ -16346,7 +16346,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
       "DeletionPolicy": "Retain",
       "DependsOn": [
         "ApiTestEE73F324",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -16527,7 +16527,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
     "ApiTestCloudWatchRole56ED0814": {
       "DeletionPolicy": "Retain",
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -16592,9 +16592,9 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC478d03cfc098ec71622fc8a95b5e8d6d66b": {
+    "ApiTestDeployment153EC478a540cf96c2f3638f1db06413ff4bc26e": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -16639,7 +16639,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
     "ApiTestDeploymentStageprod660267A6": {
       "DependsOn": [
         "ApiTestAccount272B5CDD",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -16684,7 +16684,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTestDeployment153EC478d03cfc098ec71622fc8a95b5e8d6d66b",
+          "Ref": "ApiTestDeployment153EC478a540cf96c2f3638f1db06413ff4bc26e",
         },
         "MethodSettings": [
           {
@@ -16703,7 +16703,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
     },
     "ApiTestEE73F324": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -16744,7 +16744,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
           },
           "Key": {
             "Fn::GetAtt": [
-              "ApiTestPrepareSpecResource58706514",
+              "ApiTestPrepareSpecCustomResourceC9800EE6",
               "outputSpecKey",
             ],
           },
@@ -16822,7 +16822,137 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "ApiTestPrepareSpecA3536D2B": {
+    "ApiTestPrepareSpecCustomResourceC9800EE6": {
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "Arn",
+          ],
+        },
+        "corsOptions": {
+          "allowHeaders": [
+            "Content-Type",
+            "X-Amz-Date",
+            "Authorization",
+            "X-Api-Key",
+            "X-Amz-Security-Token",
+            "X-Amz-User-Agent",
+            "x-amz-content-sha256",
+          ],
+          "allowMethods": [
+            "OPTIONS",
+            "GET",
+            "PUT",
+            "POST",
+            "DELETE",
+            "PATCH",
+            "HEAD",
+          ],
+          "allowOrigins": [
+            "*",
+          ],
+          "statusCode": 200,
+        },
+        "defaultAuthorizerReference": {
+          "authorizerId": "aws.auth.sigv4",
+        },
+        "inputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+        },
+        "integrations": {
+          "testOperation": {
+            "integration": {
+              "httpMethod": "POST",
+              "passthroughBehavior": "WHEN_NO_MATCH",
+              "type": "AWS_PROXY",
+              "uri": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":apigateway:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":lambda:path/2015-03-31/functions/",
+                    {
+                      "Fn::GetAtt": [
+                        "LambdaD247545B",
+                        "Arn",
+                      ],
+                    },
+                    "/invocations",
+                  ],
+                ],
+              },
+            },
+          },
+        },
+        "operationLookup": {
+          "testOperation": {
+            "method": "get",
+            "path": "/test",
+          },
+        },
+        "outputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+        },
+        "securitySchemes": {
+          "aws.auth.sigv4": {
+            "in": "header",
+            "name": "Authorization",
+            "type": "apiKey",
+            "x-amazon-apigateway-authtype": "awsSigv4",
+          },
+        },
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ApiTestPrepareSpecHandler46C6FEB5": {
       "DependsOn": [
         "ApiTestPrepareSpecRole44D562E5",
       ],
@@ -16865,7 +16995,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
           },
           "S3Key": "7f5f734c4b1912c2e0519cc77c4a123953110c510f49ff2b58500ae796674fbf.zip",
         },
-        "FunctionName": "Default-PrepareSpec3E755E54",
+        "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -16928,7 +17058,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "ApiTestPrepareSpecA3536D2B",
+                    "ApiTestPrepareSpecHandler46C6FEB5",
                     "Arn",
                   ],
                 },
@@ -16938,7 +17068,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "ApiTestPrepareSpecA3536D2B",
+                          "ApiTestPrepareSpecHandler46C6FEB5",
                           "Arn",
                         ],
                       },
@@ -17038,7 +17168,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider",
                         ],
                       ],
                     },
@@ -17054,7 +17184,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider:*",
                         ],
                       ],
                     },
@@ -17069,137 +17199,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecResource58706514": {
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
-            "Arn",
-          ],
-        },
-        "corsOptions": {
-          "allowHeaders": [
-            "Content-Type",
-            "X-Amz-Date",
-            "Authorization",
-            "X-Api-Key",
-            "X-Amz-Security-Token",
-            "X-Amz-User-Agent",
-            "x-amz-content-sha256",
-          ],
-          "allowMethods": [
-            "OPTIONS",
-            "GET",
-            "PUT",
-            "POST",
-            "DELETE",
-            "PATCH",
-            "HEAD",
-          ],
-          "allowOrigins": [
-            "*",
-          ],
-          "statusCode": 200,
-        },
-        "defaultAuthorizerReference": {
-          "authorizerId": "aws.auth.sigv4",
-        },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
-                ],
-              },
-            },
-          },
-        },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {
-          "aws.auth.sigv4": {
-            "in": "header",
-            "name": "Authorization",
-            "type": "apiKey",
-            "x-amazon-apigateway-authtype": "awsSigv4",
-          },
-        },
-      },
-      "Type": "AWS::CloudFormation::CustomResource",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
+    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -17251,18 +17251,18 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
           },
           "S3Key": "f2d30cfc360482320a52a4fcde8a70f3569df79ab30be24650fda58eb60052cf.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
               "Fn::GetAtt": [
-                "ApiTestPrepareSpecA3536D2B",
+                "ApiTestPrepareSpecHandler46C6FEB5",
                 "Arn",
               ],
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
+        "FunctionName": "Default-3E755E54PrepSpecProvider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -17282,7 +17282,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -17300,7 +17300,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -17381,7 +17381,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec",
                         ],
                       ],
                     },
@@ -17397,7 +17397,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec:*",
                         ],
                       ],
                     },
@@ -17765,7 +17765,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
       "DeletionPolicy": "Retain",
       "DependsOn": [
         "ApiTestEE73F324",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -17946,7 +17946,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
     "ApiTestCloudWatchRole56ED0814": {
       "DeletionPolicy": "Retain",
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -18011,9 +18011,9 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC4785add1d36cd869d400a7b7fed7f178c12": {
+    "ApiTestDeployment153EC47818452aad75ab6cbc8f46ee5fe2293a71": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -18058,7 +18058,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
     "ApiTestDeploymentStageprod660267A6": {
       "DependsOn": [
         "ApiTestAccount272B5CDD",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -18103,7 +18103,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTestDeployment153EC4785add1d36cd869d400a7b7fed7f178c12",
+          "Ref": "ApiTestDeployment153EC47818452aad75ab6cbc8f46ee5fe2293a71",
         },
         "MethodSettings": [
           {
@@ -18122,7 +18122,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
     },
     "ApiTestEE73F324": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -18163,7 +18163,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
           },
           "Key": {
             "Fn::GetAtt": [
-              "ApiTestPrepareSpecResource58706514",
+              "ApiTestPrepareSpecCustomResourceC9800EE6",
               "outputSpecKey",
             ],
           },
@@ -18517,254 +18517,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "ApiTestPrepareSpecA3536D2B": {
-      "DependsOn": [
-        "ApiTestPrepareSpecRole44D562E5",
-      ],
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "7f5f734c4b1912c2e0519cc77c4a123953110c510f49ff2b58500ae796674fbf.zip",
-        },
-        "FunctionName": "Default-PrepareSpec3E755E54",
-        "Handler": "index.handler",
-        "Role": {
-          "Fn::GetAtt": [
-            "ApiTestPrepareSpecRole44D562E5",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs18.x",
-        "Timeout": 30,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78": {
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "id": "AwsSolutions-IAM5",
-              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
-            },
-            {
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "lambda:InvokeFunction",
-              "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::GetAtt": [
-                    "ApiTestPrepareSpecA3536D2B",
-                    "Arn",
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Fn::GetAtt": [
-                          "ApiTestPrepareSpecA3536D2B",
-                          "Arn",
-                        ],
-                      },
-                      ":*",
-                    ],
-                  ],
-                },
-              ],
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
-        "Roles": [
-          {
-            "Ref": "ApiTestPrepareSpecProviderRoleF47822B8",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "ApiTestPrepareSpecProviderRoleF47822B8": {
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "id": "AwsSolutions-IAM5",
-              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
-            },
-            {
-              "id": "AwsPrototyping-IAMNoWildcardPermissions",
-              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "Policies": [
-          {
-            "PolicyDocument": {
-              "Statement": [
-                {
-                  "Action": [
-                    "logs:CreateLogGroup",
-                    "logs:CreateLogStream",
-                    "logs:PutLogEvents",
-                  ],
-                  "Effect": "Allow",
-                  "Resource": [
-                    {
-                      "Fn::Join": [
-                        "",
-                        [
-                          "arn:aws:logs:",
-                          {
-                            "Ref": "AWS::Region",
-                          },
-                          ":",
-                          {
-                            "Ref": "AWS::AccountId",
-                          },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
-                        ],
-                      ],
-                    },
-                    {
-                      "Fn::Join": [
-                        "",
-                        [
-                          "arn:aws:logs:",
-                          {
-                            "Ref": "AWS::Region",
-                          },
-                          ":",
-                          {
-                            "Ref": "AWS::AccountId",
-                          },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
-                        ],
-                      ],
-                    },
-                  ],
-                },
-              ],
-              "Version": "2012-10-17",
-            },
-            "PolicyName": "logs",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "ApiTestPrepareSpecResource58706514": {
+    "ApiTestPrepareSpecCustomResourceC9800EE6": {
       "DeletionPolicy": "Delete",
       "Metadata": {
         "cdk_nag": {
@@ -18801,7 +18554,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
       "Properties": {
         "ServiceToken": {
           "Fn::GetAtt": [
-            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
+            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
             "Arn",
           ],
         },
@@ -19038,7 +18791,254 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
     },
-    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
+    "ApiTestPrepareSpecHandler46C6FEB5": {
+      "DependsOn": [
+        "ApiTestPrepareSpecRole44D562E5",
+      ],
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "7f5f734c4b1912c2e0519cc77c4a123953110c510f49ff2b58500ae796674fbf.zip",
+        },
+        "FunctionName": "Default-3E755E54PrepSpec",
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiTestPrepareSpecRole44D562E5",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78": {
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "ApiTestPrepareSpecHandler46C6FEB5",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "ApiTestPrepareSpecHandler46C6FEB5",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
+        "Roles": [
+          {
+            "Ref": "ApiTestPrepareSpecProviderRoleF47822B8",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiTestPrepareSpecProviderRoleF47822B8": {
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:logs:",
+                          {
+                            "Ref": "AWS::Region",
+                          },
+                          ":",
+                          {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider",
+                        ],
+                      ],
+                    },
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:logs:",
+                          {
+                            "Ref": "AWS::Region",
+                          },
+                          ":",
+                          {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider:*",
+                        ],
+                      ],
+                    },
+                  ],
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "logs",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -19090,18 +19090,18 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
           },
           "S3Key": "f2d30cfc360482320a52a4fcde8a70f3569df79ab30be24650fda58eb60052cf.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
               "Fn::GetAtt": [
-                "ApiTestPrepareSpecA3536D2B",
+                "ApiTestPrepareSpecHandler46C6FEB5",
                 "Arn",
               ],
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
+        "FunctionName": "Default-3E755E54PrepSpecProvider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -19121,7 +19121,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -19139,7 +19139,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -19220,7 +19220,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec",
                         ],
                       ],
                     },
@@ -19236,7 +19236,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec:*",
                         ],
                       ],
                     },
@@ -19888,7 +19888,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
       "DeletionPolicy": "Retain",
       "DependsOn": [
         "ApiTestEE73F324",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -20069,7 +20069,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
     "ApiTestCloudWatchRole56ED0814": {
       "DeletionPolicy": "Retain",
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -20134,9 +20134,9 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC478ceb82d8af49203a3c6f0cbcb8e11f21c": {
+    "ApiTestDeployment153EC478a28890a7ac67f65a56f78d242bf067d5": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -20181,7 +20181,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
     "ApiTestDeploymentStageprod660267A6": {
       "DependsOn": [
         "ApiTestAccount272B5CDD",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -20226,7 +20226,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTestDeployment153EC478ceb82d8af49203a3c6f0cbcb8e11f21c",
+          "Ref": "ApiTestDeployment153EC478a28890a7ac67f65a56f78d242bf067d5",
         },
         "MethodSettings": [
           {
@@ -20245,7 +20245,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
     },
     "ApiTestEE73F324": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -20286,7 +20286,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
           },
           "Key": {
             "Fn::GetAtt": [
-              "ApiTestPrepareSpecResource58706514",
+              "ApiTestPrepareSpecCustomResourceC9800EE6",
               "outputSpecKey",
             ],
           },
@@ -20295,7 +20295,90 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
-    "ApiTestPrepareSpecA3536D2B": {
+    "ApiTestPrepareSpecCustomResourceC9800EE6": {
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "Arn",
+          ],
+        },
+        "inputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+        },
+        "integrations": {
+          "testOperation": {
+            "integration": {
+              "requestTemplates": {
+                "application/json": "{"statusCode": 200}",
+              },
+              "responses": {
+                "default": {
+                  "responseParameters": {},
+                  "responseTemplates": {
+                    "application/json": "{"message":"message"}",
+                  },
+                  "statusCode": "200",
+                },
+              },
+              "type": "MOCK",
+            },
+          },
+        },
+        "operationLookup": {
+          "testOperation": {
+            "method": "get",
+            "path": "/test",
+          },
+        },
+        "outputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+        },
+        "securitySchemes": {},
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ApiTestPrepareSpecHandler46C6FEB5": {
       "DependsOn": [
         "ApiTestPrepareSpecRole44D562E5",
       ],
@@ -20338,7 +20421,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
           },
           "S3Key": "7f5f734c4b1912c2e0519cc77c4a123953110c510f49ff2b58500ae796674fbf.zip",
         },
-        "FunctionName": "Default-PrepareSpec3E755E54",
+        "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -20401,7 +20484,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "ApiTestPrepareSpecA3536D2B",
+                    "ApiTestPrepareSpecHandler46C6FEB5",
                     "Arn",
                   ],
                 },
@@ -20411,7 +20494,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "ApiTestPrepareSpecA3536D2B",
+                          "ApiTestPrepareSpecHandler46C6FEB5",
                           "Arn",
                         ],
                       },
@@ -20511,7 +20594,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider",
                         ],
                       ],
                     },
@@ -20527,7 +20610,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider:*",
                         ],
                       ],
                     },
@@ -20542,90 +20625,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecResource58706514": {
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
-            "Arn",
-          ],
-        },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "requestTemplates": {
-                "application/json": "{"statusCode": 200}",
-              },
-              "responses": {
-                "default": {
-                  "responseParameters": {},
-                  "responseTemplates": {
-                    "application/json": "{"message":"message"}",
-                  },
-                  "statusCode": "200",
-                },
-              },
-              "type": "MOCK",
-            },
-          },
-        },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
-      },
-      "Type": "AWS::CloudFormation::CustomResource",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
+    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -20677,18 +20677,18 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
           },
           "S3Key": "f2d30cfc360482320a52a4fcde8a70f3569df79ab30be24650fda58eb60052cf.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
               "Fn::GetAtt": [
-                "ApiTestPrepareSpecA3536D2B",
+                "ApiTestPrepareSpecHandler46C6FEB5",
                 "Arn",
               ],
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
+        "FunctionName": "Default-3E755E54PrepSpecProvider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -20708,7 +20708,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -20726,7 +20726,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -20807,7 +20807,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec",
                         ],
                       ],
                     },
@@ -20823,7 +20823,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec:*",
                         ],
                       ],
                     },
@@ -21067,7 +21067,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
       "DeletionPolicy": "Retain",
       "DependsOn": [
         "ApiTestEE73F324",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -21248,7 +21248,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
     "ApiTestCloudWatchRole56ED0814": {
       "DeletionPolicy": "Retain",
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -21313,9 +21313,9 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC47872a7f3a0ed9dc65fe43142c523ae46d2": {
+    "ApiTestDeployment153EC4783e3e5eeaa8a8e6d23441a25ca55384d3": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -21360,7 +21360,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
     "ApiTestDeploymentStageprod660267A6": {
       "DependsOn": [
         "ApiTestAccount272B5CDD",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -21405,7 +21405,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTestDeployment153EC47872a7f3a0ed9dc65fe43142c523ae46d2",
+          "Ref": "ApiTestDeployment153EC4783e3e5eeaa8a8e6d23441a25ca55384d3",
         },
         "MethodSettings": [
           {
@@ -21424,7 +21424,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
     },
     "ApiTestEE73F324": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -21465,7 +21465,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
           },
           "Key": {
             "Fn::GetAtt": [
-              "ApiTestPrepareSpecResource58706514",
+              "ApiTestPrepareSpecCustomResourceC9800EE6",
               "outputSpecKey",
             ],
           },
@@ -21474,7 +21474,118 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
       },
       "Type": "AWS::ApiGateway::RestApi",
     },
-    "ApiTestPrepareSpecA3536D2B": {
+    "ApiTestPrepareSpecCustomResourceC9800EE6": {
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "Arn",
+          ],
+        },
+        "corsOptions": {
+          "allowHeaders": [
+            "Content-Type",
+            "X-Amz-Date",
+            "Authorization",
+            "X-Api-Key",
+            "X-Amz-Security-Token",
+            "X-Amz-User-Agent",
+            "x-amz-content-sha256",
+          ],
+          "allowMethods": [
+            "OPTIONS",
+            "GET",
+            "PUT",
+            "POST",
+            "DELETE",
+            "PATCH",
+            "HEAD",
+          ],
+          "allowOrigins": [
+            "*",
+          ],
+          "statusCode": 204,
+        },
+        "inputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+        },
+        "integrations": {
+          "testOperation": {
+            "integration": {
+              "requestTemplates": {
+                "application/json": "{"statusCode": 200}",
+              },
+              "responses": {
+                "default": {
+                  "responseParameters": {
+                    "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'",
+                    "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+                    "method.response.header.Access-Control-Allow-Origin": "'*'",
+                  },
+                  "responseTemplates": {
+                    "application/json": "{"message":"message"}",
+                  },
+                  "statusCode": "200",
+                },
+              },
+              "type": "MOCK",
+            },
+          },
+        },
+        "operationLookup": {
+          "testOperation": {
+            "method": "get",
+            "path": "/test",
+          },
+        },
+        "outputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+        },
+        "securitySchemes": {},
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ApiTestPrepareSpecHandler46C6FEB5": {
       "DependsOn": [
         "ApiTestPrepareSpecRole44D562E5",
       ],
@@ -21517,7 +21628,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
           },
           "S3Key": "7f5f734c4b1912c2e0519cc77c4a123953110c510f49ff2b58500ae796674fbf.zip",
         },
-        "FunctionName": "Default-PrepareSpec3E755E54",
+        "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -21580,7 +21691,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "ApiTestPrepareSpecA3536D2B",
+                    "ApiTestPrepareSpecHandler46C6FEB5",
                     "Arn",
                   ],
                 },
@@ -21590,7 +21701,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
                     [
                       {
                         "Fn::GetAtt": [
-                          "ApiTestPrepareSpecA3536D2B",
+                          "ApiTestPrepareSpecHandler46C6FEB5",
                           "Arn",
                         ],
                       },
@@ -21690,7 +21801,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider",
                         ],
                       ],
                     },
@@ -21706,7 +21817,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider:*",
                         ],
                       ],
                     },
@@ -21721,118 +21832,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecResource58706514": {
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
-            "Arn",
-          ],
-        },
-        "corsOptions": {
-          "allowHeaders": [
-            "Content-Type",
-            "X-Amz-Date",
-            "Authorization",
-            "X-Api-Key",
-            "X-Amz-Security-Token",
-            "X-Amz-User-Agent",
-            "x-amz-content-sha256",
-          ],
-          "allowMethods": [
-            "OPTIONS",
-            "GET",
-            "PUT",
-            "POST",
-            "DELETE",
-            "PATCH",
-            "HEAD",
-          ],
-          "allowOrigins": [
-            "*",
-          ],
-          "statusCode": 204,
-        },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "requestTemplates": {
-                "application/json": "{"statusCode": 200}",
-              },
-              "responses": {
-                "default": {
-                  "responseParameters": {
-                    "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'",
-                    "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
-                    "method.response.header.Access-Control-Allow-Origin": "'*'",
-                  },
-                  "responseTemplates": {
-                    "application/json": "{"message":"message"}",
-                  },
-                  "statusCode": "200",
-                },
-              },
-              "type": "MOCK",
-            },
-          },
-        },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
-      },
-      "Type": "AWS::CloudFormation::CustomResource",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
+    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -21884,18 +21884,18 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
           },
           "S3Key": "f2d30cfc360482320a52a4fcde8a70f3569df79ab30be24650fda58eb60052cf.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
               "Fn::GetAtt": [
-                "ApiTestPrepareSpecA3536D2B",
+                "ApiTestPrepareSpecHandler46C6FEB5",
                 "Arn",
               ],
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
+        "FunctionName": "Default-3E755E54PrepSpecProvider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -21915,7 +21915,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -21933,7 +21933,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -22014,7 +22014,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec",
                         ],
                       ],
                     },
@@ -22030,7 +22030,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec:*",
                         ],
                       ],
                     },
@@ -22349,7 +22349,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
       "DeletionPolicy": "Retain",
       "DependsOn": [
         "ApiTestEE73F324",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -22530,7 +22530,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
     "ApiTestCloudWatchRole56ED0814": {
       "DeletionPolicy": "Retain",
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -22595,9 +22595,9 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC47813942105e6971276a23d1a170029add6": {
+    "ApiTestDeployment153EC478ed5e71f4a5bc4f71e07a9dafbe8ea425": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -22642,7 +22642,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
     "ApiTestDeploymentStageprod660267A6": {
       "DependsOn": [
         "ApiTestAccount272B5CDD",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -22687,7 +22687,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTestDeployment153EC47813942105e6971276a23d1a170029add6",
+          "Ref": "ApiTestDeployment153EC478ed5e71f4a5bc4f71e07a9dafbe8ea425",
         },
         "MethodSettings": [
           {
@@ -22706,7 +22706,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
     },
     "ApiTestEE73F324": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -22747,7 +22747,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
           },
           "Key": {
             "Fn::GetAtt": [
-              "ApiTestPrepareSpecResource58706514",
+              "ApiTestPrepareSpecCustomResourceC9800EE6",
               "outputSpecKey",
             ],
           },
@@ -22825,7 +22825,103 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "ApiTestPrepareSpecA3536D2B": {
+    "ApiTestPrepareSpecCustomResourceC9800EE6": {
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "Arn",
+          ],
+        },
+        "inputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "6060611f34e7c9e9000a19922d48dfd8d47d66cbf3715fb30e173c4b51d9061b.json",
+        },
+        "integrations": {
+          "testOperation": {
+            "integration": {
+              "httpMethod": "POST",
+              "passthroughBehavior": "WHEN_NO_MATCH",
+              "type": "AWS_PROXY",
+              "uri": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":apigateway:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":lambda:path/2015-03-31/functions/",
+                    {
+                      "Fn::GetAtt": [
+                        "LambdaD247545B",
+                        "Arn",
+                      ],
+                    },
+                    "/invocations",
+                  ],
+                ],
+              },
+            },
+          },
+        },
+        "operationLookup": {
+          "testOperation": {
+            "method": "get",
+            "path": "/test/{param1}/fixed/{param2}/{param3}",
+          },
+        },
+        "outputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "6060611f34e7c9e9000a19922d48dfd8d47d66cbf3715fb30e173c4b51d9061b.json-prepared",
+        },
+        "securitySchemes": {},
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ApiTestPrepareSpecHandler46C6FEB5": {
       "DependsOn": [
         "ApiTestPrepareSpecRole44D562E5",
       ],
@@ -22868,7 +22964,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
           },
           "S3Key": "7f5f734c4b1912c2e0519cc77c4a123953110c510f49ff2b58500ae796674fbf.zip",
         },
-        "FunctionName": "Default-PrepareSpec3E755E54",
+        "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -22931,7 +23027,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "ApiTestPrepareSpecA3536D2B",
+                    "ApiTestPrepareSpecHandler46C6FEB5",
                     "Arn",
                   ],
                 },
@@ -22941,7 +23037,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "ApiTestPrepareSpecA3536D2B",
+                          "ApiTestPrepareSpecHandler46C6FEB5",
                           "Arn",
                         ],
                       },
@@ -23041,7 +23137,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider",
                         ],
                       ],
                     },
@@ -23057,7 +23153,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider:*",
                         ],
                       ],
                     },
@@ -23072,103 +23168,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecResource58706514": {
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
-            "Arn",
-          ],
-        },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "6060611f34e7c9e9000a19922d48dfd8d47d66cbf3715fb30e173c4b51d9061b.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
-                ],
-              },
-            },
-          },
-        },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test/{param1}/fixed/{param2}/{param3}",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "6060611f34e7c9e9000a19922d48dfd8d47d66cbf3715fb30e173c4b51d9061b.json-prepared",
-        },
-        "securitySchemes": {},
-      },
-      "Type": "AWS::CloudFormation::CustomResource",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
+    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -23220,18 +23220,18 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
           },
           "S3Key": "f2d30cfc360482320a52a4fcde8a70f3569df79ab30be24650fda58eb60052cf.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
               "Fn::GetAtt": [
-                "ApiTestPrepareSpecA3536D2B",
+                "ApiTestPrepareSpecHandler46C6FEB5",
                 "Arn",
               ],
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
+        "FunctionName": "Default-3E755E54PrepSpecProvider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -23251,7 +23251,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -23269,7 +23269,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -23350,7 +23350,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec",
                         ],
                       ],
                     },
@@ -23366,7 +23366,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec:*",
                         ],
                       ],
                     },
@@ -23651,7 +23651,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
       "DeletionPolicy": "Retain",
       "DependsOn": [
         "ApiTestEE73F324",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -23901,7 +23901,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
     "ApiTestCloudWatchRole56ED0814": {
       "DeletionPolicy": "Retain",
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -23966,9 +23966,9 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC478950afb915db24dc651450ed2227b1233": {
+    "ApiTestDeployment153EC478ba688c73ecd411d6bc46f33941546de6": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -24013,7 +24013,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
     "ApiTestDeploymentStageprod660267A6": {
       "DependsOn": [
         "ApiTestAccount272B5CDD",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -24058,7 +24058,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTestDeployment153EC478950afb915db24dc651450ed2227b1233",
+          "Ref": "ApiTestDeployment153EC478ba688c73ecd411d6bc46f33941546de6",
         },
         "MethodSettings": [
           {
@@ -24077,7 +24077,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
     },
     "ApiTestEE73F324": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -24118,7 +24118,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
           },
           "Key": {
             "Fn::GetAtt": [
-              "ApiTestPrepareSpecResource58706514",
+              "ApiTestPrepareSpecCustomResourceC9800EE6",
               "outputSpecKey",
             ],
           },
@@ -24196,7 +24196,103 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "ApiTestPrepareSpecA3536D2B": {
+    "ApiTestPrepareSpecCustomResourceC9800EE6": {
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "Arn",
+          ],
+        },
+        "inputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+        },
+        "integrations": {
+          "testOperation": {
+            "integration": {
+              "httpMethod": "POST",
+              "passthroughBehavior": "WHEN_NO_MATCH",
+              "type": "AWS_PROXY",
+              "uri": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":apigateway:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":lambda:path/2015-03-31/functions/",
+                    {
+                      "Fn::GetAtt": [
+                        "LambdaD247545B",
+                        "Arn",
+                      ],
+                    },
+                    "/invocations",
+                  ],
+                ],
+              },
+            },
+          },
+        },
+        "operationLookup": {
+          "testOperation": {
+            "method": "get",
+            "path": "/test",
+          },
+        },
+        "outputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+        },
+        "securitySchemes": {},
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ApiTestPrepareSpecHandler46C6FEB5": {
       "DependsOn": [
         "ApiTestPrepareSpecRole44D562E5",
       ],
@@ -24239,7 +24335,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
           },
           "S3Key": "7f5f734c4b1912c2e0519cc77c4a123953110c510f49ff2b58500ae796674fbf.zip",
         },
-        "FunctionName": "Default-PrepareSpec3E755E54",
+        "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -24302,7 +24398,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "ApiTestPrepareSpecA3536D2B",
+                    "ApiTestPrepareSpecHandler46C6FEB5",
                     "Arn",
                   ],
                 },
@@ -24312,7 +24408,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "ApiTestPrepareSpecA3536D2B",
+                          "ApiTestPrepareSpecHandler46C6FEB5",
                           "Arn",
                         ],
                       },
@@ -24412,7 +24508,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider",
                         ],
                       ],
                     },
@@ -24428,7 +24524,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider:*",
                         ],
                       ],
                     },
@@ -24443,103 +24539,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecResource58706514": {
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
-            "Arn",
-          ],
-        },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
-                ],
-              },
-            },
-          },
-        },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
-      },
-      "Type": "AWS::CloudFormation::CustomResource",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
+    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -24591,18 +24591,18 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
           },
           "S3Key": "f2d30cfc360482320a52a4fcde8a70f3569df79ab30be24650fda58eb60052cf.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
               "Fn::GetAtt": [
-                "ApiTestPrepareSpecA3536D2B",
+                "ApiTestPrepareSpecHandler46C6FEB5",
                 "Arn",
               ],
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
+        "FunctionName": "Default-3E755E54PrepSpecProvider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -24622,7 +24622,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -24640,7 +24640,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -24721,7 +24721,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec",
                         ],
                       ],
                     },
@@ -24737,7 +24737,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec:*",
                         ],
                       ],
                     },
@@ -24963,7 +24963,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
       "DeletionPolicy": "Retain",
       "DependsOn": [
         "ApiTestEE73F324",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -25011,7 +25011,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
     "ApiTestCloudWatchRole56ED0814": {
       "DeletionPolicy": "Retain",
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -25076,9 +25076,9 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestDeployment153EC478950afb915db24dc651450ed2227b1233": {
+    "ApiTestDeployment153EC478ba688c73ecd411d6bc46f33941546de6": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -25123,7 +25123,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
     "ApiTestDeploymentStageprod660267A6": {
       "DependsOn": [
         "ApiTestAccount272B5CDD",
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -25168,7 +25168,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
         },
         "DeploymentId": {
-          "Ref": "ApiTestDeployment153EC478950afb915db24dc651450ed2227b1233",
+          "Ref": "ApiTestDeployment153EC478ba688c73ecd411d6bc46f33941546de6",
         },
         "MethodSettings": [
           {
@@ -25187,7 +25187,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
     },
     "ApiTestEE73F324": {
       "DependsOn": [
-        "ApiTestPrepareSpecResource58706514",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -25228,7 +25228,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
           },
           "Key": {
             "Fn::GetAtt": [
-              "ApiTestPrepareSpecResource58706514",
+              "ApiTestPrepareSpecCustomResourceC9800EE6",
               "outputSpecKey",
             ],
           },
@@ -25306,7 +25306,103 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "ApiTestPrepareSpecA3536D2B": {
+    "ApiTestPrepareSpecCustomResourceC9800EE6": {
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "Arn",
+          ],
+        },
+        "inputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+        },
+        "integrations": {
+          "testOperation": {
+            "integration": {
+              "httpMethod": "POST",
+              "passthroughBehavior": "WHEN_NO_MATCH",
+              "type": "AWS_PROXY",
+              "uri": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":apigateway:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":lambda:path/2015-03-31/functions/",
+                    {
+                      "Fn::GetAtt": [
+                        "LambdaD247545B",
+                        "Arn",
+                      ],
+                    },
+                    "/invocations",
+                  ],
+                ],
+              },
+            },
+          },
+        },
+        "operationLookup": {
+          "testOperation": {
+            "method": "get",
+            "path": "/test",
+          },
+        },
+        "outputSpecLocation": {
+          "bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+        },
+        "securitySchemes": {},
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ApiTestPrepareSpecHandler46C6FEB5": {
       "DependsOn": [
         "ApiTestPrepareSpecRole44D562E5",
       ],
@@ -25349,7 +25445,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
           },
           "S3Key": "7f5f734c4b1912c2e0519cc77c4a123953110c510f49ff2b58500ae796674fbf.zip",
         },
-        "FunctionName": "Default-PrepareSpec3E755E54",
+        "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -25412,7 +25508,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
               "Resource": [
                 {
                   "Fn::GetAtt": [
-                    "ApiTestPrepareSpecA3536D2B",
+                    "ApiTestPrepareSpecHandler46C6FEB5",
                     "Arn",
                   ],
                 },
@@ -25422,7 +25518,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
                     [
                       {
                         "Fn::GetAtt": [
-                          "ApiTestPrepareSpecA3536D2B",
+                          "ApiTestPrepareSpecHandler46C6FEB5",
                           "Arn",
                         ],
                       },
@@ -25522,7 +25618,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider",
                         ],
                       ],
                     },
@@ -25538,7 +25634,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54-Provider:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider:*",
                         ],
                       ],
                     },
@@ -25553,103 +25649,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "ApiTestPrepareSpecResource58706514": {
-      "DeletionPolicy": "Delete",
-      "Metadata": {
-        "cdk_nag": {
-          "rules_to_suppress": [
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsSolutions-IAM4",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "applies_to": [
-                {
-                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
-                },
-              ],
-              "id": "AwsPrototyping-IAMNoManagedPolicies",
-              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
-            },
-            {
-              "id": "AwsSolutions-APIG2",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-            {
-              "id": "AwsPrototyping-APIGWRequestValidation",
-              "reason": "This construct implements fine grained validation via OpenApi.",
-            },
-          ],
-        },
-      },
-      "Properties": {
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300",
-            "Arn",
-          ],
-        },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
-                ],
-              },
-            },
-          },
-        },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
-      },
-      "Type": "AWS::CloudFormation::CustomResource",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "ApiTestPrepareSpecResourceProviderframeworkonEventDB3DA300": {
+    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
       "DependsOn": [
         "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
         "ApiTestPrepareSpecProviderRoleF47822B8",
@@ -25701,18 +25701,18 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
           },
           "S3Key": "f2d30cfc360482320a52a4fcde8a70f3569df79ab30be24650fda58eb60052cf.zip",
         },
-        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecResourceProvider)",
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
         "Environment": {
           "Variables": {
             "USER_ON_EVENT_FUNCTION_ARN": {
               "Fn::GetAtt": [
-                "ApiTestPrepareSpecA3536D2B",
+                "ApiTestPrepareSpecHandler46C6FEB5",
                 "Arn",
               ],
             },
           },
         },
-        "FunctionName": "Default-PrepareSpec3E755E54-Provider",
+        "FunctionName": "Default-3E755E54PrepSpecProvider",
         "Handler": "framework.onEvent",
         "Role": {
           "Fn::GetAtt": [
@@ -25732,7 +25732,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsSolutions-IAM5",
@@ -25750,7 +25750,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
             {
               "applies_to": [
                 {
-                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-PrepareSpec3E755E54:*/g",
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
                 },
               ],
               "id": "AwsPrototyping-IAMNoWildcardPermissions",
@@ -25831,7 +25831,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec",
                         ],
                       ],
                     },
@@ -25847,7 +25847,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
                           {
                             "Ref": "AWS::AccountId",
                           },
-                          ":log-group:/aws/lambda/Default-PrepareSpec3E755E54:*",
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec:*",
                         ],
                       ],
                     },


### PR DESCRIPTION
Truncate the lambda function names for the custom resource to ensure they are below the max length of 64 characters.

Fixes #615
