### PR TITLE
fix(type-safe-api): fix missing generate-next script

### DIFF
--- a/packages/type-safe-api/project.json
+++ b/packages/type-safe-api/project.json
@@ -20,7 +20,8 @@
         "{projectRoot}/coverage",
         "{projectRoot}/test-reports",
         "{projectRoot}/docs/api",
-        "{projectRoot}/scripts/type-safe-api/custom/smithy-async-transformer/aws-pdk-smithy-async-transformer.jar"
+        "{projectRoot}/scripts/type-safe-api/custom/smithy-async-transformer/aws-pdk-smithy-async-transformer.jar",
+        "{projectRoot}/scripts/type-safe-api/generators/generate.js"
       ],
       "dependsOn": [
         "^build"

--- a/projenrc/projects/type-safe-api-project.ts
+++ b/projenrc/projects/type-safe-api-project.ts
@@ -144,6 +144,10 @@ export class TypeSafeApiProject extends PDKProject {
     this.preCompileTask.exec(
       `esbuild --bundle scripts/type-safe-api/generators/generate.ts --platform=node --outfile=${generateScript}`
     );
+    NxProject.of(this)?.addBuildTargetFiles(
+      [],
+      [`{projectRoot}/${generateScript}`]
+    );
     this.gitignore.addPatterns(generateScript);
 
     this.generateInterfaces();


### PR DESCRIPTION
The [PR build](https://github.com/aws/aws-pdk/actions/runs/11114340056/job/30880598442) generated `generate.js`, but it's not considered a build output and therefore [the release build](https://github.com/aws/aws-pdk/actions/runs/11115935235/job/30885435265) which used the cached artifacts was missing the `generate.js` script.

Fix by ensuring `generate.js` is considered a build output.