### PR TITLE
fix(type-safe-api): deserialize python body with model_validate instead of from_json

### DIFF
--- a/packages/type-safe-api/scripts/type-safe-api/generators/python/templates/operationConfig.mustache
+++ b/packages/type-safe-api/scripts/type-safe-api/generators/python/templates/operationConfig.mustache
@@ -71,7 +71,7 @@ def parse_body(body, content_types, model):
     """
     if len([c for c in content_types if c != 'application/json']) == 0:
         if model != Any:
-            body = model.from_json(body)
+            body = model.model_validate(json.loads(body))
         else:
             body = json.loads(body or '{}')
     return body

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
@@ -1136,7 +1136,7 @@ def parse_body(body, content_types, model):
     """
     if len([c for c in content_types if c != 'application/json']) == 0:
         if model != Any:
-            body = model.from_json(body)
+            body = model.model_validate(json.loads(body))
         else:
             body = json.loads(body or '{}')
     return body
@@ -7636,7 +7636,7 @@ def parse_body(body, content_types, model):
     """
     if len([c for c in content_types if c != 'application/json']) == 0:
         if model != Any:
-            body = model.from_json(body)
+            body = model.model_validate(json.loads(body))
         else:
             body = json.loads(body or '{}')
     return body


### PR DESCRIPTION
A bug in OpenAPI Generator can cause some fields to be omitted when deserializing python models which make use of `allOf` to compose schemas:

https://github.com/OpenAPITools/openapi-generator/issues/12778

Instead of using the generated `from_json` method which may omit fields to deserialize, we use the pydantic `model_validate` method directly.

This doesn't happen for Smithy as it doesn't have inheritance (rather it uses mixins), but can be a gotcha if using OpenAPI directly. For example if you have an OpenAPI spec like this:

```yaml
    MyOperationInput:
      type: object
      properties:
        foo:
          type: string
      allOf:
        - $ref: "#/components/schemas/AnotherSchema"
      required:
        - foo
    AnotherSchema:
      type: object
      properties:
        bar:
          type: string
```

The OpenAPI generator bug causes `foo` to go missing in the `from_dict` method which `from_json` calls, so the model is instantiated incorrectly.

```python
    @classmethod
    def from_dict(cls, obj: Dict) -> Self:
        """Create an instance of PostHelloInput from a dict"""
        if obj is None:
            return None

        if not isinstance(obj, dict):
            return cls.model_validate(obj)

        _obj = cls.model_validate({
            "bar": obj.get("bar"),
        })
        return _obj
```

Using `model_validate` directly works around this bug.