### PR TITLE
fix: do no fail silently when issues occur during publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
           path: dist
       - name: Release
         working-directory: dist/packages/pdk
-        run: pnpm --package publib@latest dlx publib-npm || echo "Ignore `basename $PWD` - no dist/js"
+        run: pnpm --package publib@latest dlx publib-npm
         env:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
@@ -123,7 +123,7 @@ jobs:
           path: dist
       - name: Release
         working-directory: dist/packages/pdk
-        run: pnpm --package publib@latest dlx publib-maven || echo "Ignore `basename $PWD` - no dist/java"
+        run: pnpm --package publib@latest dlx publib-maven
         env:
           MAVEN_ENDPOINT: https://aws.oss.sonatype.org
           MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
@@ -155,7 +155,7 @@ jobs:
           path: dist
       - name: Release
         working-directory: dist/packages/pdk
-        run: pnpm --package publib@latest dlx publib-pypi || echo "Ignore `basename $PWD` - no dist/python"
+        run: pnpm --package publib@latest dlx publib-pypi
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}


### PR DESCRIPTION
The release workflow is succeeding even though there are issues when publishing to package managers. This is due to the fact that errors were being swallowed due to legacy code that had not been removed. This PR ensures that the respective publish commands do not fail silently anymore.

With respect to the PYPI issue, this is not a bug on our side but rather a limitation on the project size on the PYPI side (default 10GB limit for all releases). I have raised this issue to have this increased to 50Gb: https://github.com/pypi/support/issues/3558

Longer term, we may need to throttle python releases to once per week/month in order to slow the rate at which we will consume this limit.

fix #689 