### PR TITLE
fix: change packing to use npm pack to included nested node_modules

### DIFF
--- a/packages/pdk/.projen/tasks.json
+++ b/packages/pdk/.projen/tasks.json
@@ -116,7 +116,7 @@
       "description": "Create java language bindings",
       "steps": [
         {
-          "exec": "jsii-pacmak -v --target java --pack-command='rm -rf build && pnpm --config.shamefully-hoist=true --config.hoist=true --config.symlinks=false --config.shared-workspace-lockfile=false --filter=@aws/pdk deploy build && cd build && pnpm pack && mv *.tgz .. && cd .. && rm -rf build'"
+          "exec": "jsii-pacmak -vvvv --target java --pack-command='rm -rf build && pnpm --config.shamefully-hoist=true --config.node-linker=hoisted --config.hoist=true --config.symlinks=false --config.shared-workspace-lockfile=false --filter=@aws/pdk -P deploy build && cd build && npm pack && mv *.tgz .. && cd .. && rm -rf build'"
         }
       ]
     },
@@ -125,7 +125,7 @@
       "description": "Create js language bindings",
       "steps": [
         {
-          "exec": "jsii-pacmak -v --target js --pack-command='rm -rf build && pnpm --config.shamefully-hoist=true --config.hoist=true --config.symlinks=false --config.shared-workspace-lockfile=false --filter=@aws/pdk deploy build && cd build && pnpm pack && mv *.tgz .. && cd .. && rm -rf build'"
+          "exec": "jsii-pacmak -vvvv --target js --pack-command='rm -rf build && pnpm --config.shamefully-hoist=true --config.node-linker=hoisted --config.hoist=true --config.symlinks=false --config.shared-workspace-lockfile=false --filter=@aws/pdk -P deploy build && cd build && npm pack && mv *.tgz .. && cd .. && rm -rf build'"
         }
       ]
     },
@@ -134,7 +134,7 @@
       "description": "Create python language bindings",
       "steps": [
         {
-          "exec": "jsii-pacmak -v --target python --pack-command='rm -rf build && pnpm --config.shamefully-hoist=true --config.hoist=true --config.symlinks=false --config.shared-workspace-lockfile=false --filter=@aws/pdk deploy build && cd build && pnpm pack && mv *.tgz .. && cd .. && rm -rf build'"
+          "exec": "jsii-pacmak -vvvv --target python --pack-command='rm -rf build && pnpm --config.shamefully-hoist=true --config.node-linker=hoisted --config.hoist=true --config.symlinks=false --config.shared-workspace-lockfile=false --filter=@aws/pdk -P deploy build && cd build && npm pack && mv *.tgz .. && cd .. && rm -rf build'"
         }
       ]
     },

--- a/projenrc/projects/pdk-project.ts
+++ b/projenrc/projects/pdk-project.ts
@@ -15,9 +15,9 @@ import {
 
 const PACK_COMMAND = [
   "rm -rf build",
-  "pnpm --config.shamefully-hoist=true --config.hoist=true --config.symlinks=false --config.shared-workspace-lockfile=false --filter=@aws/pdk deploy build",
+  "pnpm --config.shamefully-hoist=true --config.node-linker=hoisted --config.hoist=true --config.symlinks=false --config.shared-workspace-lockfile=false --filter=@aws/pdk -P deploy build",
   "cd build",
-  "pnpm pack",
+  "npm pack",
   "mv *.tgz ..",
   "cd ..",
   "rm -rf build",
@@ -349,7 +349,9 @@ class PDKRelease extends Release {
   private updateJavaPackageTask = (project: Project): void => {
     project.tasks
       .tryFind("package:java")
-      ?.reset(`jsii-pacmak -v --target java --pack-command='${PACK_COMMAND}'`);
+      ?.reset(
+        `jsii-pacmak -vvvv --target java --pack-command='${PACK_COMMAND}'`
+      );
   };
 
   /**
@@ -360,7 +362,7 @@ class PDKRelease extends Release {
   private updateJsPackageTask = (project: Project): void => {
     project.tasks
       .tryFind("package:js")
-      ?.reset(`jsii-pacmak -v --target js --pack-command='${PACK_COMMAND}'`);
+      ?.reset(`jsii-pacmak -vvvv --target js --pack-command='${PACK_COMMAND}'`);
   };
 
   /**
@@ -372,7 +374,7 @@ class PDKRelease extends Release {
     project.tasks
       .tryFind("package:python")
       ?.reset(
-        `jsii-pacmak -v --target python --pack-command='${PACK_COMMAND}'`
+        `jsii-pacmak -vvvv --target python --pack-command='${PACK_COMMAND}'`
       );
   };
 }


### PR DESCRIPTION
Nested node_modules were being emitted from the tgz that was being published to npm. This should hopefully resolve the issue by performing the following:

- Only install prod dependencies when running `pnpm deploy`
- Hoist installed dependencies when running `pnpm deploy`
- Use standard `npm pack` oppose to `pnpm pack`.
- Added verbose logging for the packing command to verify local vs remote manifest matching.

Fixes #755