### PR TITLE
fix: ensure pytest tests run against test directory only

### DIFF
--- a/packages/infrastructure/src/projects/python/infrastructure-py-project.ts
+++ b/packages/infrastructure/src/projects/python/infrastructure-py-project.ts
@@ -118,12 +118,16 @@ export class InfrastructurePyProject extends AwsCdkPythonApp {
         ),
     };
 
+    const tstDir = "tests";
+
     options.sample !== false &&
       this.emitSampleFiles(srcDir, [this.moduleName], mustacheConfig);
     options.sample !== false &&
-      this.emitSampleFiles(testDir, ["tests"], mustacheConfig);
+      this.emitSampleFiles(testDir, [tstDir], mustacheConfig);
 
-    this.testTask.reset("poetry run pytest ${CI:-'--snapshot-update'}");
+    this.testTask.reset(
+      `poetry run pytest ${tstDir}/ \${CI:-'--snapshot-update'}`
+    );
   }
 
   private emitSampleFiles(

--- a/packages/infrastructure/test/projects/python/__snapshots__/infrastructure-py-project.test.ts.snap
+++ b/packages/infrastructure/test/projects/python/__snapshots__/infrastructure-py-project.test.ts.snap
@@ -384,7 +384,7 @@ cython_debug/
         "name": "test",
         "steps": [
           {
-            "exec": "poetry run pytest \${CI:-'--snapshot-update'}",
+            "exec": "poetry run pytest tests/ \${CI:-'--snapshot-update'}",
           },
         ],
       },
@@ -807,7 +807,7 @@ cython_debug/
         "name": "test",
         "steps": [
           {
-            "exec": "poetry run pytest \${CI:-'--snapshot-update'}",
+            "exec": "poetry run pytest tests/ \${CI:-'--snapshot-update'}",
           },
         ],
       },
@@ -1419,7 +1419,7 @@ cython_debug/
         "name": "test",
         "steps": [
           {
-            "exec": "poetry run pytest \${CI:-'--snapshot-update'}",
+            "exec": "poetry run pytest tests/ \${CI:-'--snapshot-update'}",
           },
         ],
       },
@@ -2064,7 +2064,7 @@ cython_debug/
         "name": "test",
         "steps": [
           {
-            "exec": "poetry run pytest \${CI:-'--snapshot-update'}",
+            "exec": "poetry run pytest tests/ \${CI:-'--snapshot-update'}",
           },
         ],
       },

--- a/packages/type-safe-api/src/project/codegen/handlers/generated-python-handlers-project.ts
+++ b/packages/type-safe-api/src/project/codegen/handlers/generated-python-handlers-project.ts
@@ -63,7 +63,9 @@ export class GeneratedPythonHandlersProject extends PythonProject {
       // Pytest fails with exit code 5 when there are no tests.
       // We want to allow users to delete all their tests, or to upgrade an existing project without breaking their build
       // See: https://github.com/pytest-dev/pytest/issues/2393
-      this.testTask.reset("pytest || ([ $? = 5 ] && exit 0 || exit $?)");
+      this.testTask.reset(
+        `pytest ${this.tstDir}/ || ([ $? = 5 ] && exit 0 || exit $?)`
+      );
     }
 
     [

--- a/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
@@ -25429,7 +25429,7 @@ cython_debug/
         "name": "test",
         "steps": [
           {
-            "exec": "pytest || ([ $? = 5 ] && exit 0 || exit $?)",
+            "exec": "pytest test/ || ([ $? = 5 ] && exit 0 || exit $?)",
           },
         ],
       },

--- a/packages/type-safe-api/test/project/codegen/handlers/__snapshots__/generated-python-handlers-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/codegen/handlers/__snapshots__/generated-python-handlers-project.test.ts.snap
@@ -354,7 +354,7 @@ cython_debug/
         "name": "test",
         "steps": [
           {
-            "exec": "pytest || ([ $? = 5 ] && exit 0 || exit $?)",
+            "exec": "pytest test/ || ([ $? = 5 ] && exit 0 || exit $?)",
           },
         ],
       },


### PR DESCRIPTION
Ensure we do not erroneously pick up tests in other folders, such as cdk.out

Fixes #655
