### PR TITLE
fix(cdk-graph-plugin-diagram): ensure package.json is a cache output

### DIFF
--- a/packages/cdk-graph-plugin-diagram/project.json
+++ b/packages/cdk-graph-plugin-diagram/project.json
@@ -23,6 +23,7 @@
         "{projectRoot}/coverage",
         "{projectRoot}/test-reports",
         "{projectRoot}/docs/api",
+        "{projectRoot}/node_modules/sharp/package.json",
         "{projectRoot}/node_modules/sharp/build",
         "{projectRoot}/node_modules/sharp/vendor"
       ],

--- a/projenrc/projects/cdk-graph-plugin-diagram-project.ts
+++ b/projenrc/projects/cdk-graph-plugin-diagram-project.ts
@@ -94,6 +94,7 @@ export class CdkGraphPluginDiagramProject extends CdkGraphPluginProject {
           },
         ],
         outputs: [
+          "{projectRoot}/node_modules/sharp/package.json",
           "{projectRoot}/node_modules/sharp/build",
           "{projectRoot}/node_modules/sharp/vendor",
         ],


### PR DESCRIPTION
The sharp:prebuild task modified the files array for the sharp package however it is not cached.