### PR TITLE
feat(type-safe-api): support configuring lambda handler runtime versions

### DIFF
--- a/packages/type-safe-api/docs/developer_guides/type-safe-api/lambda_handlers.md
+++ b/packages/type-safe-api/docs/developer_guides/type-safe-api/lambda_handlers.md
@@ -415,3 +415,79 @@ If your lambda handlers rely on native dependencies, you will need to ensure you
 
 !!!warning
     For TypeScript and Java, you may need to override the `package` task for the handlers project to run the appropriate commands to build your handlers with their native dependencies, or consider consuming them using a [Lambda layer](https://docs.aws.amazon.com/lambda/latest/dg/chapter-layers.html).
+
+## Runtime Versions
+
+You can configure the desired runtime versions of your handler projects in your `.projenrc`. This adjusts the appropriate project settings (such as the language level and packaging command), as well as configures the function CDK constructs to target this runtime version.
+
+For example:
+
+=== "TS"
+
+    ```ts
+    new TypeSafeApiProject({
+      ...
+      handlers: {
+        languages: [Language.PYTHON, Language.JAVA, Language.TYPESCRIPT],
+        options: {
+          python: {
+            runtimeVersion: PythonVersion.PYTHON_3_12,
+          },
+          java: {
+            runtimeVersion: JavaVersion.JAVA_21,
+          },
+          typescript: {
+            runtimeVersion: NodeVersion.NODE_20,
+          },
+        }
+      }
+    });
+    ```
+
+=== "JAVA"
+
+    ```java
+    new TypeSafeApiProject(TypeSafeApiProjectOptions.builder()
+            ...
+            .handlers(HandlersConfiguration.builder()
+                    .languages(Arrays.asList(Language.PYTHON))
+                    .options(GeneratedHandlersCodeOptions.builder()
+                            .python(GeneratedPythonHandlersOptions.builder()
+                                    .runtimeVersion(PythonVersion.PYTHON_3_12)
+                                    .build())
+                            .java(GeneratedJavaHandlersOptions.builder()
+                                    .runtimeVersion(JavaVersion.JAVA_21)
+                                    .build())
+                            .typescript(GeneratedTypeScriptHandlersOptions.builder()
+                                    .runtimeVersion(NodeVersion.NODE_20)
+                                    .build())
+                            .build())
+                    .build())
+            .build());
+    ```
+
+=== "PYTHON"
+
+    ```python
+
+    TypeSafeApiProject(
+        ...
+        handlers=HandlersConfiguration(
+            languages=[Language.PYTHON],
+            options=GeneratedHandlersCodeOptions(
+                python=GeneratedPythonHandlersOptions(
+                    runtime_version=PythonVersion.PYTHON_3_12
+                ),
+                java=GeneratedJavaHandlersOptions(
+                    runtime_version=JavaVersion.JAVA_21
+                ),
+                typescript=GeneratedTypeScriptHandlersOptions(
+                    runtime_version=NodeVersion.NODE_20
+                ),
+            )
+        ),
+    )
+    ```
+
+!!!note
+    You will need to have the specified runtime version (or greater) installed on your system in order to make use of it.

--- a/packages/type-safe-api/scripts/type-safe-api/generators/java-cdk-infrastructure/templates/functions.handlebars
+++ b/packages/type-safe-api/scripts/type-safe-api/generators/java-cdk-infrastructure/templates/functions.handlebars
@@ -114,11 +114,11 @@ public class {{operationIdCamelCase}}FunctionProps implements {{#startsWith vend
     private final String handler = "{{#apiInfo}}{{#apis.0}}{{vendorExtensions.x-handlers-java-package}}{{/apis.0}}{{/apiInfo}}.{{operationIdCamelCase}}Handler";
     {{~/startsWith}}
     {{#startsWith vendorExtensions.x-handler.language 'typescript' ~}}
-    private final Runtime runtime = Runtime.NODEJS_18_X;
+    private final Runtime runtime = Runtime.{{#apiInfo}}{{#apis.0}}{{vendorExtensions.x-handlers-node-lambda-runtime-version}}{{/apis.0}}{{/apiInfo}};
     {{~/startsWith}}{{#startsWith vendorExtensions.x-handler.language 'python' ~}}
-    private final Runtime runtime = Runtime.PYTHON_3_11;
+    private final Runtime runtime = Runtime.{{#apiInfo}}{{#apis.0}}{{vendorExtensions.x-handlers-python-lambda-runtime-version}}{{/apis.0}}{{/apiInfo}};
     {{~/startsWith}}{{#startsWith vendorExtensions.x-handler.language 'java' ~}}
-    private final Runtime runtime = Runtime.JAVA_17;
+    private final Runtime runtime = Runtime.{{#apiInfo}}{{#apis.0}}{{vendorExtensions.x-handlers-java-lambda-runtime-version}}{{/apis.0}}{{/apiInfo}};
     {{~/startsWith}}
 
     // Props with defaults

--- a/packages/type-safe-api/scripts/type-safe-api/generators/python-cdk-infrastructure/templates/functions.handlebars
+++ b/packages/type-safe-api/scripts/type-safe-api/generators/python-cdk-infrastructure/templates/functions.handlebars
@@ -27,11 +27,11 @@ class {{operationIdCamelCase}}Function({{#startsWith vendorExtensions.x-handler.
     def __init__(self, scope, id, **kwargs):
         super().__init__(scope, id,
             {{#startsWith vendorExtensions.x-handler.language 'typescript' ~}}
-            runtime=Runtime.NODEJS_18_X,
+            runtime=Runtime.{{#apiInfo}}{{#apis.0}}{{vendorExtensions.x-handlers-node-lambda-runtime-version}}{{/apis.0}}{{/apiInfo}},
             {{~/startsWith}}{{#startsWith vendorExtensions.x-handler.language 'python' ~}}
-            runtime=Runtime.PYTHON_3_11,
+            runtime=Runtime.{{#apiInfo}}{{#apis.0}}{{vendorExtensions.x-handlers-python-lambda-runtime-version}}{{/apis.0}}{{/apiInfo}},
             {{~/startsWith}}{{#startsWith vendorExtensions.x-handler.language 'java' ~}}
-            runtime=Runtime.JAVA_17,
+            runtime=Runtime.{{#apiInfo}}{{#apis.0}}{{vendorExtensions.x-handlers-java-lambda-runtime-version}}{{/apis.0}}{{/apiInfo}},
             {{~/startsWith}}
             {{#startsWith vendorExtensions.x-handler.language 'typescript' ~}}
             handler="index.handler",

--- a/packages/type-safe-api/scripts/type-safe-api/generators/typescript-cdk-infrastructure/templates/functions.handlebars
+++ b/packages/type-safe-api/scripts/type-safe-api/generators/typescript-cdk-infrastructure/templates/functions.handlebars
@@ -30,11 +30,11 @@ export class {{operationIdCamelCase}}Function extends {{#startsWith vendorExtens
   constructor(scope: Construct, id: string, props?: {{operationIdCamelCase}}FunctionProps) {
     super(scope, id, {
       {{#startsWith vendorExtensions.x-handler.language 'typescript' ~}}
-      runtime: Runtime.NODEJS_18_X,
+      runtime: Runtime.{{#apiInfo}}{{#apis.0}}{{vendorExtensions.x-handlers-node-lambda-runtime-version}}{{/apis.0}}{{/apiInfo}},
       {{~/startsWith}}{{#startsWith vendorExtensions.x-handler.language 'python' ~}}
-      runtime: Runtime.PYTHON_3_11,
+      runtime: Runtime.{{#apiInfo}}{{#apis.0}}{{vendorExtensions.x-handlers-python-lambda-runtime-version}}{{/apis.0}}{{/apiInfo}},
       {{~/startsWith}}{{#startsWith vendorExtensions.x-handler.language 'java' ~}}
-      runtime: Runtime.JAVA_17,
+      runtime: Runtime.{{#apiInfo}}{{#apis.0}}{{vendorExtensions.x-handlers-java-lambda-runtime-version}}{{/apis.0}}{{/apiInfo}},
       {{~/startsWith}}
       {{#startsWith vendorExtensions.x-handler.language 'typescript' ~}}
       handler: "index.handler",

--- a/packages/type-safe-api/src/project/codegen/components/utils.ts
+++ b/packages/type-safe-api/src/project/codegen/components/utils.ts
@@ -6,6 +6,7 @@ import * as readPkg from "read-pkg-up";
 import { Language, Library } from "../../languages";
 import { MockResponseDataGenerationOptions } from "../../types";
 import { GeneratedHandlersProjects } from "../generate";
+import { RuntimeVersionUtils } from "../runtime-version-utils";
 
 /**
  * Enum for generator directories for non-runtime generators
@@ -243,5 +244,14 @@ export const getHandlersProjectVendorExtensions = (
         java.pom.version,
         `${java.pom.artifactId}-${java.pom.version}.jar`
       )
+    : "",
+  "x-handlers-node-lambda-runtime-version": typescript
+    ? RuntimeVersionUtils.NODE.getLambdaRuntime(typescript.runtimeVersion)
+    : "",
+  "x-handlers-python-lambda-runtime-version": python
+    ? RuntimeVersionUtils.PYTHON.getLambdaRuntime(python.runtimeVersion)
+    : "",
+  "x-handlers-java-lambda-runtime-version": java
+    ? RuntimeVersionUtils.JAVA.getLambdaRuntime(java.runtimeVersion)
     : "",
 });

--- a/packages/type-safe-api/src/project/codegen/handlers/generated-java-handlers-project.ts
+++ b/packages/type-safe-api/src/project/codegen/handlers/generated-java-handlers-project.ts
@@ -3,6 +3,7 @@ SPDX-License-Identifier: Apache-2.0 */
 import * as path from "path";
 import { DependencyType, SampleDir } from "projen";
 import { JavaProject } from "projen/lib/java";
+import { JavaVersion } from "../../languages";
 import {
   CodeGenerationSourceOptions,
   GeneratedJavaHandlersOptions,
@@ -19,6 +20,7 @@ import {
   TypeSafeApiScript,
 } from "../components/utils";
 import { GeneratedJavaRuntimeProject } from "../runtime/generated-java-runtime-project";
+import { RuntimeVersionUtils } from "../runtime-version-utils";
 
 export interface GeneratedJavaHandlersProjectOptions
   extends GeneratedJavaHandlersOptions,
@@ -53,14 +55,23 @@ export class GeneratedJavaHandlersProject extends JavaProject {
    */
   public readonly packageName: string;
 
+  /**
+   * Java runtime version for the handlers
+   */
+  public readonly runtimeVersion: JavaVersion;
+
   constructor(options: GeneratedJavaHandlersProjectOptions) {
     super({
       sample: false,
       junit: false,
+      compileOptions: RuntimeVersionUtils.JAVA.getMavenCompileOptions(
+        options.runtimeVersion
+      ),
       ...(options as any),
     });
     TypeSafeApiCommandEnvironment.ensure(this);
     this.options = options;
+    this.runtimeVersion = options.runtimeVersion ?? JavaVersion.JAVA_17;
     this.packageName = `${this.pom.groupId}.${this.name}.handlers`;
     this.srcDir = path.join(
       "src",

--- a/packages/type-safe-api/src/project/codegen/runtime-version-utils.ts
+++ b/packages/type-safe-api/src/project/codegen/runtime-version-utils.ts
@@ -1,0 +1,160 @@
+/*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0 */
+import { MavenCompileOptions } from "projen/lib/java";
+import { JavaVersion, NodeVersion, PythonVersion } from "../languages";
+
+/**
+ * Utilities for java runtime versions
+ */
+class JavaRuntimeVersionUtils {
+  /**
+   * Get the maven compile options for the given java runtime
+   */
+  public static getMavenCompileOptions = (
+    runtimeVersion?: JavaVersion
+  ): MavenCompileOptions => {
+    switch (runtimeVersion) {
+      case JavaVersion.JAVA_21:
+        return { source: "21", target: "21" };
+      case JavaVersion.JAVA_17:
+        return { source: "17", target: "17" };
+      case JavaVersion.JAVA_11:
+        return { source: "11", target: "11" };
+      case JavaVersion.JAVA_8:
+      case undefined: // For backwards compatibility the default source and compile target version is Java 8, running on the Java 17 runtime
+        return { source: "1.8", target: "1.8" };
+      default:
+        throw new Error(`Unsupported runtime version ${runtimeVersion}`);
+    }
+  };
+
+  /**
+   * Return the CDK lambda runtime constant for the given java version
+   * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda.Runtime.html
+   */
+  public static getLambdaRuntime = (runtimeVersion: JavaVersion): string => {
+    switch (runtimeVersion) {
+      case JavaVersion.JAVA_8:
+        return "JAVA_8_CORRETTO";
+      case JavaVersion.JAVA_11:
+        return "JAVA_11";
+      case JavaVersion.JAVA_17:
+        return "JAVA_17";
+      case JavaVersion.JAVA_21:
+        return "JAVA_21";
+      default:
+        throw new Error(`Unsupported java runtime ${runtimeVersion}`);
+    }
+  };
+}
+
+/**
+ * Utilities for node runtime versions
+ */
+class NodeRuntimeVersionUtils {
+  /**
+   * Return the CDK lambda runtime constant for the given node version
+   * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda.Runtime.html
+   */
+  public static getLambdaRuntime = (runtimeVersion: NodeVersion): string => {
+    switch (runtimeVersion) {
+      case NodeVersion.NODE_18:
+        return "NODEJS_18_X";
+      case NodeVersion.NODE_20:
+        return "NODEJS_20_X";
+      default:
+        throw new Error(`Unsupported node runtime ${runtimeVersion}`);
+    }
+  };
+
+  /**
+   * Return the target node version for esbuild
+   * @see https://esbuild.github.io/api/#target
+   */
+  public static getEsbuildNodeTarget = (
+    runtimeVersion: NodeVersion
+  ): string => {
+    switch (runtimeVersion) {
+      case NodeVersion.NODE_20:
+        return "node20";
+      case NodeVersion.NODE_18:
+        return "node18";
+      default:
+        throw new Error(`Unsupported node runtime ${runtimeVersion}`);
+    }
+  };
+}
+
+/**
+ * Utilities for python runtime versions
+ */
+class PythonRuntimeVersionUtils {
+  /**
+   * Return the CDK lambda runtime constant for the given python version
+   * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda.Runtime.html
+   */
+  public static getLambdaRuntime = (runtimeVersion: PythonVersion): string => {
+    switch (runtimeVersion) {
+      case PythonVersion.PYTHON_3_11:
+        return "PYTHON_3_11";
+      case PythonVersion.PYTHON_3_12:
+        return "PYTHON_3_12";
+      default:
+        throw new Error(`Unsupported python runtime ${runtimeVersion}`);
+    }
+  };
+
+  /**
+   * Return the version string used for a dependency on python
+   */
+  public static getPythonDependencyVersion = (
+    runtimeVersion: PythonVersion
+  ): string => {
+    return `python@^${PythonRuntimeVersionUtils.getPythonVersionString(
+      runtimeVersion
+    )}`;
+  };
+
+  /**
+   * Return the version string used for packaging python lambdas with pip
+   */
+  public static getPipPackagingPythonVersion = (
+    runtimeVersion: PythonVersion
+  ): string => {
+    return PythonRuntimeVersionUtils.getPythonVersionString(runtimeVersion);
+  };
+
+  /**
+   * Return the version string for python
+   */
+  private static getPythonVersionString = (
+    runtimeVersion: PythonVersion
+  ): string => {
+    switch (runtimeVersion) {
+      case PythonVersion.PYTHON_3_12:
+        return "3.12";
+      case PythonVersion.PYTHON_3_11:
+        return "3.11";
+      default:
+        throw new Error(`Unsupported python runtime ${runtimeVersion}`);
+    }
+  };
+}
+
+/**
+ * A collection of utilities for runtime versions.
+ */
+export class RuntimeVersionUtils {
+  /**
+   * Java utilities
+   */
+  public static JAVA = JavaRuntimeVersionUtils;
+  /**
+   * Node utilities
+   */
+  public static NODE = NodeRuntimeVersionUtils;
+  /**
+   * Python utilities
+   */
+  public static PYTHON = PythonRuntimeVersionUtils;
+}

--- a/packages/type-safe-api/src/project/languages.ts
+++ b/packages/type-safe-api/src/project/languages.ts
@@ -10,6 +10,32 @@ export enum Language {
 }
 
 /**
+ * Versions of node
+ */
+export enum NodeVersion {
+  NODE_18 = "NODE_18",
+  NODE_20 = "NODE_20",
+}
+
+/**
+ * Versions of java
+ */
+export enum JavaVersion {
+  JAVA_8 = "JAVA_8",
+  JAVA_11 = "JAVA_11",
+  JAVA_17 = "JAVA_17",
+  JAVA_21 = "JAVA_21",
+}
+
+/**
+ * Versions of python
+ */
+export enum PythonVersion {
+  PYTHON_3_11 = "PYTHON_3_11",
+  PYTHON_3_12 = "PYTHON_3_12",
+}
+
+/**
  * Supported libraries for code generation
  */
 export enum Library {

--- a/packages/type-safe-api/src/project/types.ts
+++ b/packages/type-safe-api/src/project/types.ts
@@ -5,6 +5,7 @@ import { JavaProject } from "projen/lib/java";
 import { PythonProject } from "projen/lib/python";
 import { TypeScriptProject } from "projen/lib/typescript";
 import { JavaProjectOptions } from "./java-project-options";
+import { JavaVersion, NodeVersion, PythonVersion } from "./languages";
 import { SmithyBuildOptions } from "./model/smithy/types";
 import { PythonProjectOptions } from "./python-project-options";
 import { TypeScriptProjectOptions } from "./typescript-project-options";
@@ -238,6 +239,12 @@ export interface GeneratedTypeScriptHandlersOptions
    * @default src/*.ts - all files directly under the src directory
    */
   readonly handlerEntryPoints?: string[];
+
+  /**
+   * Runtime version to target for the handlers
+   * @default NodeVersion.NODE_18
+   */
+  readonly runtimeVersion?: NodeVersion;
 }
 
 /**
@@ -253,6 +260,12 @@ export interface GeneratedPythonHandlersOptions
    * @default Architecture.X86_64
    */
   readonly architecture?: Architecture;
+
+  /**
+   * Runtime version to target for the handlers
+   * @default PythonVersion.PYTHON_3_11
+   */
+  readonly runtimeVersion?: PythonVersion;
 }
 
 /**
@@ -260,7 +273,13 @@ export interface GeneratedPythonHandlersOptions
  */
 export interface GeneratedJavaHandlersOptions
   extends JavaProjectOptions,
-    GeneratedWithOpenApiGeneratorOptions {}
+    GeneratedWithOpenApiGeneratorOptions {
+  /**
+   * Runtime version to target for the handlers
+   * @default JavaVersion.JAVA_17
+   */
+  readonly runtimeVersion?: JavaVersion;
+}
 
 /**
  * Options for configuring a generated typescript hooks library project

--- a/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
@@ -867,7 +867,7 @@ src
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator java --spec-path ../../../model/.api.json --output-path . --generator-dir java-cdk-infrastructure --src-dir src/main/java/com/generated/api/openapijavajavainfra/infra --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-infrastructure-package":"com.generated.api.openapijavajavainfra.infra","x-runtime-package":"com.generated.api.openapijavajavaruntime.runtime","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}'",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator java --spec-path ../../../model/.api.json --output-path . --generator-dir java-cdk-infrastructure --src-dir src/main/java/com/generated/api/openapijavajavainfra/infra --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-infrastructure-package":"com.generated.api.openapijavajavainfra.infra","x-runtime-package":"com.generated.api.openapijavajavaruntime.runtime","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}'",
           },
           {
             "exec": "mkdir -p src/main/resources",
@@ -4905,7 +4905,7 @@ src
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator java --spec-path ../../../model/.api.json --output-path . --generator-dir java-cdk-infrastructure --src-dir src/main/java/com/generated/api/openapijavajavainfra/infra --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-infrastructure-package":"com.generated.api.openapijavajavainfra.infra","x-runtime-package":"com.generated.api.openapijavajavaruntime.runtime","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}'",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator java --spec-path ../../../model/.api.json --output-path . --generator-dir java-cdk-infrastructure --src-dir src/main/java/com/generated/api/openapijavajavainfra/infra --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-infrastructure-package":"com.generated.api.openapijavajavainfra.infra","x-runtime-package":"com.generated.api.openapijavajavaruntime.runtime","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}'",
           },
           {
             "exec": "mkdir -p src/main/resources",
@@ -8171,7 +8171,7 @@ mocks
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator python-nextgen --spec-path ../../../model/.api.json --output-path . --generator-dir python-cdk-infrastructure --src-dir openapi_python_python_infra --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-module-name":"openapi_python_python_runtime","x-relative-spec-path":"../../../../model/.api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}' --generate-alias-as-model",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator python-nextgen --spec-path ../../../model/.api.json --output-path . --generator-dir python-cdk-infrastructure --src-dir openapi_python_python_infra --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-module-name":"openapi_python_python_runtime","x-relative-spec-path":"../../../../model/.api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}' --generate-alias-as-model",
           },
           {
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate-mock-data --spec-path ../../../model/.api.json --output-path .",
@@ -12105,7 +12105,7 @@ mocks
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator python-nextgen --spec-path ../../../model/.api.json --output-path . --generator-dir python-cdk-infrastructure --src-dir openapi_python_python_infra --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-module-name":"openapi_python_python_runtime","x-relative-spec-path":"../../../../model/.api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}' --generate-alias-as-model",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator python-nextgen --spec-path ../../../model/.api.json --output-path . --generator-dir python-cdk-infrastructure --src-dir openapi_python_python_infra --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-module-name":"openapi_python_python_runtime","x-relative-spec-path":"../../../../model/.api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}' --generate-alias-as-model",
           },
           {
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate-mock-data --spec-path ../../../model/.api.json --output-path .",
@@ -15306,7 +15306,7 @@ mocks
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"openapi-typescript-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}' --generate-alias-as-model",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"openapi-typescript-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}' --generate-alias-as-model",
           },
           {
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate-mock-data --spec-path ../../../model/.api.json --output-path .",
@@ -19563,7 +19563,7 @@ mocks
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"openapi-typescript-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}' --generate-alias-as-model",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"openapi-typescript-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}' --generate-alias-as-model",
           },
           {
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate-mock-data --spec-path ../../../model/.api.json --output-path .",
@@ -22649,7 +22649,7 @@ mocks
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-handlers-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"smithy_handlers_python_handlers","x-handlers-java-package":"com.generated.api.smithyhandlersjavahandlers.handlers","x-handlers-typescript-asset-path":"../../../handlers/typescript/dist/lambda","x-handlers-python-asset-path":"../../../handlers/python/dist/lambda","x-handlers-java-asset-path":"../../../handlers/java/dist/java/com/generated/api/smithy-handlers-java-handlers/0.0.0/smithy-handlers-java-handlers-0.0.0.jar"}' --generate-alias-as-model",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-handlers-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"smithy_handlers_python_handlers","x-handlers-java-package":"com.generated.api.smithyhandlersjavahandlers.handlers","x-handlers-typescript-asset-path":"../../../handlers/typescript/dist/lambda","x-handlers-python-asset-path":"../../../handlers/python/dist/lambda","x-handlers-java-asset-path":"../../../handlers/java/dist/java/com/generated/api/smithy-handlers-java-handlers/0.0.0/smithy-handlers-java-handlers-0.0.0.jar","x-handlers-node-lambda-runtime-version":"NODEJS_18_X","x-handlers-python-lambda-runtime-version":"PYTHON_3_11","x-handlers-java-lambda-runtime-version":"JAVA_17"}' --generate-alias-as-model",
           },
           {
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate-mock-data --spec-path ../../../model/.api.json --output-path .",
@@ -25441,7 +25441,7 @@ cython_debug/
             "exec": "poetry export --without-hashes --format=requirements.txt > dist/lambda/requirements.txt",
           },
           {
-            "exec": "pip install -r dist/lambda/requirements.txt --target dist/lambda --upgrade --platform manylinux2014_x86_64 --only-binary :all:",
+            "exec": "pip install -r dist/lambda/requirements.txt --target dist/lambda --upgrade --platform manylinux2014_x86_64 --only-binary :all: --python-version 3.11",
           },
         ],
       },
@@ -26131,7 +26131,7 @@ junit.xml
             "exec": "mkdir -p dist/lambda && rm -rf dist/lambda/*",
           },
           {
-            "exec": "esbuild --bundle src/*.ts --platform=node --outdir=dist/lambda",
+            "exec": "esbuild --bundle src/*.ts --platform=node --outdir=dist/lambda --target=node18",
           },
           {
             "exec": "for f in $(ls dist/lambda); do mkdir dist/lambda/$(basename $f .js) && mv dist/lambda/$f dist/lambda/$(basename $f .js)/index.js; done",
@@ -27435,7 +27435,7 @@ mocks
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-typescript-react-query-hooks-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}' --generate-alias-as-model",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-typescript-react-query-hooks-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}' --generate-alias-as-model",
           },
           {
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate-mock-data --spec-path ../../../model/.api.json --output-path .",
@@ -30384,7 +30384,7 @@ src
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator java --spec-path ../../../model/.api.json --output-path . --generator-dir java-cdk-infrastructure --src-dir src/main/java/com/generated/api/smithyjavajavainfra/infra --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-infrastructure-package":"com.generated.api.smithyjavajavainfra.infra","x-runtime-package":"com.generated.api.smithyjavajavaruntime.runtime","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}'",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator java --spec-path ../../../model/.api.json --output-path . --generator-dir java-cdk-infrastructure --src-dir src/main/java/com/generated/api/smithyjavajavainfra/infra --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-infrastructure-package":"com.generated.api.smithyjavajavainfra.infra","x-runtime-package":"com.generated.api.smithyjavajavaruntime.runtime","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}'",
           },
           {
             "exec": "mkdir -p src/main/resources",
@@ -34515,7 +34515,7 @@ src
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator java --spec-path ../../../model/.api.json --output-path . --generator-dir java-cdk-infrastructure --src-dir src/main/java/com/generated/api/smithyjavajavainfra/infra --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-infrastructure-package":"com.generated.api.smithyjavajavainfra.infra","x-runtime-package":"com.generated.api.smithyjavajavaruntime.runtime","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}'",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator java --spec-path ../../../model/.api.json --output-path . --generator-dir java-cdk-infrastructure --src-dir src/main/java/com/generated/api/smithyjavajavainfra/infra --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-infrastructure-package":"com.generated.api.smithyjavajavainfra.infra","x-runtime-package":"com.generated.api.smithyjavajavaruntime.runtime","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}'",
           },
           {
             "exec": "mkdir -p src/main/resources",
@@ -37868,7 +37868,7 @@ mocks
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-npm-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}' --generate-alias-as-model",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-npm-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}' --generate-alias-as-model",
           },
           {
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate-mock-data --spec-path ../../../model/.api.json --output-path .",
@@ -41321,7 +41321,7 @@ mocks
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-npm-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}' --generate-alias-as-model",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-npm-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}' --generate-alias-as-model",
           },
           {
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate-mock-data --spec-path ../../../model/.api.json --output-path .",
@@ -43890,7 +43890,7 @@ resolution-mode=highest
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-pnpm-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}' --generate-alias-as-model",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-pnpm-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}' --generate-alias-as-model",
           },
           {
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate-mock-data --spec-path ../../../model/.api.json --output-path .",
@@ -47358,7 +47358,7 @@ mocks
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-pnpm-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}' --generate-alias-as-model",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-pnpm-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}' --generate-alias-as-model",
           },
           {
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate-mock-data --spec-path ../../../model/.api.json --output-path .",
@@ -49934,7 +49934,7 @@ mocks
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator python-nextgen --spec-path ../../../model/.api.json --output-path . --generator-dir python-cdk-infrastructure --src-dir smithy_python_python_infra --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-module-name":"smithy_python_python_runtime","x-relative-spec-path":"../../../../model/.api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}' --generate-alias-as-model",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator python-nextgen --spec-path ../../../model/.api.json --output-path . --generator-dir python-cdk-infrastructure --src-dir smithy_python_python_infra --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-module-name":"smithy_python_python_runtime","x-relative-spec-path":"../../../../model/.api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}' --generate-alias-as-model",
           },
           {
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate-mock-data --spec-path ../../../model/.api.json --output-path .",
@@ -53961,7 +53961,7 @@ mocks
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator python-nextgen --spec-path ../../../model/.api.json --output-path . --generator-dir python-cdk-infrastructure --src-dir smithy_python_python_infra --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-module-name":"smithy_python_python_runtime","x-relative-spec-path":"../../../../model/.api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}' --generate-alias-as-model",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator python-nextgen --spec-path ../../../model/.api.json --output-path . --generator-dir python-cdk-infrastructure --src-dir smithy_python_python_infra --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-module-name":"smithy_python_python_runtime","x-relative-spec-path":"../../../../model/.api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}' --generate-alias-as-model",
           },
           {
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate-mock-data --spec-path ../../../model/.api.json --output-path .",
@@ -57255,7 +57255,7 @@ mocks
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-typescript-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}' --generate-alias-as-model",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-typescript-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}' --generate-alias-as-model",
           },
           {
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate-mock-data --spec-path ../../../model/.api.json --output-path .",
@@ -61605,7 +61605,7 @@ mocks
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-typescript-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}' --generate-alias-as-model",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-typescript-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}' --generate-alias-as-model",
           },
           {
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate-mock-data --spec-path ../../../model/.api.json --output-path .",
@@ -65218,7 +65218,7 @@ mocks
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-yarn-berry-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}' --generate-alias-as-model",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-yarn-berry-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}' --generate-alias-as-model",
           },
           {
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate-mock-data --spec-path ../../../model/.api.json --output-path .",
@@ -68711,7 +68711,7 @@ mocks
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-yarn-berry-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}' --generate-alias-as-model",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-yarn-berry-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}' --generate-alias-as-model",
           },
           {
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate-mock-data --spec-path ../../../model/.api.json --output-path .",
@@ -71297,7 +71297,7 @@ mocks
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-yarn-classic-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}' --generate-alias-as-model",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-yarn-classic-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}' --generate-alias-as-model",
           },
           {
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate-mock-data --spec-path ../../../model/.api.json --output-path .",
@@ -74751,7 +74751,7 @@ mocks
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-yarn-classic-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}' --generate-alias-as-model",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path ../../../model/.api.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"smithy-yarn-classic-typescript-runtime","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}' --generate-alias-as-model",
           },
           {
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate-mock-data --spec-path ../../../model/.api.json --output-path .",

--- a/packages/type-safe-api/test/project/codegen/__snapshots__/runtime-version-utils.test.ts.snap
+++ b/packages/type-safe-api/test/project/codegen/__snapshots__/runtime-version-utils.test.ts.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RuntimeVersionUtils Java maps maven compile options for JAVA_8 1`] = `
+{
+  "source": "1.8",
+  "target": "1.8",
+}
+`;
+
+exports[`RuntimeVersionUtils Java maps maven compile options for JAVA_11 1`] = `
+{
+  "source": "11",
+  "target": "11",
+}
+`;
+
+exports[`RuntimeVersionUtils Java maps maven compile options for JAVA_17 1`] = `
+{
+  "source": "17",
+  "target": "17",
+}
+`;
+
+exports[`RuntimeVersionUtils Java maps maven compile options for JAVA_21 1`] = `
+{
+  "source": "21",
+  "target": "21",
+}
+`;
+
+exports[`RuntimeVersionUtils Java maps the lambda runtime version for JAVA_8 1`] = `"JAVA_8_CORRETTO"`;
+
+exports[`RuntimeVersionUtils Java maps the lambda runtime version for JAVA_11 1`] = `"JAVA_11"`;
+
+exports[`RuntimeVersionUtils Java maps the lambda runtime version for JAVA_17 1`] = `"JAVA_17"`;
+
+exports[`RuntimeVersionUtils Java maps the lambda runtime version for JAVA_21 1`] = `"JAVA_21"`;
+
+exports[`RuntimeVersionUtils Node maps the esbuild target for NODE_18 1`] = `"node18"`;
+
+exports[`RuntimeVersionUtils Node maps the esbuild target for NODE_20 1`] = `"node20"`;
+
+exports[`RuntimeVersionUtils Node maps the lambda runtime version for NODE_18 1`] = `"NODEJS_18_X"`;
+
+exports[`RuntimeVersionUtils Node maps the lambda runtime version for NODE_20 1`] = `"NODEJS_20_X"`;
+
+exports[`RuntimeVersionUtils Python maps the lambda runtime version for PYTHON_3_11 1`] = `"PYTHON_3_11"`;
+
+exports[`RuntimeVersionUtils Python maps the lambda runtime version for PYTHON_3_12 1`] = `"PYTHON_3_12"`;
+
+exports[`RuntimeVersionUtils Python maps the pip packaging python version for PYTHON_3_11 1`] = `"3.11"`;
+
+exports[`RuntimeVersionUtils Python maps the pip packaging python version for PYTHON_3_12 1`] = `"3.12"`;
+
+exports[`RuntimeVersionUtils Python maps the python dependency version for PYTHON_3_11 1`] = `"python@^3.11"`;
+
+exports[`RuntimeVersionUtils Python maps the python dependency version for PYTHON_3_12 1`] = `"python@^3.12"`;

--- a/packages/type-safe-api/test/project/codegen/handlers/__snapshots__/generated-python-handlers-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/codegen/handlers/__snapshots__/generated-python-handlers-project.test.ts.snap
@@ -314,7 +314,7 @@ cython_debug/
             "exec": "poetry export --without-hashes --format=requirements.txt > dist/lambda/requirements.txt",
           },
           {
-            "exec": "pip install -r dist/lambda/requirements.txt --target dist/lambda --upgrade --platform manylinux2014_x86_64 --only-binary :all:",
+            "exec": "pip install -r dist/lambda/requirements.txt --target dist/lambda --upgrade --platform manylinux2014_x86_64 --only-binary :all: --python-version 3.11",
           },
         ],
       },

--- a/packages/type-safe-api/test/project/codegen/handlers/__snapshots__/generated-typescript-handlers-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/codegen/handlers/__snapshots__/generated-typescript-handlers-project.test.ts.snap
@@ -896,7 +896,7 @@ pull_request_rules:
             "exec": "mkdir -p dist/lambda && rm -rf dist/lambda/*",
           },
           {
-            "exec": "esbuild --bundle src/*.ts --platform=node --outdir=dist/lambda",
+            "exec": "esbuild --bundle src/*.ts --platform=node --outdir=dist/lambda --target=node18",
           },
           {
             "exec": "for f in $(ls dist/lambda); do mkdir dist/lambda/$(basename $f .js) && mv dist/lambda/$f dist/lambda/$(basename $f .js)/index.js; done",

--- a/packages/type-safe-api/test/project/codegen/infrastructure/cdk/__snapshots__/generated-java-cdk-infrastructure-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/codegen/infrastructure/cdk/__snapshots__/generated-java-cdk-infrastructure-project.test.ts.snap
@@ -340,7 +340,7 @@ src
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator java --spec-path my-spec.json --output-path . --generator-dir java-cdk-infrastructure --src-dir src/main/java/test/test-java-infra/infra --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-infrastructure-package":"test.test-java-infra.infra","x-runtime-package":"test.test-java-client.runtime","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}'",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator java --spec-path my-spec.json --output-path . --generator-dir java-cdk-infrastructure --src-dir src/main/java/test/test-java-infra/infra --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-infrastructure-package":"test.test-java-infra.infra","x-runtime-package":"test.test-java-client.runtime","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}'",
           },
           {
             "exec": "mkdir -p src/main/resources",

--- a/packages/type-safe-api/test/project/codegen/infrastructure/cdk/__snapshots__/generated-python-cdk-infrastructure-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/codegen/infrastructure/cdk/__snapshots__/generated-python-cdk-infrastructure-project.test.ts.snap
@@ -303,7 +303,7 @@ mocks
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator python-nextgen --spec-path my-spec.json --output-path . --generator-dir python-cdk-infrastructure --src-dir test_infra --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-module-name":"test_client","x-relative-spec-path":"../my-spec.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}' --generate-alias-as-model",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator python-nextgen --spec-path my-spec.json --output-path . --generator-dir python-cdk-infrastructure --src-dir test_infra --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-module-name":"test_client","x-relative-spec-path":"../my-spec.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}' --generate-alias-as-model",
           },
           {
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate-mock-data --spec-path my-spec.json --output-path .",

--- a/packages/type-safe-api/test/project/codegen/infrastructure/cdk/__snapshots__/generated-typescript-cdk-infrastructure-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/codegen/infrastructure/cdk/__snapshots__/generated-typescript-cdk-infrastructure-project.test.ts.snap
@@ -595,7 +595,7 @@ pull_request_rules:
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.clean-openapi-generated-code --code-path .",
           },
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path my-spec.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"test-ts-client","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":""}' --generate-alias-as-model",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate --generator typescript-fetch --spec-path my-spec.json --output-path . --generator-dir typescript-cdk-infrastructure --src-dir src --tst-dir test --openapi-normalizer "KEEP_ONLY_FIRST_TAG_IN_OPERATION=true" --extra-vendor-extensions '{"x-runtime-package-name":"test-ts-client","x-relative-spec-path":"../assets/api.json","x-enable-mock-integrations":true,"x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}' --generate-alias-as-model",
           },
           {
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api.generate-mock-data --spec-path my-spec.json --output-path .",

--- a/packages/type-safe-api/test/project/codegen/runtime-version-utils.test.ts
+++ b/packages/type-safe-api/test/project/codegen/runtime-version-utils.test.ts
@@ -1,0 +1,75 @@
+/*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0 */
+import { JavaVersion, NodeVersion, PythonVersion } from "../../../src";
+import { RuntimeVersionUtils } from "../../../src/project/codegen/runtime-version-utils";
+
+describe("RuntimeVersionUtils", () => {
+  describe("Node", () => {
+    it.each(Object.values(NodeVersion))(
+      "maps the esbuild target for %s",
+      (version) => {
+        expect(
+          RuntimeVersionUtils.NODE.getEsbuildNodeTarget(version)
+        ).toMatchSnapshot();
+      }
+    );
+
+    it.each(Object.values(NodeVersion))(
+      "maps the lambda runtime version for %s",
+      (version) => {
+        expect(
+          RuntimeVersionUtils.NODE.getLambdaRuntime(version)
+        ).toMatchSnapshot();
+      }
+    );
+  });
+
+  describe("Java", () => {
+    it.each(Object.values(JavaVersion))(
+      "maps maven compile options for %s",
+      (version) => {
+        expect(
+          RuntimeVersionUtils.JAVA.getMavenCompileOptions(version)
+        ).toMatchSnapshot();
+      }
+    );
+
+    it.each(Object.values(JavaVersion))(
+      "maps the lambda runtime version for %s",
+      (version) => {
+        expect(
+          RuntimeVersionUtils.JAVA.getLambdaRuntime(version)
+        ).toMatchSnapshot();
+      }
+    );
+  });
+
+  describe("Python", () => {
+    it.each(Object.values(PythonVersion))(
+      "maps the pip packaging python version for %s",
+      (version) => {
+        expect(
+          RuntimeVersionUtils.PYTHON.getPipPackagingPythonVersion(version)
+        ).toMatchSnapshot();
+      }
+    );
+
+    it.each(Object.values(PythonVersion))(
+      "maps the python dependency version for %s",
+      (version) => {
+        expect(
+          RuntimeVersionUtils.PYTHON.getPythonDependencyVersion(version)
+        ).toMatchSnapshot();
+      }
+    );
+
+    it.each(Object.values(PythonVersion))(
+      "maps the lambda runtime version for %s",
+      (version) => {
+        expect(
+          RuntimeVersionUtils.PYTHON.getLambdaRuntime(version)
+        ).toMatchSnapshot();
+      }
+    );
+  });
+});


### PR DESCRIPTION
Users can now specify the runtime version for python, java and typescript (node) lambda handlers. As well as the lambda runtime version, this configures settings for the project itself to target that particular runtime, and is therefore configured in the projenrc.

Fixes #672
