### PR TITLE
fix(cloudscape-react-ts-website): fix missing client error when using generated hooks

### DIFF
--- a/packages/cloudscape-react-ts-website/samples/cloudscape-react-ts-website/src/hooks/useTypeSafeApiClient.ts.mustache
+++ b/packages/cloudscape-react-ts-website/samples/cloudscape-react-ts-website/src/hooks/useTypeSafeApiClient.ts.mustache
@@ -11,7 +11,7 @@ export const use{{{apiNameSafe}}}ApiClient = () => {
   const runtimeContext = useContext(RuntimeConfigContext);
 
   return useMemo(() => {
-    return runtimeContext?.apiUrl
+    return runtimeContext?.typeSafeApis?.["{{{apiName}}}"]
       ? new {{{apiNameSafe}}}Api(
           new {{{apiNameSafe}}}ApiConfiguration({
             basePath: runtimeContext.typeSafeApis["{{{apiName}}}"],
@@ -19,6 +19,6 @@ export const use{{{apiNameSafe}}}ApiClient = () => {
           })
         )
       : undefined;
-  }, [client, runtimeContext?.typeSafeApis["{{{apiName}}}"]]);
+  }, [client, runtimeContext?.typeSafeApis?.["{{{apiName}}}"]]);
 };
 {{/typeSafeApis}}

--- a/packages/cloudscape-react-ts-website/test/__snapshots__/cloudscape-react-ts-website-project.test.ts.snap
+++ b/packages/cloudscape-react-ts-website/test/__snapshots__/cloudscape-react-ts-website-project.test.ts.snap
@@ -4037,7 +4037,7 @@ export const useMyServiceApiClient = () => {
   const runtimeContext = useContext(RuntimeConfigContext);
 
   return useMemo(() => {
-    return runtimeContext?.apiUrl
+    return runtimeContext?.typeSafeApis?.["MyService"]
       ? new MyServiceApi(
           new MyServiceApiConfiguration({
             basePath: runtimeContext.typeSafeApis["MyService"],
@@ -4045,7 +4045,7 @@ export const useMyServiceApiClient = () => {
           })
         )
       : undefined;
-  }, [client, runtimeContext?.typeSafeApis["MyService"]]);
+  }, [client, runtimeContext?.typeSafeApis?.["MyService"]]);
 };
 ",
   "src/index.tsx": "/*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.


### PR DESCRIPTION
Website generated code was expecting the old `apiUrl` in runtime context, which was replaced in favour of `typeSafeApis` for multiple api support.