### PR TITLE
fix: do not enforce CI builds when upgrading deps

### DIFF
--- a/.github/workflows/upgrade-mainline.yml
+++ b/.github/workflows/upgrade-mainline.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       patch_created: ${{ steps.create_patch.outputs.patch_created }}
     env:
-      CI: "false" # TODO: this doesn't do anything given we check for existence of CI env not value
+      CI: ""
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
When CI=false, this results in the following command not executing as expected:

`jest --passWithNoTests ${CI:-'--updateSnapshot'} ${NX_WORKSPACE_ROOT:+'--runInBand'}`

What actually gets rendered is:

`jest --passWithNoTests false ${NX_WORKSPACE_ROOT:+'--runInBand'}`

Whereas what we want is:

`jest --passWithNoTests --updateSnapshot ${NX_WORKSPACE_ROOT:+'--runInBand'}`

To achieve this, we need to simply set CI to ''.