### PR TITLE
fix: remove env from generated infra sample code

### DIFF
--- a/packages/infrastructure/samples/infrastructure/java/src/java/groupId/Main.java.mustache
+++ b/packages/infrastructure/samples/infrastructure/java/src/java/groupId/Main.java.mustache
@@ -19,8 +19,6 @@ import {{{groupId}}}.stacks.ApplicationStack;
 import java.util.Arrays;
 
 import software.amazon.awscdk.App;
-import software.amazon.awscdk.Environment;
-import software.amazon.awscdk.StackProps;
 
 public class Main {
   public static void main(final String[] args) {
@@ -28,12 +26,7 @@ public class Main {
         .nagPacks(Arrays.asList(new AwsPrototypingChecks()))
         .build());
 
-    new ApplicationStack(app, "{{{stackName}}}", StackProps.builder()
-        .env(Environment.builder()
-            .account(System.getenv("CDK_DEFAULT_ACCOUNT"))
-            .region(System.getenv("CDK_DEFAULT_REGION"))
-            .build())
-        .build());
+    new ApplicationStack(app, "{{{stackName}}}");
 
     CdkGraph graph = new CdkGraph(app, ICdkGraphProps.builder()
         .plugins(Arrays.asList(

--- a/packages/infrastructure/samples/infrastructure/python/src/main.py.mustache
+++ b/packages/infrastructure/samples/infrastructure/python/src/main.py.mustache
@@ -1,19 +1,12 @@
 import os
-from aws_cdk import Environment
 from aws_pdk.cdk_graph import CdkGraph, FilterPreset, Filters, IFilter, IGraphFilterPlan
 from aws_pdk.cdk_graph_plugin_diagram import CdkGraphDiagramPlugin, IDiagramConfigBase
 from aws_pdk.cdk_graph_plugin_threat_composer import CdkGraphThreatComposerPlugin
 from aws_pdk.pdk_nag import PDKNag, AwsPrototypingChecks
 from {{{moduleName}}}.stacks.application_stack import ApplicationStack
 
-# for development, use account/region from cdk cli
-dev_env = Environment(
-  account=os.getenv('CDK_DEFAULT_ACCOUNT'),
-  region=os.getenv('CDK_DEFAULT_REGION')
-)
-
 app = PDKNag.app(nag_packs=[AwsPrototypingChecks()])
-ApplicationStack(app, "{{{stackName}}}", env=dev_env)
+ApplicationStack(app, "{{{stackName}}}")
 
 graph = CdkGraph(app, plugins=[
     CdkGraphDiagramPlugin(

--- a/packages/infrastructure/samples/infrastructure/typescript/src/main.ts.mustache
+++ b/packages/infrastructure/samples/infrastructure/typescript/src/main.ts.mustache
@@ -4,19 +4,13 @@ import { CdkGraphThreatComposerPlugin } from "@aws/pdk/cdk-graph-plugin-threat-c
 import { AwsPrototypingChecks, PDKNag } from "@aws/pdk/pdk-nag";
 import { ApplicationStack } from "./stacks/application-stack";
 
-// for development, use account/region from cdk cli
-const devEnv = {
-  account: process.env.CDK_DEFAULT_ACCOUNT,
-  region: process.env.CDK_DEFAULT_REGION,
-};
-
 /* eslint-disable @typescript-eslint/no-floating-promises */
 (async () => {
   const app = PDKNag.app({
     nagPacks: [new AwsPrototypingChecks()],
   });
 
-  new ApplicationStack(app, "{{{stackName}}}", { env: devEnv });
+  new ApplicationStack(app, "{{{stackName}}}");
 
   const graph = new CdkGraph(app, {
     plugins: [

--- a/packages/infrastructure/test/projects/java/__snapshots__/infrastructure-java-project.test.ts.snap
+++ b/packages/infrastructure/test/projects/java/__snapshots__/infrastructure-java-project.test.ts.snap
@@ -612,8 +612,6 @@ import software.aws.infra.stacks.ApplicationStack;
 import java.util.Arrays;
 
 import software.amazon.awscdk.App;
-import software.amazon.awscdk.Environment;
-import software.amazon.awscdk.StackProps;
 
 public class Main {
   public static void main(final String[] args) {
@@ -621,12 +619,7 @@ public class Main {
         .nagPacks(Arrays.asList(new AwsPrototypingChecks()))
         .build());
 
-    new ApplicationStack(app, "infra-dev", StackProps.builder()
-        .env(Environment.builder()
-            .account(System.getenv("CDK_DEFAULT_ACCOUNT"))
-            .region(System.getenv("CDK_DEFAULT_REGION"))
-            .build())
-        .build());
+    new ApplicationStack(app, "infra-dev");
 
     CdkGraph graph = new CdkGraph(app, ICdkGraphProps.builder()
         .plugins(Arrays.asList(
@@ -1544,8 +1537,6 @@ import software.aws.infra.stacks.ApplicationStack;
 import java.util.Arrays;
 
 import software.amazon.awscdk.App;
-import software.amazon.awscdk.Environment;
-import software.amazon.awscdk.StackProps;
 
 public class Main {
   public static void main(final String[] args) {
@@ -1553,12 +1544,7 @@ public class Main {
         .nagPacks(Arrays.asList(new AwsPrototypingChecks()))
         .build());
 
-    new ApplicationStack(app, "infra-dev", StackProps.builder()
-        .env(Environment.builder()
-            .account(System.getenv("CDK_DEFAULT_ACCOUNT"))
-            .region(System.getenv("CDK_DEFAULT_REGION"))
-            .build())
-        .build());
+    new ApplicationStack(app, "infra-dev");
 
     CdkGraph graph = new CdkGraph(app, ICdkGraphProps.builder()
         .plugins(Arrays.asList(
@@ -2553,8 +2539,6 @@ import software.aws.infra.stacks.ApplicationStack;
 import java.util.Arrays;
 
 import software.amazon.awscdk.App;
-import software.amazon.awscdk.Environment;
-import software.amazon.awscdk.StackProps;
 
 public class Main {
   public static void main(final String[] args) {
@@ -2562,12 +2546,7 @@ public class Main {
         .nagPacks(Arrays.asList(new AwsPrototypingChecks()))
         .build());
 
-    new ApplicationStack(app, "infra-dev", StackProps.builder()
-        .env(Environment.builder()
-            .account(System.getenv("CDK_DEFAULT_ACCOUNT"))
-            .region(System.getenv("CDK_DEFAULT_REGION"))
-            .build())
-        .build());
+    new ApplicationStack(app, "infra-dev");
 
     CdkGraph graph = new CdkGraph(app, ICdkGraphProps.builder()
         .plugins(Arrays.asList(
@@ -3627,8 +3606,6 @@ import software.aws.infra.stacks.ApplicationStack;
 import java.util.Arrays;
 
 import software.amazon.awscdk.App;
-import software.amazon.awscdk.Environment;
-import software.amazon.awscdk.StackProps;
 
 public class Main {
   public static void main(final String[] args) {
@@ -3636,12 +3613,7 @@ public class Main {
         .nagPacks(Arrays.asList(new AwsPrototypingChecks()))
         .build());
 
-    new ApplicationStack(app, "infra-dev", StackProps.builder()
-        .env(Environment.builder()
-            .account(System.getenv("CDK_DEFAULT_ACCOUNT"))
-            .region(System.getenv("CDK_DEFAULT_REGION"))
-            .build())
-        .build());
+    new ApplicationStack(app, "infra-dev");
 
     CdkGraph graph = new CdkGraph(app, ICdkGraphProps.builder()
         .plugins(Arrays.asList(
@@ -4778,8 +4750,6 @@ import software.aws.infra.stacks.ApplicationStack;
 import java.util.Arrays;
 
 import software.amazon.awscdk.App;
-import software.amazon.awscdk.Environment;
-import software.amazon.awscdk.StackProps;
 
 public class Main {
   public static void main(final String[] args) {
@@ -4787,12 +4757,7 @@ public class Main {
         .nagPacks(Arrays.asList(new AwsPrototypingChecks()))
         .build());
 
-    new ApplicationStack(app, "infra-dev", StackProps.builder()
-        .env(Environment.builder()
-            .account(System.getenv("CDK_DEFAULT_ACCOUNT"))
-            .region(System.getenv("CDK_DEFAULT_REGION"))
-            .build())
-        .build());
+    new ApplicationStack(app, "infra-dev");
 
     CdkGraph graph = new CdkGraph(app, ICdkGraphProps.builder()
         .plugins(Arrays.asList(
@@ -5968,8 +5933,6 @@ import software.aws.infra.stacks.ApplicationStack;
 import java.util.Arrays;
 
 import software.amazon.awscdk.App;
-import software.amazon.awscdk.Environment;
-import software.amazon.awscdk.StackProps;
 
 public class Main {
   public static void main(final String[] args) {
@@ -5977,12 +5940,7 @@ public class Main {
         .nagPacks(Arrays.asList(new AwsPrototypingChecks()))
         .build());
 
-    new ApplicationStack(app, "infra-dev", StackProps.builder()
-        .env(Environment.builder()
-            .account(System.getenv("CDK_DEFAULT_ACCOUNT"))
-            .region(System.getenv("CDK_DEFAULT_REGION"))
-            .build())
-        .build());
+    new ApplicationStack(app, "infra-dev");
 
     CdkGraph graph = new CdkGraph(app, ICdkGraphProps.builder()
         .plugins(Arrays.asList(
@@ -7064,8 +7022,6 @@ import software.aws.infra.stacks.ApplicationStack;
 import java.util.Arrays;
 
 import software.amazon.awscdk.App;
-import software.amazon.awscdk.Environment;
-import software.amazon.awscdk.StackProps;
 
 public class Main {
   public static void main(final String[] args) {
@@ -7073,12 +7029,7 @@ public class Main {
         .nagPacks(Arrays.asList(new AwsPrototypingChecks()))
         .build());
 
-    new ApplicationStack(app, "infra-dev", StackProps.builder()
-        .env(Environment.builder()
-            .account(System.getenv("CDK_DEFAULT_ACCOUNT"))
-            .region(System.getenv("CDK_DEFAULT_REGION"))
-            .build())
-        .build());
+    new ApplicationStack(app, "infra-dev");
 
     CdkGraph graph = new CdkGraph(app, ICdkGraphProps.builder()
         .plugins(Arrays.asList(

--- a/packages/infrastructure/test/projects/python/__snapshots__/infrastructure-py-project.test.ts.snap
+++ b/packages/infrastructure/test/projects/python/__snapshots__/infrastructure-py-project.test.ts.snap
@@ -449,21 +449,14 @@ class ApplicationStack(Stack):
 
 ",
   "main.py": "import os
-from aws_cdk import Environment
 from aws_pdk.cdk_graph import CdkGraph, FilterPreset, Filters, IFilter, IGraphFilterPlan
 from aws_pdk.cdk_graph_plugin_diagram import CdkGraphDiagramPlugin, IDiagramConfigBase
 from aws_pdk.cdk_graph_plugin_threat_composer import CdkGraphThreatComposerPlugin
 from aws_pdk.pdk_nag import PDKNag, AwsPrototypingChecks
 from infra.stacks.application_stack import ApplicationStack
 
-# for development, use account/region from cdk cli
-dev_env = Environment(
-  account=os.getenv('CDK_DEFAULT_ACCOUNT'),
-  region=os.getenv('CDK_DEFAULT_REGION')
-)
-
 app = PDKNag.app(nag_packs=[AwsPrototypingChecks()])
-ApplicationStack(app, "infra-dev", env=dev_env)
+ApplicationStack(app, "infra-dev")
 
 graph = CdkGraph(app, plugins=[
     CdkGraphDiagramPlugin(
@@ -1161,21 +1154,14 @@ class ApplicationStack(Stack):
 
 ",
   "infra/main.py": "import os
-from aws_cdk import Environment
 from aws_pdk.cdk_graph import CdkGraph, FilterPreset, Filters, IFilter, IGraphFilterPlan
 from aws_pdk.cdk_graph_plugin_diagram import CdkGraphDiagramPlugin, IDiagramConfigBase
 from aws_pdk.cdk_graph_plugin_threat_composer import CdkGraphThreatComposerPlugin
 from aws_pdk.pdk_nag import PDKNag, AwsPrototypingChecks
 from infra.stacks.application_stack import ApplicationStack
 
-# for development, use account/region from cdk cli
-dev_env = Environment(
-  account=os.getenv('CDK_DEFAULT_ACCOUNT'),
-  region=os.getenv('CDK_DEFAULT_REGION')
-)
-
 app = PDKNag.app(nag_packs=[AwsPrototypingChecks()])
-ApplicationStack(app, "infra-dev", env=dev_env)
+ApplicationStack(app, "infra-dev")
 
 graph = CdkGraph(app, plugins=[
     CdkGraphDiagramPlugin(
@@ -2051,21 +2037,14 @@ class ApplicationStack(Stack):
 
 ",
   "infra/main.py": "import os
-from aws_cdk import Environment
 from aws_pdk.cdk_graph import CdkGraph, FilterPreset, Filters, IFilter, IGraphFilterPlan
 from aws_pdk.cdk_graph_plugin_diagram import CdkGraphDiagramPlugin, IDiagramConfigBase
 from aws_pdk.cdk_graph_plugin_threat_composer import CdkGraphThreatComposerPlugin
 from aws_pdk.pdk_nag import PDKNag, AwsPrototypingChecks
 from infra.stacks.application_stack import ApplicationStack
 
-# for development, use account/region from cdk cli
-dev_env = Environment(
-  account=os.getenv('CDK_DEFAULT_ACCOUNT'),
-  region=os.getenv('CDK_DEFAULT_REGION')
-)
-
 app = PDKNag.app(nag_packs=[AwsPrototypingChecks()])
-ApplicationStack(app, "infra-dev", env=dev_env)
+ApplicationStack(app, "infra-dev")
 
 graph = CdkGraph(app, plugins=[
     CdkGraphDiagramPlugin(
@@ -3001,21 +2980,14 @@ class ApplicationStack(Stack):
 
 ",
   "infra/main.py": "import os
-from aws_cdk import Environment
 from aws_pdk.cdk_graph import CdkGraph, FilterPreset, Filters, IFilter, IGraphFilterPlan
 from aws_pdk.cdk_graph_plugin_diagram import CdkGraphDiagramPlugin, IDiagramConfigBase
 from aws_pdk.cdk_graph_plugin_threat_composer import CdkGraphThreatComposerPlugin
 from aws_pdk.pdk_nag import PDKNag, AwsPrototypingChecks
 from infra.stacks.application_stack import ApplicationStack
 
-# for development, use account/region from cdk cli
-dev_env = Environment(
-  account=os.getenv('CDK_DEFAULT_ACCOUNT'),
-  region=os.getenv('CDK_DEFAULT_REGION')
-)
-
 app = PDKNag.app(nag_packs=[AwsPrototypingChecks()])
-ApplicationStack(app, "infra-dev", env=dev_env)
+ApplicationStack(app, "infra-dev")
 
 graph = CdkGraph(app, plugins=[
     CdkGraphDiagramPlugin(
@@ -3994,21 +3966,14 @@ class ApplicationStack(Stack):
 
 ",
   "infra/main.py": "import os
-from aws_cdk import Environment
 from aws_pdk.cdk_graph import CdkGraph, FilterPreset, Filters, IFilter, IGraphFilterPlan
 from aws_pdk.cdk_graph_plugin_diagram import CdkGraphDiagramPlugin, IDiagramConfigBase
 from aws_pdk.cdk_graph_plugin_threat_composer import CdkGraphThreatComposerPlugin
 from aws_pdk.pdk_nag import PDKNag, AwsPrototypingChecks
 from infra.stacks.application_stack import ApplicationStack
 
-# for development, use account/region from cdk cli
-dev_env = Environment(
-  account=os.getenv('CDK_DEFAULT_ACCOUNT'),
-  region=os.getenv('CDK_DEFAULT_REGION')
-)
-
 app = PDKNag.app(nag_packs=[AwsPrototypingChecks()])
-ApplicationStack(app, "infra-dev", env=dev_env)
+ApplicationStack(app, "infra-dev")
 
 graph = CdkGraph(app, plugins=[
     CdkGraphDiagramPlugin(
@@ -4929,21 +4894,14 @@ class ApplicationStack(Stack):
 
 ",
   "infra/main.py": "import os
-from aws_cdk import Environment
 from aws_pdk.cdk_graph import CdkGraph, FilterPreset, Filters, IFilter, IGraphFilterPlan
 from aws_pdk.cdk_graph_plugin_diagram import CdkGraphDiagramPlugin, IDiagramConfigBase
 from aws_pdk.cdk_graph_plugin_threat_composer import CdkGraphThreatComposerPlugin
 from aws_pdk.pdk_nag import PDKNag, AwsPrototypingChecks
 from infra.stacks.application_stack import ApplicationStack
 
-# for development, use account/region from cdk cli
-dev_env = Environment(
-  account=os.getenv('CDK_DEFAULT_ACCOUNT'),
-  region=os.getenv('CDK_DEFAULT_REGION')
-)
-
 app = PDKNag.app(nag_packs=[AwsPrototypingChecks()])
-ApplicationStack(app, "infra-dev", env=dev_env)
+ApplicationStack(app, "infra-dev")
 
 graph = CdkGraph(app, plugins=[
     CdkGraphDiagramPlugin(
@@ -5762,21 +5720,14 @@ class ApplicationStack(Stack):
 
 ",
   "infra/main.py": "import os
-from aws_cdk import Environment
 from aws_pdk.cdk_graph import CdkGraph, FilterPreset, Filters, IFilter, IGraphFilterPlan
 from aws_pdk.cdk_graph_plugin_diagram import CdkGraphDiagramPlugin, IDiagramConfigBase
 from aws_pdk.cdk_graph_plugin_threat_composer import CdkGraphThreatComposerPlugin
 from aws_pdk.pdk_nag import PDKNag, AwsPrototypingChecks
 from infra.stacks.application_stack import ApplicationStack
 
-# for development, use account/region from cdk cli
-dev_env = Environment(
-  account=os.getenv('CDK_DEFAULT_ACCOUNT'),
-  region=os.getenv('CDK_DEFAULT_REGION')
-)
-
 app = PDKNag.app(nag_packs=[AwsPrototypingChecks()])
-ApplicationStack(app, "infra-dev", env=dev_env)
+ApplicationStack(app, "infra-dev")
 
 graph = CdkGraph(app, plugins=[
     CdkGraphDiagramPlugin(

--- a/packages/infrastructure/test/projects/typescript/__snapshots__/infrastructure-ts-project.test.ts.snap
+++ b/packages/infrastructure/test/projects/typescript/__snapshots__/infrastructure-ts-project.test.ts.snap
@@ -1171,19 +1171,13 @@ import { CdkGraphThreatComposerPlugin } from "@aws/pdk/cdk-graph-plugin-threat-c
 import { AwsPrototypingChecks, PDKNag } from "@aws/pdk/pdk-nag";
 import { ApplicationStack } from "./stacks/application-stack";
 
-// for development, use account/region from cdk cli
-const devEnv = {
-  account: process.env.CDK_DEFAULT_ACCOUNT,
-  region: process.env.CDK_DEFAULT_REGION,
-};
-
 /* eslint-disable @typescript-eslint/no-floating-promises */
 (async () => {
   const app = PDKNag.app({
     nagPacks: [new AwsPrototypingChecks()],
   });
 
-  new ApplicationStack(app, "infra-dev", { env: devEnv });
+  new ApplicationStack(app, "infra-dev");
 
   const graph = new CdkGraph(app, {
     plugins: [
@@ -2400,19 +2394,13 @@ import { CdkGraphThreatComposerPlugin } from "@aws/pdk/cdk-graph-plugin-threat-c
 import { AwsPrototypingChecks, PDKNag } from "@aws/pdk/pdk-nag";
 import { ApplicationStack } from "./stacks/application-stack";
 
-// for development, use account/region from cdk cli
-const devEnv = {
-  account: process.env.CDK_DEFAULT_ACCOUNT,
-  region: process.env.CDK_DEFAULT_REGION,
-};
-
 /* eslint-disable @typescript-eslint/no-floating-promises */
 (async () => {
   const app = PDKNag.app({
     nagPacks: [new AwsPrototypingChecks()],
   });
 
-  new ApplicationStack(app, "infra-dev", { env: devEnv });
+  new ApplicationStack(app, "infra-dev");
 
   const graph = new CdkGraph(app, {
     plugins: [
@@ -3689,19 +3677,13 @@ import { CdkGraphThreatComposerPlugin } from "@aws/pdk/cdk-graph-plugin-threat-c
 import { AwsPrototypingChecks, PDKNag } from "@aws/pdk/pdk-nag";
 import { ApplicationStack } from "./stacks/application-stack";
 
-// for development, use account/region from cdk cli
-const devEnv = {
-  account: process.env.CDK_DEFAULT_ACCOUNT,
-  region: process.env.CDK_DEFAULT_REGION,
-};
-
 /* eslint-disable @typescript-eslint/no-floating-promises */
 (async () => {
   const app = PDKNag.app({
     nagPacks: [new AwsPrototypingChecks()],
   });
 
-  new ApplicationStack(app, "infra-dev", { env: devEnv });
+  new ApplicationStack(app, "infra-dev");
 
   const graph = new CdkGraph(app, {
     plugins: [
@@ -5064,19 +5046,13 @@ import { CdkGraphThreatComposerPlugin } from "@aws/pdk/cdk-graph-plugin-threat-c
 import { AwsPrototypingChecks, PDKNag } from "@aws/pdk/pdk-nag";
 import { ApplicationStack } from "./stacks/application-stack";
 
-// for development, use account/region from cdk cli
-const devEnv = {
-  account: process.env.CDK_DEFAULT_ACCOUNT,
-  region: process.env.CDK_DEFAULT_REGION,
-};
-
 /* eslint-disable @typescript-eslint/no-floating-promises */
 (async () => {
   const app = PDKNag.app({
     nagPacks: [new AwsPrototypingChecks()],
   });
 
-  new ApplicationStack(app, "infra-dev", { env: devEnv });
+  new ApplicationStack(app, "infra-dev");
 
   const graph = new CdkGraph(app, {
     plugins: [
@@ -6510,19 +6486,13 @@ import { CdkGraphThreatComposerPlugin } from "@aws/pdk/cdk-graph-plugin-threat-c
 import { AwsPrototypingChecks, PDKNag } from "@aws/pdk/pdk-nag";
 import { ApplicationStack } from "./stacks/application-stack";
 
-// for development, use account/region from cdk cli
-const devEnv = {
-  account: process.env.CDK_DEFAULT_ACCOUNT,
-  region: process.env.CDK_DEFAULT_REGION,
-};
-
 /* eslint-disable @typescript-eslint/no-floating-promises */
 (async () => {
   const app = PDKNag.app({
     nagPacks: [new AwsPrototypingChecks()],
   });
 
-  new ApplicationStack(app, "infra-dev", { env: devEnv });
+  new ApplicationStack(app, "infra-dev");
 
   const graph = new CdkGraph(app, {
     plugins: [
@@ -7874,19 +7844,13 @@ import { CdkGraphThreatComposerPlugin } from "@aws/pdk/cdk-graph-plugin-threat-c
 import { AwsPrototypingChecks, PDKNag } from "@aws/pdk/pdk-nag";
 import { ApplicationStack } from "./stacks/application-stack";
 
-// for development, use account/region from cdk cli
-const devEnv = {
-  account: process.env.CDK_DEFAULT_ACCOUNT,
-  region: process.env.CDK_DEFAULT_REGION,
-};
-
 /* eslint-disable @typescript-eslint/no-floating-promises */
 (async () => {
   const app = PDKNag.app({
     nagPacks: [new AwsPrototypingChecks()],
   });
 
-  new ApplicationStack(app, "infra-dev", { env: devEnv });
+  new ApplicationStack(app, "infra-dev");
 
   const graph = new CdkGraph(app, {
     plugins: [
@@ -9083,19 +9047,13 @@ import { CdkGraphThreatComposerPlugin } from "@aws/pdk/cdk-graph-plugin-threat-c
 import { AwsPrototypingChecks, PDKNag } from "@aws/pdk/pdk-nag";
 import { ApplicationStack } from "./stacks/application-stack";
 
-// for development, use account/region from cdk cli
-const devEnv = {
-  account: process.env.CDK_DEFAULT_ACCOUNT,
-  region: process.env.CDK_DEFAULT_REGION,
-};
-
 /* eslint-disable @typescript-eslint/no-floating-promises */
 (async () => {
   const app = PDKNag.app({
     nagPacks: [new AwsPrototypingChecks()],
   });
 
-  new ApplicationStack(app, "infra-dev", { env: devEnv });
+  new ApplicationStack(app, "infra-dev");
 
   const graph = new CdkGraph(app, {
     plugins: [


### PR DESCRIPTION
Previously we were passing in an env taking the users currently configured account and region. The problem with this is that if deploying via a cloud assembly, these params were hardcoded to the values at synth time which is problematic. By omitting the env entirely, it will resolve all occurrences of region and account with a substitution to be resolved at deployment time.