### PR TITLE
fix(type-safe-api): fix pydantic core missing in lambda issue

### DIFF
--- a/packages/type-safe-api/src/project/codegen/handlers/generated-python-handlers-project.ts
+++ b/packages/type-safe-api/src/project/codegen/handlers/generated-python-handlers-project.ts
@@ -70,7 +70,7 @@ export class GeneratedPythonHandlersProject extends PythonProject {
     }
 
     [
-      "python@^3.9",
+      "python@^3.11",
       `${options.generatedPythonTypes.name}@{path="${path.relative(
         this.outdir,
         options.generatedPythonTypes.outdir

--- a/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
@@ -25331,7 +25331,7 @@ cython_debug/
       {
         "name": "python",
         "type": "runtime",
-        "version": "^3.9",
+        "version": "^3.11",
       },
       {
         "name": "smithy-handlers-python-runtime",
@@ -25610,7 +25610,7 @@ include = [
   include = "smithy_handlers_python_handlers"
 
   [tool.poetry.dependencies]
-  python = "^3.9"
+  python = "^3.11"
 
     [tool.poetry.dependencies.smithy-handlers-python-runtime]
     path = "../../generated/runtime/python"

--- a/packages/type-safe-api/test/project/codegen/handlers/__snapshots__/generated-python-handlers-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/codegen/handlers/__snapshots__/generated-python-handlers-project.test.ts.snap
@@ -158,7 +158,7 @@ cython_debug/
       {
         "name": "python",
         "type": "runtime",
-        "version": "^3.9",
+        "version": "^3.11",
       },
       {
         "name": "test-python-client",
@@ -393,7 +393,7 @@ include = [ "test_handlers", "test_handlers/**/*.py" ]
   include = "test_handlers"
 
   [tool.poetry.dependencies]
-  python = "^3.9"
+  python = "^3.11"
 
     [tool.poetry.dependencies.test-python-client]
     path = "../python-client"


### PR DESCRIPTION
The upgrade of the python runtime to the latest openapi generator introduced pydantic v2 which has a native component (pydantic core). While the appropriate cross-architecture build command is used, a mismatch in python version can cause this native dependency to appear to be missing at runtime in a lambda function. This change upgrades the handler project to use python 3.11, ensuring the build command uses the same version of python as the lambdas.

Fixes #669
