### PR TITLE
chore(docs): fix typo and incorrect comments; add consuming local pdk guide

### DIFF
--- a/docs/content/contributing/index.md
+++ b/docs/content/contributing/index.md
@@ -7,7 +7,7 @@ Please read through this document before submitting any issues or pull requests 
 ## Getting Started
 
 Fork the repository and clone it to your local machine.
-```console
+```
 $ pnpm i && pnpm build
 ```
 
@@ -137,6 +137,34 @@ describe("<MyPackage> Unit Tests", () => {
   });
 });
 ```
+
+#### Consuming local PDK in a test project
+
+Firstly, go to directory `packages/pdk` and run a build `pnpm build`, and then go to directory `packages/pdk/dist/js` and extract package in artifact (something like `pdk@0.0.0.jsii.tgz`) there, so `package` folder and the `.tgz` file are in the same directory.
+
+Secondly, in the test project's `.projenrc.ts`, add to the `devDeps` and package resolution like below and run `pdk` to install the local PDK package:
+
+```ts
+const monorepo = new MonorepoTsProject({
+  packageManager: NodePackageManager.PNPM,
+  devDeps: [
+    "@aws/pdk@file:/path/to/pdk/packages/pdk/dist/js/package",
+  ],
+  name: "test",
+  projenrcTs: true,
+});
+
+monorepo.package.addPackageResolutions("@aws/pdk@file:/path/to/pdk/packages/pdk/dist/js/package");
+```
+
+Lastly, you could import the local PDK in your test project.
+
+```ts
+import { monorepo, my_package } from "@aws/pdk";
+
+const myProject = new my_package.MyPackageProject(...);
+```
+
 
 ## Reporting Bugs/Feature Requests
 

--- a/docs/content/contributing/index.md
+++ b/docs/content/contributing/index.md
@@ -4,6 +4,13 @@ Thank you for your interest in contributing to the AWS PDK. Whether it's a bug r
 
 Please read through this document before submitting any issues or pull requests to ensure we have all the necessary information to effectively respond to your bug report or contribution.
 
+## Getting Started
+
+Fork the repository and clone it to your local machine.
+```console
+$ pnpm i && pnpm build
+```
+
 ## Project Structure
 
 The structure of this project is as follows:

--- a/docs/content/getting_started/index.md
+++ b/docs/content/getting_started/index.md
@@ -158,7 +158,7 @@ All AWS PDK developers, even those working in Python or Java, need Node.js 16 or
 
 ### PDK CLI
 
-Once your NodeJs ruuntime is set up, run the following command to install the pdk CLI:
+Once your NodeJs runtime is set up, run the following command to install the pdk CLI:
 
 ```bash
 npm install -g @aws/pdk

--- a/packages/infrastructure/src/projects/java/infrastructure-java-project.ts
+++ b/packages/infrastructure/src/projects/java/infrastructure-java-project.ts
@@ -47,7 +47,7 @@ export interface InfrastructureJavaProjectOptions extends AwsCdkJavaAppOptions {
 }
 
 /**
- * Synthesizes a Infrastructure Typescript Project.
+ * Synthesizes a Infrastructure Java Project.
  */
 export class InfrastructureJavaProject extends AwsCdkJavaApp {
   constructor(options: InfrastructureJavaProjectOptions) {


### PR DESCRIPTION
Fixes #
typo and incorrect comments
add readme steps to consuming local PDK in a test project