### PR TITLE
fix: no LICENSE file if licensed param is false

### DIFF
--- a/packages/infrastructure/test/projects/typescript/infrastructure-ts-project.test.ts
+++ b/packages/infrastructure/test/projects/typescript/infrastructure-ts-project.test.ts
@@ -85,4 +85,18 @@ describe("InfrastructureTsProject", () => {
       }))
     ).toMatchSnapshot();
   });
+
+  it("Skips license generation when told to", () => {
+    const tsWithLic = new InfrastructureTsProject({
+      name: "withlic",
+    });
+    const dirSnapshotWithLic = synthSnapshot(tsWithLic);
+    expect(dirSnapshotWithLic.LICENSE).toBeDefined();
+    const tsNoLic = new InfrastructureTsProject({
+      name: "nolic",
+      licensed: false,
+    });
+    const dirSnapshotNoLIc = synthSnapshot(tsNoLic);
+    expect(dirSnapshotNoLIc.LICENSE).not.toBeDefined();
+  });
 });

--- a/packages/monorepo/src/components/nx-configurator.ts
+++ b/packages/monorepo/src/components/nx-configurator.ts
@@ -130,6 +130,8 @@ export interface NxConfiguratorOptions {
    */
   readonly defaultReleaseBranch?: string;
 
+  readonly licensed?: boolean;
+
   /**
    * Default package license config.
    *
@@ -143,6 +145,7 @@ export interface NxConfiguratorOptions {
  */
 export class NxConfigurator extends Component implements INxProjectCore {
   public readonly nx: NxWorkspace;
+  private readonly licensed?: boolean;
   private readonly licenseOptions?: LicenseOptions;
   private nxPlugins: { [dep: string]: string } = {};
 
@@ -176,6 +179,7 @@ export class NxConfigurator extends Component implements INxProjectCore {
       description: "Generate dependency graph for monorepo",
     });
 
+    this.licensed = options?.licensed;
     this.licenseOptions = options?.licenseOptions;
     this.nx = NxWorkspace.of(project) || new NxWorkspace(project);
     this.nx.affected.defaultBase = options?.defaultReleaseBranch ?? "mainline";
@@ -500,6 +504,9 @@ export class NxConfigurator extends Component implements INxProjectCore {
    * Add licenses to any subprojects which don't already have a license.
    */
   private _addLicenses() {
+    if (false === this.licensed) {
+      return;
+    }
     [this.project, ...this.project.subprojects]
       .filter(
         (p) => p.components.find((c) => c instanceof License) === undefined

--- a/packages/monorepo/src/projects/typescript/monorepo-ts.ts
+++ b/packages/monorepo/src/projects/typescript/monorepo-ts.ts
@@ -129,6 +129,8 @@ export interface MonorepoTsProjectOptions extends TypeScriptProjectOptions {
    */
   readonly disableNodeWarnings?: boolean;
 
+  readonly licensed?: boolean;
+
   /**
    * Default license to apply to all PDK managed packages.
    *
@@ -203,6 +205,7 @@ export class MonorepoTsProject
 
     this.nxConfigurator = new NxConfigurator(this, {
       defaultReleaseBranch,
+      licensed: options.licensed,
       licenseOptions: options.licenseOptions,
     });
     this._options = options;

--- a/packages/monorepo/test/monorepo.test.ts
+++ b/packages/monorepo/test/monorepo.test.ts
@@ -406,4 +406,18 @@ describe("NX Monorepo Unit Tests", () => {
     });
     expect(synthSnapshot(py)["pyproject.toml"]).toMatchSnapshot();
   });
+
+  it("Skips license generation when told to", () => {
+    const tsWithLic = new MonorepoTsProject({
+      name: "withlic",
+    });
+    const dirSnapshotWithLic = synthSnapshot(tsWithLic);
+    expect(dirSnapshotWithLic.LICENSE).toBeDefined();
+    const tsNoLic = new MonorepoTsProject({
+      name: "nolic",
+      licensed: false,
+    });
+    const dirSnapshotNoLIc = synthSnapshot(tsNoLic);
+    expect(dirSnapshotNoLIc.LICENSE).not.toBeDefined();
+  });
 });


### PR DESCRIPTION
Fixes the issue that `licensed: false` still generates a LICENSE file, which is at least confusing for internal code