### PR TITLE
fix: resolve various bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 /.tools/

--- a/packages/infrastructure/samples/infrastructure/python/src/main.py.mustache
+++ b/packages/infrastructure/samples/infrastructure/python/src/main.py.mustache
@@ -8,8 +8,8 @@ from {{{moduleName}}}.stacks.application_stack import ApplicationStack
 
 app = PDKNag.app(nag_packs=[AwsPrototypingChecks()])
 ApplicationStack(app, "{{{stackName}}}-sandbox", env=Environment(
-    account=os.environ["CDK_DEFAULT_ACCOUNT"],
-    region=os.environ["CDK_DEFAULT_REGION"]
+    account=os.getenv("CDK_DEFAULT_ACCOUNT"),
+    region=os.getenv("CDK_DEFAULT_REGION")
 ))
 {{#stages}}
 ApplicationStack(app, "{{{stackName}}}-{{{stageName}}}", env=Environment(

--- a/packages/infrastructure/samples/infrastructure/typescript/src/stacks/application-stack.ts.mustache
+++ b/packages/infrastructure/samples/infrastructure/typescript/src/stacks/application-stack.ts.mustache
@@ -15,6 +15,7 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
+    // @ts-ignore
     const userIdentity = new UserIdentity(this, `${id}UserIdentity`{{#allowSignup}}, {
       allowSignup: true,
     }{{/allowSignup}});

--- a/packages/infrastructure/test/projects/python/__snapshots__/infrastructure-py-project.test.ts.snap
+++ b/packages/infrastructure/test/projects/python/__snapshots__/infrastructure-py-project.test.ts.snap
@@ -463,8 +463,8 @@ from infra.stacks.application_stack import ApplicationStack
 
 app = PDKNag.app(nag_packs=[AwsPrototypingChecks()])
 ApplicationStack(app, "infra-dev-sandbox", env=Environment(
-    account=os.environ["CDK_DEFAULT_ACCOUNT"],
-    region=os.environ["CDK_DEFAULT_REGION"]
+    account=os.getenv("CDK_DEFAULT_ACCOUNT"),
+    region=os.getenv("CDK_DEFAULT_REGION")
 ))
 
 graph = CdkGraph(app, plugins=[
@@ -1184,8 +1184,8 @@ from infra.stacks.application_stack import ApplicationStack
 
 app = PDKNag.app(nag_packs=[AwsPrototypingChecks()])
 ApplicationStack(app, "infra-dev-sandbox", env=Environment(
-    account=os.environ["CDK_DEFAULT_ACCOUNT"],
-    region=os.environ["CDK_DEFAULT_REGION"]
+    account=os.getenv("CDK_DEFAULT_ACCOUNT"),
+    region=os.getenv("CDK_DEFAULT_REGION")
 ))
 
 graph = CdkGraph(app, plugins=[
@@ -2077,8 +2077,8 @@ from infra.stacks.application_stack import ApplicationStack
 
 app = PDKNag.app(nag_packs=[AwsPrototypingChecks()])
 ApplicationStack(app, "infra-dev-sandbox", env=Environment(
-    account=os.environ["CDK_DEFAULT_ACCOUNT"],
-    region=os.environ["CDK_DEFAULT_REGION"]
+    account=os.getenv("CDK_DEFAULT_ACCOUNT"),
+    region=os.getenv("CDK_DEFAULT_REGION")
 ))
 
 graph = CdkGraph(app, plugins=[
@@ -3030,8 +3030,8 @@ from infra.stacks.application_stack import ApplicationStack
 
 app = PDKNag.app(nag_packs=[AwsPrototypingChecks()])
 ApplicationStack(app, "infra-dev-sandbox", env=Environment(
-    account=os.environ["CDK_DEFAULT_ACCOUNT"],
-    region=os.environ["CDK_DEFAULT_REGION"]
+    account=os.getenv("CDK_DEFAULT_ACCOUNT"),
+    region=os.getenv("CDK_DEFAULT_REGION")
 ))
 
 graph = CdkGraph(app, plugins=[
@@ -4020,8 +4020,8 @@ from infra.stacks.application_stack import ApplicationStack
 
 app = PDKNag.app(nag_packs=[AwsPrototypingChecks()])
 ApplicationStack(app, "infra-dev-sandbox", env=Environment(
-    account=os.environ["CDK_DEFAULT_ACCOUNT"],
-    region=os.environ["CDK_DEFAULT_REGION"]
+    account=os.getenv("CDK_DEFAULT_ACCOUNT"),
+    region=os.getenv("CDK_DEFAULT_REGION")
 ))
 
 graph = CdkGraph(app, plugins=[
@@ -4952,8 +4952,8 @@ from infra.stacks.application_stack import ApplicationStack
 
 app = PDKNag.app(nag_packs=[AwsPrototypingChecks()])
 ApplicationStack(app, "infra-dev-sandbox", env=Environment(
-    account=os.environ["CDK_DEFAULT_ACCOUNT"],
-    region=os.environ["CDK_DEFAULT_REGION"]
+    account=os.getenv("CDK_DEFAULT_ACCOUNT"),
+    region=os.getenv("CDK_DEFAULT_REGION")
 ))
 
 graph = CdkGraph(app, plugins=[
@@ -5621,8 +5621,8 @@ from infra.stacks.application_stack import ApplicationStack
 
 app = PDKNag.app(nag_packs=[AwsPrototypingChecks()])
 ApplicationStack(app, "infra-dev-sandbox", env=Environment(
-    account=os.environ["CDK_DEFAULT_ACCOUNT"],
-    region=os.environ["CDK_DEFAULT_REGION"]
+    account=os.getenv("CDK_DEFAULT_ACCOUNT"),
+    region=os.getenv("CDK_DEFAULT_REGION")
 ))
 ApplicationStack(app, "infra-dev-Beta", env=Environment(
     account="1",
@@ -6325,8 +6325,8 @@ from infra.stacks.application_stack import ApplicationStack
 
 app = PDKNag.app(nag_packs=[AwsPrototypingChecks()])
 ApplicationStack(app, "infra-dev-sandbox", env=Environment(
-    account=os.environ["CDK_DEFAULT_ACCOUNT"],
-    region=os.environ["CDK_DEFAULT_REGION"]
+    account=os.getenv("CDK_DEFAULT_ACCOUNT"),
+    region=os.getenv("CDK_DEFAULT_REGION")
 ))
 
 graph = CdkGraph(app, plugins=[

--- a/packages/infrastructure/test/projects/typescript/__snapshots__/infrastructure-ts-project.test.ts.snap
+++ b/packages/infrastructure/test/projects/typescript/__snapshots__/infrastructure-ts-project.test.ts.snap
@@ -1222,6 +1222,7 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
+    // @ts-ignore
     const userIdentity = new UserIdentity(this, \`\${id}UserIdentity\`);
   }
 }
@@ -2453,6 +2454,7 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
+    // @ts-ignore
     const userIdentity = new UserIdentity(this, \`\${id}UserIdentity\`);
     new Api(this, "Api", {
       userIdentity,
@@ -3746,6 +3748,7 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
+    // @ts-ignore
     const userIdentity = new UserIdentity(this, \`\${id}UserIdentity\`);
     const api = new Api(this, "Api", {
       userIdentity,
@@ -5127,6 +5130,7 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
+    // @ts-ignore
     const userIdentity = new UserIdentity(this, \`\${id}UserIdentity\`);
     const api = new Api(this, "Api", {
       userIdentity,
@@ -6581,6 +6585,7 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
+    // @ts-ignore
     const userIdentity = new UserIdentity(this, \`\${id}UserIdentity\`);
     const api = new Api(this, "Api", {
       userIdentity,
@@ -7955,6 +7960,7 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
+    // @ts-ignore
     const userIdentity = new UserIdentity(this, \`\${id}UserIdentity\`);
     const api = new Api(this, "Api", {
       userIdentity,
@@ -9292,6 +9298,7 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
+    // @ts-ignore
     const userIdentity = new UserIdentity(this, \`\${id}UserIdentity\`);
   }
 }
@@ -10498,6 +10505,7 @@ export class ApplicationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
+    // @ts-ignore
     const userIdentity = new UserIdentity(this, \`\${id}UserIdentity\`);
     new Website(this, "Website", {
       userIdentity,

--- a/packages/monorepo/src/components/nx-configurator.ts
+++ b/packages/monorepo/src/components/nx-configurator.ts
@@ -156,8 +156,8 @@ export class NxConfigurator extends Component implements INxProjectCore {
 
   constructor(project: Project, options?: NxConfiguratorOptions) {
     super(project);
-
-    project.addGitIgnore(".nx/cache");
+    project.addGitIgnore(".nx/*");
+    project.addGitIgnore("!.nx/plugins");
     project.addTask("run-many", {
       receiveArgs: true,
       exec: NodePackageUtils.command.exec(

--- a/packages/monorepo/test/__snapshots__/monorepo.test.ts.snap
+++ b/packages/monorepo/test/__snapshots__/monorepo.test.ts.snap
@@ -201,7 +201,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/pnpm-workspace.yaml
@@ -2238,7 +2239,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -4263,7 +4265,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 .yarn/*
@@ -6307,7 +6310,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -8593,7 +8597,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -10835,7 +10840,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -11873,7 +11879,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -13879,7 +13886,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -17394,7 +17402,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -18432,7 +18441,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -19403,7 +19413,8 @@ dmypy.json
 .pyre/
 .pytype/
 cython_debug/
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/package.json
@@ -20589,7 +20600,8 @@ another
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -21632,7 +21644,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/pnpm-workspace.yaml
@@ -23685,7 +23698,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json
@@ -24736,7 +24750,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/.syncpackrc.json

--- a/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
@@ -3256,7 +3256,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/packages/api/generated/runtime/README.md
@@ -12682,7 +12683,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/packages/api/generated/runtime/README.md
@@ -22335,7 +22337,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/packages/api/generated/runtime/README.md
@@ -39346,7 +39349,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/packages/api/generated/runtime/README.md
@@ -48305,7 +48309,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/packages/api/generated/runtime/README.md
@@ -55706,7 +55711,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/packages/api/generated/runtime/README.md
@@ -63775,7 +63781,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/packages/api/generated/runtime/README.md
@@ -73616,7 +73623,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/packages/api/generated/runtime/README.md
@@ -82594,7 +82602,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 .yarn/*
@@ -90035,7 +90044,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/packages/api/generated/runtime/README.md

--- a/packages/type-safe-api/test/project/__snapshots__/type-safe-websocket-api-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/__snapshots__/type-safe-websocket-api-project.test.ts.snap
@@ -2213,7 +2213,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/packages/api/generated/runtime/README.md
@@ -14818,7 +14819,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/packages/api/generated/runtime/README.md
@@ -21364,7 +21366,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/packages/api/generated/runtime/README.md
@@ -27930,7 +27933,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/packages/api/generated/runtime/README.md
@@ -34496,7 +34500,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 .yarn/*
@@ -41082,7 +41087,8 @@ jspm_packages/
 /lib
 /dist/
 !/.eslintrc.json
-.nx/cache
+.nx/*
+!.nx/plugins
 !/nx.json
 !/.nxignore
 !/packages/api/generated/runtime/README.md


### PR DESCRIPTION
- infra(py): change to getenv as previous we were getting a KeyError if the variable was unset
- infra(ts): @ts-ignore for unused variable in ts infra in the event no additional infra is configured.
- monorepo: ignore .nx directory (except for plugins).