### PR TITLE
chore: Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/aws-arch-pricing.yml
+++ b/.github/workflows/aws-arch-pricing.yml
@@ -35,12 +35,12 @@ jobs:
         # ignore diff if only the pricing manifest json was modified
         run: |-
           git add .
-          git diff --staged --name-only --exit-code -- ':!packages/aws-arch/static/aws-pricing-manifest.json' || echo "::set-output name=has_mutations::true"
+          git diff --staged --name-only --exit-code -- ':!packages/aws-arch/static/aws-pricing-manifest.json' || echo "has_mutations=true" >> $GITHUB_OUTPUT
       - if: steps.mutation_check.outputs.has_mutations
         id: create_patch
         name: Create Patch
         run: |-
-          git diff --staged --patch --exit-code > .repo.patch || echo "::set-output name=patch_created::true"
+          git diff --staged --patch --exit-code > .repo.patch || echo "patch_created=true" >> $GITHUB_OUTPUT
       - if: steps.create_patch.outputs.patch_created
         name: Upload patch
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         run: git diff --ignore-space-at-eol --exit-code
       - name: Check for new commits
         id: git_remote
-        run: echo ::set-output name=latest_commit::"$(git ls-remote origin -h ${{ github.ref }} | cut -f1)"
+        run: echo "latest_commit=$(git ls-remote origin -h ${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT
       - name: Extract Dists
         run: rsync -a . ./dist --include="*/" --include="/docs/dist/**" --include="/packages/pdk/dist/**" --exclude="*" --prune-empty-dirs
       - name: Upload artifact

--- a/.github/workflows/upgrade-mainline.yml
+++ b/.github/workflows/upgrade-mainline.yml
@@ -28,7 +28,7 @@ jobs:
         name: Find mutations
         run: |-
           git add .
-          git diff --staged --patch --exit-code > .repo.patch || echo "::set-output name=patch_created::true"
+          git diff --staged --patch --exit-code > .repo.patch || echo "patch_created=true" >> $GITHUB_OUTPUT
       - if: steps.create_patch.outputs.patch_created
         name: Upload patch
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
## Description

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
run: echo ::set-output name=latest_commit::"$(git ls-remote origin -h ${{ github.ref }} | cut -f1)"
```

**TO-BE**

```yaml
run: echo "latest_commit=$(git ls-remote origin -h ${{ github.ref }} | cut -f1)" >> $GITHUB_OUTPUT
```