### PR TITLE
fix(type-safe-api): add empty README.md for generated python projects

### DIFF
--- a/packages/type-safe-api/src/project/codegen/infrastructure/cdk/generated-python-cdk-infrastructure-base-project.ts
+++ b/packages/type-safe-api/src/project/codegen/infrastructure/cdk/generated-python-cdk-infrastructure-base-project.ts
@@ -120,13 +120,13 @@ export abstract class GeneratedPythonCdkInfrastructureBaseProject extends Python
     // The poetry install that runs as part of post synthesis expects there to be some code present, but code isn't
     // generated until build time. This means that the first install will fail when either generating the project for
     // the first time or checking out a fresh copy (since generated code is not checked in to version control). We
-    // therefore add a blank __init__.py as our first install step to keep poetry happy until the generator overwrites
-    // it.
+    // therefore add a blank __init__.py and README.md as our first install step to keep poetry happy until the
+    // generator overwrites it.
     ["install", "install:ci"].forEach((t) =>
       this.tasks
         .tryFind(t)
         ?.prependExec(
-          `mkdir -p ${this.moduleName} && touch ${this.moduleName}/__init__.py`
+          `mkdir -p ${this.moduleName} && touch ${this.moduleName}/__init__.py README.md`
         )
     );
   }

--- a/packages/type-safe-api/src/project/codegen/runtime/generated-python-runtime-base-project.ts
+++ b/packages/type-safe-api/src/project/codegen/runtime/generated-python-runtime-base-project.ts
@@ -113,13 +113,13 @@ export abstract class GeneratedPythonRuntimeBaseProject extends PythonProject {
     // The poetry install that runs as part of post synthesis expects there to be some code present, but code isn't
     // generated until build time. This means that the first install will fail when either generating the project for
     // the first time or checking out a fresh copy (since generated code is not checked in to version control). We
-    // therefore add a blank __init__.py as our first install step to keep poetry happy until the generator overwrites
-    // it.
+    // therefore add a blank __init__.py and README.md as our first install step to keep poetry happy until the
+    // generator overwrites it.
     ["install", "install:ci"].forEach((t) =>
       this.tasks
         .tryFind(t)
         ?.prependExec(
-          `mkdir -p ${this.moduleName} && touch ${this.moduleName}/__init__.py`
+          `mkdir -p ${this.moduleName} && touch ${this.moduleName}/__init__.py README.md`
         )
     );
   }

--- a/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
@@ -2037,7 +2037,7 @@ pyproject.toml
         "name": "install",
         "steps": [
           {
-            "exec": "mkdir -p openapi_java_python_runtime && touch openapi_java_python_runtime/__init__.py",
+            "exec": "mkdir -p openapi_java_python_runtime && touch openapi_java_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -2049,7 +2049,7 @@ pyproject.toml
         "name": "install:ci",
         "steps": [
           {
-            "exec": "mkdir -p openapi_java_python_runtime && touch openapi_java_python_runtime/__init__.py",
+            "exec": "mkdir -p openapi_java_python_runtime && touch openapi_java_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -7759,7 +7759,7 @@ pyproject.toml
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
-            "exec": "mkdir -p openapi_java_python_runtime && touch openapi_java_python_runtime/__init__.py",
+            "exec": "mkdir -p openapi_java_python_runtime && touch openapi_java_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -7780,7 +7780,7 @@ pyproject.toml
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
-            "exec": "mkdir -p openapi_java_python_runtime && touch openapi_java_python_runtime/__init__.py",
+            "exec": "mkdir -p openapi_java_python_runtime && touch openapi_java_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -10422,7 +10422,7 @@ mocks
         "name": "install",
         "steps": [
           {
-            "exec": "mkdir -p openapi_python_python_infra && touch openapi_python_python_infra/__init__.py",
+            "exec": "mkdir -p openapi_python_python_infra && touch openapi_python_python_infra/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -10434,7 +10434,7 @@ mocks
         "name": "install:ci",
         "steps": [
           {
-            "exec": "mkdir -p openapi_python_python_infra && touch openapi_python_python_infra/__init__.py",
+            "exec": "mkdir -p openapi_python_python_infra && touch openapi_python_python_infra/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -11464,7 +11464,7 @@ pyproject.toml
         "name": "install",
         "steps": [
           {
-            "exec": "mkdir -p openapi_python_python_runtime && touch openapi_python_python_runtime/__init__.py",
+            "exec": "mkdir -p openapi_python_python_runtime && touch openapi_python_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -11476,7 +11476,7 @@ pyproject.toml
         "name": "install:ci",
         "steps": [
           {
-            "exec": "mkdir -p openapi_python_python_runtime && touch openapi_python_python_runtime/__init__.py",
+            "exec": "mkdir -p openapi_python_python_runtime && touch openapi_python_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -15568,7 +15568,7 @@ mocks
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
-            "exec": "mkdir -p openapi_python_python_infra && touch openapi_python_python_infra/__init__.py",
+            "exec": "mkdir -p openapi_python_python_infra && touch openapi_python_python_infra/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -15589,7 +15589,7 @@ mocks
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
-            "exec": "mkdir -p openapi_python_python_infra && touch openapi_python_python_infra/__init__.py",
+            "exec": "mkdir -p openapi_python_python_infra && touch openapi_python_python_infra/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -17118,7 +17118,7 @@ pyproject.toml
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
-            "exec": "mkdir -p openapi_python_python_runtime && touch openapi_python_python_runtime/__init__.py",
+            "exec": "mkdir -p openapi_python_python_runtime && touch openapi_python_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -17139,7 +17139,7 @@ pyproject.toml
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
-            "exec": "mkdir -p openapi_python_python_runtime && touch openapi_python_python_runtime/__init__.py",
+            "exec": "mkdir -p openapi_python_python_runtime && touch openapi_python_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -21118,7 +21118,7 @@ pyproject.toml
         "name": "install",
         "steps": [
           {
-            "exec": "mkdir -p openapi_typescript_python_runtime && touch openapi_typescript_python_runtime/__init__.py",
+            "exec": "mkdir -p openapi_typescript_python_runtime && touch openapi_typescript_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -21130,7 +21130,7 @@ pyproject.toml
         "name": "install:ci",
         "steps": [
           {
-            "exec": "mkdir -p openapi_typescript_python_runtime && touch openapi_typescript_python_runtime/__init__.py",
+            "exec": "mkdir -p openapi_typescript_python_runtime && touch openapi_typescript_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -26830,7 +26830,7 @@ pyproject.toml
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
-            "exec": "mkdir -p openapi_typescript_python_runtime && touch openapi_typescript_python_runtime/__init__.py",
+            "exec": "mkdir -p openapi_typescript_python_runtime && touch openapi_typescript_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -26851,7 +26851,7 @@ pyproject.toml
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
-            "exec": "mkdir -p openapi_typescript_python_runtime && touch openapi_typescript_python_runtime/__init__.py",
+            "exec": "mkdir -p openapi_typescript_python_runtime && touch openapi_typescript_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -30354,7 +30354,7 @@ pyproject.toml
         "name": "install",
         "steps": [
           {
-            "exec": "mkdir -p smithy_handlers_python_runtime && touch smithy_handlers_python_runtime/__init__.py",
+            "exec": "mkdir -p smithy_handlers_python_runtime && touch smithy_handlers_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -30366,7 +30366,7 @@ pyproject.toml
         "name": "install:ci",
         "steps": [
           {
-            "exec": "mkdir -p smithy_handlers_python_runtime && touch smithy_handlers_python_runtime/__init__.py",
+            "exec": "mkdir -p smithy_handlers_python_runtime && touch smithy_handlers_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -38036,7 +38036,7 @@ pyproject.toml
         "name": "install",
         "steps": [
           {
-            "exec": "mkdir -p smithy_java_python_runtime && touch smithy_java_python_runtime/__init__.py",
+            "exec": "mkdir -p smithy_java_python_runtime && touch smithy_java_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -38048,7 +38048,7 @@ pyproject.toml
         "name": "install:ci",
         "steps": [
           {
-            "exec": "mkdir -p smithy_java_python_runtime && touch smithy_java_python_runtime/__init__.py",
+            "exec": "mkdir -p smithy_java_python_runtime && touch smithy_java_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -43852,7 +43852,7 @@ pyproject.toml
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
-            "exec": "mkdir -p smithy_java_python_runtime && touch smithy_java_python_runtime/__init__.py",
+            "exec": "mkdir -p smithy_java_python_runtime && touch smithy_java_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -43873,7 +43873,7 @@ pyproject.toml
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
-            "exec": "mkdir -p smithy_java_python_runtime && touch smithy_java_python_runtime/__init__.py",
+            "exec": "mkdir -p smithy_java_python_runtime && touch smithy_java_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -61426,7 +61426,7 @@ mocks
         "name": "install",
         "steps": [
           {
-            "exec": "mkdir -p smithy_python_python_infra && touch smithy_python_python_infra/__init__.py",
+            "exec": "mkdir -p smithy_python_python_infra && touch smithy_python_python_infra/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -61438,7 +61438,7 @@ mocks
         "name": "install:ci",
         "steps": [
           {
-            "exec": "mkdir -p smithy_python_python_infra && touch smithy_python_python_infra/__init__.py",
+            "exec": "mkdir -p smithy_python_python_infra && touch smithy_python_python_infra/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -62468,7 +62468,7 @@ pyproject.toml
         "name": "install",
         "steps": [
           {
-            "exec": "mkdir -p smithy_python_python_runtime && touch smithy_python_python_runtime/__init__.py",
+            "exec": "mkdir -p smithy_python_python_runtime && touch smithy_python_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -62480,7 +62480,7 @@ pyproject.toml
         "name": "install:ci",
         "steps": [
           {
-            "exec": "mkdir -p smithy_python_python_runtime && touch smithy_python_python_runtime/__init__.py",
+            "exec": "mkdir -p smithy_python_python_runtime && touch smithy_python_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -66666,7 +66666,7 @@ mocks
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
-            "exec": "mkdir -p smithy_python_python_infra && touch smithy_python_python_infra/__init__.py",
+            "exec": "mkdir -p smithy_python_python_infra && touch smithy_python_python_infra/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -66687,7 +66687,7 @@ mocks
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
-            "exec": "mkdir -p smithy_python_python_infra && touch smithy_python_python_infra/__init__.py",
+            "exec": "mkdir -p smithy_python_python_infra && touch smithy_python_python_infra/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -68216,7 +68216,7 @@ pyproject.toml
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
-            "exec": "mkdir -p smithy_python_python_runtime && touch smithy_python_python_runtime/__init__.py",
+            "exec": "mkdir -p smithy_python_python_runtime && touch smithy_python_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -68237,7 +68237,7 @@ pyproject.toml
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
-            "exec": "mkdir -p smithy_python_python_runtime && touch smithy_python_python_runtime/__init__.py",
+            "exec": "mkdir -p smithy_python_python_runtime && touch smithy_python_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -72310,7 +72310,7 @@ pyproject.toml
         "name": "install",
         "steps": [
           {
-            "exec": "mkdir -p smithy_typescript_python_runtime && touch smithy_typescript_python_runtime/__init__.py",
+            "exec": "mkdir -p smithy_typescript_python_runtime && touch smithy_typescript_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -72322,7 +72322,7 @@ pyproject.toml
         "name": "install:ci",
         "steps": [
           {
-            "exec": "mkdir -p smithy_typescript_python_runtime && touch smithy_typescript_python_runtime/__init__.py",
+            "exec": "mkdir -p smithy_typescript_python_runtime && touch smithy_typescript_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -78116,7 +78116,7 @@ pyproject.toml
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
-            "exec": "mkdir -p smithy_typescript_python_runtime && touch smithy_typescript_python_runtime/__init__.py",
+            "exec": "mkdir -p smithy_typescript_python_runtime && touch smithy_typescript_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -78137,7 +78137,7 @@ pyproject.toml
             "exec": "poetry env use python$PYTHON_VERSION",
           },
           {
-            "exec": "mkdir -p smithy_typescript_python_runtime && touch smithy_typescript_python_runtime/__init__.py",
+            "exec": "mkdir -p smithy_typescript_python_runtime && touch smithy_typescript_python_runtime/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",

--- a/packages/type-safe-api/test/project/codegen/infrastructure/cdk/__snapshots__/generated-python-async-cdk-infrastructure-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/codegen/infrastructure/cdk/__snapshots__/generated-python-async-cdk-infrastructure-project.test.ts.snap
@@ -332,7 +332,7 @@ mocks
         "name": "install",
         "steps": [
           {
-            "exec": "mkdir -p test_infra && touch test_infra/__init__.py",
+            "exec": "mkdir -p test_infra && touch test_infra/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -344,7 +344,7 @@ mocks
         "name": "install:ci",
         "steps": [
           {
-            "exec": "mkdir -p test_infra && touch test_infra/__init__.py",
+            "exec": "mkdir -p test_infra && touch test_infra/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",

--- a/packages/type-safe-api/test/project/codegen/infrastructure/cdk/__snapshots__/generated-python-cdk-infrastructure-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/codegen/infrastructure/cdk/__snapshots__/generated-python-cdk-infrastructure-project.test.ts.snap
@@ -336,7 +336,7 @@ mocks
         "name": "install",
         "steps": [
           {
-            "exec": "mkdir -p test_infra && touch test_infra/__init__.py",
+            "exec": "mkdir -p test_infra && touch test_infra/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -348,7 +348,7 @@ mocks
         "name": "install:ci",
         "steps": [
           {
-            "exec": "mkdir -p test_infra && touch test_infra/__init__.py",
+            "exec": "mkdir -p test_infra && touch test_infra/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",

--- a/packages/type-safe-api/test/project/codegen/types/__snapshots__/generated-python-async-runtime-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/codegen/types/__snapshots__/generated-python-async-runtime-project.test.ts.snap
@@ -334,7 +334,7 @@ pyproject.toml
         "name": "install",
         "steps": [
           {
-            "exec": "mkdir -p test && touch test/__init__.py",
+            "exec": "mkdir -p test && touch test/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -346,7 +346,7 @@ pyproject.toml
         "name": "install:ci",
         "steps": [
           {
-            "exec": "mkdir -p test && touch test/__init__.py",
+            "exec": "mkdir -p test && touch test/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",

--- a/packages/type-safe-api/test/project/codegen/types/__snapshots__/generated-python-runtime-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/codegen/types/__snapshots__/generated-python-runtime-project.test.ts.snap
@@ -334,7 +334,7 @@ pyproject.toml
         "name": "install",
         "steps": [
           {
-            "exec": "mkdir -p test && touch test/__init__.py",
+            "exec": "mkdir -p test && touch test/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -346,7 +346,7 @@ pyproject.toml
         "name": "install:ci",
         "steps": [
           {
-            "exec": "mkdir -p test && touch test/__init__.py",
+            "exec": "mkdir -p test && touch test/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
@@ -331,7 +331,7 @@ test_project/interceptors/__init__.py",
         "name": "install",
         "steps": [
           {
-            "exec": "mkdir -p test_project && touch test_project/__init__.py",
+            "exec": "mkdir -p test_project && touch test_project/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -343,7 +343,7 @@ test_project/interceptors/__init__.py",
         "name": "install:ci",
         "steps": [
           {
-            "exec": "mkdir -p test_project && touch test_project/__init__.py",
+            "exec": "mkdir -p test_project && touch test_project/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",
@@ -4753,7 +4753,7 @@ test_project/interceptors/__init__.py",
         "name": "install",
         "steps": [
           {
-            "exec": "mkdir -p test_project && touch test_project/__init__.py",
+            "exec": "mkdir -p test_project && touch test_project/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -4765,7 +4765,7 @@ test_project/interceptors/__init__.py",
         "name": "install:ci",
         "steps": [
           {
-            "exec": "mkdir -p test_project && touch test_project/__init__.py",
+            "exec": "mkdir -p test_project && touch test_project/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",

--- a/packages/type-safe-api/test/scripts/generators/async/__snapshots__/python.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/async/__snapshots__/python.test.ts.snap
@@ -245,7 +245,7 @@ test_project/interceptors/__init__.py",
         "name": "install",
         "steps": [
           {
-            "exec": "mkdir -p test_project && touch test_project/__init__.py",
+            "exec": "mkdir -p test_project && touch test_project/__init__.py README.md",
           },
           {
             "exec": "poetry update",
@@ -257,7 +257,7 @@ test_project/interceptors/__init__.py",
         "name": "install:ci",
         "steps": [
           {
-            "exec": "mkdir -p test_project && touch test_project/__init__.py",
+            "exec": "mkdir -p test_project && touch test_project/__init__.py README.md",
           },
           {
             "exec": "poetry check --lock && poetry install",


### PR DESCRIPTION
The poetry install that runs as part of post synthesis expects there to be some code present, but code isn't generated until build time. This means that the first install will fail when either generating the project for the first time or checking out a fresh copy (since generated code is not checked in to version control).

To fix this, we add a blank README.md file in addition to the __init__.py file as the first install step to keep poetry happy until the generator overwrites it.

Fixes #813 