### PR TITLE
feat: add support for enabling self signup in Cognito

### DIFF
--- a/packages/cloudscape-react-ts-website/samples/cloudscape-react-ts-website/src/components/Auth/index.tsx.mustache
+++ b/packages/cloudscape-react-ts-website/samples/cloudscape-react-ts-website/src/components/Auth/index.tsx.mustache
@@ -24,6 +24,24 @@ const Auth: React.FC<any> = ({ children }) => {
       clientId={runtimeContext.userPoolWebClientId}
       region={runtimeContext.region}
       identityPoolId={runtimeContext.identityPoolId}
+      {{#allowSignup}}allowSignup={true}
+      {{/allowSignup}}signUpAttributes={[
+        {
+            displayName: "Email",
+            name: "email",
+            required: true,
+        },
+        {
+            displayName: "Given name",
+            name: "given_name",
+            required: true,
+        },
+        {
+            displayName: "Last name",
+            name: "family_name",
+            required: true,
+        }
+      ]}
     >
       {children}
     </CognitoAuth>

--- a/packages/cloudscape-react-ts-website/src/cloudscape-react-ts-website-project.ts
+++ b/packages/cloudscape-react-ts-website/src/cloudscape-react-ts-website-project.ts
@@ -31,6 +31,13 @@ export interface CloudscapeReactTsWebsiteProjectOptions
   readonly publicDir?: string;
 
   /**
+   * Whether to enable self sign-up.
+   *
+   * @default false
+   */
+  readonly allowSignup?: boolean;
+
+  /**
    * TypeSafeApi instance to use when setting up the initial project sample code.
    * @deprecated use typeSafeApis
    */
@@ -54,6 +61,7 @@ export interface CloudscapeReactTsWebsiteProjectOptions
  */
 export class CloudscapeReactTsWebsiteProject extends ReactTypeScriptProject {
   public readonly applicationName: string;
+  public readonly allowSignup: boolean;
   public readonly publicDir: string;
   public readonly typeSafeApis?: TypeSafeApiProject[];
   public readonly typeSafeWebSocketApis?: TypeSafeWebSocketApiProject[];
@@ -106,6 +114,7 @@ export class CloudscapeReactTsWebsiteProject extends ReactTypeScriptProject {
     this.testTask.exec("react-scripts test --watchAll=false --passWithNoTests");
 
     this.applicationName = options.applicationName ?? "Sample App";
+    this.allowSignup = options.allowSignup ?? false;
     this.publicDir = options.publicDir ?? "public";
     const srcDir = path.resolve(
       __dirname,
@@ -173,6 +182,7 @@ export class CloudscapeReactTsWebsiteProject extends ReactTypeScriptProject {
       typeSafeApisReversed: [...apis].reverse(),
       typeSafeWebSocketApis: webSocketApis,
       typeSafeWebSocketApisReversed: [...webSocketApis].reverse(),
+      allowSignup: options.allowSignup ?? false,
     };
 
     new SampleDir(this, this.srcdir, {

--- a/packages/cloudscape-react-ts-website/test/__snapshots__/cloudscape-react-ts-website-project.test.ts.snap
+++ b/packages/cloudscape-react-ts-website/test/__snapshots__/cloudscape-react-ts-website-project.test.ts.snap
@@ -1150,6 +1150,23 @@ const Auth: React.FC<any> = ({ children }) => {
       clientId={runtimeContext.userPoolWebClientId}
       region={runtimeContext.region}
       identityPoolId={runtimeContext.identityPoolId}
+      signUpAttributes={[
+        {
+            displayName: "Email",
+            name: "email",
+            required: true,
+        },
+        {
+            displayName: "Given name",
+            name: "given_name",
+            required: true,
+        },
+        {
+            displayName: "Last name",
+            name: "family_name",
+            required: true,
+        }
+      ]}
     >
       {children}
     </CognitoAuth>
@@ -2696,6 +2713,23 @@ const Auth: React.FC<any> = ({ children }) => {
       clientId={runtimeContext.userPoolWebClientId}
       region={runtimeContext.region}
       identityPoolId={runtimeContext.identityPoolId}
+      signUpAttributes={[
+        {
+            displayName: "Email",
+            name: "email",
+            required: true,
+        },
+        {
+            displayName: "Given name",
+            name: "given_name",
+            required: true,
+        },
+        {
+            displayName: "Last name",
+            name: "family_name",
+            required: true,
+        }
+      ]}
     >
       {children}
     </CognitoAuth>
@@ -3991,6 +4025,23 @@ const Auth: React.FC<any> = ({ children }) => {
       clientId={runtimeContext.userPoolWebClientId}
       region={runtimeContext.region}
       identityPoolId={runtimeContext.identityPoolId}
+      signUpAttributes={[
+        {
+            displayName: "Email",
+            name: "email",
+            required: true,
+        },
+        {
+            displayName: "Given name",
+            name: "given_name",
+            required: true,
+        },
+        {
+            displayName: "Last name",
+            name: "family_name",
+            required: true,
+        }
+      ]}
     >
       {children}
     </CognitoAuth>

--- a/packages/identity/src/user-identity.ts
+++ b/packages/identity/src/user-identity.ts
@@ -17,6 +17,13 @@ const WEB_CLIENT_ID = "WebClient";
  */
 export interface UserIdentityProps {
   /**
+   * Allow self sign up
+   *
+   * @default - false
+   */
+  readonly allowSignup?: boolean;
+
+  /**
    * User provided Cognito UserPool.
    *
    * @default - a userpool with mfa will be created.
@@ -42,7 +49,11 @@ export class UserIdentity extends Construct {
 
     // Unless explicitly stated, created a default Cognito User Pool and Web Client.
     this.userPool = !props?.userPool
-      ? new UserPoolWithMfa(this, "UserPool")
+      ? new UserPoolWithMfa(
+          this,
+          "UserPool",
+          props?.allowSignup ? { selfSignUpEnabled: true } : undefined
+        )
       : props.userPool;
 
     this.identityPool = new IdentityPool(

--- a/packages/infrastructure/samples/infrastructure/java/src/java/groupId/stacks/ApplicationStack.java.mustache
+++ b/packages/infrastructure/samples/infrastructure/java/src/java/groupId/stacks/ApplicationStack.java.mustache
@@ -9,7 +9,8 @@ import {{{groupId}}}.constructs.apis.{{{apiName}}};
 import {{{groupId}}}.constructs.websites.{{{websiteName}}};
 {{/cloudscapeReactTsWebsites}}
 import software.aws.pdk.identity.UserIdentity;
-import software.constructs.Construct;
+{{#allowSignup}}import software.aws.pdk.identity.UserIdentityProps;
+{{/allowSignup}}import software.constructs.Construct;
 
 public class ApplicationStack extends Stack {
     public ApplicationStack(Construct scope, String id) {
@@ -19,7 +20,10 @@ public class ApplicationStack extends Stack {
     public ApplicationStack(Construct scope, String id, StackProps props) {
         super(scope, id, props);
 
-        UserIdentity userIdentity = new UserIdentity(this, String.format("%sUserIdentity", id));
+        UserIdentity userIdentity = new UserIdentity(this, String.format("%sUserIdentity", id){{#allowSignup}},
+          UserIdentityProps.builder()
+            .allowSignup(true)
+            .build(){{/allowSignup}});
         {{#typeSafeApis}}
         {{#cloudscapeReactTsWebsites.0}}{{{apiName}}} {{{apiNameLowercase}}} = {{/cloudscapeReactTsWebsites.0}}new {{{apiName}}}(this, "{{{apiName}}}", userIdentity);
         {{/typeSafeApis}}

--- a/packages/infrastructure/samples/infrastructure/python/src/stacks/application_stack.py.mustache
+++ b/packages/infrastructure/samples/infrastructure/python/src/stacks/application_stack.py.mustache
@@ -12,7 +12,7 @@ class ApplicationStack(Stack):
     def __init__(self, scope: Construct, id: str, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
 
-        user_identity = UserIdentity(self, '{}UserIdentity'.format(id))
+        user_identity = UserIdentity(self, '{}UserIdentity'.format(id){{#allowSignup}}, allow_signup=True{{/allowSignup}})
         {{#typeSafeApis}}
         {{#cloudscapeReactTsWebsites.0}}{{{apiNameLowercase}}} = {{/cloudscapeReactTsWebsites.0}}{{{apiName}}}(self, '{{{apiName}}}', user_identity)
         {{/typeSafeApis}}

--- a/packages/infrastructure/samples/infrastructure/typescript/src/stacks/application-stack.ts.mustache
+++ b/packages/infrastructure/samples/infrastructure/typescript/src/stacks/application-stack.ts.mustache
@@ -15,7 +15,9 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    const userIdentity = new UserIdentity(this, `${id}UserIdentity`);
+    const userIdentity = new UserIdentity(this, `${id}UserIdentity`{{#allowSignup}}, {
+      allowSignup: true,
+    }{{/allowSignup}});
     {{#typeSafeApis}}
     {{#cloudscapeReactTsWebsites.0}}const {{{apiNameLowercase}}} = {{/cloudscapeReactTsWebsites.0}}new {{{apiName}}}(this, "{{{apiName}}}", {
       userIdentity,

--- a/packages/infrastructure/src/projects/java/infrastructure-java-project.ts
+++ b/packages/infrastructure/src/projects/java/infrastructure-java-project.ts
@@ -24,6 +24,13 @@ export interface InfrastructureJavaProjectOptions extends AwsCdkJavaAppOptions {
   readonly stackName?: string;
 
   /**
+   * Allow self sign up for the UserIdentity construct.
+   *
+   * @default - false
+   */
+  readonly allowSignup?: boolean;
+
+  /**
    * TypeSafeApi instance to use when setting up the initial project sample code.
    * @deprecated use typeSafeApis
    */
@@ -149,6 +156,7 @@ export class InfrastructureJavaProject extends AwsCdkJavaApp {
 
     const mustacheConfig = {
       stackName: options.stackName || DEFAULT_STACK_NAME,
+      allowSignup: options.allowSignup ?? false,
       groupId,
       typeSafeApis: this.generateTypeSafeMustacheConfig(groupId, typeSafeApis),
       cloudscapeReactTsWebsites: cloudscapeReactTsWebsites.map((csWebsite) => {

--- a/packages/infrastructure/src/projects/python/infrastructure-py-project.ts
+++ b/packages/infrastructure/src/projects/python/infrastructure-py-project.ts
@@ -24,6 +24,13 @@ export interface InfrastructurePyProjectOptions extends AwsCdkPythonAppOptions {
   readonly stackName?: string;
 
   /**
+   * Allow self sign up for the UserIdentity construct.
+   *
+   * @default - false
+   */
+  readonly allowSignup?: boolean;
+
+  /**
    * TypeSafeApi instance to use when setting up the initial project sample code.
    * @deprecated use typeSafeApis
    */
@@ -128,6 +135,7 @@ export class InfrastructurePyProject extends AwsCdkPythonApp {
 
     const mustacheConfig = {
       stackName: options.stackName || DEFAULT_STACK_NAME,
+      allowSignup: options.allowSignup ?? false,
       moduleName,
       typeSafeApis: this.generateTypeSafeMustacheConfig(
         moduleName,

--- a/packages/infrastructure/src/projects/typescript/infrastructure-ts-project.ts
+++ b/packages/infrastructure/src/projects/typescript/infrastructure-ts-project.ts
@@ -29,6 +29,13 @@ export interface InfrastructureTsProjectOptions
   readonly stackName?: string;
 
   /**
+   * Allow self sign up for the UserIdentity construct.
+   *
+   * @default - false
+   */
+  readonly allowSignup?: boolean;
+
+  /**
    * TypeSafeApi instance to use when setting up the initial project sample code.
    * @deprecated use typeSafeApis
    */
@@ -135,6 +142,7 @@ export class InfrastructureTsProject extends AwsCdkTypeScriptApp {
 
     const mustacheConfig = {
       stackName: options.stackName || DEFAULT_STACK_NAME,
+      allowSignup: options.allowSignup ?? false,
       typeSafeApis: this.generateTypeSafeMustacheConfig(typeSafeApis),
       typeSafeWebSocketApis: this.generateTypeSafeMustacheConfig(
         typeSafeWebSocketApis


### PR DESCRIPTION
Add support for enabling users to opt-in to self registration on the Cognito User Pool. This PR makes the following changes:

- Add a allowSignup option to be passing into the CloudscapeReactTSWebsite so that the UI can render the signup page.
- Add a allowSignup option to the infrastructure packages to enable signup on the Cognito User Pool.
- Modify Infrastructure templates to enable signup in the generated application-stack.