### PR TITLE
fix(type-safe-api): path undefined issue for particular node versions

### DIFF
--- a/packages/type-safe-api/scripts/type-safe-api/generators/generate-next.ts
+++ b/packages/type-safe-api/scripts/type-safe-api/generators/generate-next.ts
@@ -649,7 +649,7 @@ export default async (argv: string[], rootScriptDir: string) => {
   const templates = args.templateDirs.flatMap(t => fs.readdirSync(resolveTemplateDir(rootScriptDir, t), {
     recursive: true,
     withFileTypes: true
-  }).filter(f => f.isFile() && f.name.endsWith('.ejs')).map(f => path.join(f.parentPath, f.name)));
+  }).filter(f => f.isFile() && f.name.endsWith('.ejs')).map(f => path.join(f.parentPath ?? f.path, f.name)));
 
   // Render the templates with the data from the spec
   const renderedFiles = templates.map((template) => {


### PR DESCRIPTION
The fs.dirent class uses `parentPath` as the preferred member for the path of a file entry, however some node versions still use the now deprecated `path` member and `parentPath` is undefined, causing the generate script to fail to find templates.

Address this by falling back to the `path` member.

Fixes #838
