### PR TITLE
fix(type-safe-api): passed hooks tsconfig parameter was ignored

### DIFF
--- a/packages/type-safe-api/src/project/codegen/library/typescript-react-query-hooks-library.ts
+++ b/packages/type-safe-api/src/project/codegen/library/typescript-react-query-hooks-library.ts
@@ -22,7 +22,7 @@ export class TypescriptReactQueryHooksLibrary extends GeneratedTypescriptLibrary
   constructor(options: GeneratedTypescriptReactQueryHooksProjectOptions) {
     super({
       ...options,
-      tsconfig: {
+      tsconfig: options.tsconfig ?? {
         compilerOptions: {
           jsx: TypeScriptJsxMode.REACT,
         },

--- a/packages/type-safe-api/src/project/codegen/library/typescript-websocket-hooks-library.ts
+++ b/packages/type-safe-api/src/project/codegen/library/typescript-websocket-hooks-library.ts
@@ -26,7 +26,7 @@ export class TypescriptWebsocketHooksLibrary extends GeneratedTypescriptLibraryP
   constructor(options: TypescriptWebsocketHooksLibraryOptions) {
     super({
       ...options,
-      tsconfig: {
+      tsconfig: options.tsconfig ?? {
         compilerOptions: {
           jsx: TypeScriptJsxMode.REACT,
         },


### PR DESCRIPTION
Fixes #

When `tsconfig` is passed for hooks packages, it's ignored. This PR fixes this issue.

Example:

```ts
library: {
  libraries: [Library.TYPESCRIPT_REACT_QUERY_HOOKS],
  options: {
    typescriptReactQueryHooks: {
      tsconfig: { ... }
    }
  }
},
```

or

```ts
library: {
  libraries: [WebSocketLibrary.TYPESCRIPT_WEBSOCKET_HOOKS],
  options: {
    typescriptWebSocketClient: {
      tsconfig: { ... }
    }
  }
},
```