### PR TITLE
refactor: removing code for validating non null getAuthenticatedUser function

### DIFF
--- a/packages/cloudscape-react-ts-website/samples/cloudscape-react-ts-website/src/layouts/App/index.tsx.mustache
+++ b/packages/cloudscape-react-ts-website/samples/cloudscape-react-ts-website/src/layouts/App/index.tsx.mustache
@@ -44,16 +44,14 @@ const App: React.FC = () => {
   const location = useLocation();
 
   useEffect(() => {
-    if (getAuthenticatedUser) {
-      const authUser = getAuthenticatedUser();
-      setUsername(authUser?.getUsername());
+    const authUser = getAuthenticatedUser();
+    setUsername(authUser?.getUsername());
 
-      authUser?.getSession(() => {
-        authUser.getUserAttributes((_, attributes) => {
-          setEmail(attributes?.find((a) => a.Name === "email")?.Value);
-        });
+    authUser?.getSession(() => {
+      authUser.getUserAttributes((_, attributes) => {
+        setEmail(attributes?.find((a) => a.Name === "email")?.Value);
       });
-    }
+    });
   }, [getAuthenticatedUser, setUsername, setEmail]);
 
   const setAppLayoutPropsSafe = useCallback(
@@ -103,7 +101,7 @@ const App: React.FC = () => {
         }
         onSignout={() =>
           new Promise(() => {
-            getAuthenticatedUser && getAuthenticatedUser()?.signOut();
+            getAuthenticatedUser()?.signOut();
             window.location.href = "/";
           })
         }

--- a/packages/cloudscape-react-ts-website/samples/cloudscape-react-ts-website/src/pages/ApiExplorer/index.tsx.mustache
+++ b/packages/cloudscape-react-ts-website/samples/cloudscape-react-ts-website/src/pages/ApiExplorer/index.tsx.mustache
@@ -42,7 +42,7 @@ const ApiExplorer: React.FC = () => {
    */
   const sigv4Interceptor = useCallback(async (r: any) => {
     const { accessKeyId, secretAccessKey, sessionToken } = await getCredentials(
-      getAuthenticatedUser?.()!,
+      getAuthenticatedUser()!,
       region,
       identityPoolId,
       userPoolId

--- a/packages/cloudscape-react-ts-website/test/__snapshots__/cloudscape-react-ts-website-project.test.ts.snap
+++ b/packages/cloudscape-react-ts-website/test/__snapshots__/cloudscape-react-ts-website-project.test.ts.snap
@@ -1291,16 +1291,14 @@ const App: React.FC = () => {
   const location = useLocation();
 
   useEffect(() => {
-    if (getAuthenticatedUser) {
-      const authUser = getAuthenticatedUser();
-      setUsername(authUser?.getUsername());
+    const authUser = getAuthenticatedUser();
+    setUsername(authUser?.getUsername());
 
-      authUser?.getSession(() => {
-        authUser.getUserAttributes((_, attributes) => {
-          setEmail(attributes?.find((a) => a.Name === "email")?.Value);
-        });
+    authUser?.getSession(() => {
+      authUser.getUserAttributes((_, attributes) => {
+        setEmail(attributes?.find((a) => a.Name === "email")?.Value);
       });
-    }
+    });
   }, [getAuthenticatedUser, setUsername, setEmail]);
 
   const setAppLayoutPropsSafe = useCallback(
@@ -1350,7 +1348,7 @@ const App: React.FC = () => {
         }
         onSignout={() =>
           new Promise(() => {
-            getAuthenticatedUser && getAuthenticatedUser()?.signOut();
+            getAuthenticatedUser()?.signOut();
             window.location.href = "/";
           })
         }
@@ -2825,16 +2823,14 @@ const App: React.FC = () => {
   const location = useLocation();
 
   useEffect(() => {
-    if (getAuthenticatedUser) {
-      const authUser = getAuthenticatedUser();
-      setUsername(authUser?.getUsername());
+    const authUser = getAuthenticatedUser();
+    setUsername(authUser?.getUsername());
 
-      authUser?.getSession(() => {
-        authUser.getUserAttributes((_, attributes) => {
-          setEmail(attributes?.find((a) => a.Name === "email")?.Value);
-        });
+    authUser?.getSession(() => {
+      authUser.getUserAttributes((_, attributes) => {
+        setEmail(attributes?.find((a) => a.Name === "email")?.Value);
       });
-    }
+    });
   }, [getAuthenticatedUser, setUsername, setEmail]);
 
   const setAppLayoutPropsSafe = useCallback(
@@ -2884,7 +2880,7 @@ const App: React.FC = () => {
         }
         onSignout={() =>
           new Promise(() => {
-            getAuthenticatedUser && getAuthenticatedUser()?.signOut();
+            getAuthenticatedUser()?.signOut();
             window.location.href = "/";
           })
         }
@@ -4143,16 +4139,14 @@ const App: React.FC = () => {
   const location = useLocation();
 
   useEffect(() => {
-    if (getAuthenticatedUser) {
-      const authUser = getAuthenticatedUser();
-      setUsername(authUser?.getUsername());
+    const authUser = getAuthenticatedUser();
+    setUsername(authUser?.getUsername());
 
-      authUser?.getSession(() => {
-        authUser.getUserAttributes((_, attributes) => {
-          setEmail(attributes?.find((a) => a.Name === "email")?.Value);
-        });
+    authUser?.getSession(() => {
+      authUser.getUserAttributes((_, attributes) => {
+        setEmail(attributes?.find((a) => a.Name === "email")?.Value);
       });
-    }
+    });
   }, [getAuthenticatedUser, setUsername, setEmail]);
 
   const setAppLayoutPropsSafe = useCallback(
@@ -4202,7 +4196,7 @@ const App: React.FC = () => {
         }
         onSignout={() =>
           new Promise(() => {
-            getAuthenticatedUser && getAuthenticatedUser()?.signOut();
+            getAuthenticatedUser()?.signOut();
             window.location.href = "/";
           })
         }
@@ -4311,7 +4305,7 @@ const ApiExplorer: React.FC = () => {
    */
   const sigv4Interceptor = useCallback(async (r: any) => {
     const { accessKeyId, secretAccessKey, sessionToken } = await getCredentials(
-      getAuthenticatedUser?.()!,
+      getAuthenticatedUser()!,
       region,
       identityPoolId,
       userPoolId


### PR DESCRIPTION
Discussion: https://github.com/aws/aws-pdk/discussions/680

When PDK generates code for the frontend React website, it checks if the function `getAuthenticatedUser` is defined or not: [code pointer](https://github.com/aws/aws-pdk/blob/f99b241183c6d0a631a17d077efdc84232196d65/packages/cloudscape-react-ts-website/samples/cloudscape-react-ts-website/src/layouts/App/index.tsx.mustache#L47)
This function is fetched from the context and used inside `useEffect` as shown below:
```
const { getAuthenticatedUser } = useCognitoAuthContext();

  useEffect(() => {
    if (getAuthenticatedUser) {
      const authUser = getAuthenticatedUser();
      // code doing stuff using authUser
    }
  }, [getAuthenticatedUser, setUsername, setEmail]);
```

After [this PR](https://github.com/aws/aws-northstar/commit/214002276b285b0ba1f827c91bf3dff6c06e8575) in `aws-northstar` this check is no longer required since the `getAuthenticatedUser` has a default state for the `CognitoAuthContext` which defines the `getAuthenticatedUser` method: [code pointer](https://github.com/aws/aws-northstar/blob/97528359596c4d988f48e3fce54a0a6bca8af9b3/packages/ui/src/components/CognitoAuth/context.ts#L62-L73) 

Removing the non-null check for `getAuthenticatedUser` function definition at all places in this PR.