### PR TITLE
feat(type-safe-api): support returning multi-value headers from lambda handlers

### DIFF
--- a/packages/type-safe-api/scripts/type-safe-api/generators/java/templates/handlers.mustache
+++ b/packages/type-safe-api/scripts/type-safe-api/generators/java/templates/handlers.mustache
@@ -443,6 +443,7 @@ package {{package}}.handlers;
 {{/apiInfo}}
 
 import java.util.Map;
+import java.util.List;
 
 /**
  * Represents an HTTP response from an api operation
@@ -460,6 +461,10 @@ public interface Response {
      * Returns the response headers
      */
     Map<String, String> getHeaders();
+    /**
+     * Returns the multi-value response headers
+     */
+    Map<String, List<String>> getMultiValueHeaders();
 }
 ###TSAPI_WRITE_FILE###
 {
@@ -475,6 +480,7 @@ package {{package}}.handlers;
 {{/apiInfo}}
 
 import java.util.Map;
+import java.util.List;
 
 @lombok.experimental.SuperBuilder
 @lombok.AllArgsConstructor
@@ -483,6 +489,7 @@ public class ApiResponse implements Response {
     private String body;
     private int statusCode;
     private Map<String, String> headers;
+    private Map<String, List<String>> multiValueHeaders;
 }
 ###TSAPI_WRITE_FILE###
 {
@@ -639,6 +646,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 /**
  * An "empty" chained request input used to warm up interceptors which extend the InterceptorWithWarmup
@@ -663,6 +671,11 @@ public class InterceptorWarmupChainedRequestInput<T> implements ChainedRequestIn
 
           @Override
           public Map<String, String> getHeaders() {
+            return new HashMap<>();
+          }
+
+          @Override
+          public Map<String, List<String>> getMultiValueHeaders() {
             return new HashMap<>();
           }
         };
@@ -848,6 +861,7 @@ import {{invokerPackage}}.JSON;
 {{/apiInfo}}
 import java.util.Map;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Response with status code {{code}} for the {{nickname}} operation
@@ -864,11 +878,13 @@ public class {{operationIdCamelCase}}{{code}}Response extends RuntimeException i
     private final String body;
     {{#dataType}}private final {{#isPrimitiveType}}String{{/isPrimitiveType}}{{^isPrimitiveType}}{{.}}{{/isPrimitiveType}} typedBody;{{/dataType}}
     private final Map<String, String> headers;
+    private final Map<String, List<String>> multiValueHeaders;
 
-    private {{operationIdCamelCase}}{{code}}Response({{#dataType}}final {{#isPrimitiveType}}String{{/isPrimitiveType}}{{^isPrimitiveType}}{{.}}{{/isPrimitiveType}} body, {{/dataType}}final Map<String, String> headers) {
+    private {{operationIdCamelCase}}{{code}}Response({{#dataType}}final {{#isPrimitiveType}}String{{/isPrimitiveType}}{{^isPrimitiveType}}{{.}}{{/isPrimitiveType}} body, {{/dataType}}final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
         {{#dataType}}this.typedBody = body;{{/dataType}}
         this.body = {{#dataType}}{{#isPrimitiveType}}body{{/isPrimitiveType}}{{^isPrimitiveType}}body.toJson(){{/isPrimitiveType}}{{/dataType}}{{^dataType}}""{{/dataType}};
         this.headers = headers;
+        this.multiValueHeaders = multiValueHeaders;
     }
 
     @Override
@@ -892,18 +908,30 @@ public class {{operationIdCamelCase}}{{code}}Response extends RuntimeException i
         return this.headers;
     }
 
+    @Override
+    public Map<String, List<String>> getMultiValueHeaders() {
+        return this.multiValueHeaders;
+    }
+
     /**
      * Create a {{operationIdCamelCase}}{{code}}Response with{{^dataType}}out{{/dataType}} a body
      */
     public static {{operationIdCamelCase}}{{code}}Response of({{#dataType}}final {{#isPrimitiveType}}String{{/isPrimitiveType}}{{^isPrimitiveType}}{{.}}{{/isPrimitiveType}} body{{/dataType}}) {
-        return new {{operationIdCamelCase}}{{code}}Response({{#dataType}}body, {{/dataType}}new HashMap<>());
+        return new {{operationIdCamelCase}}{{code}}Response({{#dataType}}body, {{/dataType}}new HashMap<>(), new HashMap<>());
     }
 
     /**
      * Create a {{operationIdCamelCase}}{{code}}Response with{{^dataType}}out{{/dataType}} a body and headers
      */
     public static {{operationIdCamelCase}}{{code}}Response of({{#dataType}}final {{#isPrimitiveType}}String{{/isPrimitiveType}}{{^isPrimitiveType}}{{.}}{{/isPrimitiveType}} body, {{/dataType}}final Map<String, String> headers) {
-        return new {{operationIdCamelCase}}{{code}}Response({{#dataType}}body, {{/dataType}}headers);
+        return new {{operationIdCamelCase}}{{code}}Response({{#dataType}}body, {{/dataType}}headers, new HashMap<>());
+    }
+
+    /**
+     * Create a {{operationIdCamelCase}}{{code}}Response with{{^dataType}}out{{/dataType}} a body, headers and multi-value headers
+     */
+    public static {{operationIdCamelCase}}{{code}}Response of({{#dataType}}final {{#isPrimitiveType}}String{{/isPrimitiveType}}{{^isPrimitiveType}}{{.}}{{/isPrimitiveType}} body, {{/dataType}}final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
+        return new {{operationIdCamelCase}}{{code}}Response({{#dataType}}body, {{/dataType}}headers, multiValueHeaders);
     }
 }
 {{/responses}}
@@ -1276,7 +1304,7 @@ public abstract class {{operationIdCamelCase}} implements RequestHandler<APIGate
 
         // Initialise instance of Gson and prime serialisation and deserialisation
         new JSON();
-        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>())), ApiResponse.class);
+        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>(), new HashMap<>())), ApiResponse.class);
 
         try {
             // Prime input validation - this will likely fail for the fake event but ensures the code path is optimised
@@ -1358,6 +1386,7 @@ public abstract class {{operationIdCamelCase}} implements RequestHandler<APIGate
         return new APIGatewayProxyResponseEvent()
                 .withStatusCode(response.getStatusCode())
                 .withHeaders(responseHeaders)
+                .withMultiValueHeaders(response.getMultiValueHeaders())
                 .withBody(response.getBody());
     }
 }

--- a/packages/type-safe-api/scripts/type-safe-api/generators/python/templates/operationConfig.mustache
+++ b/packages/type-safe-api/scripts/type-safe-api/generators/python/templates/operationConfig.mustache
@@ -178,6 +178,7 @@ class ApiResponse(Exception, Generic[StatusCode, ResponseBody]):
     status_code: StatusCode
     headers: Dict[str, str]
     body: ResponseBody
+    multi_value_headers: Optional[Dict[str, List[str]]] = None
 
 class HandlerChain(Generic[RequestParameters, RequestBody, StatusCode, ResponseBody]):
     def next(self, request: ChainedApiRequest[RequestParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -349,6 +350,7 @@ def {{operationId}}_handler(_handler: {{operationIdCamelCase}}HandlerFunction = 
             return {
                 'statusCode': response.status_code,
                 'headers': response_headers,
+                'multiValueHeaders': response.multi_value_headers or {},
                 'body': response_body,
             }
         return wrapper

--- a/packages/type-safe-api/scripts/type-safe-api/generators/python/templates/response.mustache
+++ b/packages/type-safe-api/scripts/type-safe-api/generators/python/templates/response.mustache
@@ -1,4 +1,4 @@
-from typing import TypeVar, Generic, Dict
+from typing import TypeVar, Generic, Dict, List
 from {{packageName}}.api.operation_config import ApiResponse
 
 ResponseBody = TypeVar("ResponseBody")
@@ -9,36 +9,36 @@ class Response(Generic[ResponseBody]):
   """
 
   @staticmethod
-  def success(body: ResponseBody, headers: Dict[str, str] = {}) -> ApiResponse[200, ResponseBody]:
+  def success(body: ResponseBody, headers: Dict[str, str] = {}, multi_value_headers: Dict[str, List[str]] = {}) -> ApiResponse[200, ResponseBody]:
     """
     A successful response
     """
-    return ApiResponse(status_code=200, body=body, headers={**headers})
+    return ApiResponse(status_code=200, body=body, headers={**headers}, multi_value_headers={**multi_value_headers})
 
   @staticmethod
-  def bad_request(body: ResponseBody, headers: Dict[str, str] = {}) -> ApiResponse[400, ResponseBody]:
+  def bad_request(body: ResponseBody, headers: Dict[str, str] = {}, multi_value_headers: Dict[str, List[str]] = {}) -> ApiResponse[400, ResponseBody]:
     """
     A response which indicates a client error
     """
-    return ApiResponse(status_code=400, body=body, headers={**headers})
+    return ApiResponse(status_code=400, body=body, headers={**headers}, multi_value_headers={**multi_value_headers})
 
   @staticmethod
-  def not_found(body: ResponseBody, headers: Dict[str, str] = {}) -> ApiResponse[404, ResponseBody]:
+  def not_found(body: ResponseBody, headers: Dict[str, str] = {}, multi_value_headers: Dict[str, List[str]] = {}) -> ApiResponse[404, ResponseBody]:
     """
     A response which indicates the requested resource was not found
     """
-    return ApiResponse(status_code=404, body=body, headers={**headers})
+    return ApiResponse(status_code=404, body=body, headers={**headers}, multi_value_headers={**multi_value_headers})
 
   @staticmethod
-  def not_authorized(body: ResponseBody, headers: Dict[str, str] = {}) -> ApiResponse[403, ResponseBody]:
+  def not_authorized(body: ResponseBody, headers: Dict[str, str] = {}, multi_value_headers: Dict[str, List[str]] = {}) -> ApiResponse[403, ResponseBody]:
     """
     A response which indicates the caller is not authorised to perform the operation or access the resource
     """
-    return ApiResponse(status_code=403, body=body, headers={**headers})
+    return ApiResponse(status_code=403, body=body, headers={**headers}, multi_value_headers={**multi_value_headers})
 
   @staticmethod
-  def internal_failure(body: ResponseBody, headers: Dict[str, str] = {}) -> ApiResponse[500, ResponseBody]:
+  def internal_failure(body: ResponseBody, headers: Dict[str, str] = {}, multi_value_headers: Dict[str, List[str]] = {}) -> ApiResponse[500, ResponseBody]:
     """
     A response to indicate a server error
     """
-    return ApiResponse(status_code=500, body=body, headers={**headers})
+    return ApiResponse(status_code=500, body=body, headers={**headers}, multi_value_headers={**multi_value_headers})

--- a/packages/type-safe-api/scripts/type-safe-api/generators/typescript/templates/operationConfig.mustache
+++ b/packages/type-safe-api/scripts/type-safe-api/generators/typescript/templates/operationConfig.mustache
@@ -180,6 +180,7 @@ type OperationApiGatewayLambdaHandler<T extends OperationIds> = (event: APIGatew
 export interface OperationResponse<StatusCode extends number, Body> {
     statusCode: StatusCode;
     headers?: { [key: string]: string };
+    multiValueHeaders?: { [key: string]: string[] };
     body: Body;
 }
 

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/java.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/java.test.ts.snap
@@ -4153,6 +4153,7 @@ public class Tag2Api {
 package test.test.runtime.api.handlers;
 
 import java.util.Map;
+import java.util.List;
 
 @lombok.experimental.SuperBuilder
 @lombok.AllArgsConstructor
@@ -4161,6 +4162,7 @@ public class ApiResponse implements Response {
     private String body;
     private int statusCode;
     private Map<String, String> headers;
+    private Map<String, List<String>> multiValueHeaders;
 }
 ",
   "src/main/java/test/test/runtime/api/handlers/ChainedRequestInput.java": "
@@ -4737,6 +4739,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 /**
  * An "empty" chained request input used to warm up interceptors which extend the InterceptorWithWarmup
@@ -4761,6 +4764,11 @@ public class InterceptorWarmupChainedRequestInput<T> implements ChainedRequestIn
 
           @Override
           public Map<String, String> getHeaders() {
+            return new HashMap<>();
+          }
+
+          @Override
+          public Map<String, List<String>> getMultiValueHeaders() {
             return new HashMap<>();
           }
         };
@@ -4933,6 +4941,7 @@ public interface RequestInput<TInput> {
 package test.test.runtime.api.handlers;
 
 import java.util.Map;
+import java.util.List;
 
 /**
  * Represents an HTTP response from an api operation
@@ -4950,6 +4959,10 @@ public interface Response {
      * Returns the response headers
      */
     Map<String, String> getHeaders();
+    /**
+     * Returns the multi-value response headers
+     */
+    Map<String, List<String>> getMultiValueHeaders();
 }
 ",
   "src/main/java/test/test/runtime/api/handlers/both/Both.java": "
@@ -5058,7 +5071,7 @@ public abstract class Both implements RequestHandler<APIGatewayProxyRequestEvent
 
         // Initialise instance of Gson and prime serialisation and deserialisation
         new JSON();
-        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>())), ApiResponse.class);
+        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>(), new HashMap<>())), ApiResponse.class);
 
         try {
             // Prime input validation - this will likely fail for the fake event but ensures the code path is optimised
@@ -5133,6 +5146,7 @@ public abstract class Both implements RequestHandler<APIGatewayProxyRequestEvent
         return new APIGatewayProxyResponseEvent()
                 .withStatusCode(response.getStatusCode())
                 .withHeaders(responseHeaders)
+                .withMultiValueHeaders(response.getMultiValueHeaders())
                 .withBody(response.getBody());
     }
 }
@@ -5144,6 +5158,7 @@ import test.test.runtime.model.*;
 import test.test.runtime.JSON;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Response with status code 200 for the both operation
@@ -5160,11 +5175,13 @@ public class Both200Response extends RuntimeException implements BothResponse {
     private final String body;
     
     private final Map<String, String> headers;
+    private final Map<String, List<String>> multiValueHeaders;
 
-    private Both200Response(final Map<String, String> headers) {
+    private Both200Response(final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
         
         this.body = "";
         this.headers = headers;
+        this.multiValueHeaders = multiValueHeaders;
     }
 
     @Override
@@ -5183,18 +5200,30 @@ public class Both200Response extends RuntimeException implements BothResponse {
         return this.headers;
     }
 
+    @Override
+    public Map<String, List<String>> getMultiValueHeaders() {
+        return this.multiValueHeaders;
+    }
+
     /**
      * Create a Both200Response without a body
      */
     public static Both200Response of() {
-        return new Both200Response(new HashMap<>());
+        return new Both200Response(new HashMap<>(), new HashMap<>());
     }
 
     /**
      * Create a Both200Response without a body and headers
      */
     public static Both200Response of(final Map<String, String> headers) {
-        return new Both200Response(headers);
+        return new Both200Response(headers, new HashMap<>());
+    }
+
+    /**
+     * Create a Both200Response without a body, headers and multi-value headers
+     */
+    public static Both200Response of(final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
+        return new Both200Response(headers, multiValueHeaders);
     }
 }
 ",
@@ -5443,7 +5472,7 @@ public abstract class Neither implements RequestHandler<APIGatewayProxyRequestEv
 
         // Initialise instance of Gson and prime serialisation and deserialisation
         new JSON();
-        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>())), ApiResponse.class);
+        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>(), new HashMap<>())), ApiResponse.class);
 
         try {
             // Prime input validation - this will likely fail for the fake event but ensures the code path is optimised
@@ -5518,6 +5547,7 @@ public abstract class Neither implements RequestHandler<APIGatewayProxyRequestEv
         return new APIGatewayProxyResponseEvent()
                 .withStatusCode(response.getStatusCode())
                 .withHeaders(responseHeaders)
+                .withMultiValueHeaders(response.getMultiValueHeaders())
                 .withBody(response.getBody());
     }
 }
@@ -5529,6 +5559,7 @@ import test.test.runtime.model.*;
 import test.test.runtime.JSON;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Response with status code 200 for the neither operation
@@ -5545,11 +5576,13 @@ public class Neither200Response extends RuntimeException implements NeitherRespo
     private final String body;
     
     private final Map<String, String> headers;
+    private final Map<String, List<String>> multiValueHeaders;
 
-    private Neither200Response(final Map<String, String> headers) {
+    private Neither200Response(final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
         
         this.body = "";
         this.headers = headers;
+        this.multiValueHeaders = multiValueHeaders;
     }
 
     @Override
@@ -5568,18 +5601,30 @@ public class Neither200Response extends RuntimeException implements NeitherRespo
         return this.headers;
     }
 
+    @Override
+    public Map<String, List<String>> getMultiValueHeaders() {
+        return this.multiValueHeaders;
+    }
+
     /**
      * Create a Neither200Response without a body
      */
     public static Neither200Response of() {
-        return new Neither200Response(new HashMap<>());
+        return new Neither200Response(new HashMap<>(), new HashMap<>());
     }
 
     /**
      * Create a Neither200Response without a body and headers
      */
     public static Neither200Response of(final Map<String, String> headers) {
-        return new Neither200Response(headers);
+        return new Neither200Response(headers, new HashMap<>());
+    }
+
+    /**
+     * Create a Neither200Response without a body, headers and multi-value headers
+     */
+    public static Neither200Response of(final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
+        return new Neither200Response(headers, multiValueHeaders);
     }
 }
 ",
@@ -5828,7 +5873,7 @@ public abstract class Tag1 implements RequestHandler<APIGatewayProxyRequestEvent
 
         // Initialise instance of Gson and prime serialisation and deserialisation
         new JSON();
-        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>())), ApiResponse.class);
+        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>(), new HashMap<>())), ApiResponse.class);
 
         try {
             // Prime input validation - this will likely fail for the fake event but ensures the code path is optimised
@@ -5903,6 +5948,7 @@ public abstract class Tag1 implements RequestHandler<APIGatewayProxyRequestEvent
         return new APIGatewayProxyResponseEvent()
                 .withStatusCode(response.getStatusCode())
                 .withHeaders(responseHeaders)
+                .withMultiValueHeaders(response.getMultiValueHeaders())
                 .withBody(response.getBody());
     }
 }
@@ -5914,6 +5960,7 @@ import test.test.runtime.model.*;
 import test.test.runtime.JSON;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Response with status code 200 for the tag1 operation
@@ -5930,11 +5977,13 @@ public class Tag1200Response extends RuntimeException implements Tag1Response {
     private final String body;
     
     private final Map<String, String> headers;
+    private final Map<String, List<String>> multiValueHeaders;
 
-    private Tag1200Response(final Map<String, String> headers) {
+    private Tag1200Response(final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
         
         this.body = "";
         this.headers = headers;
+        this.multiValueHeaders = multiValueHeaders;
     }
 
     @Override
@@ -5953,18 +6002,30 @@ public class Tag1200Response extends RuntimeException implements Tag1Response {
         return this.headers;
     }
 
+    @Override
+    public Map<String, List<String>> getMultiValueHeaders() {
+        return this.multiValueHeaders;
+    }
+
     /**
      * Create a Tag1200Response without a body
      */
     public static Tag1200Response of() {
-        return new Tag1200Response(new HashMap<>());
+        return new Tag1200Response(new HashMap<>(), new HashMap<>());
     }
 
     /**
      * Create a Tag1200Response without a body and headers
      */
     public static Tag1200Response of(final Map<String, String> headers) {
-        return new Tag1200Response(headers);
+        return new Tag1200Response(headers, new HashMap<>());
+    }
+
+    /**
+     * Create a Tag1200Response without a body, headers and multi-value headers
+     */
+    public static Tag1200Response of(final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
+        return new Tag1200Response(headers, multiValueHeaders);
     }
 }
 ",
@@ -6213,7 +6274,7 @@ public abstract class Tag2 implements RequestHandler<APIGatewayProxyRequestEvent
 
         // Initialise instance of Gson and prime serialisation and deserialisation
         new JSON();
-        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>())), ApiResponse.class);
+        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>(), new HashMap<>())), ApiResponse.class);
 
         try {
             // Prime input validation - this will likely fail for the fake event but ensures the code path is optimised
@@ -6288,6 +6349,7 @@ public abstract class Tag2 implements RequestHandler<APIGatewayProxyRequestEvent
         return new APIGatewayProxyResponseEvent()
                 .withStatusCode(response.getStatusCode())
                 .withHeaders(responseHeaders)
+                .withMultiValueHeaders(response.getMultiValueHeaders())
                 .withBody(response.getBody());
     }
 }
@@ -6299,6 +6361,7 @@ import test.test.runtime.model.*;
 import test.test.runtime.JSON;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Response with status code 200 for the tag2 operation
@@ -6315,11 +6378,13 @@ public class Tag2200Response extends RuntimeException implements Tag2Response {
     private final String body;
     
     private final Map<String, String> headers;
+    private final Map<String, List<String>> multiValueHeaders;
 
-    private Tag2200Response(final Map<String, String> headers) {
+    private Tag2200Response(final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
         
         this.body = "";
         this.headers = headers;
+        this.multiValueHeaders = multiValueHeaders;
     }
 
     @Override
@@ -6338,18 +6403,30 @@ public class Tag2200Response extends RuntimeException implements Tag2Response {
         return this.headers;
     }
 
+    @Override
+    public Map<String, List<String>> getMultiValueHeaders() {
+        return this.multiValueHeaders;
+    }
+
     /**
      * Create a Tag2200Response without a body
      */
     public static Tag2200Response of() {
-        return new Tag2200Response(new HashMap<>());
+        return new Tag2200Response(new HashMap<>(), new HashMap<>());
     }
 
     /**
      * Create a Tag2200Response without a body and headers
      */
     public static Tag2200Response of(final Map<String, String> headers) {
-        return new Tag2200Response(headers);
+        return new Tag2200Response(headers, new HashMap<>());
+    }
+
+    /**
+     * Create a Tag2200Response without a body, headers and multi-value headers
+     */
+    public static Tag2200Response of(final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
+        return new Tag2200Response(headers, multiValueHeaders);
     }
 }
 ",
@@ -12420,6 +12497,7 @@ public class DefaultApi {
 package test.test.runtime.api.handlers;
 
 import java.util.Map;
+import java.util.List;
 
 @lombok.experimental.SuperBuilder
 @lombok.AllArgsConstructor
@@ -12428,6 +12506,7 @@ public class ApiResponse implements Response {
     private String body;
     private int statusCode;
     private Map<String, String> headers;
+    private Map<String, List<String>> multiValueHeaders;
 }
 ",
   "src/main/java/test/test/runtime/api/handlers/ChainedRequestInput.java": "
@@ -13052,6 +13131,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 /**
  * An "empty" chained request input used to warm up interceptors which extend the InterceptorWithWarmup
@@ -13076,6 +13156,11 @@ public class InterceptorWarmupChainedRequestInput<T> implements ChainedRequestIn
 
           @Override
           public Map<String, String> getHeaders() {
+            return new HashMap<>();
+          }
+
+          @Override
+          public Map<String, List<String>> getMultiValueHeaders() {
             return new HashMap<>();
           }
         };
@@ -13248,6 +13333,7 @@ public interface RequestInput<TInput> {
 package test.test.runtime.api.handlers;
 
 import java.util.Map;
+import java.util.List;
 
 /**
  * Represents an HTTP response from an api operation
@@ -13265,6 +13351,10 @@ public interface Response {
      * Returns the response headers
      */
     Map<String, String> getHeaders();
+    /**
+     * Returns the multi-value response headers
+     */
+    Map<String, List<String>> getMultiValueHeaders();
 }
 ",
   "src/main/java/test/test/runtime/api/handlers/any_request_response/AnyRequestResponse.java": "
@@ -13373,7 +13463,7 @@ public abstract class AnyRequestResponse implements RequestHandler<APIGatewayPro
 
         // Initialise instance of Gson and prime serialisation and deserialisation
         new JSON();
-        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>())), ApiResponse.class);
+        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>(), new HashMap<>())), ApiResponse.class);
 
         try {
             // Prime input validation - this will likely fail for the fake event but ensures the code path is optimised
@@ -13448,6 +13538,7 @@ public abstract class AnyRequestResponse implements RequestHandler<APIGatewayPro
         return new APIGatewayProxyResponseEvent()
                 .withStatusCode(response.getStatusCode())
                 .withHeaders(responseHeaders)
+                .withMultiValueHeaders(response.getMultiValueHeaders())
                 .withBody(response.getBody());
     }
 }
@@ -13459,6 +13550,7 @@ import test.test.runtime.model.*;
 import test.test.runtime.JSON;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Response with status code 200 for the anyRequestResponse operation
@@ -13475,11 +13567,13 @@ public class AnyRequestResponse200Response extends RuntimeException implements A
     private final String body;
     private final String typedBody;
     private final Map<String, String> headers;
+    private final Map<String, List<String>> multiValueHeaders;
 
-    private AnyRequestResponse200Response(final String body, final Map<String, String> headers) {
+    private AnyRequestResponse200Response(final String body, final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
         this.typedBody = body;
         this.body = body;
         this.headers = headers;
+        this.multiValueHeaders = multiValueHeaders;
     }
 
     @Override
@@ -13501,18 +13595,30 @@ public class AnyRequestResponse200Response extends RuntimeException implements A
         return this.headers;
     }
 
+    @Override
+    public Map<String, List<String>> getMultiValueHeaders() {
+        return this.multiValueHeaders;
+    }
+
     /**
      * Create a AnyRequestResponse200Response with a body
      */
     public static AnyRequestResponse200Response of(final String body) {
-        return new AnyRequestResponse200Response(body, new HashMap<>());
+        return new AnyRequestResponse200Response(body, new HashMap<>(), new HashMap<>());
     }
 
     /**
      * Create a AnyRequestResponse200Response with a body and headers
      */
     public static AnyRequestResponse200Response of(final String body, final Map<String, String> headers) {
-        return new AnyRequestResponse200Response(body, headers);
+        return new AnyRequestResponse200Response(body, headers, new HashMap<>());
+    }
+
+    /**
+     * Create a AnyRequestResponse200Response with a body, headers and multi-value headers
+     */
+    public static AnyRequestResponse200Response of(final String body, final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
+        return new AnyRequestResponse200Response(body, headers, multiValueHeaders);
     }
 }
 ",
@@ -13766,7 +13872,7 @@ public abstract class Empty implements RequestHandler<APIGatewayProxyRequestEven
 
         // Initialise instance of Gson and prime serialisation and deserialisation
         new JSON();
-        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>())), ApiResponse.class);
+        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>(), new HashMap<>())), ApiResponse.class);
 
         try {
             // Prime input validation - this will likely fail for the fake event but ensures the code path is optimised
@@ -13841,6 +13947,7 @@ public abstract class Empty implements RequestHandler<APIGatewayProxyRequestEven
         return new APIGatewayProxyResponseEvent()
                 .withStatusCode(response.getStatusCode())
                 .withHeaders(responseHeaders)
+                .withMultiValueHeaders(response.getMultiValueHeaders())
                 .withBody(response.getBody());
     }
 }
@@ -13852,6 +13959,7 @@ import test.test.runtime.model.*;
 import test.test.runtime.JSON;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Response with status code 204 for the empty operation
@@ -13868,11 +13976,13 @@ public class Empty204Response extends RuntimeException implements EmptyResponse 
     private final String body;
     
     private final Map<String, String> headers;
+    private final Map<String, List<String>> multiValueHeaders;
 
-    private Empty204Response(final Map<String, String> headers) {
+    private Empty204Response(final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
         
         this.body = "";
         this.headers = headers;
+        this.multiValueHeaders = multiValueHeaders;
     }
 
     @Override
@@ -13891,18 +14001,30 @@ public class Empty204Response extends RuntimeException implements EmptyResponse 
         return this.headers;
     }
 
+    @Override
+    public Map<String, List<String>> getMultiValueHeaders() {
+        return this.multiValueHeaders;
+    }
+
     /**
      * Create a Empty204Response without a body
      */
     public static Empty204Response of() {
-        return new Empty204Response(new HashMap<>());
+        return new Empty204Response(new HashMap<>(), new HashMap<>());
     }
 
     /**
      * Create a Empty204Response without a body and headers
      */
     public static Empty204Response of(final Map<String, String> headers) {
-        return new Empty204Response(headers);
+        return new Empty204Response(headers, new HashMap<>());
+    }
+
+    /**
+     * Create a Empty204Response without a body, headers and multi-value headers
+     */
+    public static Empty204Response of(final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
+        return new Empty204Response(headers, multiValueHeaders);
     }
 }
 ",
@@ -14151,7 +14273,7 @@ public abstract class MapResponse implements RequestHandler<APIGatewayProxyReque
 
         // Initialise instance of Gson and prime serialisation and deserialisation
         new JSON();
-        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>())), ApiResponse.class);
+        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>(), new HashMap<>())), ApiResponse.class);
 
         try {
             // Prime input validation - this will likely fail for the fake event but ensures the code path is optimised
@@ -14226,6 +14348,7 @@ public abstract class MapResponse implements RequestHandler<APIGatewayProxyReque
         return new APIGatewayProxyResponseEvent()
                 .withStatusCode(response.getStatusCode())
                 .withHeaders(responseHeaders)
+                .withMultiValueHeaders(response.getMultiValueHeaders())
                 .withBody(response.getBody());
     }
 }
@@ -14237,6 +14360,7 @@ import test.test.runtime.model.*;
 import test.test.runtime.JSON;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Response with status code 200 for the mapResponse operation
@@ -14253,11 +14377,13 @@ public class MapResponse200Response extends RuntimeException implements MapRespo
     private final String body;
     private final MapResponse typedBody;
     private final Map<String, String> headers;
+    private final Map<String, List<String>> multiValueHeaders;
 
-    private MapResponse200Response(final MapResponse body, final Map<String, String> headers) {
+    private MapResponse200Response(final MapResponse body, final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
         this.typedBody = body;
         this.body = body.toJson();
         this.headers = headers;
+        this.multiValueHeaders = multiValueHeaders;
     }
 
     @Override
@@ -14279,18 +14405,30 @@ public class MapResponse200Response extends RuntimeException implements MapRespo
         return this.headers;
     }
 
+    @Override
+    public Map<String, List<String>> getMultiValueHeaders() {
+        return this.multiValueHeaders;
+    }
+
     /**
      * Create a MapResponse200Response with a body
      */
     public static MapResponse200Response of(final MapResponse body) {
-        return new MapResponse200Response(body, new HashMap<>());
+        return new MapResponse200Response(body, new HashMap<>(), new HashMap<>());
     }
 
     /**
      * Create a MapResponse200Response with a body and headers
      */
     public static MapResponse200Response of(final MapResponse body, final Map<String, String> headers) {
-        return new MapResponse200Response(body, headers);
+        return new MapResponse200Response(body, headers, new HashMap<>());
+    }
+
+    /**
+     * Create a MapResponse200Response with a body, headers and multi-value headers
+     */
+    public static MapResponse200Response of(final MapResponse body, final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
+        return new MapResponse200Response(body, headers, multiValueHeaders);
     }
 }
 ",
@@ -14539,7 +14677,7 @@ public abstract class MediaTypes implements RequestHandler<APIGatewayProxyReques
 
         // Initialise instance of Gson and prime serialisation and deserialisation
         new JSON();
-        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>())), ApiResponse.class);
+        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>(), new HashMap<>())), ApiResponse.class);
 
         try {
             // Prime input validation - this will likely fail for the fake event but ensures the code path is optimised
@@ -14614,6 +14752,7 @@ public abstract class MediaTypes implements RequestHandler<APIGatewayProxyReques
         return new APIGatewayProxyResponseEvent()
                 .withStatusCode(response.getStatusCode())
                 .withHeaders(responseHeaders)
+                .withMultiValueHeaders(response.getMultiValueHeaders())
                 .withBody(response.getBody());
     }
 }
@@ -14625,6 +14764,7 @@ import test.test.runtime.model.*;
 import test.test.runtime.JSON;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Response with status code 200 for the mediaTypes operation
@@ -14641,11 +14781,13 @@ public class MediaTypes200Response extends RuntimeException implements MediaType
     private final String body;
     private final String typedBody;
     private final Map<String, String> headers;
+    private final Map<String, List<String>> multiValueHeaders;
 
-    private MediaTypes200Response(final String body, final Map<String, String> headers) {
+    private MediaTypes200Response(final String body, final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
         this.typedBody = body;
         this.body = body;
         this.headers = headers;
+        this.multiValueHeaders = multiValueHeaders;
     }
 
     @Override
@@ -14667,18 +14809,30 @@ public class MediaTypes200Response extends RuntimeException implements MediaType
         return this.headers;
     }
 
+    @Override
+    public Map<String, List<String>> getMultiValueHeaders() {
+        return this.multiValueHeaders;
+    }
+
     /**
      * Create a MediaTypes200Response with a body
      */
     public static MediaTypes200Response of(final String body) {
-        return new MediaTypes200Response(body, new HashMap<>());
+        return new MediaTypes200Response(body, new HashMap<>(), new HashMap<>());
     }
 
     /**
      * Create a MediaTypes200Response with a body and headers
      */
     public static MediaTypes200Response of(final String body, final Map<String, String> headers) {
-        return new MediaTypes200Response(body, headers);
+        return new MediaTypes200Response(body, headers, new HashMap<>());
+    }
+
+    /**
+     * Create a MediaTypes200Response with a body, headers and multi-value headers
+     */
+    public static MediaTypes200Response of(final String body, final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
+        return new MediaTypes200Response(body, headers, multiValueHeaders);
     }
 }
 ",
@@ -14932,7 +15086,7 @@ public abstract class MultipleContentTypes implements RequestHandler<APIGatewayP
 
         // Initialise instance of Gson and prime serialisation and deserialisation
         new JSON();
-        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>())), ApiResponse.class);
+        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>(), new HashMap<>())), ApiResponse.class);
 
         try {
             // Prime input validation - this will likely fail for the fake event but ensures the code path is optimised
@@ -15007,6 +15161,7 @@ public abstract class MultipleContentTypes implements RequestHandler<APIGatewayP
         return new APIGatewayProxyResponseEvent()
                 .withStatusCode(response.getStatusCode())
                 .withHeaders(responseHeaders)
+                .withMultiValueHeaders(response.getMultiValueHeaders())
                 .withBody(response.getBody());
     }
 }
@@ -15018,6 +15173,7 @@ import test.test.runtime.model.*;
 import test.test.runtime.JSON;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Response with status code 200 for the multipleContentTypes operation
@@ -15034,11 +15190,13 @@ public class MultipleContentTypes200Response extends RuntimeException implements
     private final String body;
     private final String typedBody;
     private final Map<String, String> headers;
+    private final Map<String, List<String>> multiValueHeaders;
 
-    private MultipleContentTypes200Response(final String body, final Map<String, String> headers) {
+    private MultipleContentTypes200Response(final String body, final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
         this.typedBody = body;
         this.body = body;
         this.headers = headers;
+        this.multiValueHeaders = multiValueHeaders;
     }
 
     @Override
@@ -15060,18 +15218,30 @@ public class MultipleContentTypes200Response extends RuntimeException implements
         return this.headers;
     }
 
+    @Override
+    public Map<String, List<String>> getMultiValueHeaders() {
+        return this.multiValueHeaders;
+    }
+
     /**
      * Create a MultipleContentTypes200Response with a body
      */
     public static MultipleContentTypes200Response of(final String body) {
-        return new MultipleContentTypes200Response(body, new HashMap<>());
+        return new MultipleContentTypes200Response(body, new HashMap<>(), new HashMap<>());
     }
 
     /**
      * Create a MultipleContentTypes200Response with a body and headers
      */
     public static MultipleContentTypes200Response of(final String body, final Map<String, String> headers) {
-        return new MultipleContentTypes200Response(body, headers);
+        return new MultipleContentTypes200Response(body, headers, new HashMap<>());
+    }
+
+    /**
+     * Create a MultipleContentTypes200Response with a body, headers and multi-value headers
+     */
+    public static MultipleContentTypes200Response of(final String body, final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
+        return new MultipleContentTypes200Response(body, headers, multiValueHeaders);
     }
 }
 ",
@@ -15329,7 +15499,7 @@ public abstract class OperationOne implements RequestHandler<APIGatewayProxyRequ
 
         // Initialise instance of Gson and prime serialisation and deserialisation
         new JSON();
-        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>())), ApiResponse.class);
+        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>(), new HashMap<>())), ApiResponse.class);
 
         try {
             // Prime input validation - this will likely fail for the fake event but ensures the code path is optimised
@@ -15407,6 +15577,7 @@ public abstract class OperationOne implements RequestHandler<APIGatewayProxyRequ
         return new APIGatewayProxyResponseEvent()
                 .withStatusCode(response.getStatusCode())
                 .withHeaders(responseHeaders)
+                .withMultiValueHeaders(response.getMultiValueHeaders())
                 .withBody(response.getBody());
     }
 }
@@ -15418,6 +15589,7 @@ import test.test.runtime.model.*;
 import test.test.runtime.JSON;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Response with status code 200 for the operationOne operation
@@ -15434,11 +15606,13 @@ public class OperationOne200Response extends RuntimeException implements Operati
     private final String body;
     private final TestResponse typedBody;
     private final Map<String, String> headers;
+    private final Map<String, List<String>> multiValueHeaders;
 
-    private OperationOne200Response(final TestResponse body, final Map<String, String> headers) {
+    private OperationOne200Response(final TestResponse body, final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
         this.typedBody = body;
         this.body = body.toJson();
         this.headers = headers;
+        this.multiValueHeaders = multiValueHeaders;
     }
 
     @Override
@@ -15460,18 +15634,30 @@ public class OperationOne200Response extends RuntimeException implements Operati
         return this.headers;
     }
 
+    @Override
+    public Map<String, List<String>> getMultiValueHeaders() {
+        return this.multiValueHeaders;
+    }
+
     /**
      * Create a OperationOne200Response with a body
      */
     public static OperationOne200Response of(final TestResponse body) {
-        return new OperationOne200Response(body, new HashMap<>());
+        return new OperationOne200Response(body, new HashMap<>(), new HashMap<>());
     }
 
     /**
      * Create a OperationOne200Response with a body and headers
      */
     public static OperationOne200Response of(final TestResponse body, final Map<String, String> headers) {
-        return new OperationOne200Response(body, headers);
+        return new OperationOne200Response(body, headers, new HashMap<>());
+    }
+
+    /**
+     * Create a OperationOne200Response with a body, headers and multi-value headers
+     */
+    public static OperationOne200Response of(final TestResponse body, final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
+        return new OperationOne200Response(body, headers, multiValueHeaders);
     }
 }
 ",
@@ -15482,6 +15668,7 @@ import test.test.runtime.model.*;
 import test.test.runtime.JSON;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Response with status code 400 for the operationOne operation
@@ -15498,11 +15685,13 @@ public class OperationOne400Response extends RuntimeException implements Operati
     private final String body;
     private final ApiError typedBody;
     private final Map<String, String> headers;
+    private final Map<String, List<String>> multiValueHeaders;
 
-    private OperationOne400Response(final ApiError body, final Map<String, String> headers) {
+    private OperationOne400Response(final ApiError body, final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
         this.typedBody = body;
         this.body = body.toJson();
         this.headers = headers;
+        this.multiValueHeaders = multiValueHeaders;
     }
 
     @Override
@@ -15524,18 +15713,30 @@ public class OperationOne400Response extends RuntimeException implements Operati
         return this.headers;
     }
 
+    @Override
+    public Map<String, List<String>> getMultiValueHeaders() {
+        return this.multiValueHeaders;
+    }
+
     /**
      * Create a OperationOne400Response with a body
      */
     public static OperationOne400Response of(final ApiError body) {
-        return new OperationOne400Response(body, new HashMap<>());
+        return new OperationOne400Response(body, new HashMap<>(), new HashMap<>());
     }
 
     /**
      * Create a OperationOne400Response with a body and headers
      */
     public static OperationOne400Response of(final ApiError body, final Map<String, String> headers) {
-        return new OperationOne400Response(body, headers);
+        return new OperationOne400Response(body, headers, new HashMap<>());
+    }
+
+    /**
+     * Create a OperationOne400Response with a body, headers and multi-value headers
+     */
+    public static OperationOne400Response of(final ApiError body, final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
+        return new OperationOne400Response(body, headers, multiValueHeaders);
     }
 }
 ",
@@ -15828,7 +16029,7 @@ public abstract class WithoutOperationIdDelete implements RequestHandler<APIGate
 
         // Initialise instance of Gson and prime serialisation and deserialisation
         new JSON();
-        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>())), ApiResponse.class);
+        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>(), new HashMap<>())), ApiResponse.class);
 
         try {
             // Prime input validation - this will likely fail for the fake event but ensures the code path is optimised
@@ -15903,6 +16104,7 @@ public abstract class WithoutOperationIdDelete implements RequestHandler<APIGate
         return new APIGatewayProxyResponseEvent()
                 .withStatusCode(response.getStatusCode())
                 .withHeaders(responseHeaders)
+                .withMultiValueHeaders(response.getMultiValueHeaders())
                 .withBody(response.getBody());
     }
 }
@@ -15914,6 +16116,7 @@ import test.test.runtime.model.*;
 import test.test.runtime.JSON;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Response with status code 200 for the withoutOperationIdDelete operation
@@ -15930,11 +16133,13 @@ public class WithoutOperationIdDelete200Response extends RuntimeException implem
     private final String body;
     private final TestResponse typedBody;
     private final Map<String, String> headers;
+    private final Map<String, List<String>> multiValueHeaders;
 
-    private WithoutOperationIdDelete200Response(final TestResponse body, final Map<String, String> headers) {
+    private WithoutOperationIdDelete200Response(final TestResponse body, final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
         this.typedBody = body;
         this.body = body.toJson();
         this.headers = headers;
+        this.multiValueHeaders = multiValueHeaders;
     }
 
     @Override
@@ -15956,18 +16161,30 @@ public class WithoutOperationIdDelete200Response extends RuntimeException implem
         return this.headers;
     }
 
+    @Override
+    public Map<String, List<String>> getMultiValueHeaders() {
+        return this.multiValueHeaders;
+    }
+
     /**
      * Create a WithoutOperationIdDelete200Response with a body
      */
     public static WithoutOperationIdDelete200Response of(final TestResponse body) {
-        return new WithoutOperationIdDelete200Response(body, new HashMap<>());
+        return new WithoutOperationIdDelete200Response(body, new HashMap<>(), new HashMap<>());
     }
 
     /**
      * Create a WithoutOperationIdDelete200Response with a body and headers
      */
     public static WithoutOperationIdDelete200Response of(final TestResponse body, final Map<String, String> headers) {
-        return new WithoutOperationIdDelete200Response(body, headers);
+        return new WithoutOperationIdDelete200Response(body, headers, new HashMap<>());
+    }
+
+    /**
+     * Create a WithoutOperationIdDelete200Response with a body, headers and multi-value headers
+     */
+    public static WithoutOperationIdDelete200Response of(final TestResponse body, final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
+        return new WithoutOperationIdDelete200Response(body, headers, multiValueHeaders);
     }
 }
 ",

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
@@ -1243,6 +1243,7 @@ class ApiResponse(Exception, Generic[StatusCode, ResponseBody]):
     status_code: StatusCode
     headers: Dict[str, str]
     body: ResponseBody
+    multi_value_headers: Optional[Dict[str, List[str]]] = None
 
 class HandlerChain(Generic[RequestParameters, RequestBody, StatusCode, ResponseBody]):
     def next(self, request: ChainedApiRequest[RequestParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -1371,6 +1372,7 @@ def neither_handler(_handler: NeitherHandlerFunction = None, interceptors: List[
             return {
                 'statusCode': response.status_code,
                 'headers': response_headers,
+                'multiValueHeaders': response.multi_value_headers or {},
                 'body': response_body,
             }
         return wrapper
@@ -1484,6 +1486,7 @@ def both_handler(_handler: BothHandlerFunction = None, interceptors: List[BothIn
             return {
                 'statusCode': response.status_code,
                 'headers': response_headers,
+                'multiValueHeaders': response.multi_value_headers or {},
                 'body': response_body,
             }
         return wrapper
@@ -1597,6 +1600,7 @@ def tag1_handler(_handler: Tag1HandlerFunction = None, interceptors: List[Tag1In
             return {
                 'statusCode': response.status_code,
                 'headers': response_headers,
+                'multiValueHeaders': response.multi_value_headers or {},
                 'body': response_body,
             }
         return wrapper
@@ -1710,6 +1714,7 @@ def tag2_handler(_handler: Tag2HandlerFunction = None, interceptors: List[Tag2In
             return {
                 'statusCode': response.status_code,
                 'headers': response_headers,
+                'multiValueHeaders': response.multi_value_headers or {},
                 'body': response_body,
             }
         return wrapper
@@ -4095,7 +4100,7 @@ def try_catch_interceptor(request: ChainedApiRequest) -> ApiResponse:
 # import models into model package
 ",
   "test_project/py.typed": "",
-  "test_project/response.py": "from typing import TypeVar, Generic, Dict
+  "test_project/response.py": "from typing import TypeVar, Generic, Dict, List
 from test_project.api.operation_config import ApiResponse
 
 ResponseBody = TypeVar("ResponseBody")
@@ -4106,39 +4111,39 @@ class Response(Generic[ResponseBody]):
   """
 
   @staticmethod
-  def success(body: ResponseBody, headers: Dict[str, str] = {}) -> ApiResponse[200, ResponseBody]:
+  def success(body: ResponseBody, headers: Dict[str, str] = {}, multi_value_headers: Dict[str, List[str]] = {}) -> ApiResponse[200, ResponseBody]:
     """
     A successful response
     """
-    return ApiResponse(status_code=200, body=body, headers={**headers})
+    return ApiResponse(status_code=200, body=body, headers={**headers}, multi_value_headers={**multi_value_headers})
 
   @staticmethod
-  def bad_request(body: ResponseBody, headers: Dict[str, str] = {}) -> ApiResponse[400, ResponseBody]:
+  def bad_request(body: ResponseBody, headers: Dict[str, str] = {}, multi_value_headers: Dict[str, List[str]] = {}) -> ApiResponse[400, ResponseBody]:
     """
     A response which indicates a client error
     """
-    return ApiResponse(status_code=400, body=body, headers={**headers})
+    return ApiResponse(status_code=400, body=body, headers={**headers}, multi_value_headers={**multi_value_headers})
 
   @staticmethod
-  def not_found(body: ResponseBody, headers: Dict[str, str] = {}) -> ApiResponse[404, ResponseBody]:
+  def not_found(body: ResponseBody, headers: Dict[str, str] = {}, multi_value_headers: Dict[str, List[str]] = {}) -> ApiResponse[404, ResponseBody]:
     """
     A response which indicates the requested resource was not found
     """
-    return ApiResponse(status_code=404, body=body, headers={**headers})
+    return ApiResponse(status_code=404, body=body, headers={**headers}, multi_value_headers={**multi_value_headers})
 
   @staticmethod
-  def not_authorized(body: ResponseBody, headers: Dict[str, str] = {}) -> ApiResponse[403, ResponseBody]:
+  def not_authorized(body: ResponseBody, headers: Dict[str, str] = {}, multi_value_headers: Dict[str, List[str]] = {}) -> ApiResponse[403, ResponseBody]:
     """
     A response which indicates the caller is not authorised to perform the operation or access the resource
     """
-    return ApiResponse(status_code=403, body=body, headers={**headers})
+    return ApiResponse(status_code=403, body=body, headers={**headers}, multi_value_headers={**multi_value_headers})
 
   @staticmethod
-  def internal_failure(body: ResponseBody, headers: Dict[str, str] = {}) -> ApiResponse[500, ResponseBody]:
+  def internal_failure(body: ResponseBody, headers: Dict[str, str] = {}, multi_value_headers: Dict[str, List[str]] = {}) -> ApiResponse[500, ResponseBody]:
     """
     A response to indicate a server error
     """
-    return ApiResponse(status_code=500, body=body, headers={**headers})
+    return ApiResponse(status_code=500, body=body, headers={**headers}, multi_value_headers={**multi_value_headers})
 ",
   "test_project/rest.py": "# coding: utf-8
 
@@ -7743,6 +7748,7 @@ class ApiResponse(Exception, Generic[StatusCode, ResponseBody]):
     status_code: StatusCode
     headers: Dict[str, str]
     body: ResponseBody
+    multi_value_headers: Optional[Dict[str, List[str]]] = None
 
 class HandlerChain(Generic[RequestParameters, RequestBody, StatusCode, ResponseBody]):
     def next(self, request: ChainedApiRequest[RequestParameters, RequestBody]) -> ApiResponse[StatusCode, ResponseBody]:
@@ -7872,6 +7878,7 @@ def any_request_response_handler(_handler: AnyRequestResponseHandlerFunction = N
             return {
                 'statusCode': response.status_code,
                 'headers': response_headers,
+                'multiValueHeaders': response.multi_value_headers or {},
                 'body': response_body,
             }
         return wrapper
@@ -7985,6 +7992,7 @@ def empty_handler(_handler: EmptyHandlerFunction = None, interceptors: List[Empt
             return {
                 'statusCode': response.status_code,
                 'headers': response_headers,
+                'multiValueHeaders': response.multi_value_headers or {},
                 'body': response_body,
             }
         return wrapper
@@ -8098,6 +8106,7 @@ def map_response_handler(_handler: MapResponseHandlerFunction = None, intercepto
             return {
                 'statusCode': response.status_code,
                 'headers': response_headers,
+                'multiValueHeaders': response.multi_value_headers or {},
                 'body': response_body,
             }
         return wrapper
@@ -8212,6 +8221,7 @@ def media_types_handler(_handler: MediaTypesHandlerFunction = None, interceptors
             return {
                 'statusCode': response.status_code,
                 'headers': response_headers,
+                'multiValueHeaders': response.multi_value_headers or {},
                 'body': response_body,
             }
         return wrapper
@@ -8326,6 +8336,7 @@ def multiple_content_types_handler(_handler: MultipleContentTypesHandlerFunction
             return {
                 'statusCode': response.status_code,
                 'headers': response_headers,
+                'multiValueHeaders': response.multi_value_headers or {},
                 'body': response_body,
             }
         return wrapper
@@ -8459,6 +8470,7 @@ def operation_one_handler(_handler: OperationOneHandlerFunction = None, intercep
             return {
                 'statusCode': response.status_code,
                 'headers': response_headers,
+                'multiValueHeaders': response.multi_value_headers or {},
                 'body': response_body,
             }
         return wrapper
@@ -8572,6 +8584,7 @@ def without_operation_id_delete_handler(_handler: WithoutOperationIdDeleteHandle
             return {
                 'statusCode': response.status_code,
                 'headers': response_headers,
+                'multiValueHeaders': response.multi_value_headers or {},
                 'body': response_body,
             }
         return wrapper
@@ -10735,7 +10748,7 @@ class TestResponseMessagesInner(BaseModel):
 
 ",
   "test_project/py.typed": "",
-  "test_project/response.py": "from typing import TypeVar, Generic, Dict
+  "test_project/response.py": "from typing import TypeVar, Generic, Dict, List
 from test_project.api.operation_config import ApiResponse
 
 ResponseBody = TypeVar("ResponseBody")
@@ -10746,39 +10759,39 @@ class Response(Generic[ResponseBody]):
   """
 
   @staticmethod
-  def success(body: ResponseBody, headers: Dict[str, str] = {}) -> ApiResponse[200, ResponseBody]:
+  def success(body: ResponseBody, headers: Dict[str, str] = {}, multi_value_headers: Dict[str, List[str]] = {}) -> ApiResponse[200, ResponseBody]:
     """
     A successful response
     """
-    return ApiResponse(status_code=200, body=body, headers={**headers})
+    return ApiResponse(status_code=200, body=body, headers={**headers}, multi_value_headers={**multi_value_headers})
 
   @staticmethod
-  def bad_request(body: ResponseBody, headers: Dict[str, str] = {}) -> ApiResponse[400, ResponseBody]:
+  def bad_request(body: ResponseBody, headers: Dict[str, str] = {}, multi_value_headers: Dict[str, List[str]] = {}) -> ApiResponse[400, ResponseBody]:
     """
     A response which indicates a client error
     """
-    return ApiResponse(status_code=400, body=body, headers={**headers})
+    return ApiResponse(status_code=400, body=body, headers={**headers}, multi_value_headers={**multi_value_headers})
 
   @staticmethod
-  def not_found(body: ResponseBody, headers: Dict[str, str] = {}) -> ApiResponse[404, ResponseBody]:
+  def not_found(body: ResponseBody, headers: Dict[str, str] = {}, multi_value_headers: Dict[str, List[str]] = {}) -> ApiResponse[404, ResponseBody]:
     """
     A response which indicates the requested resource was not found
     """
-    return ApiResponse(status_code=404, body=body, headers={**headers})
+    return ApiResponse(status_code=404, body=body, headers={**headers}, multi_value_headers={**multi_value_headers})
 
   @staticmethod
-  def not_authorized(body: ResponseBody, headers: Dict[str, str] = {}) -> ApiResponse[403, ResponseBody]:
+  def not_authorized(body: ResponseBody, headers: Dict[str, str] = {}, multi_value_headers: Dict[str, List[str]] = {}) -> ApiResponse[403, ResponseBody]:
     """
     A response which indicates the caller is not authorised to perform the operation or access the resource
     """
-    return ApiResponse(status_code=403, body=body, headers={**headers})
+    return ApiResponse(status_code=403, body=body, headers={**headers}, multi_value_headers={**multi_value_headers})
 
   @staticmethod
-  def internal_failure(body: ResponseBody, headers: Dict[str, str] = {}) -> ApiResponse[500, ResponseBody]:
+  def internal_failure(body: ResponseBody, headers: Dict[str, str] = {}, multi_value_headers: Dict[str, List[str]] = {}) -> ApiResponse[500, ResponseBody]:
     """
     A response to indicate a server error
     """
-    return ApiResponse(status_code=500, body=body, headers={**headers})
+    return ApiResponse(status_code=500, body=body, headers={**headers}, multi_value_headers={**multi_value_headers})
 ",
   "test_project/rest.py": "# coding: utf-8
 

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript.test.ts.snap
@@ -326,6 +326,7 @@ type OperationApiGatewayLambdaHandler<T extends OperationIds> = (event: APIGatew
 export interface OperationResponse<StatusCode extends number, Body> {
     statusCode: StatusCode;
     headers?: { [key: string]: string };
+    multiValueHeaders?: { [key: string]: string[] };
     body: Body;
 }
 
@@ -2391,6 +2392,7 @@ type OperationApiGatewayLambdaHandler<T extends OperationIds> = (event: APIGatew
 export interface OperationResponse<StatusCode extends number, Body> {
     statusCode: StatusCode;
     headers?: { [key: string]: string };
+    multiValueHeaders?: { [key: string]: string[] };
     body: Body;
 }
 


### PR DESCRIPTION
API gateway supports returning multi-value headers in lambda proxy responses. This change exposes this from the type-safe lambda handler wrappers.

