### PR TITLE
fix(cdk-graph-plugin-threat-composer): use smaller svg diagram to avoid size limit

### DIFF
--- a/packages/cdk-graph-plugin-threat-composer/src/plugin.ts
+++ b/packages/cdk-graph-plugin-threat-composer/src/plugin.ts
@@ -95,12 +95,12 @@ export class CdkGraphThreatComposerPlugin implements ICdkGraphPlugin {
     let architectureImageDataUri: string | undefined = undefined;
 
     const architectureDiagramArtifact: CdkGraphArtifact | undefined =
-      context.artifacts.DIAGRAM_PNG;
+      context.artifacts.DIAGRAM_SVG;
     if (architectureDiagramArtifact) {
       const diagramBinaryContent = fs.readFileSync(
         architectureDiagramArtifact.filepath
       );
-      architectureImageDataUri = `data:image/png;base64,${diagramBinaryContent.toString(
+      architectureImageDataUri = `data:image/svg+xml;base64,${diagramBinaryContent.toString(
         "base64"
       )}`;
     }


### PR DESCRIPTION
Embed the svg diagram into the generated threat model instead of the png as it is much smaller, and does not exceed threat composer's 1MB image size limit.

Fixes #721
