### PR TITLE
fix: remove the pdk and projen bins from the virtual envs as we want …

### DIFF
--- a/packages/infrastructure/test/projects/python/__snapshots__/infrastructure-py-project.test.ts.snap
+++ b/packages/infrastructure/test/projects/python/__snapshots__/infrastructure-py-project.test.ts.snap
@@ -770,6 +770,9 @@ cython_debug/
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
+          },
+          {
             "exec": "poetry update",
           },
         ],
@@ -783,6 +786,9 @@ cython_debug/
         "steps": [
           {
             "exec": "poetry env use python$PYTHON_VERSION",
+          },
+          {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -1623,6 +1629,9 @@ cython_debug/
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
+          },
+          {
             "exec": "poetry update",
           },
         ],
@@ -1636,6 +1645,9 @@ cython_debug/
         "steps": [
           {
             "exec": "poetry env use python$PYTHON_VERSION",
+          },
+          {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -2511,6 +2523,9 @@ cython_debug/
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
+          },
+          {
             "exec": "poetry update",
           },
         ],
@@ -2524,6 +2539,9 @@ cython_debug/
         "steps": [
           {
             "exec": "poetry env use python$PYTHON_VERSION",
+          },
+          {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -3458,6 +3476,9 @@ cython_debug/
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
+          },
+          {
             "exec": "poetry update",
           },
         ],
@@ -3471,6 +3492,9 @@ cython_debug/
         "steps": [
           {
             "exec": "poetry env use python$PYTHON_VERSION",
+          },
+          {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -4432,6 +4456,9 @@ cython_debug/
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
+          },
+          {
             "exec": "poetry update",
           },
         ],
@@ -4445,6 +4472,9 @@ cython_debug/
         "steps": [
           {
             "exec": "poetry env use python$PYTHON_VERSION",
+          },
+          {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -5342,6 +5372,9 @@ cython_debug/
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
+          },
+          {
             "exec": "poetry update",
           },
         ],
@@ -5355,6 +5388,9 @@ cython_debug/
         "steps": [
           {
             "exec": "poetry env use python$PYTHON_VERSION",
+          },
+          {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
           },
           {
             "exec": "poetry check --lock && poetry install",

--- a/packages/monorepo/src/components/nx-configurator.ts
+++ b/packages/monorepo/src/components/nx-configurator.ts
@@ -197,9 +197,14 @@ export class NxConfigurator extends Component implements INxProjectCore {
       ["install", "install:ci"].forEach((t) => {
         const task = project.tasks.tryFind(t);
 
-        // Setup env
-        const cmd = "poetry env use python$PYTHON_VERSION";
-        task?.steps[0]?.exec !== cmd && task?.prependExec(cmd);
+        // Setup env and ensure the projen & pdk bins are removed from the venv as we always want to use the npx variant
+        [
+          "rm -f `poetry env info -p`/bin/projen `poetry env info -p`/bin/pdk",
+          "poetry env use python$PYTHON_VERSION",
+        ].forEach(
+          (cmd) =>
+            !task?.steps.find((s) => s.exec === cmd) && task?.prependExec(cmd)
+        );
 
         const pythonVersion = project.deps.tryGetDependency("python")?.version;
         task!.env(

--- a/packages/monorepo/test/__snapshots__/monorepo.test.ts.snap
+++ b/packages/monorepo/test/__snapshots__/monorepo.test.ts.snap
@@ -9555,6 +9555,9 @@ cython_debug/
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
+          },
+          {
             "exec": "poetry update",
           },
         ],
@@ -9568,6 +9571,9 @@ cython_debug/
         "steps": [
           {
             "exec": "poetry env use python$PYTHON_VERSION",
+          },
+          {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -10144,6 +10150,9 @@ cython_debug/
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
+          },
+          {
             "exec": "poetry update",
           },
         ],
@@ -10157,6 +10166,9 @@ cython_debug/
         "steps": [
           {
             "exec": "poetry env use python$PYTHON_VERSION",
+          },
+          {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -19565,6 +19577,9 @@ link-workspace-packages=true
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
+          },
+          {
             "exec": "poetry update",
           },
           {
@@ -19581,6 +19596,9 @@ link-workspace-packages=true
         "steps": [
           {
             "exec": "poetry env use python$PYTHON_VERSION",
+          },
+          {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
           },
           {
             "exec": "poetry check --lock && poetry install",

--- a/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
@@ -7760,6 +7760,9 @@ pyproject.toml
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
+          },
+          {
             "exec": "mkdir -p openapi_java_python_runtime && touch openapi_java_python_runtime/__init__.py",
           },
           {
@@ -7776,6 +7779,9 @@ pyproject.toml
         "steps": [
           {
             "exec": "poetry env use python$PYTHON_VERSION",
+          },
+          {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
           },
           {
             "exec": "mkdir -p openapi_java_python_runtime && touch openapi_java_python_runtime/__init__.py",
@@ -15570,6 +15576,9 @@ mocks
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
+          },
+          {
             "exec": "mkdir -p openapi_python_python_infra && touch openapi_python_python_infra/__init__.py",
           },
           {
@@ -15586,6 +15595,9 @@ mocks
         "steps": [
           {
             "exec": "poetry env use python$PYTHON_VERSION",
+          },
+          {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
           },
           {
             "exec": "mkdir -p openapi_python_python_infra && touch openapi_python_python_infra/__init__.py",
@@ -17112,6 +17124,9 @@ pyproject.toml
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
+          },
+          {
             "exec": "mkdir -p openapi_python_python_runtime && touch openapi_python_python_runtime/__init__.py",
           },
           {
@@ -17128,6 +17143,9 @@ pyproject.toml
         "steps": [
           {
             "exec": "poetry env use python$PYTHON_VERSION",
+          },
+          {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
           },
           {
             "exec": "mkdir -p openapi_python_python_runtime && touch openapi_python_python_runtime/__init__.py",
@@ -26834,6 +26852,9 @@ pyproject.toml
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
+          },
+          {
             "exec": "mkdir -p openapi_typescript_python_runtime && touch openapi_typescript_python_runtime/__init__.py",
           },
           {
@@ -26850,6 +26871,9 @@ pyproject.toml
         "steps": [
           {
             "exec": "poetry env use python$PYTHON_VERSION",
+          },
+          {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
           },
           {
             "exec": "mkdir -p openapi_typescript_python_runtime && touch openapi_typescript_python_runtime/__init__.py",
@@ -43894,6 +43918,9 @@ pyproject.toml
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
+          },
+          {
             "exec": "mkdir -p smithy_java_python_runtime && touch smithy_java_python_runtime/__init__.py",
           },
           {
@@ -43910,6 +43937,9 @@ pyproject.toml
         "steps": [
           {
             "exec": "poetry env use python$PYTHON_VERSION",
+          },
+          {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
           },
           {
             "exec": "mkdir -p smithy_java_python_runtime && touch smithy_java_python_runtime/__init__.py",
@@ -66749,6 +66779,9 @@ mocks
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
+          },
+          {
             "exec": "mkdir -p smithy_python_python_infra && touch smithy_python_python_infra/__init__.py",
           },
           {
@@ -66765,6 +66798,9 @@ mocks
         "steps": [
           {
             "exec": "poetry env use python$PYTHON_VERSION",
+          },
+          {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
           },
           {
             "exec": "mkdir -p smithy_python_python_infra && touch smithy_python_python_infra/__init__.py",
@@ -68291,6 +68327,9 @@ pyproject.toml
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
+          },
+          {
             "exec": "mkdir -p smithy_python_python_runtime && touch smithy_python_python_runtime/__init__.py",
           },
           {
@@ -68307,6 +68346,9 @@ pyproject.toml
         "steps": [
           {
             "exec": "poetry env use python$PYTHON_VERSION",
+          },
+          {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
           },
           {
             "exec": "mkdir -p smithy_python_python_runtime && touch smithy_python_python_runtime/__init__.py",
@@ -78201,6 +78243,9 @@ pyproject.toml
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
+          },
+          {
             "exec": "mkdir -p smithy_typescript_python_runtime && touch smithy_typescript_python_runtime/__init__.py",
           },
           {
@@ -78217,6 +78262,9 @@ pyproject.toml
         "steps": [
           {
             "exec": "poetry env use python$PYTHON_VERSION",
+          },
+          {
+            "exec": "rm -f \`poetry env info -p\`/bin/projen \`poetry env info -p\`/bin/pdk",
           },
           {
             "exec": "mkdir -p smithy_typescript_python_runtime && touch smithy_typescript_python_runtime/__init__.py",


### PR DESCRIPTION
Python's Venv is taking precendence for the projen and pdk bin's, even for non python projects. To remedy this, we simply remove the bins ensuring the npx variant will be used. This also significantly improves performance as a nice side-effect :)