### PR TITLE
fix(monorepo): exclude projen from version update during monorepo upgrade-deps

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -205,7 +205,7 @@
           "receiveArgs": true
         },
         {
-          "exec": "pnpm exec npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor"
+          "exec": "pnpm exec npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor"
         },
         {
           "exec": "pnpm exec syncpack fix-mismatches"

--- a/packages/monorepo/src/projects/typescript/monorepo-ts.ts
+++ b/packages/monorepo/src/projects/typescript/monorepo-ts.ts
@@ -509,6 +509,7 @@ export class MonorepoTsProject
         NodePackageUtils.command.exec(
           this.package.packageManager,
           "npm-check-updates",
+          "--reject projen",
           "--deep",
           "--rejectVersion",
           "0.0.0",

--- a/packages/monorepo/test/__snapshots__/monorepo.test.ts.snap
+++ b/packages/monorepo/test/__snapshots__/monorepo.test.ts.snap
@@ -590,7 +590,7 @@ yes=true
         "name": "upgrade-deps",
         "steps": [
           {
-            "exec": "pnpm exec npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "pnpm exec npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "pnpm exec syncpack fix-mismatches",
@@ -2618,7 +2618,7 @@ tsconfig.tsbuildinfo
         "name": "upgrade-deps",
         "steps": [
           {
-            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "yarn npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "yarn syncpack fix-mismatches",
@@ -4649,7 +4649,7 @@ tsconfig.tsbuildinfo
         "name": "upgrade-deps",
         "steps": [
           {
-            "exec": "yarn exec npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "yarn exec npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "yarn exec syncpack fix-mismatches",
@@ -6693,7 +6693,7 @@ tsconfig.tsbuildinfo
             "receiveArgs": true,
           },
           {
-            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "yarn npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "yarn syncpack fix-mismatches",
@@ -8992,7 +8992,7 @@ tsconfig.tsbuildinfo
             "receiveArgs": true,
           },
           {
-            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "yarn npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "yarn syncpack fix-mismatches",
@@ -11219,7 +11219,7 @@ tsconfig.tsbuildinfo
         "name": "upgrade-deps",
         "steps": [
           {
-            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "yarn npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "yarn syncpack fix-mismatches",
@@ -12253,7 +12253,7 @@ tsconfig.tsbuildinfo
         "name": "upgrade-deps",
         "steps": [
           {
-            "exec": "bun x npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "bun x npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "bun x syncpack fix-mismatches",
@@ -14281,7 +14281,7 @@ tsconfig.tsbuildinfo
             "receiveArgs": true,
           },
           {
-            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "yarn npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "yarn syncpack fix-mismatches",
@@ -17782,7 +17782,7 @@ tsconfig.tsbuildinfo
         "name": "upgrade-deps",
         "steps": [
           {
-            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "yarn npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "yarn syncpack fix-mismatches",
@@ -18820,7 +18820,7 @@ tsconfig.tsbuildinfo
         "name": "upgrade-deps",
         "steps": [
           {
-            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "yarn npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "yarn syncpack fix-mismatches",
@@ -20981,7 +20981,7 @@ pattern1.txt
         "name": "upgrade-deps",
         "steps": [
           {
-            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "yarn npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "yarn syncpack fix-mismatches",
@@ -22033,7 +22033,7 @@ yes=true
         "name": "upgrade-deps",
         "steps": [
           {
-            "exec": "pnpm exec npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "pnpm exec npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "pnpm exec syncpack fix-mismatches",
@@ -24077,7 +24077,7 @@ tsconfig.tsbuildinfo
         "name": "upgrade-deps",
         "steps": [
           {
-            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "yarn npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "yarn syncpack fix-mismatches",
@@ -25129,7 +25129,7 @@ tsconfig.tsbuildinfo
         "name": "upgrade-deps",
         "steps": [
           {
-            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "yarn npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "yarn syncpack fix-mismatches",

--- a/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
@@ -3602,7 +3602,7 @@ tsconfig.tsbuildinfo
             "receiveArgs": true,
           },
           {
-            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "yarn npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "yarn syncpack fix-mismatches",
@@ -12960,7 +12960,7 @@ tsconfig.tsbuildinfo
             "receiveArgs": true,
           },
           {
-            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "yarn npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "yarn syncpack fix-mismatches",
@@ -22491,7 +22491,7 @@ tsconfig.tsbuildinfo
             "receiveArgs": true,
           },
           {
-            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "yarn npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "yarn syncpack fix-mismatches",
@@ -39122,7 +39122,7 @@ tsconfig.tsbuildinfo
             "receiveArgs": true,
           },
           {
-            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "yarn npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "yarn syncpack fix-mismatches",
@@ -47947,7 +47947,7 @@ tsconfig.tsbuildinfo
             "receiveArgs": true,
           },
           {
-            "exec": "npx npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "npx npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "npx syncpack fix-mismatches",
@@ -55182,7 +55182,7 @@ yes=true
             "receiveArgs": true,
           },
           {
-            "exec": "pnpm exec npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "pnpm exec npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "pnpm exec syncpack fix-mismatches",
@@ -63131,7 +63131,7 @@ tsconfig.tsbuildinfo
             "receiveArgs": true,
           },
           {
-            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "yarn npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "yarn syncpack fix-mismatches",
@@ -72850,7 +72850,7 @@ tsconfig.tsbuildinfo
             "receiveArgs": true,
           },
           {
-            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "yarn npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "yarn syncpack fix-mismatches",
@@ -81645,7 +81645,7 @@ tsconfig.tsbuildinfo
             "receiveArgs": true,
           },
           {
-            "exec": "yarn exec npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "yarn exec npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "yarn exec syncpack fix-mismatches",
@@ -88905,7 +88905,7 @@ tsconfig.tsbuildinfo
             "receiveArgs": true,
           },
           {
-            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "yarn npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "yarn syncpack fix-mismatches",

--- a/packages/type-safe-api/test/project/__snapshots__/type-safe-websocket-api-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/__snapshots__/type-safe-websocket-api-project.test.ts.snap
@@ -2611,7 +2611,7 @@ tsconfig.tsbuildinfo
             "receiveArgs": true,
           },
           {
-            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "yarn npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "yarn syncpack fix-mismatches",
@@ -15274,7 +15274,7 @@ tsconfig.tsbuildinfo
             "receiveArgs": true,
           },
           {
-            "exec": "npx npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "npx npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "npx syncpack fix-mismatches",
@@ -21849,7 +21849,7 @@ yes=true
             "receiveArgs": true,
           },
           {
-            "exec": "pnpm exec npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "pnpm exec npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "pnpm exec syncpack fix-mismatches",
@@ -28424,7 +28424,7 @@ tsconfig.tsbuildinfo
             "receiveArgs": true,
           },
           {
-            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "yarn npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "yarn syncpack fix-mismatches",
@@ -35014,7 +35014,7 @@ tsconfig.tsbuildinfo
             "receiveArgs": true,
           },
           {
-            "exec": "yarn exec npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "yarn exec npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "yarn exec syncpack fix-mismatches",
@@ -41614,7 +41614,7 @@ tsconfig.tsbuildinfo
             "receiveArgs": true,
           },
           {
-            "exec": "yarn npm-check-updates --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
+            "exec": "yarn npm-check-updates --reject projen --deep --rejectVersion 0.0.0 -u --dep prod,dev,peer,optional,bundle --target=minor",
           },
           {
             "exec": "yarn syncpack fix-mismatches",


### PR DESCRIPTION
Added `--reject projen` to `npm-check-updates` step of `upgrade-deps` task.

Fixes: #837