### PR TITLE
fix(type-safe-api): ensure uniqueness of waf web acl name

### DIFF
--- a/packages/type-safe-api/src/construct/waf/open-api-gateway-web-acl.ts
+++ b/packages/type-safe-api/src/construct/waf/open-api-gateway-web-acl.ts
@@ -33,12 +33,12 @@ export class OpenApiGatewayWebAcl extends Construct {
 
     const aclName = `${PDKNag.getStackPrefix(Stack.of(this))
       .split("/")
-      .join("-")}-${id}-WebAcl`;
+      .join("-")}${id}-${this.node.addr.slice(-8)}`;
     const ipSetName = `${aclName}-IPSet`;
 
     // Create the IP Set if requested
     this.ipSet = props.cidrAllowList
-      ? new CfnIPSet(this, "IPSet", {
+      ? new CfnIPSet(this, "ApiIPSet", {
           name: ipSetName,
           addresses: props.cidrAllowList.cidrRanges,
           ipAddressVersion: props.cidrAllowList.cidrType,
@@ -120,7 +120,7 @@ export class OpenApiGatewayWebAcl extends Construct {
       ),
     ];
 
-    this.webAcl = new CfnWebACL(this, "WebACL", {
+    this.webAcl = new CfnWebACL(this, "ApiWebACL", {
       name: aclName,
       defaultAction: {
         // Allow by default, and use rules to deny unwanted requests

--- a/packages/type-safe-api/test/construct/__snapshots__/type-safe-rest-api.test.ts.snap
+++ b/packages/type-safe-api/test/construct/__snapshots__/type-safe-rest-api.test.ts.snap
@@ -153,7 +153,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTest1ApiTest1AclWebACL4CD0F6DD": {
+    "ApiTest1ApiTest1AclApiWebACL8A393435": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -190,7 +190,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
         "DefaultAction": {
           "Allow": {},
         },
-        "Name": "Default--ApiTest1-Acl-WebAcl",
+        "Name": "Default-ApiTest1-Acl-167629db",
         "Rules": [
           {
             "Name": "AWS-AWSManagedRulesCommonRuleSet",
@@ -206,7 +206,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest1-Acl-WebAcl-AWS-AWSManagedRulesCommonRuleSet",
+              "MetricName": "Default-ApiTest1-Acl-167629db-AWS-AWSManagedRulesCommonRuleSet",
               "SampledRequestsEnabled": true,
             },
           },
@@ -214,7 +214,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
         "Scope": "REGIONAL",
         "VisibilityConfig": {
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "Default--ApiTest1-Acl-WebAcl",
+          "MetricName": "Default-ApiTest1-Acl-167629db",
           "SampledRequestsEnabled": true,
         },
       },
@@ -279,7 +279,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
         },
         "WebACLArn": {
           "Fn::GetAtt": [
-            "ApiTest1ApiTest1AclWebACL4CD0F6DD",
+            "ApiTest1ApiTest1AclApiWebACL8A393435",
             "Arn",
           ],
         },
@@ -1329,7 +1329,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTest2ApiTest2AclWebACL627F765E": {
+    "ApiTest2ApiTest2AclApiWebACL9F8F771B": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -1366,7 +1366,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
         "DefaultAction": {
           "Allow": {},
         },
-        "Name": "Default--ApiTest2-Acl-WebAcl",
+        "Name": "Default-ApiTest2-Acl-0b53f63e",
         "Rules": [
           {
             "Name": "AWS-AWSManagedRulesCommonRuleSet",
@@ -1382,7 +1382,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest2-Acl-WebAcl-AWS-AWSManagedRulesCommonRuleSet",
+              "MetricName": "Default-ApiTest2-Acl-0b53f63e-AWS-AWSManagedRulesCommonRuleSet",
               "SampledRequestsEnabled": true,
             },
           },
@@ -1390,7 +1390,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
         "Scope": "REGIONAL",
         "VisibilityConfig": {
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "Default--ApiTest2-Acl-WebAcl",
+          "MetricName": "Default-ApiTest2-Acl-0b53f63e",
           "SampledRequestsEnabled": true,
         },
       },
@@ -1455,7 +1455,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
         },
         "WebACLArn": {
           "Fn::GetAtt": [
-            "ApiTest2ApiTest2AclWebACL627F765E",
+            "ApiTest2ApiTest2AclApiWebACL9F8F771B",
             "Arn",
           ],
         },
@@ -2548,7 +2548,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestApiTestAclWebACL9E75156F": {
+    "ApiTestApiTestAclApiWebACLA53F05F1": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -2585,7 +2585,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
         "DefaultAction": {
           "Allow": {},
         },
-        "Name": "Default--ApiTest-Acl-WebAcl",
+        "Name": "Default-ApiTest-Acl-b8f2cb4d",
         "Rules": [
           {
             "Name": "AWS-AWSManagedRulesCommonRuleSet",
@@ -2601,7 +2601,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest-Acl-WebAcl-AWS-AWSManagedRulesCommonRuleSet",
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-AWS-AWSManagedRulesCommonRuleSet",
               "SampledRequestsEnabled": true,
             },
           },
@@ -2609,7 +2609,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
         "Scope": "REGIONAL",
         "VisibilityConfig": {
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "Default--ApiTest-Acl-WebAcl",
+          "MetricName": "Default-ApiTest-Acl-b8f2cb4d",
           "SampledRequestsEnabled": true,
         },
       },
@@ -2674,7 +2674,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
         },
         "WebACLArn": {
           "Fn::GetAtt": [
-            "ApiTestApiTestAclWebACL9E75156F",
+            "ApiTestApiTestAclApiWebACLA53F05F1",
             "Arn",
           ],
         },
@@ -3858,7 +3858,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestApiTestAclWebACL9E75156F": {
+    "ApiTestApiTestAclApiWebACLA53F05F1": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -3895,7 +3895,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
         "DefaultAction": {
           "Allow": {},
         },
-        "Name": "Default--ApiTest-Acl-WebAcl",
+        "Name": "Default-ApiTest-Acl-b8f2cb4d",
         "Rules": [
           {
             "Name": "AWS-AWSManagedRulesCommonRuleSet",
@@ -3911,7 +3911,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest-Acl-WebAcl-AWS-AWSManagedRulesCommonRuleSet",
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-AWS-AWSManagedRulesCommonRuleSet",
               "SampledRequestsEnabled": true,
             },
           },
@@ -3919,7 +3919,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
         "Scope": "REGIONAL",
         "VisibilityConfig": {
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "Default--ApiTest-Acl-WebAcl",
+          "MetricName": "Default-ApiTest-Acl-b8f2cb4d",
           "SampledRequestsEnabled": true,
         },
       },
@@ -3984,7 +3984,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
         },
         "WebACLArn": {
           "Fn::GetAtt": [
-            "ApiTestApiTestAclWebACL9E75156F",
+            "ApiTestApiTestAclApiWebACLA53F05F1",
             "Arn",
           ],
         },
@@ -5192,7 +5192,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestApiTestAclWebACL9E75156F": {
+    "ApiTestApiTestAclApiWebACLA53F05F1": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -5229,7 +5229,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
         "DefaultAction": {
           "Allow": {},
         },
-        "Name": "Default--ApiTest-Acl-WebAcl",
+        "Name": "Default-ApiTest-Acl-b8f2cb4d",
         "Rules": [
           {
             "Name": "AWS-AWSManagedRulesCommonRuleSet",
@@ -5245,7 +5245,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest-Acl-WebAcl-AWS-AWSManagedRulesCommonRuleSet",
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-AWS-AWSManagedRulesCommonRuleSet",
               "SampledRequestsEnabled": true,
             },
           },
@@ -5253,7 +5253,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
         "Scope": "REGIONAL",
         "VisibilityConfig": {
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "Default--ApiTest-Acl-WebAcl",
+          "MetricName": "Default-ApiTest-Acl-b8f2cb4d",
           "SampledRequestsEnabled": true,
         },
       },
@@ -5318,7 +5318,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
         },
         "WebACLArn": {
           "Fn::GetAtt": [
-            "ApiTestApiTestAclWebACL9E75156F",
+            "ApiTestApiTestAclApiWebACLA53F05F1",
             "Arn",
           ],
         },
@@ -7319,7 +7319,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestApiTestAclWebACL9E75156F": {
+    "ApiTestApiTestAclApiWebACLA53F05F1": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -7356,7 +7356,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
         "DefaultAction": {
           "Allow": {},
         },
-        "Name": "Default--ApiTest-Acl-WebAcl",
+        "Name": "Default-ApiTest-Acl-b8f2cb4d",
         "Rules": [
           {
             "Name": "AWS-AWSManagedRulesCommonRuleSet",
@@ -7372,7 +7372,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest-Acl-WebAcl-AWS-AWSManagedRulesCommonRuleSet",
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-AWS-AWSManagedRulesCommonRuleSet",
               "SampledRequestsEnabled": true,
             },
           },
@@ -7380,7 +7380,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
         "Scope": "REGIONAL",
         "VisibilityConfig": {
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "Default--ApiTest-Acl-WebAcl",
+          "MetricName": "Default-ApiTest-Acl-b8f2cb4d",
           "SampledRequestsEnabled": true,
         },
       },
@@ -7445,7 +7445,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
         },
         "WebACLArn": {
           "Fn::GetAtt": [
-            "ApiTestApiTestAclWebACL9E75156F",
+            "ApiTestApiTestAclApiWebACLA53F05F1",
             "Arn",
           ],
         },
@@ -8783,7 +8783,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestApiTestAclWebACL9E75156F": {
+    "ApiTestApiTestAclApiWebACLA53F05F1": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -8820,7 +8820,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
         "DefaultAction": {
           "Allow": {},
         },
-        "Name": "Default--ApiTest-Acl-WebAcl",
+        "Name": "Default-ApiTest-Acl-b8f2cb4d",
         "Rules": [
           {
             "Name": "AWS-AWSManagedRulesCommonRuleSet",
@@ -8836,7 +8836,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest-Acl-WebAcl-AWS-AWSManagedRulesCommonRuleSet",
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-AWS-AWSManagedRulesCommonRuleSet",
               "SampledRequestsEnabled": true,
             },
           },
@@ -8844,7 +8844,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
         "Scope": "REGIONAL",
         "VisibilityConfig": {
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "Default--ApiTest-Acl-WebAcl",
+          "MetricName": "Default-ApiTest-Acl-b8f2cb4d",
           "SampledRequestsEnabled": true,
         },
       },
@@ -8909,7 +8909,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
         },
         "WebACLArn": {
           "Fn::GetAtt": [
-            "ApiTestApiTestAclWebACL9E75156F",
+            "ApiTestApiTestAclApiWebACLA53F05F1",
             "Arn",
           ],
         },
@@ -10027,7 +10027,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestApiTestAclWebACL9E75156F": {
+    "ApiTestApiTestAclApiWebACLA53F05F1": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -10064,7 +10064,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
         "DefaultAction": {
           "Allow": {},
         },
-        "Name": "Default--ApiTest-Acl-WebAcl",
+        "Name": "Default-ApiTest-Acl-b8f2cb4d",
         "Rules": [
           {
             "Name": "AWS-AWSManagedRulesCommonRuleSet",
@@ -10080,7 +10080,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest-Acl-WebAcl-AWS-AWSManagedRulesCommonRuleSet",
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-AWS-AWSManagedRulesCommonRuleSet",
               "SampledRequestsEnabled": true,
             },
           },
@@ -10088,7 +10088,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
         "Scope": "REGIONAL",
         "VisibilityConfig": {
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "Default--ApiTest-Acl-WebAcl",
+          "MetricName": "Default-ApiTest-Acl-b8f2cb4d",
           "SampledRequestsEnabled": true,
         },
       },
@@ -10153,7 +10153,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
         },
         "WebACLArn": {
           "Fn::GetAtt": [
-            "ApiTestApiTestAclWebACL9E75156F",
+            "ApiTestApiTestAclApiWebACLA53F05F1",
             "Arn",
           ],
         },
@@ -12369,7 +12369,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestApiTestAclWebACL9E75156F": {
+    "ApiTestApiTestAclApiWebACLA53F05F1": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -12406,7 +12406,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
         "DefaultAction": {
           "Allow": {},
         },
-        "Name": "Default--ApiTest-Acl-WebAcl",
+        "Name": "Default-ApiTest-Acl-b8f2cb4d",
         "Rules": [
           {
             "Name": "AWS-AWSManagedRulesCommonRuleSet",
@@ -12422,7 +12422,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest-Acl-WebAcl-AWS-AWSManagedRulesCommonRuleSet",
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-AWS-AWSManagedRulesCommonRuleSet",
               "SampledRequestsEnabled": true,
             },
           },
@@ -12430,7 +12430,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
         "Scope": "REGIONAL",
         "VisibilityConfig": {
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "Default--ApiTest-Acl-WebAcl",
+          "MetricName": "Default-ApiTest-Acl-b8f2cb4d",
           "SampledRequestsEnabled": true,
         },
       },
@@ -12495,7 +12495,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
         },
         "WebACLArn": {
           "Fn::GetAtt": [
-            "ApiTestApiTestAclWebACL9E75156F",
+            "ApiTestApiTestAclApiWebACLA53F05F1",
             "Arn",
           ],
         },
@@ -13741,7 +13741,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestApiTestAclWebACL9E75156F": {
+    "ApiTestApiTestAclApiWebACLA53F05F1": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -13778,7 +13778,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
         "DefaultAction": {
           "Allow": {},
         },
-        "Name": "Default--ApiTest-Acl-WebAcl",
+        "Name": "Default-ApiTest-Acl-b8f2cb4d",
         "Rules": [
           {
             "Name": "AWS-AWSManagedRulesCommonRuleSet",
@@ -13794,7 +13794,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest-Acl-WebAcl-AWS-AWSManagedRulesCommonRuleSet",
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-AWS-AWSManagedRulesCommonRuleSet",
               "SampledRequestsEnabled": true,
             },
           },
@@ -13802,7 +13802,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
         "Scope": "REGIONAL",
         "VisibilityConfig": {
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "Default--ApiTest-Acl-WebAcl",
+          "MetricName": "Default-ApiTest-Acl-b8f2cb4d",
           "SampledRequestsEnabled": true,
         },
       },
@@ -13867,7 +13867,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
         },
         "WebACLArn": {
           "Fn::GetAtt": [
-            "ApiTestApiTestAclWebACL9E75156F",
+            "ApiTestApiTestAclApiWebACLA53F05F1",
             "Arn",
           ],
         },
@@ -15218,7 +15218,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestApiTestAclWebACL9E75156F": {
+    "ApiTestApiTestAclApiWebACLA53F05F1": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -15255,7 +15255,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
         "DefaultAction": {
           "Allow": {},
         },
-        "Name": "Default--ApiTest-Acl-WebAcl",
+        "Name": "Default-ApiTest-Acl-b8f2cb4d",
         "Rules": [
           {
             "Name": "AWS-AWSManagedRulesAmazonIpReputationList",
@@ -15271,7 +15271,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest-Acl-WebAcl-AWS-AWSManagedRulesAmazonIpReputationList",
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-AWS-AWSManagedRulesAmazonIpReputationList",
               "SampledRequestsEnabled": true,
             },
           },
@@ -15289,7 +15289,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest-Acl-WebAcl-AWS-AWSManagedRulesAnonymousIpList",
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-AWS-AWSManagedRulesAnonymousIpList",
               "SampledRequestsEnabled": true,
             },
           },
@@ -15297,7 +15297,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
         "Scope": "REGIONAL",
         "VisibilityConfig": {
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "Default--ApiTest-Acl-WebAcl",
+          "MetricName": "Default-ApiTest-Acl-b8f2cb4d",
           "SampledRequestsEnabled": true,
         },
       },
@@ -15362,7 +15362,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
         },
         "WebACLArn": {
           "Fn::GetAtt": [
-            "ApiTestApiTestAclWebACL9E75156F",
+            "ApiTestApiTestAclApiWebACLA53F05F1",
             "Arn",
           ],
         },
@@ -16479,7 +16479,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules actio
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestApiTestAclWebACL9E75156F": {
+    "ApiTestApiTestAclApiWebACLA53F05F1": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -16516,7 +16516,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules actio
         "DefaultAction": {
           "Allow": {},
         },
-        "Name": "Default--ApiTest-Acl-WebAcl",
+        "Name": "Default-ApiTest-Acl-b8f2cb4d",
         "Rules": [
           {
             "Name": "AWS-AWSManagedRulesCommonRuleSet",
@@ -16540,7 +16540,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules actio
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest-Acl-WebAcl-AWS-AWSManagedRulesCommonRuleSet",
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-AWS-AWSManagedRulesCommonRuleSet",
               "SampledRequestsEnabled": true,
             },
           },
@@ -16548,7 +16548,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules actio
         "Scope": "REGIONAL",
         "VisibilityConfig": {
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "Default--ApiTest-Acl-WebAcl",
+          "MetricName": "Default-ApiTest-Acl-b8f2cb4d",
           "SampledRequestsEnabled": true,
         },
       },
@@ -16613,7 +16613,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules actio
         },
         "WebACLArn": {
           "Fn::GetAtt": [
-            "ApiTestApiTestAclWebACL9E75156F",
+            "ApiTestApiTestAclApiWebACLA53F05F1",
             "Arn",
           ],
         },
@@ -17730,7 +17730,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestApiTestAclWebACL9E75156F": {
+    "ApiTestApiTestAclApiWebACLA53F05F1": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -17767,7 +17767,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
         "DefaultAction": {
           "Allow": {},
         },
-        "Name": "Default--ApiTest-Acl-WebAcl",
+        "Name": "Default-ApiTest-Acl-b8f2cb4d",
         "Rules": [
           {
             "Name": "AWS-AWSManagedRulesCommonRuleSet",
@@ -17783,7 +17783,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest-Acl-WebAcl-AWS-AWSManagedRulesCommonRuleSet",
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-AWS-AWSManagedRulesCommonRuleSet",
               "SampledRequestsEnabled": true,
             },
           },
@@ -17791,7 +17791,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
         "Scope": "REGIONAL",
         "VisibilityConfig": {
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "Default--ApiTest-Acl-WebAcl",
+          "MetricName": "Default-ApiTest-Acl-b8f2cb4d",
           "SampledRequestsEnabled": true,
         },
       },
@@ -17856,7 +17856,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
         },
         "WebACLArn": {
           "Fn::GetAtt": [
-            "ApiTestApiTestAclWebACL9E75156F",
+            "ApiTestApiTestAclApiWebACLA53F05F1",
             "Arn",
           ],
         },
@@ -19149,7 +19149,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestApiTestAclWebACL9E75156F": {
+    "ApiTestApiTestAclApiWebACLA53F05F1": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -19186,7 +19186,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
         "DefaultAction": {
           "Allow": {},
         },
-        "Name": "Default--ApiTest-Acl-WebAcl",
+        "Name": "Default-ApiTest-Acl-b8f2cb4d",
         "Rules": [
           {
             "Name": "AWS-AWSManagedRulesCommonRuleSet",
@@ -19202,7 +19202,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest-Acl-WebAcl-AWS-AWSManagedRulesCommonRuleSet",
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-AWS-AWSManagedRulesCommonRuleSet",
               "SampledRequestsEnabled": true,
             },
           },
@@ -19210,7 +19210,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
         "Scope": "REGIONAL",
         "VisibilityConfig": {
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "Default--ApiTest-Acl-WebAcl",
+          "MetricName": "Default-ApiTest-Acl-b8f2cb4d",
           "SampledRequestsEnabled": true,
         },
       },
@@ -19275,7 +19275,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
         },
         "WebACLArn": {
           "Fn::GetAtt": [
-            "ApiTestApiTestAclWebACL9E75156F",
+            "ApiTestApiTestAclApiWebACLA53F05F1",
             "Arn",
           ],
         },
@@ -21272,7 +21272,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestApiTestAclWebACL9E75156F": {
+    "ApiTestApiTestAclApiWebACLA53F05F1": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -21309,7 +21309,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
         "DefaultAction": {
           "Allow": {},
         },
-        "Name": "Default--ApiTest-Acl-WebAcl",
+        "Name": "Default-ApiTest-Acl-b8f2cb4d",
         "Rules": [
           {
             "Name": "AWS-AWSManagedRulesCommonRuleSet",
@@ -21325,7 +21325,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest-Acl-WebAcl-AWS-AWSManagedRulesCommonRuleSet",
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-AWS-AWSManagedRulesCommonRuleSet",
               "SampledRequestsEnabled": true,
             },
           },
@@ -21333,7 +21333,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
         "Scope": "REGIONAL",
         "VisibilityConfig": {
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "Default--ApiTest-Acl-WebAcl",
+          "MetricName": "Default-ApiTest-Acl-b8f2cb4d",
           "SampledRequestsEnabled": true,
         },
       },
@@ -21398,7 +21398,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
         },
         "WebACLArn": {
           "Fn::GetAtt": [
-            "ApiTestApiTestAclWebACL9E75156F",
+            "ApiTestApiTestAclApiWebACLA53F05F1",
             "Arn",
           ],
         },
@@ -22451,7 +22451,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestApiTestAclWebACL9E75156F": {
+    "ApiTestApiTestAclApiWebACLA53F05F1": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -22488,7 +22488,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
         "DefaultAction": {
           "Allow": {},
         },
-        "Name": "Default--ApiTest-Acl-WebAcl",
+        "Name": "Default-ApiTest-Acl-b8f2cb4d",
         "Rules": [
           {
             "Name": "AWS-AWSManagedRulesCommonRuleSet",
@@ -22504,7 +22504,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest-Acl-WebAcl-AWS-AWSManagedRulesCommonRuleSet",
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-AWS-AWSManagedRulesCommonRuleSet",
               "SampledRequestsEnabled": true,
             },
           },
@@ -22512,7 +22512,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
         "Scope": "REGIONAL",
         "VisibilityConfig": {
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "Default--ApiTest-Acl-WebAcl",
+          "MetricName": "Default-ApiTest-Acl-b8f2cb4d",
           "SampledRequestsEnabled": true,
         },
       },
@@ -22577,7 +22577,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
         },
         "WebACLArn": {
           "Fn::GetAtt": [
-            "ApiTestApiTestAclWebACL9E75156F",
+            "ApiTestApiTestAclApiWebACLA53F05F1",
             "Arn",
           ],
         },
@@ -23733,7 +23733,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestApiTestAclWebACL9E75156F": {
+    "ApiTestApiTestAclApiWebACLA53F05F1": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -23770,7 +23770,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
         "DefaultAction": {
           "Allow": {},
         },
-        "Name": "Default--ApiTest-Acl-WebAcl",
+        "Name": "Default-ApiTest-Acl-b8f2cb4d",
         "Rules": [
           {
             "Name": "AWS-AWSManagedRulesCommonRuleSet",
@@ -23786,7 +23786,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest-Acl-WebAcl-AWS-AWSManagedRulesCommonRuleSet",
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-AWS-AWSManagedRulesCommonRuleSet",
               "SampledRequestsEnabled": true,
             },
           },
@@ -23794,7 +23794,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
         "Scope": "REGIONAL",
         "VisibilityConfig": {
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "Default--ApiTest-Acl-WebAcl",
+          "MetricName": "Default-ApiTest-Acl-b8f2cb4d",
           "SampledRequestsEnabled": true,
         },
       },
@@ -23859,7 +23859,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
         },
         "WebACLArn": {
           "Fn::GetAtt": [
-            "ApiTestApiTestAclWebACL9E75156F",
+            "ApiTestApiTestAclApiWebACLA53F05F1",
             "Arn",
           ],
         },
@@ -25035,7 +25035,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration 1`] = `
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestApiTestAclWebACL9E75156F": {
+    "ApiTestApiTestAclApiWebACLA53F05F1": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -25072,7 +25072,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration 1`] = `
         "DefaultAction": {
           "Allow": {},
         },
-        "Name": "Default--ApiTest-Acl-WebAcl",
+        "Name": "Default-ApiTest-Acl-b8f2cb4d",
         "Rules": [
           {
             "Name": "AWS-AWSManagedRulesCommonRuleSet",
@@ -25088,7 +25088,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration 1`] = `
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest-Acl-WebAcl-AWS-AWSManagedRulesCommonRuleSet",
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-AWS-AWSManagedRulesCommonRuleSet",
               "SampledRequestsEnabled": true,
             },
           },
@@ -25096,7 +25096,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration 1`] = `
         "Scope": "REGIONAL",
         "VisibilityConfig": {
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "Default--ApiTest-Acl-WebAcl",
+          "MetricName": "Default-ApiTest-Acl-b8f2cb4d",
           "SampledRequestsEnabled": true,
         },
       },
@@ -25161,7 +25161,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration 1`] = `
         },
         "WebACLArn": {
           "Fn::GetAtt": [
-            "ApiTestApiTestAclWebACL9E75156F",
+            "ApiTestApiTestAclApiWebACLA53F05F1",
             "Arn",
           ],
         },
@@ -26440,7 +26440,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and CORS 1`
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestApiTestAclWebACL9E75156F": {
+    "ApiTestApiTestAclApiWebACLA53F05F1": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -26477,7 +26477,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and CORS 1`
         "DefaultAction": {
           "Allow": {},
         },
-        "Name": "Default--ApiTest-Acl-WebAcl",
+        "Name": "Default-ApiTest-Acl-b8f2cb4d",
         "Rules": [
           {
             "Name": "AWS-AWSManagedRulesCommonRuleSet",
@@ -26493,7 +26493,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and CORS 1`
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest-Acl-WebAcl-AWS-AWSManagedRulesCommonRuleSet",
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-AWS-AWSManagedRulesCommonRuleSet",
               "SampledRequestsEnabled": true,
             },
           },
@@ -26501,7 +26501,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and CORS 1`
         "Scope": "REGIONAL",
         "VisibilityConfig": {
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "Default--ApiTest-Acl-WebAcl",
+          "MetricName": "Default-ApiTest-Acl-b8f2cb4d",
           "SampledRequestsEnabled": true,
         },
       },
@@ -26566,7 +26566,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and CORS 1`
         },
         "WebACLArn": {
           "Fn::GetAtt": [
-            "ApiTestApiTestAclWebACL9E75156F",
+            "ApiTestApiTestAclApiWebACLA53F05F1",
             "Arn",
           ],
         },
@@ -27980,7 +27980,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and catch a
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestApiTestAclWebACL9E75156F": {
+    "ApiTestApiTestAclApiWebACLA53F05F1": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -28017,7 +28017,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and catch a
         "DefaultAction": {
           "Allow": {},
         },
-        "Name": "Default--ApiTest-Acl-WebAcl",
+        "Name": "Default-ApiTest-Acl-b8f2cb4d",
         "Rules": [
           {
             "Name": "AWS-AWSManagedRulesCommonRuleSet",
@@ -28033,7 +28033,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and catch a
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest-Acl-WebAcl-AWS-AWSManagedRulesCommonRuleSet",
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-AWS-AWSManagedRulesCommonRuleSet",
               "SampledRequestsEnabled": true,
             },
           },
@@ -28041,7 +28041,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and catch a
         "Scope": "REGIONAL",
         "VisibilityConfig": {
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "Default--ApiTest-Acl-WebAcl",
+          "MetricName": "Default-ApiTest-Acl-b8f2cb4d",
           "SampledRequestsEnabled": true,
         },
       },
@@ -28106,7 +28106,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and catch a
         },
         "WebACLArn": {
           "Fn::GetAtt": [
-            "ApiTestApiTestAclWebACL9E75156F",
+            "ApiTestApiTestAclApiWebACLA53F05F1",
             "Arn",
           ],
         },
@@ -29323,7 +29323,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and custom 
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestApiTestAclWebACL9E75156F": {
+    "ApiTestApiTestAclApiWebACLA53F05F1": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -29360,7 +29360,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and custom 
         "DefaultAction": {
           "Allow": {},
         },
-        "Name": "Default--ApiTest-Acl-WebAcl",
+        "Name": "Default-ApiTest-Acl-b8f2cb4d",
         "Rules": [
           {
             "Name": "AWS-AWSManagedRulesCommonRuleSet",
@@ -29376,7 +29376,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and custom 
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest-Acl-WebAcl-AWS-AWSManagedRulesCommonRuleSet",
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-AWS-AWSManagedRulesCommonRuleSet",
               "SampledRequestsEnabled": true,
             },
           },
@@ -29384,7 +29384,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and custom 
         "Scope": "REGIONAL",
         "VisibilityConfig": {
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "Default--ApiTest-Acl-WebAcl",
+          "MetricName": "Default-ApiTest-Acl-b8f2cb4d",
           "SampledRequestsEnabled": true,
         },
       },
@@ -29449,7 +29449,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and custom 
         },
         "WebACLArn": {
           "Fn::GetAtt": [
-            "ApiTestApiTestAclWebACL9E75156F",
+            "ApiTestApiTestAclApiWebACLA53F05F1",
             "Arn",
           ],
         },
@@ -30676,7 +30676,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and props 1
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestApiTestAclWebACL9E75156F": {
+    "ApiTestApiTestAclApiWebACLA53F05F1": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -30713,7 +30713,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and props 1
         "DefaultAction": {
           "Allow": {},
         },
-        "Name": "Default--ApiTest-Acl-WebAcl",
+        "Name": "Default-ApiTest-Acl-b8f2cb4d",
         "Rules": [
           {
             "Name": "AWS-AWSManagedRulesCommonRuleSet",
@@ -30729,7 +30729,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and props 1
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest-Acl-WebAcl-AWS-AWSManagedRulesCommonRuleSet",
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-AWS-AWSManagedRulesCommonRuleSet",
               "SampledRequestsEnabled": true,
             },
           },
@@ -30737,7 +30737,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and props 1
         "Scope": "REGIONAL",
         "VisibilityConfig": {
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "Default--ApiTest-Acl-WebAcl",
+          "MetricName": "Default-ApiTest-Acl-b8f2cb4d",
           "SampledRequestsEnabled": true,
         },
       },
@@ -30802,7 +30802,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and props 1
         },
         "WebACLArn": {
           "Fn::GetAtt": [
-            "ApiTestApiTestAclWebACL9E75156F",
+            "ApiTestApiTestAclApiWebACLA53F05F1",
             "Arn",
           ],
         },
@@ -32085,7 +32085,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
       "Type": "AWS::ApiGateway::Account",
       "UpdateReplacePolicy": "Retain",
     },
-    "ApiTestApiTestAclIPSet412969EA": {
+    "ApiTestApiTestAclApiIPSet53E0D489": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -32123,12 +32123,12 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
           "1.2.3.4/5",
         ],
         "IPAddressVersion": "IPV4",
-        "Name": "Default--ApiTest-Acl-WebAcl-IPSet",
+        "Name": "Default-ApiTest-Acl-b8f2cb4d-IPSet",
         "Scope": "REGIONAL",
       },
       "Type": "AWS::WAFv2::IPSet",
     },
-    "ApiTestApiTestAclWebACL9E75156F": {
+    "ApiTestApiTestAclApiWebACLA53F05F1": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -32165,13 +32165,13 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
         "DefaultAction": {
           "Allow": {},
         },
-        "Name": "Default--ApiTest-Acl-WebAcl",
+        "Name": "Default-ApiTest-Acl-b8f2cb4d",
         "Rules": [
           {
             "Action": {
               "Block": {},
             },
-            "Name": "Default--ApiTest-Acl-WebAcl-IPSet",
+            "Name": "Default-ApiTest-Acl-b8f2cb4d-IPSet",
             "Priority": 1,
             "Statement": {
               "NotStatement": {
@@ -32179,7 +32179,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
                   "IPSetReferenceStatement": {
                     "Arn": {
                       "Fn::GetAtt": [
-                        "ApiTestApiTestAclIPSet412969EA",
+                        "ApiTestApiTestAclApiIPSet53E0D489",
                         "Arn",
                       ],
                     },
@@ -32189,7 +32189,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest-Acl-WebAcl-IPSet",
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-IPSet",
               "SampledRequestsEnabled": true,
             },
           },
@@ -32207,7 +32207,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
             },
             "VisibilityConfig": {
               "CloudWatchMetricsEnabled": true,
-              "MetricName": "Default--ApiTest-Acl-WebAcl-AWS-AWSManagedRulesCommonRuleSet",
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-AWS-AWSManagedRulesCommonRuleSet",
               "SampledRequestsEnabled": true,
             },
           },
@@ -32215,7 +32215,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
         "Scope": "REGIONAL",
         "VisibilityConfig": {
           "CloudWatchMetricsEnabled": true,
-          "MetricName": "Default--ApiTest-Acl-WebAcl",
+          "MetricName": "Default-ApiTest-Acl-b8f2cb4d",
           "SampledRequestsEnabled": true,
         },
       },
@@ -32280,7 +32280,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
         },
         "WebACLArn": {
           "Fn::GetAtt": [
-            "ApiTestApiTestAclWebACL9E75156F",
+            "ApiTestApiTestAclApiWebACLA53F05F1",
             "Arn",
           ],
         },


### PR DESCRIPTION
Fixes #750
