### PR TITLE
fix(type-safe-api): empty models generated for reused primitives

### DIFF
--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript.test.ts.snap
@@ -18,8 +18,7 @@ src/models/index.ts
 src/models/model-utils.ts
 src/models/Template.ts
 src/models/TemplateBase.ts
-src/models/TemplateBody.ts
-src/models/TemplateID.ts",
+src/models/TemplateBody.ts",
   "src/apis/DefaultApi.ts": "/* tslint:disable */
 /* eslint-disable */
 /**
@@ -90,9 +89,6 @@ import {
     TemplateBody,
     TemplateBodyFromJSON,
     TemplateBodyToJSON,
-    TemplateID,
-    TemplateIDFromJSON,
-    TemplateIDToJSON,
 } from '../../models';
 // Import request parameter interfaces
 import {
@@ -850,13 +846,6 @@ export function TemplateToJSON(value?: Template | null): any {
  * Do not edit the class manually.
  */
 import { exists, mapValues } from './model-utils';
-import type { TemplateID } from './TemplateID';
-import {
-    TemplateIDFromJSON,
-    TemplateIDFromJSONTyped,
-    TemplateIDToJSON,
-    instanceOfTemplateID,
-} from './TemplateID';
 
 /**
  * Represents the base properties of a template.
@@ -866,11 +855,11 @@ import {
  */
 export interface TemplateBase {
     /**
-     * 
-     * @type {TemplateID}
+     * The unique identifier for a template.
+     * @type {string}
      * @memberof TemplateBase
      */
-    id: TemplateID;
+    id: string;
 }
 
 
@@ -893,7 +882,7 @@ export function TemplateBaseFromJSONTyped(json: any, ignoreDiscriminator: boolea
     }
     return {
 
-        'id': TemplateIDFromJSON(json['id']),
+        'id': json['id'],
     };
 }
 
@@ -906,7 +895,7 @@ export function TemplateBaseToJSON(value?: TemplateBase | null): any {
     }
     return {
 
-        'id': TemplateIDToJSON(value.id),
+        'id': value.id,
     };
 }
 
@@ -924,13 +913,6 @@ export function TemplateBaseToJSON(value?: TemplateBase | null): any {
  * Do not edit the class manually.
  */
 import { exists, mapValues } from './model-utils';
-import type { TemplateID } from './TemplateID';
-import {
-    TemplateIDFromJSON,
-    TemplateIDFromJSONTyped,
-    TemplateIDToJSON,
-    instanceOfTemplateID,
-} from './TemplateID';
 
 /**
  * Represents the body of a template.
@@ -940,11 +922,11 @@ import {
  */
 export interface TemplateBody {
     /**
-     * 
-     * @type {TemplateID}
+     * The unique identifier for a template.
+     * @type {string}
      * @memberof TemplateBody
      */
-    parent_id?: TemplateID;
+    parent_id?: string;
     /**
      * A boolean value.
      * @type {boolean}
@@ -972,7 +954,7 @@ export function TemplateBodyFromJSONTyped(json: any, ignoreDiscriminator: boolea
     }
     return {
 
-        'parent_id': !exists(json, 'parent_id') ? undefined : TemplateIDFromJSON(json['parent_id']),
+        'parent_id': !exists(json, 'parent_id') ? undefined : json['parent_id'],
         'boolean': !exists(json, 'boolean') ? undefined : json['boolean'],
     };
 }
@@ -986,53 +968,9 @@ export function TemplateBodyToJSON(value?: TemplateBody | null): any {
     }
     return {
 
-        'parent_id': TemplateIDToJSON(value.parent_id),
+        'parent_id': value.parent_id,
         'boolean': value.boolean,
     };
-}
-
-",
-  "src/models/TemplateID.ts": "/* tslint:disable */
-/* eslint-disable */
-/**
- * My API
- * See https://github.com/aws/aws-pdk/issues/841
- *
- * The version of the OpenAPI document: 1.0.0
- *
- *
- * NOTE: This class is auto generated.
- * Do not edit the class manually.
- */
-import { exists, mapValues } from './model-utils';
-
-/**
- * The unique identifier for a template.
- * @export
- * @interface TemplateID
- */
-export interface TemplateID {
-}
-
-
-/**
- * Check if a given object implements the TemplateID interface.
- */
-export function instanceOfTemplateID(value: object): boolean {
-    let isInstance = true;
-    return isInstance;
-}
-
-export function TemplateIDFromJSON(json: any): TemplateID {
-    return TemplateIDFromJSONTyped(json, false);
-}
-
-export function TemplateIDFromJSONTyped(json: any, ignoreDiscriminator: boolean): TemplateID {
-    return json;
-}
-
-export function TemplateIDToJSON(value?: TemplateID | null): any {
-    return value;
 }
 
 ",
@@ -1041,7 +979,6 @@ export function TemplateIDToJSON(value?: TemplateID | null): any {
 export * from './Template';
 export * from './TemplateBase';
 export * from './TemplateBody';
-export * from './TemplateID';
 ",
   "src/models/model-utils.ts": "/* tslint:disable */
 /* eslint-disable */
@@ -6872,7 +6809,6 @@ src/apis/DefaultApi.ts
 src/apis/index.ts
 src/models/index.ts
 src/models/model-utils.ts
-src/models/HelloId.ts
 src/models/SayHelloResponseContent.ts
 src/models/ServiceUnavailableErrorResponseContent.ts",
   "src/apis/DefaultApi.ts": "/* tslint:disable */
@@ -6950,9 +6886,6 @@ export class DefaultApi extends runtime.BaseAPI {
 ",
   "src/apis/DefaultApi/OperationConfig.ts": "// Import models
 import {
-    HelloId,
-    HelloIdFromJSON,
-    HelloIdToJSON,
     SayHelloResponseContent,
     SayHelloResponseContentFromJSON,
     SayHelloResponseContentToJSON,
@@ -7645,50 +7578,6 @@ export const buildTryCatchInterceptor = <TStatus extends number, ErrorResponseBo
  */
 export const tryCatchInterceptor = buildTryCatchInterceptor(500, { message: 'Internal Error' });
 ",
-  "src/models/HelloId.ts": "/* tslint:disable */
-/* eslint-disable */
-/**
- * My API
- * See https://github.com/aws/aws-pdk/issues/841
- *
- * The version of the OpenAPI document: 1.0.0
- *
- *
- * NOTE: This class is auto generated.
- * Do not edit the class manually.
- */
-import { exists, mapValues } from './model-utils';
-
-/**
- * 
- * @export
- * @interface HelloId
- */
-export interface HelloId {
-}
-
-
-/**
- * Check if a given object implements the HelloId interface.
- */
-export function instanceOfHelloId(value: object): boolean {
-    let isInstance = true;
-    return isInstance;
-}
-
-export function HelloIdFromJSON(json: any): HelloId {
-    return HelloIdFromJSONTyped(json, false);
-}
-
-export function HelloIdFromJSONTyped(json: any, ignoreDiscriminator: boolean): HelloId {
-    return json;
-}
-
-export function HelloIdToJSON(value?: HelloId | null): any {
-    return value;
-}
-
-",
   "src/models/SayHelloResponseContent.ts": "/* tslint:disable */
 /* eslint-disable */
 /**
@@ -7702,13 +7591,6 @@ export function HelloIdToJSON(value?: HelloId | null): any {
  * Do not edit the class manually.
  */
 import { exists, mapValues } from './model-utils';
-import type { HelloId } from './HelloId';
-import {
-    HelloIdFromJSON,
-    HelloIdFromJSONTyped,
-    HelloIdToJSON,
-    instanceOfHelloId,
-} from './HelloId';
 
 /**
  * 
@@ -7718,10 +7600,10 @@ import {
 export interface SayHelloResponseContent {
     /**
      * 
-     * @type {HelloId}
+     * @type {string}
      * @memberof SayHelloResponseContent
      */
-    id?: HelloId;
+    id?: string;
     /**
      * 
      * @type {string}
@@ -7750,7 +7632,7 @@ export function SayHelloResponseContentFromJSONTyped(json: any, ignoreDiscrimina
     }
     return {
 
-        'id': !exists(json, 'id') ? undefined : HelloIdFromJSON(json['id']),
+        'id': !exists(json, 'id') ? undefined : json['id'],
         'message': json['message'],
     };
 }
@@ -7764,7 +7646,7 @@ export function SayHelloResponseContentToJSON(value?: SayHelloResponseContent | 
     }
     return {
 
-        'id': HelloIdToJSON(value.id),
+        'id': value.id,
         'message': value.message,
     };
 }
@@ -7838,7 +7720,6 @@ export function ServiceUnavailableErrorResponseContentToJSON(value?: ServiceUnav
 ",
   "src/models/index.ts": "/* tslint:disable */
 /* eslint-disable */
-export * from './HelloId';
 export * from './SayHelloResponseContent';
 export * from './ServiceUnavailableErrorResponseContent';
 ",
@@ -11547,7 +11428,6 @@ src/apis/DefaultApi.ts
 src/apis/index.ts
 src/models/index.ts
 src/models/model-utils.ts
-src/models/HelloId.ts
 src/models/HelloResponse.ts",
   "src/apis/DefaultApi.ts": "/* tslint:disable */
 /* eslint-disable */
@@ -11564,18 +11444,15 @@ src/models/HelloResponse.ts",
 
 import * as runtime from '../runtime';
 import type {
-  HelloId,
   HelloResponse,
 } from '../models';
 import {
-    HelloIdFromJSON,
-    HelloIdToJSON,
     HelloResponseFromJSON,
     HelloResponseToJSON,
 } from '../models';
 
 export interface SayHelloRequest {
-    id?: HelloId;
+    id?: string;
 }
 
 /**
@@ -11620,9 +11497,6 @@ export class DefaultApi extends runtime.BaseAPI {
 ",
   "src/apis/DefaultApi/OperationConfig.ts": "// Import models
 import {
-    HelloId,
-    HelloIdFromJSON,
-    HelloIdToJSON,
     HelloResponse,
     HelloResponseFromJSON,
     HelloResponseToJSON,
@@ -11843,7 +11717,7 @@ const buildHandlerChain = <RequestParameters, RequestBody, Response>(
  * Path, Query and Header parameters for SayHello
  */
 export interface SayHelloRequestParameters {
-    readonly id?: HelloId;
+    readonly id?: string;
 }
 
 /**
@@ -11906,7 +11780,7 @@ export const sayHelloHandler = (
 
     try {
       requestParameters = {
-          id: coerceParameter("id", "HelloId", false || false || false, rawSingleValueParameters, rawMultiValueParameters, false) as HelloId | undefined,
+          id: coerceParameter("id", "string", false || false || false, rawSingleValueParameters, rawMultiValueParameters, false) as string | undefined,
 
       };
     } catch (e: any) {
@@ -12302,50 +12176,6 @@ export const buildTryCatchInterceptor = <TStatus extends number, ErrorResponseBo
  */
 export const tryCatchInterceptor = buildTryCatchInterceptor(500, { message: 'Internal Error' });
 ",
-  "src/models/HelloId.ts": "/* tslint:disable */
-/* eslint-disable */
-/**
- * Example API
- * 
- *
- * The version of the OpenAPI document: 1.0.0
- *
- *
- * NOTE: This class is auto generated.
- * Do not edit the class manually.
- */
-import { exists, mapValues } from './model-utils';
-
-/**
- * 
- * @export
- * @interface HelloId
- */
-export interface HelloId {
-}
-
-
-/**
- * Check if a given object implements the HelloId interface.
- */
-export function instanceOfHelloId(value: object): boolean {
-    let isInstance = true;
-    return isInstance;
-}
-
-export function HelloIdFromJSON(json: any): HelloId {
-    return HelloIdFromJSONTyped(json, false);
-}
-
-export function HelloIdFromJSONTyped(json: any, ignoreDiscriminator: boolean): HelloId {
-    return json;
-}
-
-export function HelloIdToJSON(value?: HelloId | null): any {
-    return value;
-}
-
-",
   "src/models/HelloResponse.ts": "/* tslint:disable */
 /* eslint-disable */
 /**
@@ -12359,13 +12189,6 @@ export function HelloIdToJSON(value?: HelloId | null): any {
  * Do not edit the class manually.
  */
 import { exists, mapValues } from './model-utils';
-import type { HelloId } from './HelloId';
-import {
-    HelloIdFromJSON,
-    HelloIdFromJSONTyped,
-    HelloIdToJSON,
-    instanceOfHelloId,
-} from './HelloId';
 import type { HelloResponse } from './HelloResponse';
 import {
     HelloResponseFromJSON,
@@ -12382,10 +12205,10 @@ import {
 export interface HelloResponse {
     /**
      * 
-     * @type {HelloId}
+     * @type {string}
      * @memberof HelloResponse
      */
-    id: HelloId;
+    id: string;
     /**
      * 
      * @type {HelloResponse}
@@ -12414,7 +12237,7 @@ export function HelloResponseFromJSONTyped(json: any, ignoreDiscriminator: boole
     }
     return {
 
-        'id': HelloIdFromJSON(json['id']),
+        'id': json['id'],
         'message': !exists(json, 'message') ? undefined : HelloResponseFromJSON(json['message']),
     };
 }
@@ -12428,7 +12251,7 @@ export function HelloResponseToJSON(value?: HelloResponse | null): any {
     }
     return {
 
-        'id': HelloIdToJSON(value.id),
+        'id': value.id,
         'message': HelloResponseToJSON(value.message),
     };
 }
@@ -12436,7 +12259,6 @@ export function HelloResponseToJSON(value?: HelloResponse | null): any {
 ",
   "src/models/index.ts": "/* tslint:disable */
 /* eslint-disable */
-export * from './HelloId';
 export * from './HelloResponse';
 ",
   "src/models/model-utils.ts": "/* tslint:disable */


### PR DESCRIPTION
Address a bug where empty models were generated for primitive types defined in components.schemas.

Additionally ensure that additional types are added to the template data models/properties when nested below allOf/anyOf/oneOf.

The existing snapshots were actually incorrect for `HelloId` and `TemplateID`!
