### PR TITLE
fix: add missing typeSafeWebSocketApis runtime-config for py/java

### DIFF
--- a/packages/infrastructure/samples/infrastructure/java/src/java/groupId/constructs/websites/WebsiteConstruct.java.mustache
+++ b/packages/infrastructure/samples/infrastructure/java/src/java/groupId/constructs/websites/WebsiteConstruct.java.mustache
@@ -36,7 +36,8 @@ public class {{{websiteName}}} extends Construct {
                                     {{#typeSafeApis}}
                                     "{{{apiName}}}", {{{apiNameLowercase}}}.api.getApi().urlForPath(){{^isLast}},{{/isLast}}
                                     {{/typeSafeApis}}
-                                )
+                                ),
+                                "typeSafeWebSocketApis": Map.of()
                                 )))
                         .build())
                 .build());

--- a/packages/infrastructure/samples/infrastructure/python/src/constructs/websites/website.py.mustache
+++ b/packages/infrastructure/samples/infrastructure/python/src/constructs/websites/website.py.mustache
@@ -21,7 +21,8 @@ class {{{websiteName}}}(Construct):
                             'identityPoolId': user_identity.identity_pool.identity_pool_id,
                             'userPoolId': user_identity.user_pool.user_pool_id,
                             'userPoolWebClientId': user_identity.user_pool_client.user_pool_client_id,
-                            'typeSafeApis': { {{#typeSafeApis}}'{{{apiName}}}': {{{apiNameLowercase}}}.api.api.url_for_path(){{^isLast}}, {{/isLast}}{{/typeSafeApis}} }
+                            'typeSafeApis': { {{#typeSafeApis}}'{{{apiName}}}': {{{apiNameLowercase}}}.api.api.url_for_path(){{^isLast}}, {{/isLast}}{{/typeSafeApis}} },
+                            'typeSafeWebSocketApis': { }
                         }
                       ),
         )

--- a/packages/infrastructure/test/projects/java/__snapshots__/infrastructure-java-project.test.ts.snap
+++ b/packages/infrastructure/test/projects/java/__snapshots__/infrastructure-java-project.test.ts.snap
@@ -2712,7 +2712,8 @@ public class Website extends Construct {
                                 "userPoolId", userIdentity.getUserPool().getUserPoolId(),
                                 "userPoolWebClientId", userIdentity.getUserPoolClient().getUserPoolClientId(),
                                 "typeSafeApis", Map.of(
-                                )
+                                ),
+                                "typeSafeWebSocketApis": Map.of()
                                 )))
                         .build())
                 .build());
@@ -3863,7 +3864,8 @@ public class Website extends Construct {
                                 "userPoolId", userIdentity.getUserPool().getUserPoolId(),
                                 "userPoolWebClientId", userIdentity.getUserPoolClient().getUserPoolClientId(),
                                 "typeSafeApis", Map.of(
-                                )
+                                ),
+                                "typeSafeWebSocketApis": Map.of()
                                 )))
                         .build())
                 .build());
@@ -5017,7 +5019,8 @@ public class Website extends Construct {
                                 "userPoolId", userIdentity.getUserPool().getUserPoolId(),
                                 "userPoolWebClientId", userIdentity.getUserPoolClient().getUserPoolClientId(),
                                 "typeSafeApis", Map.of(
-                                )
+                                ),
+                                "typeSafeWebSocketApis": Map.of()
                                 )))
                         .build())
                 .build());
@@ -5065,7 +5068,8 @@ public class Website2 extends Construct {
                                 "typeSafeApis", Map.of(
                                     "Api", api.api.getApi().urlForPath(),
                                     "Api2", api2.api.getApi().urlForPath()
-                                )
+                                ),
+                                "typeSafeWebSocketApis": Map.of()
                                 )))
                         .build())
                 .build());
@@ -6132,7 +6136,8 @@ public class Website extends Construct {
                                 "userPoolId", userIdentity.getUserPool().getUserPoolId(),
                                 "userPoolWebClientId", userIdentity.getUserPoolClient().getUserPoolClientId(),
                                 "typeSafeApis", Map.of(
-                                )
+                                ),
+                                "typeSafeWebSocketApis": Map.of()
                                 )))
                         .build())
                 .build());
@@ -6180,7 +6185,8 @@ public class Website2 extends Construct {
                                 "typeSafeApis", Map.of(
                                     "Api", api.api.getApi().urlForPath(),
                                     "Api2", api2.api.getApi().urlForPath()
-                                )
+                                ),
+                                "typeSafeWebSocketApis": Map.of()
                                 )))
                         .build())
                 .build());
@@ -7153,7 +7159,8 @@ public class Website extends Construct {
                                 "userPoolId", userIdentity.getUserPool().getUserPoolId(),
                                 "userPoolWebClientId", userIdentity.getUserPoolClient().getUserPoolClientId(),
                                 "typeSafeApis", Map.of(
-                                )
+                                ),
+                                "typeSafeWebSocketApis": Map.of()
                                 )))
                         .build())
                 .build());

--- a/packages/infrastructure/test/projects/python/__snapshots__/infrastructure-py-project.test.ts.snap
+++ b/packages/infrastructure/test/projects/python/__snapshots__/infrastructure-py-project.test.ts.snap
@@ -2035,7 +2035,8 @@ class Website(Construct):
                             'identityPoolId': user_identity.identity_pool.identity_pool_id,
                             'userPoolId': user_identity.user_pool.user_pool_id,
                             'userPoolWebClientId': user_identity.user_pool_client.user_pool_client_id,
-                            'typeSafeApis': {  }
+                            'typeSafeApis': {  },
+                            'typeSafeWebSocketApis': { }
                         }
                       ),
         )
@@ -2981,7 +2982,8 @@ class Website(Construct):
                             'identityPoolId': user_identity.identity_pool.identity_pool_id,
                             'userPoolId': user_identity.user_pool.user_pool_id,
                             'userPoolWebClientId': user_identity.user_pool_client.user_pool_client_id,
-                            'typeSafeApis': {  }
+                            'typeSafeApis': {  },
+                            'typeSafeWebSocketApis': { }
                         }
                       ),
         )
@@ -3934,7 +3936,8 @@ class Website(Construct):
                             'identityPoolId': user_identity.identity_pool.identity_pool_id,
                             'userPoolId': user_identity.user_pool.user_pool_id,
                             'userPoolWebClientId': user_identity.user_pool_client.user_pool_client_id,
-                            'typeSafeApis': {  }
+                            'typeSafeApis': {  },
+                            'typeSafeWebSocketApis': { }
                         }
                       ),
         )
@@ -3963,7 +3966,8 @@ class Website2(Construct):
                             'identityPoolId': user_identity.identity_pool.identity_pool_id,
                             'userPoolId': user_identity.user_pool.user_pool_id,
                             'userPoolWebClientId': user_identity.user_pool_client.user_pool_client_id,
-                            'typeSafeApis': { 'Api': api.api.api.url_for_path(), 'Api2': api2.api.api.url_for_path() }
+                            'typeSafeApis': { 'Api': api.api.api.url_for_path(), 'Api2': api2.api.api.url_for_path() },
+                            'typeSafeWebSocketApis': { }
                         }
                       ),
         )
@@ -4862,7 +4866,8 @@ class Website(Construct):
                             'identityPoolId': user_identity.identity_pool.identity_pool_id,
                             'userPoolId': user_identity.user_pool.user_pool_id,
                             'userPoolWebClientId': user_identity.user_pool_client.user_pool_client_id,
-                            'typeSafeApis': {  }
+                            'typeSafeApis': {  },
+                            'typeSafeWebSocketApis': { }
                         }
                       ),
         )
@@ -4891,7 +4896,8 @@ class Website2(Construct):
                             'identityPoolId': user_identity.identity_pool.identity_pool_id,
                             'userPoolId': user_identity.user_pool.user_pool_id,
                             'userPoolWebClientId': user_identity.user_pool_client.user_pool_client_id,
-                            'typeSafeApis': { 'Api': api.api.api.url_for_path(), 'Api2': api2.api.api.url_for_path() }
+                            'typeSafeApis': { 'Api': api.api.api.url_for_path(), 'Api2': api2.api.api.url_for_path() },
+                            'typeSafeWebSocketApis': { }
                         }
                       ),
         )
@@ -5726,7 +5732,8 @@ class Website(Construct):
                             'identityPoolId': user_identity.identity_pool.identity_pool_id,
                             'userPoolId': user_identity.user_pool.user_pool_id,
                             'userPoolWebClientId': user_identity.user_pool_client.user_pool_client_id,
-                            'typeSafeApis': {  }
+                            'typeSafeApis': {  },
+                            'typeSafeWebSocketApis': { }
                         }
                       ),
         )


### PR DESCRIPTION
Python and Java Infra are broken at present as they do not provide the `typeSafeWebSocketApis` property. This PR sets the property with an empty object until the proper support is added for Java/Py.