### PR TITLE
fix(type-safe-api): fix websocket api client compilation issue

### DIFF
--- a/packages/type-safe-api/scripts/type-safe-api/generators/typescript-websocket-client/templates/index.ejs
+++ b/packages/type-safe-api/scripts/type-safe-api/generators/typescript-websocket-client/templates/index.ejs
@@ -8,6 +8,5 @@
 }
 ###/TSAPI_WRITE_FILE###/* tslint:disable */
 /* eslint-disable */
-export * from './runtime';
 export * from './models';
 export * from './client/client';

--- a/packages/type-safe-api/scripts/type-safe-api/generators/typescript/templates/client/models/modelUtils.ejs
+++ b/packages/type-safe-api/scripts/type-safe-api/generators/typescript/templates/client/models/modelUtils.ejs
@@ -1,0 +1,22 @@
+###TSAPI_WRITE_FILE###
+{
+  "id": "model-utils",
+  "dir": "<%= metadata.srcDir || 'src' %>/models",
+  "name": "model-utils",
+  "ext": ".ts",
+  "overwrite": true
+}
+###/TSAPI_WRITE_FILE###/* tslint:disable */
+/* eslint-disable */
+
+export function mapValues(data: any, fn: (item: any) => any) {
+  return Object.keys(data).reduce(
+    (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
+    {}
+  );
+}
+
+export function exists(json: any, key: string) {
+  const value = json[key];
+  return value !== null && value !== undefined;
+}

--- a/packages/type-safe-api/scripts/type-safe-api/generators/typescript/templates/client/models/models.ejs
+++ b/packages/type-safe-api/scripts/type-safe-api/generators/typescript/templates/client/models/models.ejs
@@ -19,7 +19,7 @@
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 <%_ model.uniqueImports.forEach((importName) => { _%>
 import type { <%= importName %> } from './<%= importName %>';
 import {

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript-react-query-hooks.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript-react-query-hooks.test.ts.snap
@@ -7,6 +7,7 @@ src/apis/DefaultApi.ts
 src/apis/Tag1Api.ts
 src/apis/Tag2Api.ts
 src/apis/index.ts
+src/models/model-utils.ts
 README.md
 src/apis/index.ts
 src/apis/DefaultApiClientProvider.tsx
@@ -586,6 +587,21 @@ export * from './Tag2ApiClientProvider';
 export * from './runtime';
 export * from './apis';
 export * from './models';",
+  "src/models/model-utils.ts": "/* tslint:disable */
+/* eslint-disable */
+
+export function mapValues(data: any, fn: (item: any) => any) {
+  return Object.keys(data).reduce(
+    (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
+    {}
+  );
+}
+
+export function exists(json: any, key: string) {
+  const value = json[key];
+  return value !== null && value !== undefined;
+}
+",
   "src/runtime.ts": "/* tslint:disable */
 /* eslint-disable */
 /**
@@ -1001,6 +1017,7 @@ exports[`Typescript React Query Hooks Code Generation Script Unit Tests Generate
 src/apis/DefaultApi.ts
 src/apis/index.ts
 src/models/index.ts
+src/models/model-utils.ts
 src/models/ApiError.ts
 src/models/PaginatedGet200Response.ts
 src/models/RegularGet200Response.ts
@@ -1636,7 +1653,7 @@ export * from './models';",
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 
 /**
  * 
@@ -1703,7 +1720,7 @@ export function ApiErrorToJSON(value?: ApiError | null): any {
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 
 /**
  * 
@@ -1777,7 +1794,7 @@ export function PaginatedGet200ResponseToJSON(value?: PaginatedGet200Response | 
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 
 /**
  * 
@@ -1843,7 +1860,7 @@ export function RegularGet200ResponseToJSON(value?: RegularGet200Response | null
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 
 /**
  * 
@@ -1909,7 +1926,7 @@ export function TestRequestToJSON(value?: TestRequest | null): any {
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 import type { TestResponseMessagesInner } from './TestResponseMessagesInner';
 import {
     TestResponseMessagesInnerFromJSON,
@@ -1982,7 +1999,7 @@ export function TestResponseToJSON(value?: TestResponse | null): any {
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 
 /**
  * 
@@ -2053,6 +2070,21 @@ export * from './RegularGet200Response';
 export * from './TestRequest';
 export * from './TestResponse';
 export * from './TestResponseMessagesInner';
+",
+  "src/models/model-utils.ts": "/* tslint:disable */
+/* eslint-disable */
+
+export function mapValues(data: any, fn: (item: any) => any) {
+  return Object.keys(data).reduce(
+    (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
+    {}
+  );
+}
+
+export function exists(json: any, key: string) {
+  const value = json[key];
+  return value !== null && value !== undefined;
+}
 ",
   "src/runtime.ts": "/* tslint:disable */
 /* eslint-disable */

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript.test.ts.snap
@@ -15,6 +15,7 @@ src/response/response.ts
 src/apis/DefaultApi.ts
 src/apis/index.ts
 src/models/index.ts
+src/models/model-utils.ts
 src/models/Template.ts
 src/models/TemplateBase.ts
 src/models/TemplateBody.ts
@@ -777,7 +778,7 @@ export const tryCatchInterceptor = buildTryCatchInterceptor(500, { message: 'Int
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 import type { TemplateBase } from './TemplateBase';
 import {
     TemplateBaseFromJSON,
@@ -862,7 +863,7 @@ export function TemplateToJSON(value?: Template | null): any {
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 import type { TemplateID } from './TemplateID';
 import {
     TemplateIDFromJSON,
@@ -936,7 +937,7 @@ export function TemplateBaseToJSON(value?: TemplateBase | null): any {
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 import type { TemplateID } from './TemplateID';
 import {
     TemplateIDFromJSON,
@@ -1017,7 +1018,7 @@ export function TemplateBodyToJSON(value?: TemplateBody | null): any {
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 
 /**
  * The unique identifier for a template.
@@ -1056,6 +1057,21 @@ export * from './Template';
 export * from './TemplateBase';
 export * from './TemplateBody';
 export * from './TemplateID';
+",
+  "src/models/model-utils.ts": "/* tslint:disable */
+/* eslint-disable */
+
+export function mapValues(data: any, fn: (item: any) => any) {
+  return Object.keys(data).reduce(
+    (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
+    {}
+  );
+}
+
+export function exists(json: any, key: string) {
+  const value = json[key];
+  return value !== null && value !== undefined;
+}
 ",
   "src/response/response.ts": "import { OperationResponse } from '..';
 
@@ -1539,6 +1555,7 @@ src/response/response.ts
 src/apis/DefaultApi.ts
 src/apis/index.ts
 src/models/index.ts
+src/models/model-utils.ts
 src/models/DataTypes200Response.ts",
   "src/apis/DefaultApi.ts": "/* tslint:disable */
 /* eslint-disable */
@@ -2289,7 +2306,7 @@ export const tryCatchInterceptor = buildTryCatchInterceptor(500, { message: 'Int
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 
 /**
  * 
@@ -2514,6 +2531,21 @@ export function DataTypes200ResponseToJSON(value?: DataTypes200Response | null):
   "src/models/index.ts": "/* tslint:disable */
 /* eslint-disable */
 export * from './DataTypes200Response';
+",
+  "src/models/model-utils.ts": "/* tslint:disable */
+/* eslint-disable */
+
+export function mapValues(data: any, fn: (item: any) => any) {
+  return Object.keys(data).reduce(
+    (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
+    {}
+  );
+}
+
+export function exists(json: any, key: string) {
+  const value = json[key];
+  return value !== null && value !== undefined;
+}
 ",
   "src/response/response.ts": "import { OperationResponse } from '..';
 
@@ -2997,6 +3029,7 @@ src/response/response.ts
 src/apis/DefaultApi.ts
 src/apis/index.ts
 src/models/index.ts
+src/models/model-utils.ts
 src/models/HelloId.ts
 src/models/SayHelloResponseContent.ts
 src/models/ServiceUnavailableErrorResponseContent.ts",
@@ -3782,7 +3815,7 @@ export const tryCatchInterceptor = buildTryCatchInterceptor(500, { message: 'Int
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 
 /**
  * 
@@ -3827,7 +3860,7 @@ export function HelloIdToJSON(value?: HelloId | null): any {
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 import type { HelloId } from './HelloId';
 import {
     HelloIdFromJSON,
@@ -3908,7 +3941,7 @@ export function SayHelloResponseContentToJSON(value?: SayHelloResponseContent | 
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 
 /**
  * 
@@ -3968,6 +4001,21 @@ export function ServiceUnavailableErrorResponseContentToJSON(value?: ServiceUnav
 export * from './HelloId';
 export * from './SayHelloResponseContent';
 export * from './ServiceUnavailableErrorResponseContent';
+",
+  "src/models/model-utils.ts": "/* tslint:disable */
+/* eslint-disable */
+
+export function mapValues(data: any, fn: (item: any) => any) {
+  return Object.keys(data).reduce(
+    (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
+    {}
+  );
+}
+
+export function exists(json: any, key: string) {
+  const value = json[key];
+  return value !== null && value !== undefined;
+}
 ",
   "src/response/response.ts": "import { OperationResponse } from '..';
 
@@ -4451,6 +4499,7 @@ src/response/response.ts
 src/apis/DefaultApi.ts
 src/apis/index.ts
 src/models/index.ts
+src/models/model-utils.ts
 src/models/MyEnum.ts",
   "src/apis/DefaultApi.ts": "/* tslint:disable */
 /* eslint-disable */
@@ -5420,7 +5469,7 @@ export const tryCatchInterceptor = buildTryCatchInterceptor(500, { message: 'Int
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 
 /**
  * 
@@ -5449,6 +5498,21 @@ export function MyEnumToJSON(value?: MyEnum | null): any {
   "src/models/index.ts": "/* tslint:disable */
 /* eslint-disable */
 export * from './MyEnum';
+",
+  "src/models/model-utils.ts": "/* tslint:disable */
+/* eslint-disable */
+
+export function mapValues(data: any, fn: (item: any) => any) {
+  return Object.keys(data).reduce(
+    (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
+    {}
+  );
+}
+
+export function exists(json: any, key: string) {
+  const value = json[key];
+  return value !== null && value !== undefined;
+}
 ",
   "src/response/response.ts": "import { OperationResponse } from '..';
 
@@ -5932,7 +5996,8 @@ src/response/response.ts
 src/apis/DefaultApi.ts
 src/apis/Tag1Api.ts
 src/apis/Tag2Api.ts
-src/apis/index.ts",
+src/apis/index.ts
+src/models/model-utils.ts",
   "src/apis/DefaultApi.ts": "/* tslint:disable */
 /* eslint-disable */
 /**
@@ -7136,6 +7201,21 @@ export const buildTryCatchInterceptor = <TStatus extends number, ErrorResponseBo
  */
 export const tryCatchInterceptor = buildTryCatchInterceptor(500, { message: 'Internal Error' });
 ",
+  "src/models/model-utils.ts": "/* tslint:disable */
+/* eslint-disable */
+
+export function mapValues(data: any, fn: (item: any) => any) {
+  return Object.keys(data).reduce(
+    (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
+    {}
+  );
+}
+
+export function exists(json: any, key: string) {
+  const value = json[key];
+  return value !== null && value !== undefined;
+}
+",
   "src/response/response.ts": "import { OperationResponse } from '..';
 
 
@@ -7618,6 +7698,7 @@ src/response/response.ts
 src/apis/DefaultApi.ts
 src/apis/index.ts
 src/models/index.ts
+src/models/model-utils.ts
 src/models/HelloId.ts
 src/models/HelloResponse.ts",
   "src/apis/DefaultApi.ts": "/* tslint:disable */
@@ -8385,7 +8466,7 @@ export const tryCatchInterceptor = buildTryCatchInterceptor(500, { message: 'Int
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 
 /**
  * 
@@ -8430,7 +8511,7 @@ export function HelloIdToJSON(value?: HelloId | null): any {
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 import type { HelloId } from './HelloId';
 import {
     HelloIdFromJSON,
@@ -8509,6 +8590,21 @@ export function HelloResponseToJSON(value?: HelloResponse | null): any {
 /* eslint-disable */
 export * from './HelloId';
 export * from './HelloResponse';
+",
+  "src/models/model-utils.ts": "/* tslint:disable */
+/* eslint-disable */
+
+export function mapValues(data: any, fn: (item: any) => any) {
+  return Object.keys(data).reduce(
+    (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
+    {}
+  );
+}
+
+export function exists(json: any, key: string) {
+  const value = json[key];
+  return value !== null && value !== undefined;
+}
 ",
   "src/response/response.ts": "import { OperationResponse } from '..';
 
@@ -8992,6 +9088,7 @@ src/response/response.ts
 src/apis/DefaultApi.ts
 src/apis/index.ts
 src/models/index.ts
+src/models/model-utils.ts
 src/models/ApiError.ts
 src/models/MapResponse.ts
 src/models/MapResponseMapPropertyValue.ts
@@ -10751,7 +10848,7 @@ export const tryCatchInterceptor = buildTryCatchInterceptor(500, { message: 'Int
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 
 /**
  * 
@@ -10818,7 +10915,7 @@ export function ApiErrorToJSON(value?: ApiError | null): any {
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 import type { MapResponseMapPropertyValue } from './MapResponseMapPropertyValue';
 import {
     MapResponseMapPropertyValueFromJSON,
@@ -10891,7 +10988,7 @@ export function MapResponseToJSON(value?: MapResponse | null): any {
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 
 /**
  * 
@@ -10966,7 +11063,7 @@ export function MapResponseMapPropertyValueToJSON(value?: MapResponseMapProperty
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 
 /**
  * This is a test request
@@ -11032,7 +11129,7 @@ export function TestRequestToJSON(value?: TestRequest | null): any {
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 import type { TestResponseMessagesInner } from './TestResponseMessagesInner';
 import {
     TestResponseMessagesInnerFromJSON,
@@ -11105,7 +11202,7 @@ export function TestResponseToJSON(value?: TestResponse | null): any {
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 
 /**
  * 
@@ -11176,6 +11273,21 @@ export * from './MapResponseMapPropertyValue';
 export * from './TestRequest';
 export * from './TestResponse';
 export * from './TestResponseMessagesInner';
+",
+  "src/models/model-utils.ts": "/* tslint:disable */
+/* eslint-disable */
+
+export function mapValues(data: any, fn: (item: any) => any) {
+  return Object.keys(data).reduce(
+    (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
+    {}
+  );
+}
+
+export function exists(json: any, key: string) {
+  const value = json[key];
+  return value !== null && value !== undefined;
+}
 ",
   "src/response/response.ts": "import { OperationResponse } from '..';
 

--- a/packages/type-safe-api/test/scripts/generators/async/__snapshots__/typescript-websocket-client.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/async/__snapshots__/typescript-websocket-client.test.ts.snap
@@ -5,6 +5,7 @@ exports[`Typescript Async Client Code Generation Script Unit Tests Generates Wit
   ".tsapi-manifest": "src/client/client.ts
 src/index.ts
 src/models/index.ts
+src/models/model-utils.ts
 src/models/ApiError.ts
 src/models/MapRequest.ts
 src/models/MapRequestMapPropertyValue.ts
@@ -524,7 +525,6 @@ export class DefaultApiWebSocketClient {
 ",
   "src/index.ts": "/* tslint:disable */
 /* eslint-disable */
-export * from './runtime';
 export * from './models';
 export * from './client/client';
 ",
@@ -540,7 +540,7 @@ export * from './client/client';
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 
 /**
  * 
@@ -607,7 +607,7 @@ export function ApiErrorToJSON(value?: ApiError | null): any {
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 import type { MapRequestMapPropertyValue } from './MapRequestMapPropertyValue';
 import {
     MapRequestMapPropertyValueFromJSON,
@@ -680,7 +680,7 @@ export function MapRequestToJSON(value?: MapRequest | null): any {
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 
 /**
  * 
@@ -755,7 +755,7 @@ export function MapRequestMapPropertyValueToJSON(value?: MapRequestMapPropertyVa
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 
 /**
  * This is a test request
@@ -821,7 +821,7 @@ export function TestRequestToJSON(value?: TestRequest | null): any {
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 import type { TestResponseMessagesInner } from './TestResponseMessagesInner';
 import {
     TestResponseMessagesInnerFromJSON,
@@ -894,7 +894,7 @@ export function TestResponseToJSON(value?: TestResponse | null): any {
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 
 /**
  * 
@@ -965,6 +965,21 @@ export * from './MapRequestMapPropertyValue';
 export * from './TestRequest';
 export * from './TestResponse';
 export * from './TestResponseMessagesInner';
+",
+  "src/models/model-utils.ts": "/* tslint:disable */
+/* eslint-disable */
+
+export function mapValues(data: any, fn: (item: any) => any) {
+  return Object.keys(data).reduce(
+    (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
+    {}
+  );
+}
+
+export function exists(json: any, key: string) {
+  const value = json[key];
+  return value !== null && value !== undefined;
+}
 ",
 }
 `;

--- a/packages/type-safe-api/test/scripts/generators/async/__snapshots__/typescript.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/async/__snapshots__/typescript.test.ts.snap
@@ -11,6 +11,7 @@ src/interceptors/index.ts
 src/server/operation-config.ts
 src/server/server-sdk.ts
 src/models/index.ts
+src/models/model-utils.ts
 src/models/ApiError.ts
 src/models/MapRequest.ts
 src/models/MapRequestMapPropertyValue.ts
@@ -216,7 +217,7 @@ export const tryCatchInterceptor = buildTryCatchInterceptor();
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 
 /**
  * 
@@ -283,7 +284,7 @@ export function ApiErrorToJSON(value?: ApiError | null): any {
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 import type { MapRequestMapPropertyValue } from './MapRequestMapPropertyValue';
 import {
     MapRequestMapPropertyValueFromJSON,
@@ -356,7 +357,7 @@ export function MapRequestToJSON(value?: MapRequest | null): any {
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 
 /**
  * 
@@ -431,7 +432,7 @@ export function MapRequestMapPropertyValueToJSON(value?: MapRequestMapPropertyVa
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 
 /**
  * This is a test request
@@ -497,7 +498,7 @@ export function TestRequestToJSON(value?: TestRequest | null): any {
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 import type { TestResponseMessagesInner } from './TestResponseMessagesInner';
 import {
     TestResponseMessagesInnerFromJSON,
@@ -570,7 +571,7 @@ export function TestResponseToJSON(value?: TestResponse | null): any {
  * NOTE: This class is auto generated.
  * Do not edit the class manually.
  */
-import { exists, mapValues } from '../runtime';
+import { exists, mapValues } from './model-utils';
 
 /**
  * 
@@ -641,6 +642,21 @@ export * from './MapRequestMapPropertyValue';
 export * from './TestRequest';
 export * from './TestResponse';
 export * from './TestResponseMessagesInner';
+",
+  "src/models/model-utils.ts": "/* tslint:disable */
+/* eslint-disable */
+
+export function mapValues(data: any, fn: (item: any) => any) {
+  return Object.keys(data).reduce(
+    (acc, key) => ({ ...acc, [key]: fn(data[key]) }),
+    {}
+  );
+}
+
+export function exists(json: any, key: string) {
+  const value = json[key];
+  return value !== null && value !== undefined;
+}
 ",
   "src/server/operation-config.ts": "// Import models
 import {


### PR DESCRIPTION
The websocket api client library failed to compile due to a missing `runtime.ts` file, which the models depend on. As `runtime.ts` is predominantly http api focussed, we add a `model-utils.ts` file with just the required methods such that models are independent of http api files.
