### PR TITLE
fix(type-safe-api): missing runtime modules in Lambda deployment

### DIFF
--- a/packages/type-safe-api/src/project/codegen/handlers/generated-python-handlers-base-project.ts
+++ b/packages/type-safe-api/src/project/codegen/handlers/generated-python-handlers-base-project.ts
@@ -132,7 +132,7 @@ export abstract class GeneratedPythonHandlersBaseProject extends PythonProject {
       `cp -r ${this.moduleName} dist/lambda/${this.moduleName}`
     );
     this.packageTask.exec(
-      "poetry export --without-hashes --format=requirements.txt > dist/lambda/requirements.txt"
+      "poetry export --without-hashes --format=requirements.txt | sed -E 's/^-e[[:space:]]+//' > dist/lambda/requirements.txt"
     );
     // Select the platform based on the specified architecture, defaulting to x86_64
     // See: https://docs.aws.amazon.com/lambda/latest/dg/python-package.html#python-package-native-libraries

--- a/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
@@ -31894,7 +31894,7 @@ cython_debug/
             "exec": "cp -r smithy_handlers_python_handlers dist/lambda/smithy_handlers_python_handlers",
           },
           {
-            "exec": "poetry export --without-hashes --format=requirements.txt > dist/lambda/requirements.txt",
+            "exec": "poetry export --without-hashes --format=requirements.txt | sed -E 's/^-e[[:space:]]+//' > dist/lambda/requirements.txt",
           },
           {
             "exec": "pip install -r dist/lambda/requirements.txt --target dist/lambda --upgrade --platform manylinux2014_x86_64 --only-binary :all: --python-version 3.11",

--- a/packages/type-safe-api/test/project/codegen/handlers/__snapshots__/generated-python-async-handlers-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/codegen/handlers/__snapshots__/generated-python-async-handlers-project.test.ts.snap
@@ -341,7 +341,7 @@ cython_debug/
             "exec": "cp -r test_handlers dist/lambda/test_handlers",
           },
           {
-            "exec": "poetry export --without-hashes --format=requirements.txt > dist/lambda/requirements.txt",
+            "exec": "poetry export --without-hashes --format=requirements.txt | sed -E 's/^-e[[:space:]]+//' > dist/lambda/requirements.txt",
           },
           {
             "exec": "pip install -r dist/lambda/requirements.txt --target dist/lambda --upgrade --platform manylinux2014_x86_64 --only-binary :all: --python-version 3.11",

--- a/packages/type-safe-api/test/project/codegen/handlers/__snapshots__/generated-python-handlers-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/codegen/handlers/__snapshots__/generated-python-handlers-project.test.ts.snap
@@ -341,7 +341,7 @@ cython_debug/
             "exec": "cp -r test_handlers dist/lambda/test_handlers",
           },
           {
-            "exec": "poetry export --without-hashes --format=requirements.txt > dist/lambda/requirements.txt",
+            "exec": "poetry export --without-hashes --format=requirements.txt | sed -E 's/^-e[[:space:]]+//' > dist/lambda/requirements.txt",
           },
           {
             "exec": "pip install -r dist/lambda/requirements.txt --target dist/lambda --upgrade --platform manylinux2014_x86_64 --only-binary :all: --python-version 3.11",


### PR DESCRIPTION
Fixes the issue where generated runtime modules were not packaged in the Lambda deployment, causing ImportModuleError when executing Python handlers.

The fix modifies the packaging task in GeneratedPythonHandlersBaseProject to strip the '-e' flag from exported requirements.txt. This ensures runtime modules are installed as regular packages instead of editable installations.

Changes:
- Update 'poetry export' command to pipe output through 'sed' and remove '-e' prefix.
- Update corresponding snapshot tests for new package task command.

Fixes #791 