### PR TITLE
fix(type-safe-api): fix named composite models and composite model types

### DIFF
--- a/packages/type-safe-api/scripts/type-safe-api/generators/typescript/templates/client/models/models.ejs
+++ b/packages/type-safe-api/scripts/type-safe-api/generators/typescript/templates/client/models/models.ejs
@@ -62,8 +62,8 @@ export type <%- model.name %> =<% model.properties.forEach((composedType, i) => 
  <%_ } _%>
  */
 export interface <%= model.name %> {
-<%_ if (model.additionalProperties) { _%>
-    [key: string]: <%- model.additionalProperties.typescriptType %>;
+<%_ if (model.export === "dictionary" && model.link) { _%>
+    [key: string]: <%- model.link.typescriptType %>;
 <%_ } _%>
 <%_ model.properties.forEach((property) => { _%>
     /**
@@ -126,7 +126,7 @@ export function <%= model.name %>FromJSONTyped(json: any, ignoreDiscriminator: b
 <%_ } else { _%>
     return {
 
-<%_ if (model.additionalProperties) { _%>
+<%_ if (model.export === "dictionary") { _%>
             ...json,
 <%_ } _%>
 <%_ model.properties.forEach((property) => { _%>
@@ -173,7 +173,7 @@ export function <%= model.name %>ToJSON(value?: <%= model.name %> | null): any {
 <%_ } else { _%>
     return {
 
-<%_ if (model.additionalProperties) { _%>
+<%_ if (model.export === "dictionary") { _%>
             ...value,
 <%_ } _%>
 <%_ model.properties.forEach((property) => { _%>

--- a/packages/type-safe-api/test/resources/specs/edge-cases.yaml
+++ b/packages/type-safe-api/test/resources/specs/edge-cases.yaml
@@ -118,6 +118,26 @@ paths:
                     string
               required:
                 - someProperty
+  /named-one-of:
+    post:
+      operationId: namedOneOf
+      responses:
+        200:
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NamedOneOfUnion"
+  /array-of-one-ofs:
+    post:
+      operationId: arrayOfOneOfs
+      responses:
+        200:
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ArrayOfOneOfs"
 components:
   schemas:
     MyEnum:
@@ -126,3 +146,22 @@ components:
         - one
         - two
         - three
+    NamedOneOfUnion:
+      oneOf:
+        - type: object
+          title: namedOneOf
+          properties:
+            foo:
+              type: string
+        - type: object
+          title: anotherNamedOneOf
+          properties:
+            bar:
+              type: string
+    ArrayOfOneOfs:
+      type: object
+      properties:
+        oneOfs:
+          type: array
+          items:
+            $ref: "#/components/schemas/NamedOneOfUnion"

--- a/packages/type-safe-api/test/resources/specs/edge-cases.yaml
+++ b/packages/type-safe-api/test/resources/specs/edge-cases.yaml
@@ -138,6 +138,16 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ArrayOfOneOfs"
+  /additional-properties:
+    post:
+      operationId: dictionary
+      responses:
+        200:
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdditionalPropertiesResponse"
 components:
   schemas:
     MyEnum:
@@ -165,3 +175,23 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/NamedOneOfUnion"
+    AdditionalPropertiesResponse:
+      type: object
+      properties:
+        dictionaryOfObjects:
+          $ref: "#/components/schemas/Dictionary"
+        dictionaryOfPrimitives:
+          type: object
+          additionalProperties:
+            type: string
+    Dictionary:
+      type: object
+      additionalProperties:
+        type: array
+        items:
+          $ref: "#/components/schemas/SomeObject"
+    SomeObject:
+      type: object
+      properties:
+        a:
+          type: string

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/java.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/java.test.ts.snap
@@ -30335,36 +30335,42 @@ src/main/java/test/test/runtime/api/handlers/InterceptorWarmupChainedRequestInpu
 src/main/java/test/test/runtime/api/handlers/InterceptorWithWarmup.java
 src/main/java/test/test/runtime/api/handlers/array_of_one_ofs/ArrayOfOneOfsResponse.java
 src/main/java/test/test/runtime/api/handlers/array_request_parameters/ArrayRequestParametersResponse.java
+src/main/java/test/test/runtime/api/handlers/dictionary/DictionaryResponse.java
 src/main/java/test/test/runtime/api/handlers/inline_enum/InlineEnumResponse.java
 src/main/java/test/test/runtime/api/handlers/inline_request_body/InlineRequestBodyResponse.java
 src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOfResponse.java
 src/main/java/test/test/runtime/api/handlers/reserved_keywords/ReservedKeywordsResponse.java
 src/main/java/test/test/runtime/api/handlers/array_of_one_ofs/ArrayOfOneOfs200Response.java
 src/main/java/test/test/runtime/api/handlers/array_request_parameters/ArrayRequestParameters200Response.java
+src/main/java/test/test/runtime/api/handlers/dictionary/Dictionary200Response.java
 src/main/java/test/test/runtime/api/handlers/inline_enum/InlineEnum200Response.java
 src/main/java/test/test/runtime/api/handlers/inline_request_body/InlineRequestBody204Response.java
 src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOf200Response.java
 src/main/java/test/test/runtime/api/handlers/reserved_keywords/ReservedKeywords200Response.java
 src/main/java/test/test/runtime/api/handlers/array_of_one_ofs/ArrayOfOneOfsRequestParameters.java
 src/main/java/test/test/runtime/api/handlers/array_request_parameters/ArrayRequestParametersRequestParameters.java
+src/main/java/test/test/runtime/api/handlers/dictionary/DictionaryRequestParameters.java
 src/main/java/test/test/runtime/api/handlers/inline_enum/InlineEnumRequestParameters.java
 src/main/java/test/test/runtime/api/handlers/inline_request_body/InlineRequestBodyRequestParameters.java
 src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOfRequestParameters.java
 src/main/java/test/test/runtime/api/handlers/reserved_keywords/ReservedKeywordsRequestParameters.java
 src/main/java/test/test/runtime/api/handlers/array_of_one_ofs/ArrayOfOneOfsInput.java
 src/main/java/test/test/runtime/api/handlers/array_request_parameters/ArrayRequestParametersInput.java
+src/main/java/test/test/runtime/api/handlers/dictionary/DictionaryInput.java
 src/main/java/test/test/runtime/api/handlers/inline_enum/InlineEnumInput.java
 src/main/java/test/test/runtime/api/handlers/inline_request_body/InlineRequestBodyInput.java
 src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOfInput.java
 src/main/java/test/test/runtime/api/handlers/reserved_keywords/ReservedKeywordsInput.java
 src/main/java/test/test/runtime/api/handlers/array_of_one_ofs/ArrayOfOneOfsRequestInput.java
 src/main/java/test/test/runtime/api/handlers/array_request_parameters/ArrayRequestParametersRequestInput.java
+src/main/java/test/test/runtime/api/handlers/dictionary/DictionaryRequestInput.java
 src/main/java/test/test/runtime/api/handlers/inline_enum/InlineEnumRequestInput.java
 src/main/java/test/test/runtime/api/handlers/inline_request_body/InlineRequestBodyRequestInput.java
 src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOfRequestInput.java
 src/main/java/test/test/runtime/api/handlers/reserved_keywords/ReservedKeywordsRequestInput.java
 src/main/java/test/test/runtime/api/handlers/array_of_one_ofs/ArrayOfOneOfs.java
 src/main/java/test/test/runtime/api/handlers/array_request_parameters/ArrayRequestParameters.java
+src/main/java/test/test/runtime/api/handlers/dictionary/Dictionary.java
 src/main/java/test/test/runtime/api/handlers/inline_enum/InlineEnum.java
 src/main/java/test/test/runtime/api/handlers/inline_request_body/InlineRequestBody.java
 src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOf.java
@@ -30398,14 +30404,17 @@ src/main/java/test/test/runtime/ServerConfiguration.java
 src/main/java/test/test/runtime/ServerVariable.java
 src/main/java/test/test/runtime/StringUtil.java
 src/main/java/test/test/runtime/model/AbstractOpenApiSchema.java
+src/main/java/test/test/runtime/model/AdditionalPropertiesResponse.java
 src/main/java/test/test/runtime/model/AnotherNamedOneOf.java
 src/main/java/test/test/runtime/model/ArrayOfOneOfs.java
+src/main/java/test/test/runtime/model/Dictionary.java
 src/main/java/test/test/runtime/model/InlineEnum200Response.java
 src/main/java/test/test/runtime/model/InlineEnum200ResponseCategoryEnum.java
 src/main/java/test/test/runtime/model/InlineRequestBodyRequestContent.java
 src/main/java/test/test/runtime/model/MyEnum.java
 src/main/java/test/test/runtime/model/NamedOneOf.java
-src/main/java/test/test/runtime/model/NamedOneOfUnion.java",
+src/main/java/test/test/runtime/model/NamedOneOfUnion.java
+src/main/java/test/test/runtime/model/SomeObject.java",
   "src/main/java/test/test/runtime/ApiCallback.java": "/*
  * Edge Cases
  * 
@@ -32472,12 +32481,15 @@ public class JSON {
         gsonBuilder.registerTypeAdapter(OffsetDateTime.class, offsetDateTimeTypeAdapter);
         gsonBuilder.registerTypeAdapter(LocalDate.class, localDateTypeAdapter);
         gsonBuilder.registerTypeAdapter(byte[].class, byteArrayAdapter);
+        gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.AdditionalPropertiesResponse.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.AnotherNamedOneOf.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.ArrayOfOneOfs.CustomTypeAdapterFactory());
+        gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.Dictionary.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.InlineEnum200Response.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.InlineRequestBodyRequestContent.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.NamedOneOf.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.NamedOneOfUnion.CustomTypeAdapterFactory());
+        gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.SomeObject.CustomTypeAdapterFactory());
         gson = gsonBuilder.create();
     }
 
@@ -33178,6 +33190,7 @@ import java.io.IOException;
 
 import java.math.BigDecimal;
 import java.io.File;
+import test.test.runtime.model.AdditionalPropertiesResponse;
 import test.test.runtime.model.ArrayOfOneOfs;
 import test.test.runtime.model.InlineEnum200Response;
 import test.test.runtime.model.InlineRequestBodyRequestContent;
@@ -33647,6 +33660,151 @@ public class DefaultApi {
     
     public APIarrayRequestParametersRequest arrayRequestParameters() {
         return new APIarrayRequestParametersRequest();
+    }
+    private okhttp3.Call dictionaryCall(final ApiCallback _callback) throws ApiException {
+        String basePath = null;
+        // Operation Servers
+        String[] localBasePaths = new String[] {  };
+
+        // Determine Base Path to Use
+        if (localCustomBaseUrl != null){
+            basePath = localCustomBaseUrl;
+        } else if ( localBasePaths.length > 0 ) {
+            basePath = localBasePaths[localHostIndex];
+        } else {
+            basePath = null;
+        }
+
+        Object localVarPostBody = null;
+
+        // create path and map variables
+        String localVarPath = "/additional-properties";
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        final String[] localVarAccepts = {
+            "application/json"
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        if (localVarContentType != null) {
+            localVarHeaderParams.put("Content-Type", localVarContentType);
+        }
+
+        String[] localVarAuthNames = new String[] {  };
+        return localVarApiClient.buildCall(basePath, localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call dictionaryValidateBeforeCall(final ApiCallback _callback) throws ApiException {
+        return dictionaryCall(_callback);
+
+    }
+
+    private ApiResponse<AdditionalPropertiesResponse> dictionaryWithHttpInfo() throws ApiException {
+        okhttp3.Call localVarCall = dictionaryValidateBeforeCall(null);
+        Type localVarReturnType = new TypeToken<AdditionalPropertiesResponse>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+
+    private okhttp3.Call dictionaryAsync(final ApiCallback<AdditionalPropertiesResponse> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = dictionaryValidateBeforeCall(_callback);
+        Type localVarReturnType = new TypeToken<AdditionalPropertiesResponse>(){}.getType();
+        localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+        return localVarCall;
+    }
+
+    public class APIdictionaryRequest {
+
+        private APIdictionaryRequest() {
+        }
+
+        /**
+         * Build call for dictionary
+         * @param _callback ApiCallback API callback
+         * @return Call to execute
+         * @throws ApiException If fail to serialize the request body object
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> ok </td><td>  -  </td></tr>
+         </table>
+         */
+        public okhttp3.Call buildCall(final ApiCallback _callback) throws ApiException {
+            return dictionaryCall(_callback);
+        }
+
+        /**
+         * Execute dictionary request
+         * @return AdditionalPropertiesResponse
+         * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> ok </td><td>  -  </td></tr>
+         </table>
+         */
+        public AdditionalPropertiesResponse execute() throws ApiException {
+            ApiResponse<AdditionalPropertiesResponse> localVarResp = dictionaryWithHttpInfo();
+            return localVarResp.getData();
+        }
+
+        /**
+         * Execute dictionary request with HTTP info returned
+         * @return ApiResponse&lt;AdditionalPropertiesResponse&gt;
+         * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> ok </td><td>  -  </td></tr>
+         </table>
+         */
+        public ApiResponse<AdditionalPropertiesResponse> executeWithHttpInfo() throws ApiException {
+            return dictionaryWithHttpInfo();
+        }
+
+        /**
+         * Execute dictionary request (asynchronously)
+         * @param _callback The callback to be executed when the API call finishes
+         * @return The request call
+         * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> ok </td><td>  -  </td></tr>
+         </table>
+         */
+        public okhttp3.Call executeAsync(final ApiCallback<AdditionalPropertiesResponse> _callback) throws ApiException {
+            return dictionaryAsync(_callback);
+        }
+    }
+
+    /**
+     * 
+     * 
+     * @return APIdictionaryRequest
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> ok </td><td>  -  </td></tr>
+     </table>
+     */
+    
+    public APIdictionaryRequest dictionary() {
+        return new APIdictionaryRequest();
     }
     private okhttp3.Call inlineEnumCall(final ApiCallback _callback) throws ApiException {
         String basePath = null;
@@ -34325,6 +34483,7 @@ package test.test.runtime.api.handlers;
 
 import test.test.runtime.api.handlers.array_of_one_ofs.*;
 import test.test.runtime.api.handlers.array_request_parameters.*;
+import test.test.runtime.api.handlers.dictionary.*;
 import test.test.runtime.api.handlers.inline_enum.*;
 import test.test.runtime.api.handlers.inline_request_body.*;
 import test.test.runtime.api.handlers.named_one_of.*;
@@ -34348,6 +34507,7 @@ import java.util.Collections;
 public abstract class HandlerRouter implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
     private static final String arrayOfOneOfsMethodAndPath = Handlers.concatMethodAndPath("POST", "/array-of-one-ofs");
     private static final String arrayRequestParametersMethodAndPath = Handlers.concatMethodAndPath("GET", "/array-request-parameters");
+    private static final String dictionaryMethodAndPath = Handlers.concatMethodAndPath("POST", "/additional-properties");
     private static final String inlineEnumMethodAndPath = Handlers.concatMethodAndPath("GET", "/inline-enum");
     private static final String inlineRequestBodyMethodAndPath = Handlers.concatMethodAndPath("POST", "/inline-request-body");
     private static final String namedOneOfMethodAndPath = Handlers.concatMethodAndPath("POST", "/named-one-of");
@@ -34355,6 +34515,7 @@ public abstract class HandlerRouter implements RequestHandler<APIGatewayProxyReq
 
     private final ArrayOfOneOfs constructedArrayOfOneOfs;
     private final ArrayRequestParameters constructedArrayRequestParameters;
+    private final Dictionary constructedDictionary;
     private final InlineEnum constructedInlineEnum;
     private final InlineRequestBody constructedInlineRequestBody;
     private final NamedOneOf constructedNamedOneOf;
@@ -34368,6 +34529,10 @@ public abstract class HandlerRouter implements RequestHandler<APIGatewayProxyReq
      * This method must return your implementation of the ArrayRequestParameters operation
      */
     public abstract ArrayRequestParameters arrayRequestParameters();
+    /**
+     * This method must return your implementation of the Dictionary operation
+     */
+    public abstract Dictionary dictionary();
     /**
      * This method must return your implementation of the InlineEnum operation
      */
@@ -34388,6 +34553,7 @@ public abstract class HandlerRouter implements RequestHandler<APIGatewayProxyReq
     private static enum Route {
         arrayOfOneOfsRoute,
         arrayRequestParametersRoute,
+        dictionaryRoute,
         inlineEnumRoute,
         inlineRequestBodyRoute,
         namedOneOfRoute,
@@ -34402,6 +34568,7 @@ public abstract class HandlerRouter implements RequestHandler<APIGatewayProxyReq
     public HandlerRouter() {
         this.routes.put(arrayOfOneOfsMethodAndPath, Route.arrayOfOneOfsRoute);
         this.routes.put(arrayRequestParametersMethodAndPath, Route.arrayRequestParametersRoute);
+        this.routes.put(dictionaryMethodAndPath, Route.dictionaryRoute);
         this.routes.put(inlineEnumMethodAndPath, Route.inlineEnumRoute);
         this.routes.put(inlineRequestBodyMethodAndPath, Route.inlineRequestBodyRoute);
         this.routes.put(namedOneOfMethodAndPath, Route.namedOneOfRoute);
@@ -34411,6 +34578,7 @@ public abstract class HandlerRouter implements RequestHandler<APIGatewayProxyReq
         // https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
         this.constructedArrayOfOneOfs = this.arrayOfOneOfs();
         this.constructedArrayRequestParameters = this.arrayRequestParameters();
+        this.constructedDictionary = this.dictionary();
         this.constructedInlineEnum = this.inlineEnum();
         this.constructedInlineRequestBody = this.inlineRequestBody();
         this.constructedNamedOneOf = this.namedOneOf();
@@ -34442,6 +34610,10 @@ public abstract class HandlerRouter implements RequestHandler<APIGatewayProxyReq
                 List<Interceptor<ArrayRequestParametersInput>> arrayRequestParametersInterceptors = Handlers.getAnnotationInterceptors(this.getClass());
                 arrayRequestParametersInterceptors.addAll(this.getInterceptors());
                 return this.constructedArrayRequestParameters.handleRequestWithAdditionalInterceptors(event, context, arrayRequestParametersInterceptors);
+            case dictionaryRoute:
+                List<Interceptor<DictionaryInput>> dictionaryInterceptors = Handlers.getAnnotationInterceptors(this.getClass());
+                dictionaryInterceptors.addAll(this.getInterceptors());
+                return this.constructedDictionary.handleRequestWithAdditionalInterceptors(event, context, dictionaryInterceptors);
             case inlineEnumRoute:
                 List<Interceptor<InlineEnumInput>> inlineEnumInterceptors = Handlers.getAnnotationInterceptors(this.getClass());
                 inlineEnumInterceptors.addAll(this.getInterceptors());
@@ -35975,6 +36147,413 @@ import test.test.runtime.api.handlers.Response;
  * Response for the arrayRequestParameters operation
  */
 public interface ArrayRequestParametersResponse extends Response {}
+",
+  "src/main/java/test/test/runtime/api/handlers/dictionary/Dictionary.java": "
+package test.test.runtime.api.handlers.dictionary;
+
+import test.test.runtime.model.*;
+import test.test.runtime.JSON;
+import test.test.runtime.api.handlers.Interceptor;
+import test.test.runtime.api.handlers.Handlers;
+import test.test.runtime.api.handlers.*;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Collections;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import java.io.IOException;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import org.crac.Core;
+import org.crac.Resource;
+
+
+/**
+ * Lambda handler wrapper for the dictionary operation
+ */
+public abstract class Dictionary implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent>, Resource {
+    {
+        Core.getGlobalContext().register(this);
+    }
+
+    /**
+     * Handle the request for the dictionary operation
+     */
+    public abstract DictionaryResponse handle(final DictionaryRequestInput request);
+
+    /**
+     * Interceptors that the handler class has been decorated with
+     */
+    private List<Interceptor<DictionaryInput>> annotationInterceptors = Handlers.getAnnotationInterceptors(Dictionary.class);
+
+    /**
+     * For more complex interceptors that require instantiation with parameters, you may override this method to
+     * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+     * prefer the @Interceptors annotation.
+     */
+    public List<Interceptor<DictionaryInput>> getInterceptors() {
+        return Collections.emptyList();
+    }
+
+    private List<Interceptor<DictionaryInput>> getHandlerInterceptors() {
+        List<Interceptor<DictionaryInput>> interceptors = new ArrayList<>();
+        interceptors.addAll(annotationInterceptors);
+        interceptors.addAll(this.getInterceptors());
+        return interceptors;
+    }
+
+    private HandlerChain<DictionaryInput> buildChain(List<Interceptor<DictionaryInput>> interceptors) {
+        return Handlers.buildHandlerChain(interceptors, new HandlerChain<DictionaryInput>() {
+            @Override
+            public Response next(ChainedRequestInput<DictionaryInput> input) {
+                return handle(new DictionaryRequestInput(input.getEvent(), input.getContext(), input.getInterceptorContext(), input.getInput()));
+            }
+        });
+    }
+
+    private ChainedRequestInput<DictionaryInput> buildChainedRequestInput(final APIGatewayProxyRequestEvent event, final Context context, final DictionaryInput input, final Map<String, Object> interceptorContext) {
+        return new ChainedRequestInput<DictionaryInput>() {
+            @Override
+            public HandlerChain getChain() {
+                // The chain's next method ignores the chain given as input, and is pre-built to follow the remaining
+                // chain.
+                return null;
+            }
+
+            @Override
+            public APIGatewayProxyRequestEvent getEvent() {
+                return event;
+            }
+
+            @Override
+            public Context getContext() {
+                return context;
+            }
+
+            @Override
+            public DictionaryInput getInput() {
+                return input;
+            }
+
+            @Override
+            public Map<String, Object> getInterceptorContext() {
+                return interceptorContext;
+            }
+        };
+    }
+
+    @Override
+    public void beforeCheckpoint(org.crac.Context<? extends Resource> context) {
+        // Prime building the handler chain which can take a few 100ms to JIT.
+        this.buildChain(this.getHandlerInterceptors());
+        this.buildChainedRequestInput(null, null, null, null);
+
+        // Initialise instance of Gson and prime serialisation and deserialisation
+        new JSON();
+        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>(), new HashMap<>())), ApiResponse.class);
+
+        try {
+            // Prime input validation - this will likely fail for the fake event but ensures the code path is optimised
+            // ready for a real invocation
+            new DictionaryInput(new APIGatewayProxyRequestEvent()
+                    .withBody("{}")
+                    .withPathParameters(new HashMap<>())
+                    .withQueryStringParameters(new HashMap<>())
+                    .withMultiValueQueryStringParameters(new HashMap<>())
+                    .withHeaders(new HashMap<>())
+                    .withMultiValueHeaders(new HashMap<>())
+            );
+        } catch (Exception e) {
+
+        }
+
+        this.warmUp();
+    }
+
+    @Override
+    public void afterRestore(org.crac.Context<? extends Resource> context) {
+
+    }
+
+    /**
+     * Override this method to perform any warmup activities which will be executed prior to the snap-start snapshot.
+     */
+    public void warmUp() {
+
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+        return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+    }
+
+    private Map<String, String> getErrorResponseHeaders(final int statusCode) {
+        Map<String, String> headers = new HashMap<>();
+        return headers;
+    }
+
+    public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<DictionaryInput>> additionalInterceptors) {
+        final Map<String, Object> interceptorContext = new HashMap<>();
+        interceptorContext.put("operationId", "dictionary");
+
+        List<Interceptor<DictionaryInput>> interceptors = new ArrayList<>();
+        interceptors.addAll(additionalInterceptors);
+        interceptors.addAll(this.getHandlerInterceptors());
+
+        final HandlerChain chain = this.buildChain(interceptors);
+
+        DictionaryInput input;
+
+        try {
+            input = new DictionaryInput(event);
+        } catch (RuntimeException e) {
+            Map<String, String> headers = new HashMap<>();
+            headers.putAll(Handlers.extractResponseHeadersFromInterceptors(interceptors));
+            headers.putAll(this.getErrorResponseHeaders(400));
+            return new APIGatewayProxyResponseEvent()
+                .withStatusCode(400)
+                .withHeaders(headers)
+                .withBody("{\\"message\\": \\"" + e.getMessage() + "\\"}");
+        }
+
+        final Response response = chain.next(this.buildChainedRequestInput(event, context, input, interceptorContext));
+
+        Map<String, String> responseHeaders = new HashMap<>();
+        responseHeaders.putAll(this.getErrorResponseHeaders(response.getStatusCode()));
+        responseHeaders.putAll(response.getHeaders());
+
+        return new APIGatewayProxyResponseEvent()
+                .withStatusCode(response.getStatusCode())
+                .withHeaders(responseHeaders)
+                .withMultiValueHeaders(response.getMultiValueHeaders())
+                .withBody(response.getBody());
+    }
+}
+",
+  "src/main/java/test/test/runtime/api/handlers/dictionary/Dictionary200Response.java": "
+package test.test.runtime.api.handlers.dictionary;
+
+import test.test.runtime.model.*;
+import test.test.runtime.JSON;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Response with status code 200 for the dictionary operation
+ */
+public class Dictionary200Response extends RuntimeException implements DictionaryResponse {
+    static {
+        // JSON has a static instance of Gson which is instantiated lazily the first time it is initialised.
+        // Create an instance here if required to ensure that the static Gson instance is always available.
+        if (JSON.getGson() == null) {
+            new JSON();
+        }
+    }
+
+    private final String body;
+    private final AdditionalPropertiesResponse typedBody;
+    private final Map<String, String> headers;
+    private final Map<String, List<String>> multiValueHeaders;
+
+    private Dictionary200Response(final AdditionalPropertiesResponse body, final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
+        this.typedBody = body;
+        this.body = body.toJson();
+        this.headers = headers;
+        this.multiValueHeaders = multiValueHeaders;
+    }
+
+    @Override
+    public int getStatusCode() {
+        return 200;
+    }
+
+    @Override
+    public String getBody() {
+        return this.body;
+    }
+
+    public AdditionalPropertiesResponse getTypedBody() {
+        return this.typedBody;
+    }
+
+    @Override
+    public Map<String, String> getHeaders() {
+        return this.headers;
+    }
+
+    @Override
+    public Map<String, List<String>> getMultiValueHeaders() {
+        return this.multiValueHeaders;
+    }
+
+    /**
+     * Create a Dictionary200Response with a body
+     */
+    public static Dictionary200Response of(final AdditionalPropertiesResponse body) {
+        return new Dictionary200Response(body, new HashMap<>(), new HashMap<>());
+    }
+
+    /**
+     * Create a Dictionary200Response with a body and headers
+     */
+    public static Dictionary200Response of(final AdditionalPropertiesResponse body, final Map<String, String> headers) {
+        return new Dictionary200Response(body, headers, new HashMap<>());
+    }
+
+    /**
+     * Create a Dictionary200Response with a body, headers and multi-value headers
+     */
+    public static Dictionary200Response of(final AdditionalPropertiesResponse body, final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
+        return new Dictionary200Response(body, headers, multiValueHeaders);
+    }
+}
+",
+  "src/main/java/test/test/runtime/api/handlers/dictionary/DictionaryInput.java": "
+package test.test.runtime.api.handlers.dictionary;
+
+import test.test.runtime.model.*;
+import test.test.runtime.JSON;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.Map;
+import java.util.HashMap;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import java.io.IOException;
+
+/**
+ * Input for the dictionary operation
+ */
+@lombok.Builder
+@lombok.AllArgsConstructor
+public class DictionaryInput {
+    static {
+        // JSON has a static instance of Gson which is instantiated lazily the first time it is initialised.
+        // Create an instance here if required to ensure that the static Gson instance is always available.
+        if (JSON.getGson() == null) {
+            new JSON();
+        }
+    }
+
+    private final DictionaryRequestParameters requestParameters;
+
+    public DictionaryInput(final APIGatewayProxyRequestEvent event) {
+        this.requestParameters = new DictionaryRequestParameters(event);
+    }
+
+    public DictionaryRequestParameters getRequestParameters() {
+        return this.requestParameters;
+    }
+
+}
+",
+  "src/main/java/test/test/runtime/api/handlers/dictionary/DictionaryRequestInput.java": "
+package test.test.runtime.api.handlers.dictionary;
+
+import test.test.runtime.model.*;
+import test.test.runtime.api.handlers.RequestInput;
+import java.util.List;
+import java.util.Optional;
+import java.util.Map;
+import java.util.HashMap;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import java.io.IOException;
+import com.amazonaws.services.lambda.runtime.Context;
+
+/**
+ * Full request input for the dictionary operation, including the raw API Gateway event
+ */
+@lombok.Builder
+@lombok.AllArgsConstructor
+public class DictionaryRequestInput implements RequestInput<DictionaryInput> {
+    private final APIGatewayProxyRequestEvent event;
+    private final Context context;
+    private final Map<String, Object> interceptorContext;
+    private final DictionaryInput input;
+
+    /**
+     * Returns the typed request input, with path, query and body parameters
+     */
+    public DictionaryInput getInput() {
+        return this.input;
+    }
+
+    /**
+     * Returns the raw API Gateway event
+     */
+    public APIGatewayProxyRequestEvent getEvent() {
+        return this.event;
+    }
+
+    /**
+     * Returns the lambda context
+     */
+    public Context getContext() {
+        return this.context;
+    }
+
+    /**
+     * Returns the interceptor context, which may contain values set by request interceptors
+     */
+    public Map<String, Object> getInterceptorContext() {
+        return this.interceptorContext;
+    }
+}
+",
+  "src/main/java/test/test/runtime/api/handlers/dictionary/DictionaryRequestParameters.java": "
+package test.test.runtime.api.handlers.dictionary;
+
+import test.test.runtime.api.handlers.Handlers;
+import java.util.Optional;
+import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.time.OffsetDateTime;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.stream.Collectors;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+
+import test.test.runtime.model.*;
+
+/**
+ * Query, path and header parameters for the Dictionary operation
+ */
+@lombok.Builder
+@lombok.AllArgsConstructor
+public class DictionaryRequestParameters {
+
+    public DictionaryRequestParameters(final APIGatewayProxyRequestEvent event) {
+        Map<String, String> rawStringParameters = new HashMap<>();
+        Handlers.putAllFromNullableMap(event.getPathParameters(), rawStringParameters);
+        Handlers.putAllFromNullableMap(event.getQueryStringParameters(), rawStringParameters);
+        Handlers.putAllFromNullableMap(event.getHeaders(), rawStringParameters);
+        Map<String, String> decodedStringParameters = Handlers.decodeRequestParameters(rawStringParameters);
+
+        Map<String, List<String>> rawStringArrayParameters = new HashMap<>();
+        Handlers.putAllFromNullableMap(event.getMultiValueQueryStringParameters(), rawStringArrayParameters);
+        Handlers.putAllFromNullableMap(event.getMultiValueHeaders(), rawStringArrayParameters);
+        Map<String, List<String>> decodedStringArrayParameters = Handlers.decodeRequestArrayParameters(rawStringArrayParameters);
+
+    }
+
+}
+",
+  "src/main/java/test/test/runtime/api/handlers/dictionary/DictionaryResponse.java": "
+package test.test.runtime.api.handlers.dictionary;
+
+import test.test.runtime.api.handlers.Response;
+
+/**
+ * Response for the dictionary operation
+ */
+public interface DictionaryResponse extends Response {}
 ",
   "src/main/java/test/test/runtime/api/handlers/inline_enum/InlineEnum.java": "
 package test.test.runtime.api.handlers.inline_enum;
@@ -37975,6 +38554,7 @@ import java.util.Map;
 public class OperationConfig<T> {
     private T arrayOfOneOfs;
     private T arrayRequestParameters;
+    private T dictionary;
     private T inlineEnum;
     private T inlineRequestBody;
     private T namedOneOf;
@@ -37984,6 +38564,7 @@ public class OperationConfig<T> {
         Map<String, T> map = new HashMap<>();
         map.put("arrayOfOneOfs", this.arrayOfOneOfs);
         map.put("arrayRequestParameters", this.arrayRequestParameters);
+        map.put("dictionary", this.dictionary);
         map.put("inlineEnum", this.inlineEnum);
         map.put("inlineRequestBody", this.inlineRequestBody);
         map.put("namedOneOf", this.namedOneOf);
@@ -38027,6 +38608,11 @@ public class OperationLookup {
             .method("GET")
             .contentTypes(Arrays.asList("application/json"))
             .build());
+        config.put("dictionary", OperationLookupEntry.builder()
+            .path("/additional-properties")
+            .method("POST")
+            .contentTypes(Arrays.asList("application/json"))
+            .build());
         config.put("inlineEnum", OperationLookupEntry.builder()
             .path("/inline-enum")
             .method("GET")
@@ -38064,6 +38650,7 @@ public class Operations {
         return OperationConfig.<T>builder()
                 .arrayOfOneOfs(value)
                 .arrayRequestParameters(value)
+                .dictionary(value)
                 .inlineEnum(value)
                 .inlineRequestBody(value)
                 .namedOneOf(value)
@@ -38453,6 +39040,271 @@ public abstract class AbstractOpenApiSchema {
 
 
 
+}
+",
+  "src/main/java/test/test/runtime/model/AdditionalPropertiesResponse.java": "/*
+ * Edge Cases
+ * 
+ *
+ * The version of the OpenAPI document: 1.0.0
+ *
+ *
+ * NOTE: This class is auto generated.
+ * Do not edit the class manually.
+ */
+
+
+package test.test.runtime.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import test.test.runtime.model.Dictionary;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+
+import javax.ws.rs.core.GenericType;
+
+import java.io.IOException;
+import java.io.File;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import java.lang.reflect.Type;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.List;
+import java.util.Set;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import test.test.runtime.JSON;
+
+/**
+ * AdditionalPropertiesResponse
+ */
+@lombok.AllArgsConstructor @lombok.experimental.SuperBuilder
+public class AdditionalPropertiesResponse {
+  public static final String SERIALIZED_NAME_DICTIONARY_OF_OBJECTS = "dictionaryOfObjects";
+  @SerializedName(SERIALIZED_NAME_DICTIONARY_OF_OBJECTS)
+  private Dictionary dictionaryOfObjects;
+
+  public static final String SERIALIZED_NAME_DICTIONARY_OF_PRIMITIVES = "dictionaryOfPrimitives";
+  @SerializedName(SERIALIZED_NAME_DICTIONARY_OF_PRIMITIVES)
+  private Map<String, String> dictionaryOfPrimitives = null;
+
+  public AdditionalPropertiesResponse() {
+  }
+
+  public AdditionalPropertiesResponse dictionaryOfObjects(Dictionary dictionaryOfObjects) {
+
+    this.dictionaryOfObjects = dictionaryOfObjects;
+    return this;
+  }
+
+   /**
+   * Get dictionaryOfObjects
+   * @return dictionaryOfObjects
+  **/
+  @javax.annotation.Nullable
+  public Dictionary getDictionaryOfObjects() {
+    return dictionaryOfObjects;
+  }
+
+
+  public void setDictionaryOfObjects(Dictionary dictionaryOfObjects) {
+    this.dictionaryOfObjects = dictionaryOfObjects;
+  }
+
+  public AdditionalPropertiesResponse dictionaryOfPrimitives(Map<String, String> dictionaryOfPrimitives) {
+
+    this.dictionaryOfPrimitives = dictionaryOfPrimitives;
+    return this;
+  }
+
+  public AdditionalPropertiesResponse putDictionaryOfPrimitivesItem(String key, String dictionaryOfPrimitivesItem) {
+    if (this.dictionaryOfPrimitives == null) {
+      this.dictionaryOfPrimitives = new HashMap<>();
+    }
+    this.dictionaryOfPrimitives.put(key, dictionaryOfPrimitivesItem);
+    return this;
+  }
+
+   /**
+   * Get dictionaryOfPrimitives
+   * @return dictionaryOfPrimitives
+  **/
+  @javax.annotation.Nullable
+  public Map<String, String> getDictionaryOfPrimitives() {
+    return dictionaryOfPrimitives;
+  }
+
+
+  public void setDictionaryOfPrimitives(Map<String, String> dictionaryOfPrimitives) {
+    this.dictionaryOfPrimitives = dictionaryOfPrimitives;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AdditionalPropertiesResponse additionalPropertiesResponse = (AdditionalPropertiesResponse) o;
+    return Objects.equals(this.dictionaryOfObjects, additionalPropertiesResponse.dictionaryOfObjects) &&
+        Objects.equals(this.dictionaryOfPrimitives, additionalPropertiesResponse.dictionaryOfPrimitives);
+        
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(dictionaryOfObjects, dictionaryOfPrimitives);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class AdditionalPropertiesResponse {\\n");
+    sb.append("    dictionaryOfObjects: ").append(toIndentedString(dictionaryOfObjects)).append("\\n");
+    sb.append("    dictionaryOfPrimitives: ").append(toIndentedString(dictionaryOfPrimitives)).append("\\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\\n", "\\n    ");
+  }
+
+
+  public static HashSet<String> openapiFields;
+  public static HashSet<String> openapiRequiredFields;
+
+  static {
+    // a set of all properties/fields (JSON key names)
+    openapiFields = new HashSet<String>();
+    openapiFields.add("dictionaryOfObjects");
+    openapiFields.add("dictionaryOfPrimitives");
+
+    // a set of required properties/fields (JSON key names)
+    openapiRequiredFields = new HashSet<String>();
+  }
+
+ /**
+  * Validates the JSON Object and throws an exception if issues found
+  *
+  * @param jsonObj JSON Object
+  * @throws IOException if the JSON Object is invalid with respect to AdditionalPropertiesResponse
+  */
+  public static void validateJsonObject(JsonObject jsonObj) throws IOException {
+      if (jsonObj == null) {
+        if (!AdditionalPropertiesResponse.openapiRequiredFields.isEmpty()) { // has required fields but JSON object is null
+          throw new IllegalArgumentException(String.format("The required field(s) %s in AdditionalPropertiesResponse is not found in the empty JSON string", AdditionalPropertiesResponse.openapiRequiredFields.toString()));
+        }
+      }
+
+      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
+      // check to see if the JSON string contains additional fields
+      for (Entry<String, JsonElement> entry : entries) {
+        if (!AdditionalPropertiesResponse.openapiFields.contains(entry.getKey())) {
+          throw new IllegalArgumentException(String.format("The field \`%s\` in the JSON string is not defined in the \`AdditionalPropertiesResponse\` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
+        }
+      }
+      // validate the optional field \`dictionaryOfObjects\`
+      if (jsonObj.get("dictionaryOfObjects") != null && !jsonObj.get("dictionaryOfObjects").isJsonNull()) {
+        Dictionary.validateJsonObject(jsonObj.getAsJsonObject("dictionaryOfObjects"));
+      }
+      if ((jsonObj.get("dictionaryOfPrimitives") != null && !jsonObj.get("dictionaryOfPrimitives").isJsonNull()) && !jsonObj.get("dictionaryOfPrimitives").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format("Expected the field \`dictionaryOfPrimitives\` to be a primitive type in the JSON string but got \`%s\`", jsonObj.get("dictionaryOfPrimitives").toString()));
+      }
+  }
+
+  public static class CustomTypeAdapterFactory implements TypeAdapterFactory {
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+       if (!AdditionalPropertiesResponse.class.isAssignableFrom(type.getRawType())) {
+         return null; // this class only serializes 'AdditionalPropertiesResponse' and its subtypes
+       }
+       final TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
+       final TypeAdapter<AdditionalPropertiesResponse> thisAdapter
+                        = gson.getDelegateAdapter(this, TypeToken.get(AdditionalPropertiesResponse.class));
+
+       return (TypeAdapter<T>) new TypeAdapter<AdditionalPropertiesResponse>() {
+           @Override
+           public void write(JsonWriter out, AdditionalPropertiesResponse value) throws IOException {
+             JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             elementAdapter.write(out, obj);
+           }
+
+           @Override
+           public AdditionalPropertiesResponse read(JsonReader in) throws IOException {
+             JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
+             validateJsonObject(jsonObj);
+             return thisAdapter.fromJsonTree(jsonObj);
+           }
+
+       }.nullSafe();
+    }
+  }
+
+ /**
+  * Create an instance of AdditionalPropertiesResponse given an JSON string
+  *
+  * @param jsonString JSON string
+  * @return An instance of AdditionalPropertiesResponse
+  * @throws IOException if the JSON string is invalid with respect to AdditionalPropertiesResponse
+  */
+  public static AdditionalPropertiesResponse fromJson(String jsonString) throws IOException {
+    return JSON.getGson().fromJson(jsonString, AdditionalPropertiesResponse.class);
+  }
+
+ /**
+  * Convert an instance of AdditionalPropertiesResponse to an JSON string
+  *
+  * @return JSON string
+  */
+  public String toJson() {
+    return JSON.getGson().toJson(this);
+  }
 }
 ",
   "src/main/java/test/test/runtime/model/AnotherNamedOneOf.java": "/*
@@ -38907,6 +39759,201 @@ public class ArrayOfOneOfs {
 
  /**
   * Convert an instance of ArrayOfOneOfs to an JSON string
+  *
+  * @return JSON string
+  */
+  public String toJson() {
+    return JSON.getGson().toJson(this);
+  }
+}
+",
+  "src/main/java/test/test/runtime/model/Dictionary.java": "/*
+ * Edge Cases
+ * 
+ *
+ * The version of the OpenAPI document: 1.0.0
+ *
+ *
+ * NOTE: This class is auto generated.
+ * Do not edit the class manually.
+ */
+
+
+package test.test.runtime.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+
+import javax.ws.rs.core.GenericType;
+
+import java.io.IOException;
+import java.io.File;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import java.lang.reflect.Type;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.List;
+import java.util.Set;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import test.test.runtime.JSON;
+
+/**
+ * Dictionary
+ */
+@lombok.AllArgsConstructor @lombok.experimental.SuperBuilder
+public class Dictionary {
+  public Dictionary() {
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Dictionary dictionary = (Dictionary) o;
+    return 
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash();
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class Dictionary {\\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\\n", "\\n    ");
+  }
+
+
+  public static HashSet<String> openapiFields;
+  public static HashSet<String> openapiRequiredFields;
+
+  static {
+    // a set of all properties/fields (JSON key names)
+    openapiFields = new HashSet<String>();
+
+    // a set of required properties/fields (JSON key names)
+    openapiRequiredFields = new HashSet<String>();
+  }
+
+ /**
+  * Validates the JSON Object and throws an exception if issues found
+  *
+  * @param jsonObj JSON Object
+  * @throws IOException if the JSON Object is invalid with respect to Dictionary
+  */
+  public static void validateJsonObject(JsonObject jsonObj) throws IOException {
+      if (jsonObj == null) {
+        if (!Dictionary.openapiRequiredFields.isEmpty()) { // has required fields but JSON object is null
+          throw new IllegalArgumentException(String.format("The required field(s) %s in Dictionary is not found in the empty JSON string", Dictionary.openapiRequiredFields.toString()));
+        }
+      }
+
+      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
+      // check to see if the JSON string contains additional fields
+      for (Entry<String, JsonElement> entry : entries) {
+        if (!Dictionary.openapiFields.contains(entry.getKey())) {
+          throw new IllegalArgumentException(String.format("The field \`%s\` in the JSON string is not defined in the \`Dictionary\` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
+        }
+      }
+  }
+
+  public static class CustomTypeAdapterFactory implements TypeAdapterFactory {
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+       if (!Dictionary.class.isAssignableFrom(type.getRawType())) {
+         return null; // this class only serializes 'Dictionary' and its subtypes
+       }
+       final TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
+       final TypeAdapter<Dictionary> thisAdapter
+                        = gson.getDelegateAdapter(this, TypeToken.get(Dictionary.class));
+
+       return (TypeAdapter<T>) new TypeAdapter<Dictionary>() {
+           @Override
+           public void write(JsonWriter out, Dictionary value) throws IOException {
+             JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             elementAdapter.write(out, obj);
+           }
+
+           @Override
+           public Dictionary read(JsonReader in) throws IOException {
+             JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
+             validateJsonObject(jsonObj);
+             return thisAdapter.fromJsonTree(jsonObj);
+           }
+
+       }.nullSafe();
+    }
+  }
+
+ /**
+  * Create an instance of Dictionary given an JSON string
+  *
+  * @param jsonString JSON string
+  * @return An instance of Dictionary
+  * @throws IOException if the JSON string is invalid with respect to Dictionary
+  */
+  public static Dictionary fromJson(String jsonString) throws IOException {
+    return JSON.getGson().fromJson(jsonString, Dictionary.class);
+  }
+
+ /**
+  * Convert an instance of Dictionary to an JSON string
   *
   * @return JSON string
   */
@@ -40122,6 +41169,231 @@ public class NamedOneOfUnion extends AbstractOpenApiSchema {
     return JSON.getGson().toJson(this);
   }
 
+}
+",
+  "src/main/java/test/test/runtime/model/SomeObject.java": "/*
+ * Edge Cases
+ * 
+ *
+ * The version of the OpenAPI document: 1.0.0
+ *
+ *
+ * NOTE: This class is auto generated.
+ * Do not edit the class manually.
+ */
+
+
+package test.test.runtime.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+
+import javax.ws.rs.core.GenericType;
+
+import java.io.IOException;
+import java.io.File;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import java.lang.reflect.Type;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.List;
+import java.util.Set;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import test.test.runtime.JSON;
+
+/**
+ * SomeObject
+ */
+@lombok.AllArgsConstructor @lombok.experimental.SuperBuilder
+public class SomeObject {
+  public static final String SERIALIZED_NAME_A = "a";
+  @SerializedName(SERIALIZED_NAME_A)
+  private String a;
+
+  public SomeObject() {
+  }
+
+  public SomeObject a(String a) {
+
+    this.a = a;
+    return this;
+  }
+
+   /**
+   * Get a
+   * @return a
+  **/
+  @javax.annotation.Nullable
+  public String getA() {
+    return a;
+  }
+
+
+  public void setA(String a) {
+    this.a = a;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SomeObject someObject = (SomeObject) o;
+    return Objects.equals(this.a, someObject.a);
+        
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(a);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class SomeObject {\\n");
+    sb.append("    a: ").append(toIndentedString(a)).append("\\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\\n", "\\n    ");
+  }
+
+
+  public static HashSet<String> openapiFields;
+  public static HashSet<String> openapiRequiredFields;
+
+  static {
+    // a set of all properties/fields (JSON key names)
+    openapiFields = new HashSet<String>();
+    openapiFields.add("a");
+
+    // a set of required properties/fields (JSON key names)
+    openapiRequiredFields = new HashSet<String>();
+  }
+
+ /**
+  * Validates the JSON Object and throws an exception if issues found
+  *
+  * @param jsonObj JSON Object
+  * @throws IOException if the JSON Object is invalid with respect to SomeObject
+  */
+  public static void validateJsonObject(JsonObject jsonObj) throws IOException {
+      if (jsonObj == null) {
+        if (!SomeObject.openapiRequiredFields.isEmpty()) { // has required fields but JSON object is null
+          throw new IllegalArgumentException(String.format("The required field(s) %s in SomeObject is not found in the empty JSON string", SomeObject.openapiRequiredFields.toString()));
+        }
+      }
+
+      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
+      // check to see if the JSON string contains additional fields
+      for (Entry<String, JsonElement> entry : entries) {
+        if (!SomeObject.openapiFields.contains(entry.getKey())) {
+          throw new IllegalArgumentException(String.format("The field \`%s\` in the JSON string is not defined in the \`SomeObject\` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
+        }
+      }
+      if ((jsonObj.get("a") != null && !jsonObj.get("a").isJsonNull()) && !jsonObj.get("a").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format("Expected the field \`a\` to be a primitive type in the JSON string but got \`%s\`", jsonObj.get("a").toString()));
+      }
+  }
+
+  public static class CustomTypeAdapterFactory implements TypeAdapterFactory {
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+       if (!SomeObject.class.isAssignableFrom(type.getRawType())) {
+         return null; // this class only serializes 'SomeObject' and its subtypes
+       }
+       final TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
+       final TypeAdapter<SomeObject> thisAdapter
+                        = gson.getDelegateAdapter(this, TypeToken.get(SomeObject.class));
+
+       return (TypeAdapter<T>) new TypeAdapter<SomeObject>() {
+           @Override
+           public void write(JsonWriter out, SomeObject value) throws IOException {
+             JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             elementAdapter.write(out, obj);
+           }
+
+           @Override
+           public SomeObject read(JsonReader in) throws IOException {
+             JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
+             validateJsonObject(jsonObj);
+             return thisAdapter.fromJsonTree(jsonObj);
+           }
+
+       }.nullSafe();
+    }
+  }
+
+ /**
+  * Create an instance of SomeObject given an JSON string
+  *
+  * @param jsonString JSON string
+  * @return An instance of SomeObject
+  * @throws IOException if the JSON string is invalid with respect to SomeObject
+  */
+  public static SomeObject fromJson(String jsonString) throws IOException {
+    return JSON.getGson().fromJson(jsonString, SomeObject.class);
+  }
+
+ /**
+  * Convert an instance of SomeObject to an JSON string
+  *
+  * @return JSON string
+  */
+  public String toJson() {
+    return JSON.getGson().toJson(this);
+  }
 }
 ",
 }

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/java.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/java.test.ts.snap
@@ -30333,29 +30333,41 @@ src/main/java/test/test/runtime/api/handlers/RequestInput.java
 src/main/java/test/test/runtime/api/handlers/ChainedRequestInput.java
 src/main/java/test/test/runtime/api/handlers/InterceptorWarmupChainedRequestInput.java
 src/main/java/test/test/runtime/api/handlers/InterceptorWithWarmup.java
+src/main/java/test/test/runtime/api/handlers/array_of_one_ofs/ArrayOfOneOfsResponse.java
 src/main/java/test/test/runtime/api/handlers/array_request_parameters/ArrayRequestParametersResponse.java
 src/main/java/test/test/runtime/api/handlers/inline_enum/InlineEnumResponse.java
 src/main/java/test/test/runtime/api/handlers/inline_request_body/InlineRequestBodyResponse.java
+src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOfResponse.java
 src/main/java/test/test/runtime/api/handlers/reserved_keywords/ReservedKeywordsResponse.java
+src/main/java/test/test/runtime/api/handlers/array_of_one_ofs/ArrayOfOneOfs200Response.java
 src/main/java/test/test/runtime/api/handlers/array_request_parameters/ArrayRequestParameters200Response.java
 src/main/java/test/test/runtime/api/handlers/inline_enum/InlineEnum200Response.java
 src/main/java/test/test/runtime/api/handlers/inline_request_body/InlineRequestBody204Response.java
+src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOf200Response.java
 src/main/java/test/test/runtime/api/handlers/reserved_keywords/ReservedKeywords200Response.java
+src/main/java/test/test/runtime/api/handlers/array_of_one_ofs/ArrayOfOneOfsRequestParameters.java
 src/main/java/test/test/runtime/api/handlers/array_request_parameters/ArrayRequestParametersRequestParameters.java
 src/main/java/test/test/runtime/api/handlers/inline_enum/InlineEnumRequestParameters.java
 src/main/java/test/test/runtime/api/handlers/inline_request_body/InlineRequestBodyRequestParameters.java
+src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOfRequestParameters.java
 src/main/java/test/test/runtime/api/handlers/reserved_keywords/ReservedKeywordsRequestParameters.java
+src/main/java/test/test/runtime/api/handlers/array_of_one_ofs/ArrayOfOneOfsInput.java
 src/main/java/test/test/runtime/api/handlers/array_request_parameters/ArrayRequestParametersInput.java
 src/main/java/test/test/runtime/api/handlers/inline_enum/InlineEnumInput.java
 src/main/java/test/test/runtime/api/handlers/inline_request_body/InlineRequestBodyInput.java
+src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOfInput.java
 src/main/java/test/test/runtime/api/handlers/reserved_keywords/ReservedKeywordsInput.java
+src/main/java/test/test/runtime/api/handlers/array_of_one_ofs/ArrayOfOneOfsRequestInput.java
 src/main/java/test/test/runtime/api/handlers/array_request_parameters/ArrayRequestParametersRequestInput.java
 src/main/java/test/test/runtime/api/handlers/inline_enum/InlineEnumRequestInput.java
 src/main/java/test/test/runtime/api/handlers/inline_request_body/InlineRequestBodyRequestInput.java
+src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOfRequestInput.java
 src/main/java/test/test/runtime/api/handlers/reserved_keywords/ReservedKeywordsRequestInput.java
+src/main/java/test/test/runtime/api/handlers/array_of_one_ofs/ArrayOfOneOfs.java
 src/main/java/test/test/runtime/api/handlers/array_request_parameters/ArrayRequestParameters.java
 src/main/java/test/test/runtime/api/handlers/inline_enum/InlineEnum.java
 src/main/java/test/test/runtime/api/handlers/inline_request_body/InlineRequestBody.java
+src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOf.java
 src/main/java/test/test/runtime/api/handlers/reserved_keywords/ReservedKeywords.java
 src/main/java/test/test/runtime/api/handlers/HandlerRouter.java
 src/main/java/test/test/runtime/api/interceptors/TryCatchInterceptor.java
@@ -30386,10 +30398,14 @@ src/main/java/test/test/runtime/ServerConfiguration.java
 src/main/java/test/test/runtime/ServerVariable.java
 src/main/java/test/test/runtime/StringUtil.java
 src/main/java/test/test/runtime/model/AbstractOpenApiSchema.java
+src/main/java/test/test/runtime/model/AnotherNamedOneOf.java
+src/main/java/test/test/runtime/model/ArrayOfOneOfs.java
 src/main/java/test/test/runtime/model/InlineEnum200Response.java
 src/main/java/test/test/runtime/model/InlineEnum200ResponseCategoryEnum.java
 src/main/java/test/test/runtime/model/InlineRequestBodyRequestContent.java
-src/main/java/test/test/runtime/model/MyEnum.java",
+src/main/java/test/test/runtime/model/MyEnum.java
+src/main/java/test/test/runtime/model/NamedOneOf.java
+src/main/java/test/test/runtime/model/NamedOneOfUnion.java",
   "src/main/java/test/test/runtime/ApiCallback.java": "/*
  * Edge Cases
  * 
@@ -32456,8 +32472,12 @@ public class JSON {
         gsonBuilder.registerTypeAdapter(OffsetDateTime.class, offsetDateTimeTypeAdapter);
         gsonBuilder.registerTypeAdapter(LocalDate.class, localDateTypeAdapter);
         gsonBuilder.registerTypeAdapter(byte[].class, byteArrayAdapter);
+        gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.AnotherNamedOneOf.CustomTypeAdapterFactory());
+        gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.ArrayOfOneOfs.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.InlineEnum200Response.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.InlineRequestBodyRequestContent.CustomTypeAdapterFactory());
+        gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.NamedOneOf.CustomTypeAdapterFactory());
+        gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.NamedOneOfUnion.CustomTypeAdapterFactory());
         gson = gsonBuilder.create();
     }
 
@@ -33158,9 +33178,11 @@ import java.io.IOException;
 
 import java.math.BigDecimal;
 import java.io.File;
+import test.test.runtime.model.ArrayOfOneOfs;
 import test.test.runtime.model.InlineEnum200Response;
 import test.test.runtime.model.InlineRequestBodyRequestContent;
 import test.test.runtime.model.MyEnum;
+import test.test.runtime.model.NamedOneOfUnion;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -33206,6 +33228,151 @@ public class DefaultApi {
         this.localCustomBaseUrl = customBaseUrl;
     }
 
+    private okhttp3.Call arrayOfOneOfsCall(final ApiCallback _callback) throws ApiException {
+        String basePath = null;
+        // Operation Servers
+        String[] localBasePaths = new String[] {  };
+
+        // Determine Base Path to Use
+        if (localCustomBaseUrl != null){
+            basePath = localCustomBaseUrl;
+        } else if ( localBasePaths.length > 0 ) {
+            basePath = localBasePaths[localHostIndex];
+        } else {
+            basePath = null;
+        }
+
+        Object localVarPostBody = null;
+
+        // create path and map variables
+        String localVarPath = "/array-of-one-ofs";
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        final String[] localVarAccepts = {
+            "application/json"
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        if (localVarContentType != null) {
+            localVarHeaderParams.put("Content-Type", localVarContentType);
+        }
+
+        String[] localVarAuthNames = new String[] {  };
+        return localVarApiClient.buildCall(basePath, localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call arrayOfOneOfsValidateBeforeCall(final ApiCallback _callback) throws ApiException {
+        return arrayOfOneOfsCall(_callback);
+
+    }
+
+    private ApiResponse<ArrayOfOneOfs> arrayOfOneOfsWithHttpInfo() throws ApiException {
+        okhttp3.Call localVarCall = arrayOfOneOfsValidateBeforeCall(null);
+        Type localVarReturnType = new TypeToken<ArrayOfOneOfs>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+
+    private okhttp3.Call arrayOfOneOfsAsync(final ApiCallback<ArrayOfOneOfs> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = arrayOfOneOfsValidateBeforeCall(_callback);
+        Type localVarReturnType = new TypeToken<ArrayOfOneOfs>(){}.getType();
+        localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+        return localVarCall;
+    }
+
+    public class APIarrayOfOneOfsRequest {
+
+        private APIarrayOfOneOfsRequest() {
+        }
+
+        /**
+         * Build call for arrayOfOneOfs
+         * @param _callback ApiCallback API callback
+         * @return Call to execute
+         * @throws ApiException If fail to serialize the request body object
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> ok </td><td>  -  </td></tr>
+         </table>
+         */
+        public okhttp3.Call buildCall(final ApiCallback _callback) throws ApiException {
+            return arrayOfOneOfsCall(_callback);
+        }
+
+        /**
+         * Execute arrayOfOneOfs request
+         * @return ArrayOfOneOfs
+         * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> ok </td><td>  -  </td></tr>
+         </table>
+         */
+        public ArrayOfOneOfs execute() throws ApiException {
+            ApiResponse<ArrayOfOneOfs> localVarResp = arrayOfOneOfsWithHttpInfo();
+            return localVarResp.getData();
+        }
+
+        /**
+         * Execute arrayOfOneOfs request with HTTP info returned
+         * @return ApiResponse&lt;ArrayOfOneOfs&gt;
+         * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> ok </td><td>  -  </td></tr>
+         </table>
+         */
+        public ApiResponse<ArrayOfOneOfs> executeWithHttpInfo() throws ApiException {
+            return arrayOfOneOfsWithHttpInfo();
+        }
+
+        /**
+         * Execute arrayOfOneOfs request (asynchronously)
+         * @param _callback The callback to be executed when the API call finishes
+         * @return The request call
+         * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> ok </td><td>  -  </td></tr>
+         </table>
+         */
+        public okhttp3.Call executeAsync(final ApiCallback<ArrayOfOneOfs> _callback) throws ApiException {
+            return arrayOfOneOfsAsync(_callback);
+        }
+    }
+
+    /**
+     * 
+     * 
+     * @return APIarrayOfOneOfsRequest
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> ok </td><td>  -  </td></tr>
+     </table>
+     */
+    
+    public APIarrayOfOneOfsRequest arrayOfOneOfs() {
+        return new APIarrayOfOneOfsRequest();
+    }
     private okhttp3.Call arrayRequestParametersCall(List<String> myStringArrayRequestParams, List<MyEnum> myEnumArrayRequestParams, List<Integer> myIntegerArrayRequestParams, List<Long> myLongArrayRequestParams, List<Integer> myInt32ArrayRequestParams, List<BigDecimal> myNumberArrayRequestParams, List<Float> myFloatArrayRequestParams, List<Double> myDoubleArrayRequestParams, MyEnum myEnumRequestParam, final ApiCallback _callback) throws ApiException {
         String basePath = null;
         // Operation Servers
@@ -33778,6 +33945,151 @@ public class DefaultApi {
     public APIinlineRequestBodyRequest inlineRequestBody() {
         return new APIinlineRequestBodyRequest();
     }
+    private okhttp3.Call namedOneOfCall(final ApiCallback _callback) throws ApiException {
+        String basePath = null;
+        // Operation Servers
+        String[] localBasePaths = new String[] {  };
+
+        // Determine Base Path to Use
+        if (localCustomBaseUrl != null){
+            basePath = localCustomBaseUrl;
+        } else if ( localBasePaths.length > 0 ) {
+            basePath = localBasePaths[localHostIndex];
+        } else {
+            basePath = null;
+        }
+
+        Object localVarPostBody = null;
+
+        // create path and map variables
+        String localVarPath = "/named-one-of";
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        final String[] localVarAccepts = {
+            "application/json"
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        if (localVarContentType != null) {
+            localVarHeaderParams.put("Content-Type", localVarContentType);
+        }
+
+        String[] localVarAuthNames = new String[] {  };
+        return localVarApiClient.buildCall(basePath, localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call namedOneOfValidateBeforeCall(final ApiCallback _callback) throws ApiException {
+        return namedOneOfCall(_callback);
+
+    }
+
+    private ApiResponse<NamedOneOfUnion> namedOneOfWithHttpInfo() throws ApiException {
+        okhttp3.Call localVarCall = namedOneOfValidateBeforeCall(null);
+        Type localVarReturnType = new TypeToken<NamedOneOfUnion>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+
+    private okhttp3.Call namedOneOfAsync(final ApiCallback<NamedOneOfUnion> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = namedOneOfValidateBeforeCall(_callback);
+        Type localVarReturnType = new TypeToken<NamedOneOfUnion>(){}.getType();
+        localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+        return localVarCall;
+    }
+
+    public class APInamedOneOfRequest {
+
+        private APInamedOneOfRequest() {
+        }
+
+        /**
+         * Build call for namedOneOf
+         * @param _callback ApiCallback API callback
+         * @return Call to execute
+         * @throws ApiException If fail to serialize the request body object
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> ok </td><td>  -  </td></tr>
+         </table>
+         */
+        public okhttp3.Call buildCall(final ApiCallback _callback) throws ApiException {
+            return namedOneOfCall(_callback);
+        }
+
+        /**
+         * Execute namedOneOf request
+         * @return NamedOneOfUnion
+         * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> ok </td><td>  -  </td></tr>
+         </table>
+         */
+        public NamedOneOfUnion execute() throws ApiException {
+            ApiResponse<NamedOneOfUnion> localVarResp = namedOneOfWithHttpInfo();
+            return localVarResp.getData();
+        }
+
+        /**
+         * Execute namedOneOf request with HTTP info returned
+         * @return ApiResponse&lt;NamedOneOfUnion&gt;
+         * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> ok </td><td>  -  </td></tr>
+         </table>
+         */
+        public ApiResponse<NamedOneOfUnion> executeWithHttpInfo() throws ApiException {
+            return namedOneOfWithHttpInfo();
+        }
+
+        /**
+         * Execute namedOneOf request (asynchronously)
+         * @param _callback The callback to be executed when the API call finishes
+         * @return The request call
+         * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> ok </td><td>  -  </td></tr>
+         </table>
+         */
+        public okhttp3.Call executeAsync(final ApiCallback<NamedOneOfUnion> _callback) throws ApiException {
+            return namedOneOfAsync(_callback);
+        }
+    }
+
+    /**
+     * 
+     * 
+     * @return APInamedOneOfRequest
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> ok </td><td>  -  </td></tr>
+     </table>
+     */
+    
+    public APInamedOneOfRequest namedOneOf() {
+        return new APInamedOneOfRequest();
+    }
     private okhttp3.Call reservedKeywordsCall(String with, String _if, String propertyClass, final ApiCallback _callback) throws ApiException {
         String basePath = null;
         // Operation Servers
@@ -34011,9 +34323,11 @@ public interface HandlerChain<TInput> {
   "src/main/java/test/test/runtime/api/handlers/HandlerRouter.java": "
 package test.test.runtime.api.handlers;
 
+import test.test.runtime.api.handlers.array_of_one_ofs.*;
 import test.test.runtime.api.handlers.array_request_parameters.*;
 import test.test.runtime.api.handlers.inline_enum.*;
 import test.test.runtime.api.handlers.inline_request_body.*;
+import test.test.runtime.api.handlers.named_one_of.*;
 import test.test.runtime.api.handlers.reserved_keywords.*;
 
 import test.test.runtime.api.handlers.Handlers;
@@ -34032,16 +34346,24 @@ import java.util.Collections;
 
 
 public abstract class HandlerRouter implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+    private static final String arrayOfOneOfsMethodAndPath = Handlers.concatMethodAndPath("POST", "/array-of-one-ofs");
     private static final String arrayRequestParametersMethodAndPath = Handlers.concatMethodAndPath("GET", "/array-request-parameters");
     private static final String inlineEnumMethodAndPath = Handlers.concatMethodAndPath("GET", "/inline-enum");
     private static final String inlineRequestBodyMethodAndPath = Handlers.concatMethodAndPath("POST", "/inline-request-body");
+    private static final String namedOneOfMethodAndPath = Handlers.concatMethodAndPath("POST", "/named-one-of");
     private static final String reservedKeywordsMethodAndPath = Handlers.concatMethodAndPath("GET", "/reserved-keywords");
 
+    private final ArrayOfOneOfs constructedArrayOfOneOfs;
     private final ArrayRequestParameters constructedArrayRequestParameters;
     private final InlineEnum constructedInlineEnum;
     private final InlineRequestBody constructedInlineRequestBody;
+    private final NamedOneOf constructedNamedOneOf;
     private final ReservedKeywords constructedReservedKeywords;
 
+    /**
+     * This method must return your implementation of the ArrayOfOneOfs operation
+     */
+    public abstract ArrayOfOneOfs arrayOfOneOfs();
     /**
      * This method must return your implementation of the ArrayRequestParameters operation
      */
@@ -34055,14 +34377,20 @@ public abstract class HandlerRouter implements RequestHandler<APIGatewayProxyReq
      */
     public abstract InlineRequestBody inlineRequestBody();
     /**
+     * This method must return your implementation of the NamedOneOf operation
+     */
+    public abstract NamedOneOf namedOneOf();
+    /**
      * This method must return your implementation of the ReservedKeywords operation
      */
     public abstract ReservedKeywords reservedKeywords();
 
     private static enum Route {
+        arrayOfOneOfsRoute,
         arrayRequestParametersRoute,
         inlineEnumRoute,
         inlineRequestBodyRoute,
+        namedOneOfRoute,
         reservedKeywordsRoute,
     }
 
@@ -34072,16 +34400,20 @@ public abstract class HandlerRouter implements RequestHandler<APIGatewayProxyReq
     private final Map<String, Route> routes = new HashMap<>();
 
     public HandlerRouter() {
+        this.routes.put(arrayOfOneOfsMethodAndPath, Route.arrayOfOneOfsRoute);
         this.routes.put(arrayRequestParametersMethodAndPath, Route.arrayRequestParametersRoute);
         this.routes.put(inlineEnumMethodAndPath, Route.inlineEnumRoute);
         this.routes.put(inlineRequestBodyMethodAndPath, Route.inlineRequestBodyRoute);
+        this.routes.put(namedOneOfMethodAndPath, Route.namedOneOfRoute);
         this.routes.put(reservedKeywordsMethodAndPath, Route.reservedKeywordsRoute);
         // Handlers are all constructed in the router's constructor such that lambda behaviour remains consistent;
         // ie resources created in the constructor remain in memory between invocations.
         // https://docs.aws.amazon.com/lambda/latest/dg/java-handler.html
+        this.constructedArrayOfOneOfs = this.arrayOfOneOfs();
         this.constructedArrayRequestParameters = this.arrayRequestParameters();
         this.constructedInlineEnum = this.inlineEnum();
         this.constructedInlineRequestBody = this.inlineRequestBody();
+        this.constructedNamedOneOf = this.namedOneOf();
         this.constructedReservedKeywords = this.reservedKeywords();
     }
 
@@ -34102,6 +34434,10 @@ public abstract class HandlerRouter implements RequestHandler<APIGatewayProxyReq
         Route route = this.routes.get(methodAndPath);
 
         switch (route) {
+            case arrayOfOneOfsRoute:
+                List<Interceptor<ArrayOfOneOfsInput>> arrayOfOneOfsInterceptors = Handlers.getAnnotationInterceptors(this.getClass());
+                arrayOfOneOfsInterceptors.addAll(this.getInterceptors());
+                return this.constructedArrayOfOneOfs.handleRequestWithAdditionalInterceptors(event, context, arrayOfOneOfsInterceptors);
             case arrayRequestParametersRoute:
                 List<Interceptor<ArrayRequestParametersInput>> arrayRequestParametersInterceptors = Handlers.getAnnotationInterceptors(this.getClass());
                 arrayRequestParametersInterceptors.addAll(this.getInterceptors());
@@ -34114,6 +34450,10 @@ public abstract class HandlerRouter implements RequestHandler<APIGatewayProxyReq
                 List<Interceptor<InlineRequestBodyInput>> inlineRequestBodyInterceptors = Handlers.getAnnotationInterceptors(this.getClass());
                 inlineRequestBodyInterceptors.addAll(this.getInterceptors());
                 return this.constructedInlineRequestBody.handleRequestWithAdditionalInterceptors(event, context, inlineRequestBodyInterceptors);
+            case namedOneOfRoute:
+                List<Interceptor<NamedOneOfInput>> namedOneOfInterceptors = Handlers.getAnnotationInterceptors(this.getClass());
+                namedOneOfInterceptors.addAll(this.getInterceptors());
+                return this.constructedNamedOneOf.handleRequestWithAdditionalInterceptors(event, context, namedOneOfInterceptors);
             case reservedKeywordsRoute:
                 List<Interceptor<ReservedKeywordsInput>> reservedKeywordsInterceptors = Handlers.getAnnotationInterceptors(this.getClass());
                 reservedKeywordsInterceptors.addAll(this.getInterceptors());
@@ -34779,6 +35119,413 @@ public interface Response {
      */
     Map<String, List<String>> getMultiValueHeaders();
 }
+",
+  "src/main/java/test/test/runtime/api/handlers/array_of_one_ofs/ArrayOfOneOfs.java": "
+package test.test.runtime.api.handlers.array_of_one_ofs;
+
+import test.test.runtime.model.*;
+import test.test.runtime.JSON;
+import test.test.runtime.api.handlers.Interceptor;
+import test.test.runtime.api.handlers.Handlers;
+import test.test.runtime.api.handlers.*;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Collections;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import java.io.IOException;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import org.crac.Core;
+import org.crac.Resource;
+
+
+/**
+ * Lambda handler wrapper for the arrayOfOneOfs operation
+ */
+public abstract class ArrayOfOneOfs implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent>, Resource {
+    {
+        Core.getGlobalContext().register(this);
+    }
+
+    /**
+     * Handle the request for the arrayOfOneOfs operation
+     */
+    public abstract ArrayOfOneOfsResponse handle(final ArrayOfOneOfsRequestInput request);
+
+    /**
+     * Interceptors that the handler class has been decorated with
+     */
+    private List<Interceptor<ArrayOfOneOfsInput>> annotationInterceptors = Handlers.getAnnotationInterceptors(ArrayOfOneOfs.class);
+
+    /**
+     * For more complex interceptors that require instantiation with parameters, you may override this method to
+     * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+     * prefer the @Interceptors annotation.
+     */
+    public List<Interceptor<ArrayOfOneOfsInput>> getInterceptors() {
+        return Collections.emptyList();
+    }
+
+    private List<Interceptor<ArrayOfOneOfsInput>> getHandlerInterceptors() {
+        List<Interceptor<ArrayOfOneOfsInput>> interceptors = new ArrayList<>();
+        interceptors.addAll(annotationInterceptors);
+        interceptors.addAll(this.getInterceptors());
+        return interceptors;
+    }
+
+    private HandlerChain<ArrayOfOneOfsInput> buildChain(List<Interceptor<ArrayOfOneOfsInput>> interceptors) {
+        return Handlers.buildHandlerChain(interceptors, new HandlerChain<ArrayOfOneOfsInput>() {
+            @Override
+            public Response next(ChainedRequestInput<ArrayOfOneOfsInput> input) {
+                return handle(new ArrayOfOneOfsRequestInput(input.getEvent(), input.getContext(), input.getInterceptorContext(), input.getInput()));
+            }
+        });
+    }
+
+    private ChainedRequestInput<ArrayOfOneOfsInput> buildChainedRequestInput(final APIGatewayProxyRequestEvent event, final Context context, final ArrayOfOneOfsInput input, final Map<String, Object> interceptorContext) {
+        return new ChainedRequestInput<ArrayOfOneOfsInput>() {
+            @Override
+            public HandlerChain getChain() {
+                // The chain's next method ignores the chain given as input, and is pre-built to follow the remaining
+                // chain.
+                return null;
+            }
+
+            @Override
+            public APIGatewayProxyRequestEvent getEvent() {
+                return event;
+            }
+
+            @Override
+            public Context getContext() {
+                return context;
+            }
+
+            @Override
+            public ArrayOfOneOfsInput getInput() {
+                return input;
+            }
+
+            @Override
+            public Map<String, Object> getInterceptorContext() {
+                return interceptorContext;
+            }
+        };
+    }
+
+    @Override
+    public void beforeCheckpoint(org.crac.Context<? extends Resource> context) {
+        // Prime building the handler chain which can take a few 100ms to JIT.
+        this.buildChain(this.getHandlerInterceptors());
+        this.buildChainedRequestInput(null, null, null, null);
+
+        // Initialise instance of Gson and prime serialisation and deserialisation
+        new JSON();
+        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>(), new HashMap<>())), ApiResponse.class);
+
+        try {
+            // Prime input validation - this will likely fail for the fake event but ensures the code path is optimised
+            // ready for a real invocation
+            new ArrayOfOneOfsInput(new APIGatewayProxyRequestEvent()
+                    .withBody("{}")
+                    .withPathParameters(new HashMap<>())
+                    .withQueryStringParameters(new HashMap<>())
+                    .withMultiValueQueryStringParameters(new HashMap<>())
+                    .withHeaders(new HashMap<>())
+                    .withMultiValueHeaders(new HashMap<>())
+            );
+        } catch (Exception e) {
+
+        }
+
+        this.warmUp();
+    }
+
+    @Override
+    public void afterRestore(org.crac.Context<? extends Resource> context) {
+
+    }
+
+    /**
+     * Override this method to perform any warmup activities which will be executed prior to the snap-start snapshot.
+     */
+    public void warmUp() {
+
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+        return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+    }
+
+    private Map<String, String> getErrorResponseHeaders(final int statusCode) {
+        Map<String, String> headers = new HashMap<>();
+        return headers;
+    }
+
+    public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<ArrayOfOneOfsInput>> additionalInterceptors) {
+        final Map<String, Object> interceptorContext = new HashMap<>();
+        interceptorContext.put("operationId", "arrayOfOneOfs");
+
+        List<Interceptor<ArrayOfOneOfsInput>> interceptors = new ArrayList<>();
+        interceptors.addAll(additionalInterceptors);
+        interceptors.addAll(this.getHandlerInterceptors());
+
+        final HandlerChain chain = this.buildChain(interceptors);
+
+        ArrayOfOneOfsInput input;
+
+        try {
+            input = new ArrayOfOneOfsInput(event);
+        } catch (RuntimeException e) {
+            Map<String, String> headers = new HashMap<>();
+            headers.putAll(Handlers.extractResponseHeadersFromInterceptors(interceptors));
+            headers.putAll(this.getErrorResponseHeaders(400));
+            return new APIGatewayProxyResponseEvent()
+                .withStatusCode(400)
+                .withHeaders(headers)
+                .withBody("{\\"message\\": \\"" + e.getMessage() + "\\"}");
+        }
+
+        final Response response = chain.next(this.buildChainedRequestInput(event, context, input, interceptorContext));
+
+        Map<String, String> responseHeaders = new HashMap<>();
+        responseHeaders.putAll(this.getErrorResponseHeaders(response.getStatusCode()));
+        responseHeaders.putAll(response.getHeaders());
+
+        return new APIGatewayProxyResponseEvent()
+                .withStatusCode(response.getStatusCode())
+                .withHeaders(responseHeaders)
+                .withMultiValueHeaders(response.getMultiValueHeaders())
+                .withBody(response.getBody());
+    }
+}
+",
+  "src/main/java/test/test/runtime/api/handlers/array_of_one_ofs/ArrayOfOneOfs200Response.java": "
+package test.test.runtime.api.handlers.array_of_one_ofs;
+
+import test.test.runtime.model.*;
+import test.test.runtime.JSON;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Response with status code 200 for the arrayOfOneOfs operation
+ */
+public class ArrayOfOneOfs200Response extends RuntimeException implements ArrayOfOneOfsResponse {
+    static {
+        // JSON has a static instance of Gson which is instantiated lazily the first time it is initialised.
+        // Create an instance here if required to ensure that the static Gson instance is always available.
+        if (JSON.getGson() == null) {
+            new JSON();
+        }
+    }
+
+    private final String body;
+    private final ArrayOfOneOfs typedBody;
+    private final Map<String, String> headers;
+    private final Map<String, List<String>> multiValueHeaders;
+
+    private ArrayOfOneOfs200Response(final ArrayOfOneOfs body, final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
+        this.typedBody = body;
+        this.body = body.toJson();
+        this.headers = headers;
+        this.multiValueHeaders = multiValueHeaders;
+    }
+
+    @Override
+    public int getStatusCode() {
+        return 200;
+    }
+
+    @Override
+    public String getBody() {
+        return this.body;
+    }
+
+    public ArrayOfOneOfs getTypedBody() {
+        return this.typedBody;
+    }
+
+    @Override
+    public Map<String, String> getHeaders() {
+        return this.headers;
+    }
+
+    @Override
+    public Map<String, List<String>> getMultiValueHeaders() {
+        return this.multiValueHeaders;
+    }
+
+    /**
+     * Create a ArrayOfOneOfs200Response with a body
+     */
+    public static ArrayOfOneOfs200Response of(final ArrayOfOneOfs body) {
+        return new ArrayOfOneOfs200Response(body, new HashMap<>(), new HashMap<>());
+    }
+
+    /**
+     * Create a ArrayOfOneOfs200Response with a body and headers
+     */
+    public static ArrayOfOneOfs200Response of(final ArrayOfOneOfs body, final Map<String, String> headers) {
+        return new ArrayOfOneOfs200Response(body, headers, new HashMap<>());
+    }
+
+    /**
+     * Create a ArrayOfOneOfs200Response with a body, headers and multi-value headers
+     */
+    public static ArrayOfOneOfs200Response of(final ArrayOfOneOfs body, final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
+        return new ArrayOfOneOfs200Response(body, headers, multiValueHeaders);
+    }
+}
+",
+  "src/main/java/test/test/runtime/api/handlers/array_of_one_ofs/ArrayOfOneOfsInput.java": "
+package test.test.runtime.api.handlers.array_of_one_ofs;
+
+import test.test.runtime.model.*;
+import test.test.runtime.JSON;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.Map;
+import java.util.HashMap;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import java.io.IOException;
+
+/**
+ * Input for the arrayOfOneOfs operation
+ */
+@lombok.Builder
+@lombok.AllArgsConstructor
+public class ArrayOfOneOfsInput {
+    static {
+        // JSON has a static instance of Gson which is instantiated lazily the first time it is initialised.
+        // Create an instance here if required to ensure that the static Gson instance is always available.
+        if (JSON.getGson() == null) {
+            new JSON();
+        }
+    }
+
+    private final ArrayOfOneOfsRequestParameters requestParameters;
+
+    public ArrayOfOneOfsInput(final APIGatewayProxyRequestEvent event) {
+        this.requestParameters = new ArrayOfOneOfsRequestParameters(event);
+    }
+
+    public ArrayOfOneOfsRequestParameters getRequestParameters() {
+        return this.requestParameters;
+    }
+
+}
+",
+  "src/main/java/test/test/runtime/api/handlers/array_of_one_ofs/ArrayOfOneOfsRequestInput.java": "
+package test.test.runtime.api.handlers.array_of_one_ofs;
+
+import test.test.runtime.model.*;
+import test.test.runtime.api.handlers.RequestInput;
+import java.util.List;
+import java.util.Optional;
+import java.util.Map;
+import java.util.HashMap;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import java.io.IOException;
+import com.amazonaws.services.lambda.runtime.Context;
+
+/**
+ * Full request input for the arrayOfOneOfs operation, including the raw API Gateway event
+ */
+@lombok.Builder
+@lombok.AllArgsConstructor
+public class ArrayOfOneOfsRequestInput implements RequestInput<ArrayOfOneOfsInput> {
+    private final APIGatewayProxyRequestEvent event;
+    private final Context context;
+    private final Map<String, Object> interceptorContext;
+    private final ArrayOfOneOfsInput input;
+
+    /**
+     * Returns the typed request input, with path, query and body parameters
+     */
+    public ArrayOfOneOfsInput getInput() {
+        return this.input;
+    }
+
+    /**
+     * Returns the raw API Gateway event
+     */
+    public APIGatewayProxyRequestEvent getEvent() {
+        return this.event;
+    }
+
+    /**
+     * Returns the lambda context
+     */
+    public Context getContext() {
+        return this.context;
+    }
+
+    /**
+     * Returns the interceptor context, which may contain values set by request interceptors
+     */
+    public Map<String, Object> getInterceptorContext() {
+        return this.interceptorContext;
+    }
+}
+",
+  "src/main/java/test/test/runtime/api/handlers/array_of_one_ofs/ArrayOfOneOfsRequestParameters.java": "
+package test.test.runtime.api.handlers.array_of_one_ofs;
+
+import test.test.runtime.api.handlers.Handlers;
+import java.util.Optional;
+import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.time.OffsetDateTime;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.stream.Collectors;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+
+import test.test.runtime.model.*;
+
+/**
+ * Query, path and header parameters for the ArrayOfOneOfs operation
+ */
+@lombok.Builder
+@lombok.AllArgsConstructor
+public class ArrayOfOneOfsRequestParameters {
+
+    public ArrayOfOneOfsRequestParameters(final APIGatewayProxyRequestEvent event) {
+        Map<String, String> rawStringParameters = new HashMap<>();
+        Handlers.putAllFromNullableMap(event.getPathParameters(), rawStringParameters);
+        Handlers.putAllFromNullableMap(event.getQueryStringParameters(), rawStringParameters);
+        Handlers.putAllFromNullableMap(event.getHeaders(), rawStringParameters);
+        Map<String, String> decodedStringParameters = Handlers.decodeRequestParameters(rawStringParameters);
+
+        Map<String, List<String>> rawStringArrayParameters = new HashMap<>();
+        Handlers.putAllFromNullableMap(event.getMultiValueQueryStringParameters(), rawStringArrayParameters);
+        Handlers.putAllFromNullableMap(event.getMultiValueHeaders(), rawStringArrayParameters);
+        Map<String, List<String>> decodedStringArrayParameters = Handlers.decodeRequestArrayParameters(rawStringArrayParameters);
+
+    }
+
+}
+",
+  "src/main/java/test/test/runtime/api/handlers/array_of_one_ofs/ArrayOfOneOfsResponse.java": "
+package test.test.runtime.api.handlers.array_of_one_ofs;
+
+import test.test.runtime.api.handlers.Response;
+
+/**
+ * Response for the arrayOfOneOfs operation
+ */
+public interface ArrayOfOneOfsResponse extends Response {}
 ",
   "src/main/java/test/test/runtime/api/handlers/array_request_parameters/ArrayRequestParameters.java": "
 package test.test.runtime.api.handlers.array_request_parameters;
@@ -36049,6 +36796,413 @@ import test.test.runtime.api.handlers.Response;
  */
 public interface InlineRequestBodyResponse extends Response {}
 ",
+  "src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOf.java": "
+package test.test.runtime.api.handlers.named_one_of;
+
+import test.test.runtime.model.*;
+import test.test.runtime.JSON;
+import test.test.runtime.api.handlers.Interceptor;
+import test.test.runtime.api.handlers.Handlers;
+import test.test.runtime.api.handlers.*;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Collections;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import java.io.IOException;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import org.crac.Core;
+import org.crac.Resource;
+
+
+/**
+ * Lambda handler wrapper for the namedOneOf operation
+ */
+public abstract class NamedOneOf implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent>, Resource {
+    {
+        Core.getGlobalContext().register(this);
+    }
+
+    /**
+     * Handle the request for the namedOneOf operation
+     */
+    public abstract NamedOneOfResponse handle(final NamedOneOfRequestInput request);
+
+    /**
+     * Interceptors that the handler class has been decorated with
+     */
+    private List<Interceptor<NamedOneOfInput>> annotationInterceptors = Handlers.getAnnotationInterceptors(NamedOneOf.class);
+
+    /**
+     * For more complex interceptors that require instantiation with parameters, you may override this method to
+     * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+     * prefer the @Interceptors annotation.
+     */
+    public List<Interceptor<NamedOneOfInput>> getInterceptors() {
+        return Collections.emptyList();
+    }
+
+    private List<Interceptor<NamedOneOfInput>> getHandlerInterceptors() {
+        List<Interceptor<NamedOneOfInput>> interceptors = new ArrayList<>();
+        interceptors.addAll(annotationInterceptors);
+        interceptors.addAll(this.getInterceptors());
+        return interceptors;
+    }
+
+    private HandlerChain<NamedOneOfInput> buildChain(List<Interceptor<NamedOneOfInput>> interceptors) {
+        return Handlers.buildHandlerChain(interceptors, new HandlerChain<NamedOneOfInput>() {
+            @Override
+            public Response next(ChainedRequestInput<NamedOneOfInput> input) {
+                return handle(new NamedOneOfRequestInput(input.getEvent(), input.getContext(), input.getInterceptorContext(), input.getInput()));
+            }
+        });
+    }
+
+    private ChainedRequestInput<NamedOneOfInput> buildChainedRequestInput(final APIGatewayProxyRequestEvent event, final Context context, final NamedOneOfInput input, final Map<String, Object> interceptorContext) {
+        return new ChainedRequestInput<NamedOneOfInput>() {
+            @Override
+            public HandlerChain getChain() {
+                // The chain's next method ignores the chain given as input, and is pre-built to follow the remaining
+                // chain.
+                return null;
+            }
+
+            @Override
+            public APIGatewayProxyRequestEvent getEvent() {
+                return event;
+            }
+
+            @Override
+            public Context getContext() {
+                return context;
+            }
+
+            @Override
+            public NamedOneOfInput getInput() {
+                return input;
+            }
+
+            @Override
+            public Map<String, Object> getInterceptorContext() {
+                return interceptorContext;
+            }
+        };
+    }
+
+    @Override
+    public void beforeCheckpoint(org.crac.Context<? extends Resource> context) {
+        // Prime building the handler chain which can take a few 100ms to JIT.
+        this.buildChain(this.getHandlerInterceptors());
+        this.buildChainedRequestInput(null, null, null, null);
+
+        // Initialise instance of Gson and prime serialisation and deserialisation
+        new JSON();
+        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>(), new HashMap<>())), ApiResponse.class);
+
+        try {
+            // Prime input validation - this will likely fail for the fake event but ensures the code path is optimised
+            // ready for a real invocation
+            new NamedOneOfInput(new APIGatewayProxyRequestEvent()
+                    .withBody("{}")
+                    .withPathParameters(new HashMap<>())
+                    .withQueryStringParameters(new HashMap<>())
+                    .withMultiValueQueryStringParameters(new HashMap<>())
+                    .withHeaders(new HashMap<>())
+                    .withMultiValueHeaders(new HashMap<>())
+            );
+        } catch (Exception e) {
+
+        }
+
+        this.warmUp();
+    }
+
+    @Override
+    public void afterRestore(org.crac.Context<? extends Resource> context) {
+
+    }
+
+    /**
+     * Override this method to perform any warmup activities which will be executed prior to the snap-start snapshot.
+     */
+    public void warmUp() {
+
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+        return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+    }
+
+    private Map<String, String> getErrorResponseHeaders(final int statusCode) {
+        Map<String, String> headers = new HashMap<>();
+        return headers;
+    }
+
+    public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<NamedOneOfInput>> additionalInterceptors) {
+        final Map<String, Object> interceptorContext = new HashMap<>();
+        interceptorContext.put("operationId", "namedOneOf");
+
+        List<Interceptor<NamedOneOfInput>> interceptors = new ArrayList<>();
+        interceptors.addAll(additionalInterceptors);
+        interceptors.addAll(this.getHandlerInterceptors());
+
+        final HandlerChain chain = this.buildChain(interceptors);
+
+        NamedOneOfInput input;
+
+        try {
+            input = new NamedOneOfInput(event);
+        } catch (RuntimeException e) {
+            Map<String, String> headers = new HashMap<>();
+            headers.putAll(Handlers.extractResponseHeadersFromInterceptors(interceptors));
+            headers.putAll(this.getErrorResponseHeaders(400));
+            return new APIGatewayProxyResponseEvent()
+                .withStatusCode(400)
+                .withHeaders(headers)
+                .withBody("{\\"message\\": \\"" + e.getMessage() + "\\"}");
+        }
+
+        final Response response = chain.next(this.buildChainedRequestInput(event, context, input, interceptorContext));
+
+        Map<String, String> responseHeaders = new HashMap<>();
+        responseHeaders.putAll(this.getErrorResponseHeaders(response.getStatusCode()));
+        responseHeaders.putAll(response.getHeaders());
+
+        return new APIGatewayProxyResponseEvent()
+                .withStatusCode(response.getStatusCode())
+                .withHeaders(responseHeaders)
+                .withMultiValueHeaders(response.getMultiValueHeaders())
+                .withBody(response.getBody());
+    }
+}
+",
+  "src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOf200Response.java": "
+package test.test.runtime.api.handlers.named_one_of;
+
+import test.test.runtime.model.*;
+import test.test.runtime.JSON;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Response with status code 200 for the namedOneOf operation
+ */
+public class NamedOneOf200Response extends RuntimeException implements NamedOneOfResponse {
+    static {
+        // JSON has a static instance of Gson which is instantiated lazily the first time it is initialised.
+        // Create an instance here if required to ensure that the static Gson instance is always available.
+        if (JSON.getGson() == null) {
+            new JSON();
+        }
+    }
+
+    private final String body;
+    private final NamedOneOfUnion typedBody;
+    private final Map<String, String> headers;
+    private final Map<String, List<String>> multiValueHeaders;
+
+    private NamedOneOf200Response(final NamedOneOfUnion body, final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
+        this.typedBody = body;
+        this.body = body.toJson();
+        this.headers = headers;
+        this.multiValueHeaders = multiValueHeaders;
+    }
+
+    @Override
+    public int getStatusCode() {
+        return 200;
+    }
+
+    @Override
+    public String getBody() {
+        return this.body;
+    }
+
+    public NamedOneOfUnion getTypedBody() {
+        return this.typedBody;
+    }
+
+    @Override
+    public Map<String, String> getHeaders() {
+        return this.headers;
+    }
+
+    @Override
+    public Map<String, List<String>> getMultiValueHeaders() {
+        return this.multiValueHeaders;
+    }
+
+    /**
+     * Create a NamedOneOf200Response with a body
+     */
+    public static NamedOneOf200Response of(final NamedOneOfUnion body) {
+        return new NamedOneOf200Response(body, new HashMap<>(), new HashMap<>());
+    }
+
+    /**
+     * Create a NamedOneOf200Response with a body and headers
+     */
+    public static NamedOneOf200Response of(final NamedOneOfUnion body, final Map<String, String> headers) {
+        return new NamedOneOf200Response(body, headers, new HashMap<>());
+    }
+
+    /**
+     * Create a NamedOneOf200Response with a body, headers and multi-value headers
+     */
+    public static NamedOneOf200Response of(final NamedOneOfUnion body, final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
+        return new NamedOneOf200Response(body, headers, multiValueHeaders);
+    }
+}
+",
+  "src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOfInput.java": "
+package test.test.runtime.api.handlers.named_one_of;
+
+import test.test.runtime.model.*;
+import test.test.runtime.JSON;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.Map;
+import java.util.HashMap;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import java.io.IOException;
+
+/**
+ * Input for the namedOneOf operation
+ */
+@lombok.Builder
+@lombok.AllArgsConstructor
+public class NamedOneOfInput {
+    static {
+        // JSON has a static instance of Gson which is instantiated lazily the first time it is initialised.
+        // Create an instance here if required to ensure that the static Gson instance is always available.
+        if (JSON.getGson() == null) {
+            new JSON();
+        }
+    }
+
+    private final NamedOneOfRequestParameters requestParameters;
+
+    public NamedOneOfInput(final APIGatewayProxyRequestEvent event) {
+        this.requestParameters = new NamedOneOfRequestParameters(event);
+    }
+
+    public NamedOneOfRequestParameters getRequestParameters() {
+        return this.requestParameters;
+    }
+
+}
+",
+  "src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOfRequestInput.java": "
+package test.test.runtime.api.handlers.named_one_of;
+
+import test.test.runtime.model.*;
+import test.test.runtime.api.handlers.RequestInput;
+import java.util.List;
+import java.util.Optional;
+import java.util.Map;
+import java.util.HashMap;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import java.io.IOException;
+import com.amazonaws.services.lambda.runtime.Context;
+
+/**
+ * Full request input for the namedOneOf operation, including the raw API Gateway event
+ */
+@lombok.Builder
+@lombok.AllArgsConstructor
+public class NamedOneOfRequestInput implements RequestInput<NamedOneOfInput> {
+    private final APIGatewayProxyRequestEvent event;
+    private final Context context;
+    private final Map<String, Object> interceptorContext;
+    private final NamedOneOfInput input;
+
+    /**
+     * Returns the typed request input, with path, query and body parameters
+     */
+    public NamedOneOfInput getInput() {
+        return this.input;
+    }
+
+    /**
+     * Returns the raw API Gateway event
+     */
+    public APIGatewayProxyRequestEvent getEvent() {
+        return this.event;
+    }
+
+    /**
+     * Returns the lambda context
+     */
+    public Context getContext() {
+        return this.context;
+    }
+
+    /**
+     * Returns the interceptor context, which may contain values set by request interceptors
+     */
+    public Map<String, Object> getInterceptorContext() {
+        return this.interceptorContext;
+    }
+}
+",
+  "src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOfRequestParameters.java": "
+package test.test.runtime.api.handlers.named_one_of;
+
+import test.test.runtime.api.handlers.Handlers;
+import java.util.Optional;
+import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.time.OffsetDateTime;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.stream.Collectors;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+
+import test.test.runtime.model.*;
+
+/**
+ * Query, path and header parameters for the NamedOneOf operation
+ */
+@lombok.Builder
+@lombok.AllArgsConstructor
+public class NamedOneOfRequestParameters {
+
+    public NamedOneOfRequestParameters(final APIGatewayProxyRequestEvent event) {
+        Map<String, String> rawStringParameters = new HashMap<>();
+        Handlers.putAllFromNullableMap(event.getPathParameters(), rawStringParameters);
+        Handlers.putAllFromNullableMap(event.getQueryStringParameters(), rawStringParameters);
+        Handlers.putAllFromNullableMap(event.getHeaders(), rawStringParameters);
+        Map<String, String> decodedStringParameters = Handlers.decodeRequestParameters(rawStringParameters);
+
+        Map<String, List<String>> rawStringArrayParameters = new HashMap<>();
+        Handlers.putAllFromNullableMap(event.getMultiValueQueryStringParameters(), rawStringArrayParameters);
+        Handlers.putAllFromNullableMap(event.getMultiValueHeaders(), rawStringArrayParameters);
+        Map<String, List<String>> decodedStringArrayParameters = Handlers.decodeRequestArrayParameters(rawStringArrayParameters);
+
+    }
+
+}
+",
+  "src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOfResponse.java": "
+package test.test.runtime.api.handlers.named_one_of;
+
+import test.test.runtime.api.handlers.Response;
+
+/**
+ * Response for the namedOneOf operation
+ */
+public interface NamedOneOfResponse extends Response {}
+",
   "src/main/java/test/test/runtime/api/handlers/reserved_keywords/ReservedKeywords.java": "
 package test.test.runtime.api.handlers.reserved_keywords;
 
@@ -36819,16 +37973,20 @@ import java.util.Map;
 // Generic type for object "keyed" by operation names
 @lombok.Builder @lombok.Getter
 public class OperationConfig<T> {
+    private T arrayOfOneOfs;
     private T arrayRequestParameters;
     private T inlineEnum;
     private T inlineRequestBody;
+    private T namedOneOf;
     private T reservedKeywords;
 
     public Map<String, T> asMap() {
         Map<String, T> map = new HashMap<>();
+        map.put("arrayOfOneOfs", this.arrayOfOneOfs);
         map.put("arrayRequestParameters", this.arrayRequestParameters);
         map.put("inlineEnum", this.inlineEnum);
         map.put("inlineRequestBody", this.inlineRequestBody);
+        map.put("namedOneOf", this.namedOneOf);
         map.put("reservedKeywords", this.reservedKeywords);
         return map;
     }
@@ -36859,6 +38017,11 @@ public class OperationLookup {
     public static Map<String, OperationLookupEntry> getOperationLookup() {
         final Map<String, OperationLookupEntry> config = new HashMap<>();
 
+        config.put("arrayOfOneOfs", OperationLookupEntry.builder()
+            .path("/array-of-one-ofs")
+            .method("POST")
+            .contentTypes(Arrays.asList("application/json"))
+            .build());
         config.put("arrayRequestParameters", OperationLookupEntry.builder()
             .path("/array-request-parameters")
             .method("GET")
@@ -36871,6 +38034,11 @@ public class OperationLookup {
             .build());
         config.put("inlineRequestBody", OperationLookupEntry.builder()
             .path("/inline-request-body")
+            .method("POST")
+            .contentTypes(Arrays.asList("application/json"))
+            .build());
+        config.put("namedOneOf", OperationLookupEntry.builder()
+            .path("/named-one-of")
             .method("POST")
             .contentTypes(Arrays.asList("application/json"))
             .build());
@@ -36894,9 +38062,11 @@ public class Operations {
      */
     public static <T> OperationConfig.OperationConfigBuilder<T> all(final T value) {
         return OperationConfig.<T>builder()
+                .arrayOfOneOfs(value)
                 .arrayRequestParameters(value)
                 .inlineEnum(value)
                 .inlineRequestBody(value)
+                .namedOneOf(value)
                 .reservedKeywords(value)
                 ;
     }
@@ -37283,6 +38453,466 @@ public abstract class AbstractOpenApiSchema {
 
 
 
+}
+",
+  "src/main/java/test/test/runtime/model/AnotherNamedOneOf.java": "/*
+ * Edge Cases
+ * 
+ *
+ * The version of the OpenAPI document: 1.0.0
+ *
+ *
+ * NOTE: This class is auto generated.
+ * Do not edit the class manually.
+ */
+
+
+package test.test.runtime.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+
+import javax.ws.rs.core.GenericType;
+
+import java.io.IOException;
+import java.io.File;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import java.lang.reflect.Type;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.List;
+import java.util.Set;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import test.test.runtime.JSON;
+
+/**
+ * AnotherNamedOneOf
+ */
+@lombok.AllArgsConstructor @lombok.experimental.SuperBuilder
+public class AnotherNamedOneOf {
+  public static final String SERIALIZED_NAME_BAR = "bar";
+  @SerializedName(SERIALIZED_NAME_BAR)
+  private String bar;
+
+  public AnotherNamedOneOf() {
+  }
+
+  public AnotherNamedOneOf bar(String bar) {
+
+    this.bar = bar;
+    return this;
+  }
+
+   /**
+   * Get bar
+   * @return bar
+  **/
+  @javax.annotation.Nullable
+  public String getBar() {
+    return bar;
+  }
+
+
+  public void setBar(String bar) {
+    this.bar = bar;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AnotherNamedOneOf anotherNamedOneOf = (AnotherNamedOneOf) o;
+    return Objects.equals(this.bar, anotherNamedOneOf.bar);
+        
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(bar);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class AnotherNamedOneOf {\\n");
+    sb.append("    bar: ").append(toIndentedString(bar)).append("\\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\\n", "\\n    ");
+  }
+
+
+  public static HashSet<String> openapiFields;
+  public static HashSet<String> openapiRequiredFields;
+
+  static {
+    // a set of all properties/fields (JSON key names)
+    openapiFields = new HashSet<String>();
+    openapiFields.add("bar");
+
+    // a set of required properties/fields (JSON key names)
+    openapiRequiredFields = new HashSet<String>();
+  }
+
+ /**
+  * Validates the JSON Object and throws an exception if issues found
+  *
+  * @param jsonObj JSON Object
+  * @throws IOException if the JSON Object is invalid with respect to AnotherNamedOneOf
+  */
+  public static void validateJsonObject(JsonObject jsonObj) throws IOException {
+      if (jsonObj == null) {
+        if (!AnotherNamedOneOf.openapiRequiredFields.isEmpty()) { // has required fields but JSON object is null
+          throw new IllegalArgumentException(String.format("The required field(s) %s in AnotherNamedOneOf is not found in the empty JSON string", AnotherNamedOneOf.openapiRequiredFields.toString()));
+        }
+      }
+
+      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
+      // check to see if the JSON string contains additional fields
+      for (Entry<String, JsonElement> entry : entries) {
+        if (!AnotherNamedOneOf.openapiFields.contains(entry.getKey())) {
+          throw new IllegalArgumentException(String.format("The field \`%s\` in the JSON string is not defined in the \`AnotherNamedOneOf\` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
+        }
+      }
+      if ((jsonObj.get("bar") != null && !jsonObj.get("bar").isJsonNull()) && !jsonObj.get("bar").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format("Expected the field \`bar\` to be a primitive type in the JSON string but got \`%s\`", jsonObj.get("bar").toString()));
+      }
+  }
+
+  public static class CustomTypeAdapterFactory implements TypeAdapterFactory {
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+       if (!AnotherNamedOneOf.class.isAssignableFrom(type.getRawType())) {
+         return null; // this class only serializes 'AnotherNamedOneOf' and its subtypes
+       }
+       final TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
+       final TypeAdapter<AnotherNamedOneOf> thisAdapter
+                        = gson.getDelegateAdapter(this, TypeToken.get(AnotherNamedOneOf.class));
+
+       return (TypeAdapter<T>) new TypeAdapter<AnotherNamedOneOf>() {
+           @Override
+           public void write(JsonWriter out, AnotherNamedOneOf value) throws IOException {
+             JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             elementAdapter.write(out, obj);
+           }
+
+           @Override
+           public AnotherNamedOneOf read(JsonReader in) throws IOException {
+             JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
+             validateJsonObject(jsonObj);
+             return thisAdapter.fromJsonTree(jsonObj);
+           }
+
+       }.nullSafe();
+    }
+  }
+
+ /**
+  * Create an instance of AnotherNamedOneOf given an JSON string
+  *
+  * @param jsonString JSON string
+  * @return An instance of AnotherNamedOneOf
+  * @throws IOException if the JSON string is invalid with respect to AnotherNamedOneOf
+  */
+  public static AnotherNamedOneOf fromJson(String jsonString) throws IOException {
+    return JSON.getGson().fromJson(jsonString, AnotherNamedOneOf.class);
+  }
+
+ /**
+  * Convert an instance of AnotherNamedOneOf to an JSON string
+  *
+  * @return JSON string
+  */
+  public String toJson() {
+    return JSON.getGson().toJson(this);
+  }
+}
+",
+  "src/main/java/test/test/runtime/model/ArrayOfOneOfs.java": "/*
+ * Edge Cases
+ * 
+ *
+ * The version of the OpenAPI document: 1.0.0
+ *
+ *
+ * NOTE: This class is auto generated.
+ * Do not edit the class manually.
+ */
+
+
+package test.test.runtime.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import test.test.runtime.model.NamedOneOfUnion;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+
+import javax.ws.rs.core.GenericType;
+
+import java.io.IOException;
+import java.io.File;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import java.lang.reflect.Type;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.List;
+import java.util.Set;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import test.test.runtime.JSON;
+
+/**
+ * ArrayOfOneOfs
+ */
+@lombok.AllArgsConstructor @lombok.experimental.SuperBuilder
+public class ArrayOfOneOfs {
+  public static final String SERIALIZED_NAME_ONE_OFS = "oneOfs";
+  @SerializedName(SERIALIZED_NAME_ONE_OFS)
+  private List<NamedOneOfUnion> oneOfs = null;
+
+  public ArrayOfOneOfs() {
+  }
+
+  public ArrayOfOneOfs oneOfs(List<NamedOneOfUnion> oneOfs) {
+
+    this.oneOfs = oneOfs;
+    return this;
+  }
+
+  public ArrayOfOneOfs addOneOfsItem(NamedOneOfUnion oneOfsItem) {
+    if (this.oneOfs == null) {
+      this.oneOfs = new ArrayList<>();
+    }
+    this.oneOfs.add(oneOfsItem);
+    return this;
+  }
+
+   /**
+   * Get oneOfs
+   * @return oneOfs
+  **/
+  @javax.annotation.Nullable
+  public List<NamedOneOfUnion> getOneOfs() {
+    return oneOfs;
+  }
+
+
+  public void setOneOfs(List<NamedOneOfUnion> oneOfs) {
+    this.oneOfs = oneOfs;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ArrayOfOneOfs arrayOfOneOfs = (ArrayOfOneOfs) o;
+    return Objects.equals(this.oneOfs, arrayOfOneOfs.oneOfs);
+        
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(oneOfs);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ArrayOfOneOfs {\\n");
+    sb.append("    oneOfs: ").append(toIndentedString(oneOfs)).append("\\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\\n", "\\n    ");
+  }
+
+
+  public static HashSet<String> openapiFields;
+  public static HashSet<String> openapiRequiredFields;
+
+  static {
+    // a set of all properties/fields (JSON key names)
+    openapiFields = new HashSet<String>();
+    openapiFields.add("oneOfs");
+
+    // a set of required properties/fields (JSON key names)
+    openapiRequiredFields = new HashSet<String>();
+  }
+
+ /**
+  * Validates the JSON Object and throws an exception if issues found
+  *
+  * @param jsonObj JSON Object
+  * @throws IOException if the JSON Object is invalid with respect to ArrayOfOneOfs
+  */
+  public static void validateJsonObject(JsonObject jsonObj) throws IOException {
+      if (jsonObj == null) {
+        if (!ArrayOfOneOfs.openapiRequiredFields.isEmpty()) { // has required fields but JSON object is null
+          throw new IllegalArgumentException(String.format("The required field(s) %s in ArrayOfOneOfs is not found in the empty JSON string", ArrayOfOneOfs.openapiRequiredFields.toString()));
+        }
+      }
+
+      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
+      // check to see if the JSON string contains additional fields
+      for (Entry<String, JsonElement> entry : entries) {
+        if (!ArrayOfOneOfs.openapiFields.contains(entry.getKey())) {
+          throw new IllegalArgumentException(String.format("The field \`%s\` in the JSON string is not defined in the \`ArrayOfOneOfs\` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
+        }
+      }
+      // ensure the optional json data is an array if present
+      if (jsonObj.get("oneOfs") != null && !jsonObj.get("oneOfs").isJsonArray()) {
+        throw new IllegalArgumentException(String.format("Expected the field \`oneOfs\` to be an array in the JSON string but got \`%s\`", jsonObj.get("oneOfs").toString()));
+      }
+  }
+
+  public static class CustomTypeAdapterFactory implements TypeAdapterFactory {
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+       if (!ArrayOfOneOfs.class.isAssignableFrom(type.getRawType())) {
+         return null; // this class only serializes 'ArrayOfOneOfs' and its subtypes
+       }
+       final TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
+       final TypeAdapter<ArrayOfOneOfs> thisAdapter
+                        = gson.getDelegateAdapter(this, TypeToken.get(ArrayOfOneOfs.class));
+
+       return (TypeAdapter<T>) new TypeAdapter<ArrayOfOneOfs>() {
+           @Override
+           public void write(JsonWriter out, ArrayOfOneOfs value) throws IOException {
+             JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             elementAdapter.write(out, obj);
+           }
+
+           @Override
+           public ArrayOfOneOfs read(JsonReader in) throws IOException {
+             JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
+             validateJsonObject(jsonObj);
+             return thisAdapter.fromJsonTree(jsonObj);
+           }
+
+       }.nullSafe();
+    }
+  }
+
+ /**
+  * Create an instance of ArrayOfOneOfs given an JSON string
+  *
+  * @param jsonString JSON string
+  * @return An instance of ArrayOfOneOfs
+  * @throws IOException if the JSON string is invalid with respect to ArrayOfOneOfs
+  */
+  public static ArrayOfOneOfs fromJson(String jsonString) throws IOException {
+    return JSON.getGson().fromJson(jsonString, ArrayOfOneOfs.class);
+  }
+
+ /**
+  * Convert an instance of ArrayOfOneOfs to an JSON string
+  *
+  * @return JSON string
+  */
+  public String toJson() {
+    return JSON.getGson().toJson(this);
+  }
 }
 ",
   "src/main/java/test/test/runtime/model/InlineEnum200Response.java": "/*
@@ -37973,6 +39603,525 @@ public enum MyEnum {
       return MyEnum.fromValue(value);
     }
   }
+}
+",
+  "src/main/java/test/test/runtime/model/NamedOneOf.java": "/*
+ * Edge Cases
+ * 
+ *
+ * The version of the OpenAPI document: 1.0.0
+ *
+ *
+ * NOTE: This class is auto generated.
+ * Do not edit the class manually.
+ */
+
+
+package test.test.runtime.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+
+import javax.ws.rs.core.GenericType;
+
+import java.io.IOException;
+import java.io.File;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import java.lang.reflect.Type;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.List;
+import java.util.Set;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import test.test.runtime.JSON;
+
+/**
+ * NamedOneOf
+ */
+@lombok.AllArgsConstructor @lombok.experimental.SuperBuilder
+public class NamedOneOf {
+  public static final String SERIALIZED_NAME_FOO = "foo";
+  @SerializedName(SERIALIZED_NAME_FOO)
+  private String foo;
+
+  public NamedOneOf() {
+  }
+
+  public NamedOneOf foo(String foo) {
+
+    this.foo = foo;
+    return this;
+  }
+
+   /**
+   * Get foo
+   * @return foo
+  **/
+  @javax.annotation.Nullable
+  public String getFoo() {
+    return foo;
+  }
+
+
+  public void setFoo(String foo) {
+    this.foo = foo;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    NamedOneOf namedOneOf = (NamedOneOf) o;
+    return Objects.equals(this.foo, namedOneOf.foo);
+        
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(foo);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class NamedOneOf {\\n");
+    sb.append("    foo: ").append(toIndentedString(foo)).append("\\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\\n", "\\n    ");
+  }
+
+
+  public static HashSet<String> openapiFields;
+  public static HashSet<String> openapiRequiredFields;
+
+  static {
+    // a set of all properties/fields (JSON key names)
+    openapiFields = new HashSet<String>();
+    openapiFields.add("foo");
+
+    // a set of required properties/fields (JSON key names)
+    openapiRequiredFields = new HashSet<String>();
+  }
+
+ /**
+  * Validates the JSON Object and throws an exception if issues found
+  *
+  * @param jsonObj JSON Object
+  * @throws IOException if the JSON Object is invalid with respect to NamedOneOf
+  */
+  public static void validateJsonObject(JsonObject jsonObj) throws IOException {
+      if (jsonObj == null) {
+        if (!NamedOneOf.openapiRequiredFields.isEmpty()) { // has required fields but JSON object is null
+          throw new IllegalArgumentException(String.format("The required field(s) %s in NamedOneOf is not found in the empty JSON string", NamedOneOf.openapiRequiredFields.toString()));
+        }
+      }
+
+      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
+      // check to see if the JSON string contains additional fields
+      for (Entry<String, JsonElement> entry : entries) {
+        if (!NamedOneOf.openapiFields.contains(entry.getKey())) {
+          throw new IllegalArgumentException(String.format("The field \`%s\` in the JSON string is not defined in the \`NamedOneOf\` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
+        }
+      }
+      if ((jsonObj.get("foo") != null && !jsonObj.get("foo").isJsonNull()) && !jsonObj.get("foo").isJsonPrimitive()) {
+        throw new IllegalArgumentException(String.format("Expected the field \`foo\` to be a primitive type in the JSON string but got \`%s\`", jsonObj.get("foo").toString()));
+      }
+  }
+
+  public static class CustomTypeAdapterFactory implements TypeAdapterFactory {
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+       if (!NamedOneOf.class.isAssignableFrom(type.getRawType())) {
+         return null; // this class only serializes 'NamedOneOf' and its subtypes
+       }
+       final TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
+       final TypeAdapter<NamedOneOf> thisAdapter
+                        = gson.getDelegateAdapter(this, TypeToken.get(NamedOneOf.class));
+
+       return (TypeAdapter<T>) new TypeAdapter<NamedOneOf>() {
+           @Override
+           public void write(JsonWriter out, NamedOneOf value) throws IOException {
+             JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             elementAdapter.write(out, obj);
+           }
+
+           @Override
+           public NamedOneOf read(JsonReader in) throws IOException {
+             JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
+             validateJsonObject(jsonObj);
+             return thisAdapter.fromJsonTree(jsonObj);
+           }
+
+       }.nullSafe();
+    }
+  }
+
+ /**
+  * Create an instance of NamedOneOf given an JSON string
+  *
+  * @param jsonString JSON string
+  * @return An instance of NamedOneOf
+  * @throws IOException if the JSON string is invalid with respect to NamedOneOf
+  */
+  public static NamedOneOf fromJson(String jsonString) throws IOException {
+    return JSON.getGson().fromJson(jsonString, NamedOneOf.class);
+  }
+
+ /**
+  * Convert an instance of NamedOneOf to an JSON string
+  *
+  * @return JSON string
+  */
+  public String toJson() {
+    return JSON.getGson().toJson(this);
+  }
+}
+",
+  "src/main/java/test/test/runtime/model/NamedOneOfUnion.java": "/*
+ * Edge Cases
+ * 
+ *
+ * The version of the OpenAPI document: 1.0.0
+ *
+ *
+ * NOTE: This class is auto generated.
+ * Do not edit the class manually.
+ */
+
+
+package test.test.runtime.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import test.test.runtime.model.AnotherNamedOneOf;
+import test.test.runtime.model.NamedOneOf;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+
+import javax.ws.rs.core.GenericType;
+
+import java.io.IOException;
+import java.io.File;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import java.lang.reflect.Type;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.List;
+import java.util.Set;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import test.test.runtime.JSON;
+
+@lombok.experimental.SuperBuilder
+public class NamedOneOfUnion extends AbstractOpenApiSchema {
+    private static final Logger log = Logger.getLogger(NamedOneOfUnion.class.getName());
+
+    public static class CustomTypeAdapterFactory implements TypeAdapterFactory {
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+            if (!NamedOneOfUnion.class.isAssignableFrom(type.getRawType())) {
+                return null; // this class only serializes 'NamedOneOfUnion' and its subtypes
+            }
+            final TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
+            final TypeAdapter<NamedOneOf> adapterNamedOneOf = gson.getDelegateAdapter(this, TypeToken.get(NamedOneOf.class));
+            final TypeAdapter<AnotherNamedOneOf> adapterAnotherNamedOneOf = gson.getDelegateAdapter(this, TypeToken.get(AnotherNamedOneOf.class));
+
+            return (TypeAdapter<T>) new TypeAdapter<NamedOneOfUnion>() {
+                @Override
+                public void write(JsonWriter out, NamedOneOfUnion value) throws IOException {
+                    if (value == null || value.getActualInstance() == null) {
+                        elementAdapter.write(out, null);
+                        return;
+                    }
+
+                    // check if the actual instance is of the type \`NamedOneOf\`
+                    if (value.getActualInstance() instanceof NamedOneOf) {
+                        JsonObject obj = adapterNamedOneOf.toJsonTree((NamedOneOf)value.getActualInstance()).getAsJsonObject();
+                        elementAdapter.write(out, obj);
+                        return;
+                    }
+
+                    // check if the actual instance is of the type \`AnotherNamedOneOf\`
+                    if (value.getActualInstance() instanceof AnotherNamedOneOf) {
+                        JsonObject obj = adapterAnotherNamedOneOf.toJsonTree((AnotherNamedOneOf)value.getActualInstance()).getAsJsonObject();
+                        elementAdapter.write(out, obj);
+                        return;
+                    }
+
+                    throw new IOException("Failed to serialize as the type doesn't match oneOf schemas: NamedOneOf, AnotherNamedOneOf");
+                }
+
+                @Override
+                public NamedOneOfUnion read(JsonReader in) throws IOException {
+                    Object deserialized = null;
+                    JsonObject jsonObject = elementAdapter.read(in).getAsJsonObject();
+
+                    int match = 0;
+                    ArrayList<String> errorMessages = new ArrayList<>();
+                    TypeAdapter actualAdapter = elementAdapter;
+
+                    // deserialize NamedOneOf
+                    try {
+                        // validate the JSON object to see if any exception is thrown
+                        NamedOneOf.validateJsonObject(jsonObject);
+                        actualAdapter = adapterNamedOneOf;
+                        match++;
+                        log.log(Level.FINER, "Input data matches schema 'NamedOneOf'");
+                    } catch (Exception e) {
+                        // deserialization failed, continue
+                        errorMessages.add(String.format("Deserialization for NamedOneOf failed with \`%s\`.", e.getMessage()));
+                        log.log(Level.FINER, "Input data does not match schema 'NamedOneOf'", e);
+                    }
+
+                    // deserialize AnotherNamedOneOf
+                    try {
+                        // validate the JSON object to see if any exception is thrown
+                        AnotherNamedOneOf.validateJsonObject(jsonObject);
+                        actualAdapter = adapterAnotherNamedOneOf;
+                        match++;
+                        log.log(Level.FINER, "Input data matches schema 'AnotherNamedOneOf'");
+                    } catch (Exception e) {
+                        // deserialization failed, continue
+                        errorMessages.add(String.format("Deserialization for AnotherNamedOneOf failed with \`%s\`.", e.getMessage()));
+                        log.log(Level.FINER, "Input data does not match schema 'AnotherNamedOneOf'", e);
+                    }
+
+                    if (match == 1) {
+                        NamedOneOfUnion ret = new NamedOneOfUnion();
+                        ret.setActualInstance(actualAdapter.fromJsonTree(jsonObject));
+                        return ret;
+                    }
+
+                    throw new IOException(String.format("Failed deserialization for NamedOneOfUnion: %d classes match result, expected 1. Detailed failure message for oneOf schemas: %s. JSON: %s", match, errorMessages, jsonObject.toString()));
+                }
+            }.nullSafe();
+        }
+    }
+
+    // store a list of schema names defined in oneOf
+    public static final Map<String, GenericType> schemas = new HashMap<String, GenericType>();
+
+    public NamedOneOfUnion() {
+        super("oneOf", Boolean.FALSE);
+    }
+
+    public NamedOneOfUnion(NamedOneOf o) {
+        super("oneOf", Boolean.FALSE);
+        setActualInstance(o);
+    }
+
+    public NamedOneOfUnion(AnotherNamedOneOf o) {
+        super("oneOf", Boolean.FALSE);
+        setActualInstance(o);
+    }
+
+    static {
+        schemas.put("NamedOneOf", new GenericType<NamedOneOf>() {
+        });
+        schemas.put("AnotherNamedOneOf", new GenericType<AnotherNamedOneOf>() {
+        });
+    }
+
+    @Override
+    public Map<String, GenericType> getSchemas() {
+        return NamedOneOfUnion.schemas;
+    }
+
+    /**
+     * Set the instance that matches the oneOf child schema, check
+     * the instance parameter is valid against the oneOf child schemas:
+     * NamedOneOf, AnotherNamedOneOf
+     *
+     * It could be an instance of the 'oneOf' schemas.
+     * The oneOf child schemas may themselves be a composed schema (allOf, anyOf, oneOf).
+     */
+    @Override
+    public void setActualInstance(Object instance) {
+        if (instance instanceof NamedOneOf) {
+            super.setActualInstance(instance);
+            return;
+        }
+
+        if (instance instanceof AnotherNamedOneOf) {
+            super.setActualInstance(instance);
+            return;
+        }
+
+        throw new RuntimeException("Invalid instance type. Must be NamedOneOf, AnotherNamedOneOf");
+    }
+
+    /**
+     * Get the actual instance, which can be the following:
+     * NamedOneOf, AnotherNamedOneOf
+     *
+     * @return The actual instance (NamedOneOf, AnotherNamedOneOf)
+     */
+    @Override
+    public Object getActualInstance() {
+        return super.getActualInstance();
+    }
+
+    /**
+     * Get the actual instance of \`NamedOneOf\`. If the actual instance is not \`NamedOneOf\`,
+     * the ClassCastException will be thrown.
+     *
+     * @return The actual instance of \`NamedOneOf\`
+     * @throws ClassCastException if the instance is not \`NamedOneOf\`
+     */
+    public NamedOneOf getNamedOneOf() throws ClassCastException {
+        return (NamedOneOf)super.getActualInstance();
+    }
+
+    /**
+     * Get the actual instance of \`AnotherNamedOneOf\`. If the actual instance is not \`AnotherNamedOneOf\`,
+     * the ClassCastException will be thrown.
+     *
+     * @return The actual instance of \`AnotherNamedOneOf\`
+     * @throws ClassCastException if the instance is not \`AnotherNamedOneOf\`
+     */
+    public AnotherNamedOneOf getAnotherNamedOneOf() throws ClassCastException {
+        return (AnotherNamedOneOf)super.getActualInstance();
+    }
+
+
+ /**
+  * Validates the JSON Object and throws an exception if issues found
+  *
+  * @param jsonObj JSON Object
+  * @throws IOException if the JSON Object is invalid with respect to NamedOneOfUnion
+  */
+  public static void validateJsonObject(JsonObject jsonObj) throws IOException {
+    // validate oneOf schemas one by one
+    int validCount = 0;
+    ArrayList<String> errorMessages = new ArrayList<>();
+    // validate the json string with NamedOneOf
+    try {
+      NamedOneOf.validateJsonObject(jsonObj);
+      validCount++;
+    } catch (Exception e) {
+      errorMessages.add(String.format("Deserialization for NamedOneOf failed with \`%s\`.", e.getMessage()));
+      // continue to the next one
+    }
+    // validate the json string with AnotherNamedOneOf
+    try {
+      AnotherNamedOneOf.validateJsonObject(jsonObj);
+      validCount++;
+    } catch (Exception e) {
+      errorMessages.add(String.format("Deserialization for AnotherNamedOneOf failed with \`%s\`.", e.getMessage()));
+      // continue to the next one
+    }
+    if (validCount != 1) {
+      throw new IOException(String.format("The JSON string is invalid for NamedOneOfUnion with oneOf schemas: NamedOneOf, AnotherNamedOneOf. %d class(es) match the result, expected 1. Detailed failure message for oneOf schemas: %s. JSON: %s", validCount, errorMessages, jsonObj.toString()));
+    }
+  }
+
+ /**
+  * Create an instance of NamedOneOfUnion given an JSON string
+  *
+  * @param jsonString JSON string
+  * @return An instance of NamedOneOfUnion
+  * @throws IOException if the JSON string is invalid with respect to NamedOneOfUnion
+  */
+  public static NamedOneOfUnion fromJson(String jsonString) throws IOException {
+    return JSON.getGson().fromJson(jsonString, NamedOneOfUnion.class);
+  }
+
+ /**
+  * Convert an instance of NamedOneOfUnion to an JSON string
+  *
+  * @return JSON string
+  */
+  public String toJson() {
+    return JSON.getGson().toJson(this);
+  }
+
 }
 ",
 }

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
@@ -17428,10 +17428,14 @@ test_project/__init__.py
 test_project/py.typed
 test_project/rest.py
 docs/DefaultApi.md
+docs/AnotherNamedOneOf.md
+docs/ArrayOfOneOfs.md
 docs/InlineEnum200Response.md
 docs/InlineEnum200ResponseCategoryEnum.md
 docs/InlineRequestBodyRequestContent.md
 docs/MyEnum.md
+docs/NamedOneOf.md
+docs/NamedOneOfUnion.md
 README.md
 test_project/interceptors/try_catch.py
 test_project/interceptors/response_headers.py
@@ -17444,10 +17448,14 @@ test_project/response.py
 test_project/api/default_api.py
 test_project/api/__init__.py
 test_project/models/__init__.py
+test_project/models/another_named_one_of.py
+test_project/models/array_of_one_ofs.py
 test_project/models/inline_enum200_response.py
 test_project/models/inline_enum200_response_category_enum.py
 test_project/models/inline_request_body_request_content.py
-test_project/models/my_enum.py",
+test_project/models/my_enum.py
+test_project/models/named_one_of.py
+test_project/models/named_one_of_union.py",
   "README.md": "# Edge Cases
 
 
@@ -17479,46 +17487,151 @@ configuration = test_project.Configuration(
 with test_project.ApiClient(configuration) as api_client:
     # Create an instance of the API class
     api_instance = test_project.DefaultApi(api_client)
-    my_string_array_request_params = [] # List[str] |  (optional)
-    my_enum_array_request_params = [] # List[MyEnum] |  (optional)
-    my_integer_array_request_params = [2436284417048576,6600606720458752,2769288930787328] # List[int] |  (optional)
-    my_long_array_request_params = [3479256564760576,857015102472192,5661035377721344] # List[int] |  (optional)
-    my_int32_array_request_params = [] # List[int] |  (optional)
-    my_number_array_request_params = [0.1599486346822232,0.4432248624507338,0.8626475473865867] # List[float] |  (optional)
-    my_float_array_request_params = [0.7941185790114105,0.005342561984434724,0.36126157245598733] # List[float] |  (optional)
-    my_double_array_request_params = [0.3810686601791531] # List[float] |  (optional)
-    my_enum_request_param = test_project.MyEnum() # MyEnum |  (optional)
 
     try:
-        api_instance.array_request_parameters(my_string_array_request_params=my_string_array_request_params, my_enum_array_request_params=my_enum_array_request_params, my_integer_array_request_params=my_integer_array_request_params, my_long_array_request_params=my_long_array_request_params, my_int32_array_request_params=my_int32_array_request_params, my_number_array_request_params=my_number_array_request_params, my_float_array_request_params=my_float_array_request_params, my_double_array_request_params=my_double_array_request_params, my_enum_request_param=my_enum_request_param)
+        api_response = api_instance.array_of_one_ofs()
+        print("The response of DefaultApi->array_of_one_ofs:\\n")
+        pprint(api_response)
     except ApiException as e:
-        print("Exception when calling DefaultApi->array_request_parameters: %s\\n" % e)
+        print("Exception when calling DefaultApi->array_of_one_ofs: %s\\n" % e)
 \`\`\`
 
 ## Documentation for API Endpoints
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
+*DefaultApi* | [**array_of_one_ofs**](docs/DefaultApi.md#array_of_one_ofs) | **POST** /array-of-one-ofs | 
 *DefaultApi* | [**array_request_parameters**](docs/DefaultApi.md#array_request_parameters) | **GET** /array-request-parameters | 
 *DefaultApi* | [**inline_enum**](docs/DefaultApi.md#inline_enum) | **GET** /inline-enum | 
 *DefaultApi* | [**inline_request_body**](docs/DefaultApi.md#inline_request_body) | **POST** /inline-request-body | 
+*DefaultApi* | [**named_one_of**](docs/DefaultApi.md#named_one_of) | **POST** /named-one-of | 
 *DefaultApi* | [**reserved_keywords**](docs/DefaultApi.md#reserved_keywords) | **GET** /reserved-keywords | 
 
 ## Documentation For Models
 
+ - [AnotherNamedOneOf](docs/AnotherNamedOneOf.md)
+ - [ArrayOfOneOfs](docs/ArrayOfOneOfs.md)
  - [InlineEnum200Response](docs/InlineEnum200Response.md)
  - [InlineEnum200ResponseCategoryEnum](docs/InlineEnum200ResponseCategoryEnum.md)
  - [InlineRequestBodyRequestContent](docs/InlineRequestBodyRequestContent.md)
  - [MyEnum](docs/MyEnum.md)
+ - [NamedOneOf](docs/NamedOneOf.md)
+ - [NamedOneOfUnion](docs/NamedOneOfUnion.md)
+",
+  "docs/AnotherNamedOneOf.md": "# AnotherNamedOneOf
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**bar** | **str** |  | [optional] 
+
+## Example
+
+\`\`\`python
+from test_project.models.another_named_one_of import AnotherNamedOneOf
+
+# TODO update the JSON string below
+json = "{}"
+# create an instance of AnotherNamedOneOf from a JSON string
+another_named_one_of_instance = AnotherNamedOneOf.from_json(json)
+# print the JSON string representation of the object
+print(AnotherNamedOneOf.to_json())
+
+# convert the object into a dict
+another_named_one_of_dict = another_named_one_of_instance.to_dict()
+# create an instance of AnotherNamedOneOf from a dict
+another_named_one_of_form_dict = another_named_one_of.from_dict(another_named_one_of_dict)
+\`\`\`
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+",
+  "docs/ArrayOfOneOfs.md": "# ArrayOfOneOfs
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**one_ofs** | **List[NamedOneOfUnion]** |  | [optional] 
+
+## Example
+
+\`\`\`python
+from test_project.models.array_of_one_ofs import ArrayOfOneOfs
+
+# TODO update the JSON string below
+json = "{}"
+# create an instance of ArrayOfOneOfs from a JSON string
+array_of_one_ofs_instance = ArrayOfOneOfs.from_json(json)
+# print the JSON string representation of the object
+print(ArrayOfOneOfs.to_json())
+
+# convert the object into a dict
+array_of_one_ofs_dict = array_of_one_ofs_instance.to_dict()
+# create an instance of ArrayOfOneOfs from a dict
+array_of_one_ofs_form_dict = array_of_one_ofs.from_dict(array_of_one_ofs_dict)
+\`\`\`
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
 ",
   "docs/DefaultApi.md": "# test_project.DefaultApi
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**array_of_one_ofs**](DefaultApi.md#array_of_one_ofs) | **POST** /array-of-one-ofs | 
 [**array_request_parameters**](DefaultApi.md#array_request_parameters) | **GET** /array-request-parameters | 
 [**inline_enum**](DefaultApi.md#inline_enum) | **GET** /inline-enum | 
 [**inline_request_body**](DefaultApi.md#inline_request_body) | **POST** /inline-request-body | 
+[**named_one_of**](DefaultApi.md#named_one_of) | **POST** /named-one-of | 
 [**reserved_keywords**](DefaultApi.md#reserved_keywords) | **GET** /reserved-keywords | 
+
+# **array_of_one_ofs**
+> ArrayOfOneOfs array_of_one_ofs()
+
+
+### Example
+
+\`\`\`python
+import time
+import test_project
+from test_project.rest import ApiException
+from pprint import pprint
+
+# Defining the host is optional and defaults to http://localhost
+# See configuration.py for a list of all supported configuration parameters.
+configuration = test_project.Configuration(
+    host = "http://localhost"
+)
+
+# Enter a context with an instance of the API client
+with test_project.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = test_project.DefaultApi(api_client)
+
+    try:
+        api_response = api_instance.array_of_one_ofs()
+        print("The response of DefaultApi->array_of_one_ofs:\\n")
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling DefaultApi->array_of_one_ofs: %s\\n" % e)
+\`\`\`
+
+### Parameters
+This endpoint does not need any parameters.
+
+### Return type
+
+[**ArrayOfOneOfs**](ArrayOfOneOfs.md)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | ok |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **array_request_parameters**
 > array_request_parameters(my_string_array_request_params=my_string_array_request_params, my_enum_array_request_params=my_enum_array_request_params, my_integer_array_request_params=my_integer_array_request_params, my_long_array_request_params=my_long_array_request_params, my_int32_array_request_params=my_int32_array_request_params, my_number_array_request_params=my_number_array_request_params, my_float_array_request_params=my_float_array_request_params, my_double_array_request_params=my_double_array_request_params, my_enum_request_param=my_enum_request_param)
@@ -17688,6 +17801,56 @@ void (empty response body)
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
+# **named_one_of**
+> NamedOneOfUnion named_one_of()
+
+
+### Example
+
+\`\`\`python
+import time
+import test_project
+from test_project.rest import ApiException
+from pprint import pprint
+
+# Defining the host is optional and defaults to http://localhost
+# See configuration.py for a list of all supported configuration parameters.
+configuration = test_project.Configuration(
+    host = "http://localhost"
+)
+
+# Enter a context with an instance of the API client
+with test_project.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = test_project.DefaultApi(api_client)
+
+    try:
+        api_response = api_instance.named_one_of()
+        print("The response of DefaultApi->named_one_of:\\n")
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling DefaultApi->named_one_of: %s\\n" % e)
+\`\`\`
+
+### Parameters
+This endpoint does not need any parameters.
+
+### Return type
+
+[**NamedOneOfUnion**](NamedOneOfUnion.md)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | ok |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
 # **reserved_keywords**
 > reserved_keywords(var_with=var_with, var_if=var_if, var_class=var_class)
 
@@ -17816,6 +17979,64 @@ Name | Type | Description | Notes
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 
 ",
+  "docs/NamedOneOf.md": "# NamedOneOf
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**foo** | **str** |  | [optional] 
+
+## Example
+
+\`\`\`python
+from test_project.models.named_one_of import NamedOneOf
+
+# TODO update the JSON string below
+json = "{}"
+# create an instance of NamedOneOf from a JSON string
+named_one_of_instance = NamedOneOf.from_json(json)
+# print the JSON string representation of the object
+print(NamedOneOf.to_json())
+
+# convert the object into a dict
+named_one_of_dict = named_one_of_instance.to_dict()
+# create an instance of NamedOneOf from a dict
+named_one_of_form_dict = named_one_of.from_dict(named_one_of_dict)
+\`\`\`
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+",
+  "docs/NamedOneOfUnion.md": "# NamedOneOfUnion
+
+## Composed Of
+
+This model can be set to one of the following types:
+
+Type | Description | Notes
+------------- | ------------- | -------------
+[**NamedOneOf**](NamedOneOf.md) | 
+[**AnotherNamedOneOf**](AnotherNamedOneOf.md) | 
+
+## Example
+
+\`\`\`python
+from test_project.models.named_one_of_union import NamedOneOfUnion
+
+# TODO update the JSON string below
+json = "{}"
+# create an instance of NamedOneOfUnion from a JSON string
+named_one_of_union_instance = NamedOneOfUnion.from_json(json)
+# print the JSON string representation of the object
+print(NamedOneOfUnion.to_json())
+
+# convert the object into a dict
+named_one_of_union_dict = named_one_of_union_instance.to_dict()
+# create an instance of NamedOneOfUnion from a dict
+named_one_of_union_form_dict = named_one_of_union.from_dict(named_one_of_union_dict)
+\`\`\`
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+",
   "poetry.toml": "# ~~ Generated by projen. To modify, edit .projenrc.py and run "npx projen".
 
 [repositories.testpypi]
@@ -17884,10 +18105,14 @@ from test_project.exceptions import ApiAttributeError
 from test_project.exceptions import ApiException
 
 # import models into sdk package
+from test_project.models.another_named_one_of import AnotherNamedOneOf
+from test_project.models.array_of_one_ofs import ArrayOfOneOfs
 from test_project.models.inline_enum200_response import InlineEnum200Response
 from test_project.models.inline_enum200_response_category_enum import InlineEnum200ResponseCategoryEnum
 from test_project.models.inline_request_body_request_content import InlineRequestBodyRequestContent
 from test_project.models.my_enum import MyEnum
+from test_project.models.named_one_of import NamedOneOf
+from test_project.models.named_one_of_union import NamedOneOfUnion
 ",
   "test_project/api/__init__.py": "# flake8: noqa
 
@@ -17918,9 +18143,11 @@ try:
 except ImportError:
     from typing_extensions import Annotated
 
+from test_project.models.array_of_one_ofs import ArrayOfOneOfs
 from test_project.models.inline_enum200_response import InlineEnum200Response
 from test_project.models.inline_request_body_request_content import InlineRequestBodyRequestContent
 from test_project.models.my_enum import MyEnum
+from test_project.models.named_one_of_union import NamedOneOfUnion
 
 from test_project.api_client import ApiClient
 from test_project.api_response import ApiResponse
@@ -17937,6 +18164,241 @@ class DefaultApi:
         if api_client is None:
             api_client = ApiClient.get_default()
         self.api_client = api_client
+
+    @validate_call
+    def array_of_one_ofs(
+        self,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ArrayOfOneOfs:
+        """array_of_one_ofs
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._array_of_one_ofs_serialize(
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "ArrayOfOneOfs"
+        }
+
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    def array_of_one_ofs_with_http_info(
+        self,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[ArrayOfOneOfs]:
+        """array_of_one_ofs
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._array_of_one_ofs_serialize(
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "ArrayOfOneOfs"
+        }
+
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    def array_of_one_ofs_without_preload_content(
+        self,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """array_of_one_ofs
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._array_of_one_ofs_serialize(
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "ArrayOfOneOfs"
+        }
+
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _array_of_one_ofs_serialize(
+        self,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> Tuple:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[str, str] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        # process the query parameters
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+
+
+        # set the HTTP header \`Accept\`
+        _header_params['Accept'] = self.api_client.select_header_accept(
+            [
+                'application/json'
+            ]
+        )
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+        ]
+
+        return self.api_client.param_serialize(
+            method='POST',
+            resource_path='/array-of-one-ofs',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
 
     @validate_call
     def array_request_parameters(
@@ -18797,6 +19259,241 @@ class DefaultApi:
 
 
     @validate_call
+    def named_one_of(
+        self,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> NamedOneOfUnion:
+        """named_one_of
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._named_one_of_serialize(
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "NamedOneOfUnion"
+        }
+
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    def named_one_of_with_http_info(
+        self,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[NamedOneOfUnion]:
+        """named_one_of
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._named_one_of_serialize(
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "NamedOneOfUnion"
+        }
+
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    def named_one_of_without_preload_content(
+        self,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """named_one_of
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._named_one_of_serialize(
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "NamedOneOfUnion"
+        }
+
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _named_one_of_serialize(
+        self,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> Tuple:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[str, str] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        # process the query parameters
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+
+
+        # set the HTTP header \`Accept\`
+        _header_params['Accept'] = self.api_client.select_header_accept(
+            [
+                'application/json'
+            ]
+        )
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+        ]
+
+        return self.api_client.param_serialize(
+            method='POST',
+            resource_path='/named-one-of',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
+
+    @validate_call
     def reserved_keywords(
         self,
         var_with: Optional[StrictStr] = None,
@@ -19084,14 +19781,21 @@ T = TypeVar('T')
 # Generic type for object keyed by operation names
 @dataclass
 class OperationConfig(Generic[T]):
+    array_of_one_ofs: T
     array_request_parameters: T
     inline_enum: T
     inline_request_body: T
+    named_one_of: T
     reserved_keywords: T
     ...
 
 # Look up path and http method for a given operation name
 OperationLookup = {
+    "array_of_one_ofs": {
+        "path": "/array-of-one-ofs",
+        "method": "POST",
+        "contentTypes": ["application/json"]
+    },
     "array_request_parameters": {
         "path": "/array-request-parameters",
         "method": "GET",
@@ -19104,6 +19808,11 @@ OperationLookup = {
     },
     "inline_request_body": {
         "path": "/inline-request-body",
+        "method": "POST",
+        "contentTypes": ["application/json"]
+    },
+    "named_one_of": {
+        "path": "/named-one-of",
         "method": "POST",
         "contentTypes": ["application/json"]
     },
@@ -19276,6 +19985,121 @@ def _build_handler_chain(_interceptors, handler) -> HandlerChain:
                 ))
         return RemainingHandlerChain()
 
+
+class ArrayOfOneOfsRequestParameters(BaseModel):
+    """
+    Query, path and header parameters for the ArrayOfOneOfs operation
+    """
+
+    class Config:
+        """Pydantic configuration"""
+        populate_by_name = True
+        validate_assignment = True
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_json(cls, json_str: str) -> ArrayOfOneOfsRequestParameters:
+        return cls.from_dict(json.loads(json_str))
+
+    def to_dict(self):
+        return self.model_dump(exclude={}, exclude_none=True)
+
+    @classmethod
+    def from_dict(cls, obj: dict) -> ArrayOfOneOfsRequestParameters:
+        if obj is None:
+            return None
+        return ArrayOfOneOfsRequestParameters.model_validate(obj)
+
+
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
+ArrayOfOneOfsRequestBody = Any
+
+ArrayOfOneOfs200OperationResponse = ApiResponse[Literal[200], ArrayOfOneOfs]
+
+ArrayOfOneOfsOperationResponses = Union[ArrayOfOneOfs200OperationResponse, ]
+
+# Request type for array_of_one_ofs
+ArrayOfOneOfsRequest = ApiRequest[ArrayOfOneOfsRequestParameters, ArrayOfOneOfsRequestBody]
+ArrayOfOneOfsChainedRequest = ChainedApiRequest[ArrayOfOneOfsRequestParameters, ArrayOfOneOfsRequestBody]
+
+class ArrayOfOneOfsHandlerFunction(Protocol):
+    def __call__(self, input: ArrayOfOneOfsRequest, **kwargs) -> ArrayOfOneOfsOperationResponses:
+        ...
+
+ArrayOfOneOfsInterceptor = Callable[[ArrayOfOneOfsChainedRequest], ArrayOfOneOfsOperationResponses]
+
+def array_of_one_ofs_handler(_handler: ArrayOfOneOfsHandlerFunction = None, interceptors: List[ArrayOfOneOfsInterceptor] = []):
+    """
+    Decorator for an api handler for the array_of_one_ofs operation, providing a typed interface for inputs and outputs
+    """
+    def _handler_wrapper(handler: ArrayOfOneOfsHandlerFunction):
+        @wraps(handler)
+        def wrapper(event, context, additional_interceptors = [], **kwargs):
+            all_interceptors = additional_interceptors + interceptors
+
+            raw_string_parameters = decode_request_parameters({
+                **(event.get('pathParameters', {}) or {}),
+                **(event.get('queryStringParameters', {}) or {}),
+                **(event.get('headers', {}) or {}),
+            })
+            raw_string_array_parameters = decode_request_parameters({
+                **(event.get('multiValueQueryStringParameters', {}) or {}),
+                **(event.get('multiValueHeaders', {}) or {}),
+            })
+
+            def response_headers_for_status_code(status_code):
+                headers_for_status = {}
+                return headers_for_status
+
+            request_parameters = None
+            try:
+                request_parameters = ArrayOfOneOfsRequestParameters.from_dict({
+                })
+            except Exception as e:
+                return {
+                    'statusCode': 400,
+                    'headers': {**response_headers_for_status_code(400), **extract_response_headers_from_interceptors(all_interceptors)},
+                    'body': '{"message": "' + str(e) + '"}',
+                }
+
+            body = {}
+            interceptor_context = {
+                "operationId": "array_of_one_ofs",
+            }
+
+            chain = _build_handler_chain(all_interceptors, handler)
+            response = chain.next(ApiRequest(
+                request_parameters,
+                body,
+                event,
+                context,
+                interceptor_context,
+            ), **kwargs)
+
+            response_headers = {** (response.headers or {}), **response_headers_for_status_code(response.status_code)}
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = response.body.to_json()
+
+            return {
+                'statusCode': response.status_code,
+                'headers': response_headers,
+                'multiValueHeaders': response.multi_value_headers or {},
+                'body': response_body,
+            }
+        return wrapper
+
+    # Support use as a decorator with no arguments, or with interceptor arguments
+    if callable(_handler):
+        return _handler_wrapper(_handler)
+    elif _handler is None:
+        return _handler_wrapper
+    else:
+        raise Exception("Positional arguments are not supported by array_of_one_ofs_handler.")
 
 class ArrayRequestParametersRequestParameters(BaseModel):
     """
@@ -19641,6 +20465,121 @@ def inline_request_body_handler(_handler: InlineRequestBodyHandlerFunction = Non
     else:
         raise Exception("Positional arguments are not supported by inline_request_body_handler.")
 
+class NamedOneOfRequestParameters(BaseModel):
+    """
+    Query, path and header parameters for the NamedOneOf operation
+    """
+
+    class Config:
+        """Pydantic configuration"""
+        populate_by_name = True
+        validate_assignment = True
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_json(cls, json_str: str) -> NamedOneOfRequestParameters:
+        return cls.from_dict(json.loads(json_str))
+
+    def to_dict(self):
+        return self.model_dump(exclude={}, exclude_none=True)
+
+    @classmethod
+    def from_dict(cls, obj: dict) -> NamedOneOfRequestParameters:
+        if obj is None:
+            return None
+        return NamedOneOfRequestParameters.model_validate(obj)
+
+
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
+NamedOneOfRequestBody = Any
+
+NamedOneOf200OperationResponse = ApiResponse[Literal[200], NamedOneOfUnion]
+
+NamedOneOfOperationResponses = Union[NamedOneOf200OperationResponse, ]
+
+# Request type for named_one_of
+NamedOneOfRequest = ApiRequest[NamedOneOfRequestParameters, NamedOneOfRequestBody]
+NamedOneOfChainedRequest = ChainedApiRequest[NamedOneOfRequestParameters, NamedOneOfRequestBody]
+
+class NamedOneOfHandlerFunction(Protocol):
+    def __call__(self, input: NamedOneOfRequest, **kwargs) -> NamedOneOfOperationResponses:
+        ...
+
+NamedOneOfInterceptor = Callable[[NamedOneOfChainedRequest], NamedOneOfOperationResponses]
+
+def named_one_of_handler(_handler: NamedOneOfHandlerFunction = None, interceptors: List[NamedOneOfInterceptor] = []):
+    """
+    Decorator for an api handler for the named_one_of operation, providing a typed interface for inputs and outputs
+    """
+    def _handler_wrapper(handler: NamedOneOfHandlerFunction):
+        @wraps(handler)
+        def wrapper(event, context, additional_interceptors = [], **kwargs):
+            all_interceptors = additional_interceptors + interceptors
+
+            raw_string_parameters = decode_request_parameters({
+                **(event.get('pathParameters', {}) or {}),
+                **(event.get('queryStringParameters', {}) or {}),
+                **(event.get('headers', {}) or {}),
+            })
+            raw_string_array_parameters = decode_request_parameters({
+                **(event.get('multiValueQueryStringParameters', {}) or {}),
+                **(event.get('multiValueHeaders', {}) or {}),
+            })
+
+            def response_headers_for_status_code(status_code):
+                headers_for_status = {}
+                return headers_for_status
+
+            request_parameters = None
+            try:
+                request_parameters = NamedOneOfRequestParameters.from_dict({
+                })
+            except Exception as e:
+                return {
+                    'statusCode': 400,
+                    'headers': {**response_headers_for_status_code(400), **extract_response_headers_from_interceptors(all_interceptors)},
+                    'body': '{"message": "' + str(e) + '"}',
+                }
+
+            body = {}
+            interceptor_context = {
+                "operationId": "named_one_of",
+            }
+
+            chain = _build_handler_chain(all_interceptors, handler)
+            response = chain.next(ApiRequest(
+                request_parameters,
+                body,
+                event,
+                context,
+                interceptor_context,
+            ), **kwargs)
+
+            response_headers = {** (response.headers or {}), **response_headers_for_status_code(response.status_code)}
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = response.body.to_json()
+
+            return {
+                'statusCode': response.status_code,
+                'headers': response_headers,
+                'multiValueHeaders': response.multi_value_headers or {},
+                'body': response_body,
+            }
+        return wrapper
+
+    # Support use as a decorator with no arguments, or with interceptor arguments
+    if callable(_handler):
+        return _handler_wrapper(_handler)
+    elif _handler is None:
+        return _handler_wrapper
+    else:
+        raise Exception("Positional arguments are not supported by named_one_of_handler.")
+
 class ReservedKeywordsRequestParameters(BaseModel):
     """
     Query, path and header parameters for the ReservedKeywords operation
@@ -19771,9 +20710,11 @@ OperationIdByMethodAndPath = { concat_method_and_path(method_and_path["method"],
 
 @dataclass
 class HandlerRouterHandlers:
+  array_of_one_ofs: Callable[[Dict, Any], Dict]
   array_request_parameters: Callable[[Dict, Any], Dict]
   inline_enum: Callable[[Dict, Any], Dict]
   inline_request_body: Callable[[Dict, Any], Dict]
+  named_one_of: Callable[[Dict, Any], Dict]
   reserved_keywords: Callable[[Dict, Any], Dict]
 
 def handler_router(handlers: HandlerRouterHandlers, interceptors: List[Interceptor] = []):
@@ -21343,10 +22284,196 @@ def try_catch_interceptor(request: ChainedApiRequest) -> ApiResponse:
 """  # noqa: E501
 
 # import models into model package
+from test_project.models.another_named_one_of import AnotherNamedOneOf
+from test_project.models.array_of_one_ofs import ArrayOfOneOfs
 from test_project.models.inline_enum200_response import InlineEnum200Response
 from test_project.models.inline_enum200_response_category_enum import InlineEnum200ResponseCategoryEnum
 from test_project.models.inline_request_body_request_content import InlineRequestBodyRequestContent
 from test_project.models.my_enum import MyEnum
+from test_project.models.named_one_of import NamedOneOf
+from test_project.models.named_one_of_union import NamedOneOfUnion
+",
+  "test_project/models/another_named_one_of.py": "# coding: utf-8
+
+"""
+    Edge Cases
+
+    No description provided
+
+    The version of the OpenAPI document: 1.0.0
+
+    NOTE: This class is auto generated.
+    Do not edit the class manually.
+"""  # noqa: E501
+
+from __future__ import annotations
+import pprint
+import re  # noqa: F401
+import json
+from enum import Enum
+from datetime import date, datetime
+from typing import Any, List, Union, ClassVar, Dict, Optional, TYPE_CHECKING
+from pydantic import Field, StrictStr, ValidationError, field_validator, BaseModel, SecretStr, StrictFloat, StrictInt, StrictBytes, StrictBool
+from decimal import Decimal
+from typing_extensions import Annotated, Literal
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
+class AnotherNamedOneOf(BaseModel):
+    """
+    AnotherNamedOneOf
+    """ # noqa: E501
+    bar: Optional[StrictStr] = None
+    __properties: ClassVar[List[str]] = ["bar"]
+
+
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True
+    }
+
+    def to_str(self) -> str:
+        """Returns the string representation of the model using alias"""
+        return pprint.pformat(self.model_dump(by_alias=True))
+
+    def to_json(self) -> str:
+        """Returns the JSON representation of the model using alias"""
+        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_json(cls, json_str: str) -> Self:
+        """Create an instance of AnotherNamedOneOf from a JSON string"""
+        return cls.from_dict(json.loads(json_str))
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the dictionary representation of the model using alias.
+
+        This has the following differences from calling pydantic's
+        \`self.model_dump(by_alias=True)\`:
+
+        * \`None\` is only added to the output dict for nullable fields that
+          were set at model initialization. Other fields with value \`None\`
+          are ignored.
+        """
+        _dict = self.model_dump(
+            by_alias=True,
+            exclude={
+            },
+            exclude_none=True,
+        )
+        return _dict
+
+    @classmethod
+    def from_dict(cls, obj: Dict) -> Self:
+        """Create an instance of AnotherNamedOneOf from a dict"""
+
+        if obj is None:
+            return None
+
+        if not isinstance(obj, dict):
+            return cls.model_validate(obj)
+
+        _obj = cls.model_validate({
+            "bar": obj.get("bar")
+        })
+        return _obj
+
+",
+  "test_project/models/array_of_one_ofs.py": "# coding: utf-8
+
+"""
+    Edge Cases
+
+    No description provided
+
+    The version of the OpenAPI document: 1.0.0
+
+    NOTE: This class is auto generated.
+    Do not edit the class manually.
+"""  # noqa: E501
+
+from __future__ import annotations
+import pprint
+import re  # noqa: F401
+import json
+from enum import Enum
+from datetime import date, datetime
+from typing import Any, List, Union, ClassVar, Dict, Optional, TYPE_CHECKING
+from pydantic import Field, StrictStr, ValidationError, field_validator, BaseModel, SecretStr, StrictFloat, StrictInt, StrictBytes, StrictBool
+from decimal import Decimal
+from typing_extensions import Annotated, Literal
+from test_project.models.named_one_of_union import NamedOneOfUnion
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
+class ArrayOfOneOfs(BaseModel):
+    """
+    ArrayOfOneOfs
+    """ # noqa: E501
+    one_ofs: Optional[List[Any]] = Field(default=None, alias="oneOfs")
+    __properties: ClassVar[List[str]] = ["oneOfs"]
+
+
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True
+    }
+
+    def to_str(self) -> str:
+        """Returns the string representation of the model using alias"""
+        return pprint.pformat(self.model_dump(by_alias=True))
+
+    def to_json(self) -> str:
+        """Returns the JSON representation of the model using alias"""
+        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_json(cls, json_str: str) -> Self:
+        """Create an instance of ArrayOfOneOfs from a JSON string"""
+        return cls.from_dict(json.loads(json_str))
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the dictionary representation of the model using alias.
+
+        This has the following differences from calling pydantic's
+        \`self.model_dump(by_alias=True)\`:
+
+        * \`None\` is only added to the output dict for nullable fields that
+          were set at model initialization. Other fields with value \`None\`
+          are ignored.
+        """
+        _dict = self.model_dump(
+            by_alias=True,
+            exclude={
+            },
+            exclude_none=True,
+        )
+        # override the default output from pydantic by calling \`to_dict()\` of one_ofs
+        if self.one_ofs:
+            _dict['oneOfs'] = self.one_ofs.to_dict()
+        return _dict
+
+    @classmethod
+    def from_dict(cls, obj: Dict) -> Self:
+        """Create an instance of ArrayOfOneOfs from a dict"""
+
+        if obj is None:
+            return None
+
+        if not isinstance(obj, dict):
+            return cls.model_validate(obj)
+
+        _obj = cls.model_validate({
+            "oneOfs": List[NamedOneOfUnion].from_dict(obj.get("oneOfs")) if obj.get("oneOfs") is not None else None
+        })
+        return _obj
+
 ",
   "test_project/models/inline_enum200_response.py": "# coding: utf-8
 
@@ -21623,6 +22750,237 @@ class MyEnum(str, Enum):
         return cls(json.loads(json_str))
 
 
+
+",
+  "test_project/models/named_one_of.py": "# coding: utf-8
+
+"""
+    Edge Cases
+
+    No description provided
+
+    The version of the OpenAPI document: 1.0.0
+
+    NOTE: This class is auto generated.
+    Do not edit the class manually.
+"""  # noqa: E501
+
+from __future__ import annotations
+import pprint
+import re  # noqa: F401
+import json
+from enum import Enum
+from datetime import date, datetime
+from typing import Any, List, Union, ClassVar, Dict, Optional, TYPE_CHECKING
+from pydantic import Field, StrictStr, ValidationError, field_validator, BaseModel, SecretStr, StrictFloat, StrictInt, StrictBytes, StrictBool
+from decimal import Decimal
+from typing_extensions import Annotated, Literal
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
+class NamedOneOf(BaseModel):
+    """
+    NamedOneOf
+    """ # noqa: E501
+    foo: Optional[StrictStr] = None
+    __properties: ClassVar[List[str]] = ["foo"]
+
+
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True
+    }
+
+    def to_str(self) -> str:
+        """Returns the string representation of the model using alias"""
+        return pprint.pformat(self.model_dump(by_alias=True))
+
+    def to_json(self) -> str:
+        """Returns the JSON representation of the model using alias"""
+        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_json(cls, json_str: str) -> Self:
+        """Create an instance of NamedOneOf from a JSON string"""
+        return cls.from_dict(json.loads(json_str))
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the dictionary representation of the model using alias.
+
+        This has the following differences from calling pydantic's
+        \`self.model_dump(by_alias=True)\`:
+
+        * \`None\` is only added to the output dict for nullable fields that
+          were set at model initialization. Other fields with value \`None\`
+          are ignored.
+        """
+        _dict = self.model_dump(
+            by_alias=True,
+            exclude={
+            },
+            exclude_none=True,
+        )
+        return _dict
+
+    @classmethod
+    def from_dict(cls, obj: Dict) -> Self:
+        """Create an instance of NamedOneOf from a dict"""
+
+        if obj is None:
+            return None
+
+        if not isinstance(obj, dict):
+            return cls.model_validate(obj)
+
+        _obj = cls.model_validate({
+            "foo": obj.get("foo")
+        })
+        return _obj
+
+",
+  "test_project/models/named_one_of_union.py": "# coding: utf-8
+
+"""
+    Edge Cases
+
+    No description provided
+
+    The version of the OpenAPI document: 1.0.0
+
+    NOTE: This class is auto generated.
+    Do not edit the class manually.
+"""  # noqa: E501
+
+from __future__ import annotations
+import pprint
+import re  # noqa: F401
+import json
+from enum import Enum
+from datetime import date, datetime
+from typing import Any, List, Union, ClassVar, Dict, Optional, TYPE_CHECKING
+from pydantic import Field, StrictStr, ValidationError, field_validator, BaseModel, SecretStr, StrictFloat, StrictInt, StrictBytes, StrictBool
+from decimal import Decimal
+from typing_extensions import Annotated, Literal
+from test_project.models.another_named_one_of import AnotherNamedOneOf
+from test_project.models.named_one_of import NamedOneOf
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
+NAMEDONEOFUNION_ONE_OF_SCHEMAS = ["NamedOneOf", "AnotherNamedOneOf"]
+
+class NamedOneOfUnion(BaseModel):
+    """
+    NamedOneOfUnion
+    """ # noqa: E501
+    # data type: NamedOneOf
+    oneof_schema_1_validator: Optional[NamedOneOf] = None
+    # data type: AnotherNamedOneOf
+    oneof_schema_2_validator: Optional[AnotherNamedOneOf] = None
+    actual_instance: Optional[Union[NamedOneOf, AnotherNamedOneOf]] = None
+    one_of_schemas: List[str] = Literal["NamedOneOf", "AnotherNamedOneOf"]
+
+    model_config = {
+        "validate_assignment": True
+    }
+
+    def __init__(self, *args, **kwargs) -> None:
+        if args:
+            if len(args) > 1:
+                raise ValueError("If a position argument is used, only 1 is allowed to set \`actual_instance\`")
+            if kwargs:
+                raise ValueError("If a position argument is used, keyword arguments cannot be used.")
+            super().__init__(actual_instance=args[0])
+        else:
+            super().__init__(**kwargs)
+
+    @field_validator('actual_instance')
+    def actual_instance_must_validate_oneof(cls, v):
+        instance = NamedOneOfUnion.model_construct()
+        error_messages = []
+        match = 0
+        # validate data type: NamedOneOf
+        if not isinstance(v, NamedOneOf):
+            error_messages.append(f"Error! Input type \`{type(v)}\` is not \`NamedOneOf\`")
+        else:
+            match += 1
+        # validate data type: AnotherNamedOneOf
+        if not isinstance(v, AnotherNamedOneOf):
+            error_messages.append(f"Error! Input type \`{type(v)}\` is not \`AnotherNamedOneOf\`")
+        else:
+            match += 1
+        if match > 1:
+            # more than 1 match
+            raise ValueError("Multiple matches found when setting \`actual_instance\` in NamedOneOfUnion with oneOf schemas: NamedOneOf, AnotherNamedOneOf. Details: " + ", ".join(error_messages))
+        elif match == 0:
+            # no match
+            raise ValueError("No match found when setting \`actual_instance\` in NamedOneOfUnion with oneOf schemas: NamedOneOf, AnotherNamedOneOf. Details: " + ", ".join(error_messages))
+        else:
+            return v
+
+    @classmethod
+    def from_dict(cls, obj: dict) -> Self:
+        return cls.from_json(json.dumps(obj))
+
+    @classmethod
+    def from_json(cls, json_str: str) -> Self:
+        """Returns the object represented by the json string"""
+        instance = cls.model_construct()
+        error_messages = []
+        match = 0
+
+        # deserialize data into NamedOneOf
+        try:
+            instance.actual_instance = NamedOneOf.from_json(json_str)
+            match += 1
+        except (ValidationError, ValueError) as e:
+            error_messages.append(str(e))
+        # deserialize data into AnotherNamedOneOf
+        try:
+            instance.actual_instance = AnotherNamedOneOf.from_json(json_str)
+            match += 1
+        except (ValidationError, ValueError) as e:
+            error_messages.append(str(e))
+
+        if match > 1:
+            # more than 1 match
+            raise ValueError("Multiple matches found when deserializing the JSON string into NamedOneOfUnion with oneOf schemas: NamedOneOf, AnotherNamedOneOf. Details: " + ", ".join(error_messages))
+        elif match == 0:
+            # no match
+            raise ValueError("No match found when deserializing the JSON string into NamedOneOfUnion with oneOf schemas: NamedOneOf, AnotherNamedOneOf. Details: " + ", ".join(error_messages))
+        else:
+            return instance
+
+    def to_json(self) -> str:
+        """Returns the JSON representation of the actual instance"""
+        if self.actual_instance is None:
+            return "null"
+
+        to_json = getattr(self.actual_instance, "to_json", None)
+        if callable(to_json):
+            return self.actual_instance.to_json()
+        else:
+            return json.dumps(self.actual_instance)
+
+    def to_dict(self) -> Dict:
+        """Returns the dict representation of the actual instance"""
+        if self.actual_instance is None:
+            return None
+
+        to_dict = getattr(self.actual_instance, "to_dict", None)
+        if callable(to_dict):
+            return self.actual_instance.to_dict()
+        else:
+            # primitive type
+            return self.actual_instance
+
+    def to_str(self) -> str:
+        """Returns the string representation of the actual instance"""
+        return pprint.pformat(self.model_dump())
 
 ",
   "test_project/py.typed": "",

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
@@ -17428,14 +17428,17 @@ test_project/__init__.py
 test_project/py.typed
 test_project/rest.py
 docs/DefaultApi.md
+docs/AdditionalPropertiesResponse.md
 docs/AnotherNamedOneOf.md
 docs/ArrayOfOneOfs.md
+docs/Dictionary.md
 docs/InlineEnum200Response.md
 docs/InlineEnum200ResponseCategoryEnum.md
 docs/InlineRequestBodyRequestContent.md
 docs/MyEnum.md
 docs/NamedOneOf.md
 docs/NamedOneOfUnion.md
+docs/SomeObject.md
 README.md
 test_project/interceptors/try_catch.py
 test_project/interceptors/response_headers.py
@@ -17448,14 +17451,17 @@ test_project/response.py
 test_project/api/default_api.py
 test_project/api/__init__.py
 test_project/models/__init__.py
+test_project/models/additional_properties_response.py
 test_project/models/another_named_one_of.py
 test_project/models/array_of_one_ofs.py
+test_project/models/dictionary.py
 test_project/models/inline_enum200_response.py
 test_project/models/inline_enum200_response_category_enum.py
 test_project/models/inline_request_body_request_content.py
 test_project/models/my_enum.py
 test_project/models/named_one_of.py
-test_project/models/named_one_of_union.py",
+test_project/models/named_one_of_union.py
+test_project/models/some_object.py",
   "README.md": "# Edge Cases
 
 
@@ -17502,6 +17508,7 @@ Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
 *DefaultApi* | [**array_of_one_ofs**](docs/DefaultApi.md#array_of_one_ofs) | **POST** /array-of-one-ofs | 
 *DefaultApi* | [**array_request_parameters**](docs/DefaultApi.md#array_request_parameters) | **GET** /array-request-parameters | 
+*DefaultApi* | [**dictionary**](docs/DefaultApi.md#dictionary) | **POST** /additional-properties | 
 *DefaultApi* | [**inline_enum**](docs/DefaultApi.md#inline_enum) | **GET** /inline-enum | 
 *DefaultApi* | [**inline_request_body**](docs/DefaultApi.md#inline_request_body) | **POST** /inline-request-body | 
 *DefaultApi* | [**named_one_of**](docs/DefaultApi.md#named_one_of) | **POST** /named-one-of | 
@@ -17509,14 +17516,45 @@ Class | Method | HTTP request | Description
 
 ## Documentation For Models
 
+ - [AdditionalPropertiesResponse](docs/AdditionalPropertiesResponse.md)
  - [AnotherNamedOneOf](docs/AnotherNamedOneOf.md)
  - [ArrayOfOneOfs](docs/ArrayOfOneOfs.md)
+ - [Dictionary](docs/Dictionary.md)
  - [InlineEnum200Response](docs/InlineEnum200Response.md)
  - [InlineEnum200ResponseCategoryEnum](docs/InlineEnum200ResponseCategoryEnum.md)
  - [InlineRequestBodyRequestContent](docs/InlineRequestBodyRequestContent.md)
  - [MyEnum](docs/MyEnum.md)
  - [NamedOneOf](docs/NamedOneOf.md)
  - [NamedOneOfUnion](docs/NamedOneOfUnion.md)
+ - [SomeObject](docs/SomeObject.md)
+",
+  "docs/AdditionalPropertiesResponse.md": "# AdditionalPropertiesResponse
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**dictionary_of_objects** | [**Dictionary**](Dictionary.md) |  | [optional] 
+**dictionary_of_primitives** | **Dict[str, str]** |  | [optional] 
+
+## Example
+
+\`\`\`python
+from test_project.models.additional_properties_response import AdditionalPropertiesResponse
+
+# TODO update the JSON string below
+json = "{}"
+# create an instance of AdditionalPropertiesResponse from a JSON string
+additional_properties_response_instance = AdditionalPropertiesResponse.from_json(json)
+# print the JSON string representation of the object
+print(AdditionalPropertiesResponse.to_json())
+
+# convert the object into a dict
+additional_properties_response_dict = additional_properties_response_instance.to_dict()
+# create an instance of AdditionalPropertiesResponse from a dict
+additional_properties_response_form_dict = additional_properties_response.from_dict(additional_properties_response_dict)
+\`\`\`
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
 ",
   "docs/AnotherNamedOneOf.md": "# AnotherNamedOneOf
 
@@ -17578,6 +17616,7 @@ Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**array_of_one_ofs**](DefaultApi.md#array_of_one_ofs) | **POST** /array-of-one-ofs | 
 [**array_request_parameters**](DefaultApi.md#array_request_parameters) | **GET** /array-request-parameters | 
+[**dictionary**](DefaultApi.md#dictionary) | **POST** /additional-properties | 
 [**inline_enum**](DefaultApi.md#inline_enum) | **GET** /inline-enum | 
 [**inline_request_body**](DefaultApi.md#inline_request_body) | **POST** /inline-request-body | 
 [**named_one_of**](DefaultApi.md#named_one_of) | **POST** /named-one-of | 
@@ -17692,6 +17731,56 @@ void (empty response body)
 
  - **Content-Type**: Not defined
  - **Accept**: Not defined
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | ok |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **dictionary**
+> AdditionalPropertiesResponse dictionary()
+
+
+### Example
+
+\`\`\`python
+import time
+import test_project
+from test_project.rest import ApiException
+from pprint import pprint
+
+# Defining the host is optional and defaults to http://localhost
+# See configuration.py for a list of all supported configuration parameters.
+configuration = test_project.Configuration(
+    host = "http://localhost"
+)
+
+# Enter a context with an instance of the API client
+with test_project.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = test_project.DefaultApi(api_client)
+
+    try:
+        api_response = api_instance.dictionary()
+        print("The response of DefaultApi->dictionary:\\n")
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling DefaultApi->dictionary: %s\\n" % e)
+\`\`\`
+
+### Parameters
+This endpoint does not need any parameters.
+
+### Return type
+
+[**AdditionalPropertiesResponse**](AdditionalPropertiesResponse.md)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
 
 ### HTTP response details
 | Status code | Description | Response headers |
@@ -17907,6 +17996,32 @@ void (empty response body)
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 ",
+  "docs/Dictionary.md": "# Dictionary
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+## Example
+
+\`\`\`python
+from test_project.models.dictionary import Dictionary
+
+# TODO update the JSON string below
+json = "{}"
+# create an instance of Dictionary from a JSON string
+dictionary_instance = Dictionary.from_json(json)
+# print the JSON string representation of the object
+print(Dictionary.to_json())
+
+# convert the object into a dict
+dictionary_dict = dictionary_instance.to_dict()
+# create an instance of Dictionary from a dict
+dictionary_form_dict = dictionary.from_dict(dictionary_dict)
+\`\`\`
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+",
   "docs/InlineEnum200Response.md": "# InlineEnum200Response
 
 ## Properties
@@ -18037,6 +18152,33 @@ named_one_of_union_form_dict = named_one_of_union.from_dict(named_one_of_union_d
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 
 ",
+  "docs/SomeObject.md": "# SomeObject
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**a** | **str** |  | [optional] 
+
+## Example
+
+\`\`\`python
+from test_project.models.some_object import SomeObject
+
+# TODO update the JSON string below
+json = "{}"
+# create an instance of SomeObject from a JSON string
+some_object_instance = SomeObject.from_json(json)
+# print the JSON string representation of the object
+print(SomeObject.to_json())
+
+# convert the object into a dict
+some_object_dict = some_object_instance.to_dict()
+# create an instance of SomeObject from a dict
+some_object_form_dict = some_object.from_dict(some_object_dict)
+\`\`\`
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+",
   "poetry.toml": "# ~~ Generated by projen. To modify, edit .projenrc.py and run "npx projen".
 
 [repositories.testpypi]
@@ -18105,14 +18247,17 @@ from test_project.exceptions import ApiAttributeError
 from test_project.exceptions import ApiException
 
 # import models into sdk package
+from test_project.models.additional_properties_response import AdditionalPropertiesResponse
 from test_project.models.another_named_one_of import AnotherNamedOneOf
 from test_project.models.array_of_one_ofs import ArrayOfOneOfs
+from test_project.models.dictionary import Dictionary
 from test_project.models.inline_enum200_response import InlineEnum200Response
 from test_project.models.inline_enum200_response_category_enum import InlineEnum200ResponseCategoryEnum
 from test_project.models.inline_request_body_request_content import InlineRequestBodyRequestContent
 from test_project.models.my_enum import MyEnum
 from test_project.models.named_one_of import NamedOneOf
 from test_project.models.named_one_of_union import NamedOneOfUnion
+from test_project.models.some_object import SomeObject
 ",
   "test_project/api/__init__.py": "# flake8: noqa
 
@@ -18143,6 +18288,7 @@ try:
 except ImportError:
     from typing_extensions import Annotated
 
+from test_project.models.additional_properties_response import AdditionalPropertiesResponse
 from test_project.models.array_of_one_ofs import ArrayOfOneOfs
 from test_project.models.inline_enum200_response import InlineEnum200Response
 from test_project.models.inline_request_body_request_content import InlineRequestBodyRequestContent
@@ -18755,6 +18901,241 @@ class DefaultApi:
         return self.api_client.param_serialize(
             method='GET',
             resource_path='/array-request-parameters',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
+
+    @validate_call
+    def dictionary(
+        self,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> AdditionalPropertiesResponse:
+        """dictionary
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._dictionary_serialize(
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "AdditionalPropertiesResponse"
+        }
+
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    def dictionary_with_http_info(
+        self,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[AdditionalPropertiesResponse]:
+        """dictionary
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._dictionary_serialize(
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "AdditionalPropertiesResponse"
+        }
+
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    def dictionary_without_preload_content(
+        self,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """dictionary
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._dictionary_serialize(
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "AdditionalPropertiesResponse"
+        }
+
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _dictionary_serialize(
+        self,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> Tuple:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[str, str] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        # process the query parameters
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+
+
+        # set the HTTP header \`Accept\`
+        _header_params['Accept'] = self.api_client.select_header_accept(
+            [
+                'application/json'
+            ]
+        )
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+        ]
+
+        return self.api_client.param_serialize(
+            method='POST',
+            resource_path='/additional-properties',
             path_params=_path_params,
             query_params=_query_params,
             header_params=_header_params,
@@ -19783,6 +20164,7 @@ T = TypeVar('T')
 class OperationConfig(Generic[T]):
     array_of_one_ofs: T
     array_request_parameters: T
+    dictionary: T
     inline_enum: T
     inline_request_body: T
     named_one_of: T
@@ -19799,6 +20181,11 @@ OperationLookup = {
     "array_request_parameters": {
         "path": "/array-request-parameters",
         "method": "GET",
+        "contentTypes": ["application/json"]
+    },
+    "dictionary": {
+        "path": "/additional-properties",
+        "method": "POST",
         "contentTypes": ["application/json"]
     },
     "inline_enum": {
@@ -20233,6 +20620,121 @@ def array_request_parameters_handler(_handler: ArrayRequestParametersHandlerFunc
         return _handler_wrapper
     else:
         raise Exception("Positional arguments are not supported by array_request_parameters_handler.")
+
+class DictionaryRequestParameters(BaseModel):
+    """
+    Query, path and header parameters for the Dictionary operation
+    """
+
+    class Config:
+        """Pydantic configuration"""
+        populate_by_name = True
+        validate_assignment = True
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_json(cls, json_str: str) -> DictionaryRequestParameters:
+        return cls.from_dict(json.loads(json_str))
+
+    def to_dict(self):
+        return self.model_dump(exclude={}, exclude_none=True)
+
+    @classmethod
+    def from_dict(cls, obj: dict) -> DictionaryRequestParameters:
+        if obj is None:
+            return None
+        return DictionaryRequestParameters.model_validate(obj)
+
+
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
+DictionaryRequestBody = Any
+
+Dictionary200OperationResponse = ApiResponse[Literal[200], AdditionalPropertiesResponse]
+
+DictionaryOperationResponses = Union[Dictionary200OperationResponse, ]
+
+# Request type for dictionary
+DictionaryRequest = ApiRequest[DictionaryRequestParameters, DictionaryRequestBody]
+DictionaryChainedRequest = ChainedApiRequest[DictionaryRequestParameters, DictionaryRequestBody]
+
+class DictionaryHandlerFunction(Protocol):
+    def __call__(self, input: DictionaryRequest, **kwargs) -> DictionaryOperationResponses:
+        ...
+
+DictionaryInterceptor = Callable[[DictionaryChainedRequest], DictionaryOperationResponses]
+
+def dictionary_handler(_handler: DictionaryHandlerFunction = None, interceptors: List[DictionaryInterceptor] = []):
+    """
+    Decorator for an api handler for the dictionary operation, providing a typed interface for inputs and outputs
+    """
+    def _handler_wrapper(handler: DictionaryHandlerFunction):
+        @wraps(handler)
+        def wrapper(event, context, additional_interceptors = [], **kwargs):
+            all_interceptors = additional_interceptors + interceptors
+
+            raw_string_parameters = decode_request_parameters({
+                **(event.get('pathParameters', {}) or {}),
+                **(event.get('queryStringParameters', {}) or {}),
+                **(event.get('headers', {}) or {}),
+            })
+            raw_string_array_parameters = decode_request_parameters({
+                **(event.get('multiValueQueryStringParameters', {}) or {}),
+                **(event.get('multiValueHeaders', {}) or {}),
+            })
+
+            def response_headers_for_status_code(status_code):
+                headers_for_status = {}
+                return headers_for_status
+
+            request_parameters = None
+            try:
+                request_parameters = DictionaryRequestParameters.from_dict({
+                })
+            except Exception as e:
+                return {
+                    'statusCode': 400,
+                    'headers': {**response_headers_for_status_code(400), **extract_response_headers_from_interceptors(all_interceptors)},
+                    'body': '{"message": "' + str(e) + '"}',
+                }
+
+            body = {}
+            interceptor_context = {
+                "operationId": "dictionary",
+            }
+
+            chain = _build_handler_chain(all_interceptors, handler)
+            response = chain.next(ApiRequest(
+                request_parameters,
+                body,
+                event,
+                context,
+                interceptor_context,
+            ), **kwargs)
+
+            response_headers = {** (response.headers or {}), **response_headers_for_status_code(response.status_code)}
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = response.body.to_json()
+
+            return {
+                'statusCode': response.status_code,
+                'headers': response_headers,
+                'multiValueHeaders': response.multi_value_headers or {},
+                'body': response_body,
+            }
+        return wrapper
+
+    # Support use as a decorator with no arguments, or with interceptor arguments
+    if callable(_handler):
+        return _handler_wrapper(_handler)
+    elif _handler is None:
+        return _handler_wrapper
+    else:
+        raise Exception("Positional arguments are not supported by dictionary_handler.")
 
 class InlineEnumRequestParameters(BaseModel):
     """
@@ -20712,6 +21214,7 @@ OperationIdByMethodAndPath = { concat_method_and_path(method_and_path["method"],
 class HandlerRouterHandlers:
   array_of_one_ofs: Callable[[Dict, Any], Dict]
   array_request_parameters: Callable[[Dict, Any], Dict]
+  dictionary: Callable[[Dict, Any], Dict]
   inline_enum: Callable[[Dict, Any], Dict]
   inline_request_body: Callable[[Dict, Any], Dict]
   named_one_of: Callable[[Dict, Any], Dict]
@@ -22284,14 +22787,112 @@ def try_catch_interceptor(request: ChainedApiRequest) -> ApiResponse:
 """  # noqa: E501
 
 # import models into model package
+from test_project.models.additional_properties_response import AdditionalPropertiesResponse
 from test_project.models.another_named_one_of import AnotherNamedOneOf
 from test_project.models.array_of_one_ofs import ArrayOfOneOfs
+from test_project.models.dictionary import Dictionary
 from test_project.models.inline_enum200_response import InlineEnum200Response
 from test_project.models.inline_enum200_response_category_enum import InlineEnum200ResponseCategoryEnum
 from test_project.models.inline_request_body_request_content import InlineRequestBodyRequestContent
 from test_project.models.my_enum import MyEnum
 from test_project.models.named_one_of import NamedOneOf
 from test_project.models.named_one_of_union import NamedOneOfUnion
+from test_project.models.some_object import SomeObject
+",
+  "test_project/models/additional_properties_response.py": "# coding: utf-8
+
+"""
+    Edge Cases
+
+    No description provided
+
+    The version of the OpenAPI document: 1.0.0
+
+    NOTE: This class is auto generated.
+    Do not edit the class manually.
+"""  # noqa: E501
+
+from __future__ import annotations
+import pprint
+import re  # noqa: F401
+import json
+from enum import Enum
+from datetime import date, datetime
+from typing import Any, List, Union, ClassVar, Dict, Optional, TYPE_CHECKING
+from pydantic import Field, StrictStr, ValidationError, field_validator, BaseModel, SecretStr, StrictFloat, StrictInt, StrictBytes, StrictBool
+from decimal import Decimal
+from typing_extensions import Annotated, Literal
+from test_project.models.dictionary import Dictionary
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
+class AdditionalPropertiesResponse(BaseModel):
+    """
+    AdditionalPropertiesResponse
+    """ # noqa: E501
+    dictionary_of_objects: Optional[Dictionary] = Field(default=None, alias="dictionaryOfObjects")
+    dictionary_of_primitives: Optional[Dict[str, StrictStr]] = Field(default=None, alias="dictionaryOfPrimitives")
+    __properties: ClassVar[List[str]] = ["dictionaryOfObjects", "dictionaryOfPrimitives"]
+
+
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True
+    }
+
+    def to_str(self) -> str:
+        """Returns the string representation of the model using alias"""
+        return pprint.pformat(self.model_dump(by_alias=True))
+
+    def to_json(self) -> str:
+        """Returns the JSON representation of the model using alias"""
+        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_json(cls, json_str: str) -> Self:
+        """Create an instance of AdditionalPropertiesResponse from a JSON string"""
+        return cls.from_dict(json.loads(json_str))
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the dictionary representation of the model using alias.
+
+        This has the following differences from calling pydantic's
+        \`self.model_dump(by_alias=True)\`:
+
+        * \`None\` is only added to the output dict for nullable fields that
+          were set at model initialization. Other fields with value \`None\`
+          are ignored.
+        """
+        _dict = self.model_dump(
+            by_alias=True,
+            exclude={
+            },
+            exclude_none=True,
+        )
+        # override the default output from pydantic by calling \`to_dict()\` of dictionary_of_objects
+        if self.dictionary_of_objects:
+            _dict['dictionaryOfObjects'] = self.dictionary_of_objects.to_dict()
+        return _dict
+
+    @classmethod
+    def from_dict(cls, obj: Dict) -> Self:
+        """Create an instance of AdditionalPropertiesResponse from a dict"""
+
+        if obj is None:
+            return None
+
+        if not isinstance(obj, dict):
+            return cls.model_validate(obj)
+
+        _obj = cls.model_validate({
+            "dictionaryOfObjects": Dictionary.from_dict(obj.get("dictionaryOfObjects")) if obj.get("dictionaryOfObjects") is not None else None,
+            "dictionaryOfPrimitives": obj.get("dictionaryOfPrimitives")
+        })
+        return _obj
+
 ",
   "test_project/models/another_named_one_of.py": "# coding: utf-8
 
@@ -22472,6 +23073,106 @@ class ArrayOfOneOfs(BaseModel):
         _obj = cls.model_validate({
             "oneOfs": List[NamedOneOfUnion].from_dict(obj.get("oneOfs")) if obj.get("oneOfs") is not None else None
         })
+        return _obj
+
+",
+  "test_project/models/dictionary.py": "# coding: utf-8
+
+"""
+    Edge Cases
+
+    No description provided
+
+    The version of the OpenAPI document: 1.0.0
+
+    NOTE: This class is auto generated.
+    Do not edit the class manually.
+"""  # noqa: E501
+
+from __future__ import annotations
+import pprint
+import re  # noqa: F401
+import json
+from enum import Enum
+from datetime import date, datetime
+from typing import Any, List, Union, ClassVar, Dict, Optional, TYPE_CHECKING
+from pydantic import Field, StrictStr, ValidationError, field_validator, BaseModel, SecretStr, StrictFloat, StrictInt, StrictBytes, StrictBool
+from decimal import Decimal
+from typing_extensions import Annotated, Literal
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
+class Dictionary(BaseModel):
+    """
+    Dictionary
+    """ # noqa: E501
+    additional_properties: Dict[str, Any] = {}
+    __properties: ClassVar[List[str]] = []
+
+
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True
+    }
+
+    def to_str(self) -> str:
+        """Returns the string representation of the model using alias"""
+        return pprint.pformat(self.model_dump(by_alias=True))
+
+    def to_json(self) -> str:
+        """Returns the JSON representation of the model using alias"""
+        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_json(cls, json_str: str) -> Self:
+        """Create an instance of Dictionary from a JSON string"""
+        return cls.from_dict(json.loads(json_str))
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the dictionary representation of the model using alias.
+
+        This has the following differences from calling pydantic's
+        \`self.model_dump(by_alias=True)\`:
+
+        * \`None\` is only added to the output dict for nullable fields that
+          were set at model initialization. Other fields with value \`None\`
+          are ignored.
+        * Fields in \`self.additional_properties\` are added to the output dict.
+        """
+        _dict = self.model_dump(
+            by_alias=True,
+            exclude={
+                "additional_properties",
+            },
+            exclude_none=True,
+        )
+        # puts key-value pairs in additional_properties in the top level
+        if self.additional_properties is not None:
+            for _key, _value in self.additional_properties.items():
+                _dict[_key] = _value
+
+        return _dict
+
+    @classmethod
+    def from_dict(cls, obj: Dict) -> Self:
+        """Create an instance of Dictionary from a dict"""
+
+        if obj is None:
+            return None
+
+        if not isinstance(obj, dict):
+            return cls.model_validate(obj)
+
+        _obj = cls.model_validate({
+        })
+        # store additional fields in additional_properties
+        for _key in obj.keys():
+            if _key not in cls.__properties:
+                _obj.additional_properties[_key] = obj.get(_key)
+
         return _obj
 
 ",
@@ -22981,6 +23682,95 @@ class NamedOneOfUnion(BaseModel):
     def to_str(self) -> str:
         """Returns the string representation of the actual instance"""
         return pprint.pformat(self.model_dump())
+
+",
+  "test_project/models/some_object.py": "# coding: utf-8
+
+"""
+    Edge Cases
+
+    No description provided
+
+    The version of the OpenAPI document: 1.0.0
+
+    NOTE: This class is auto generated.
+    Do not edit the class manually.
+"""  # noqa: E501
+
+from __future__ import annotations
+import pprint
+import re  # noqa: F401
+import json
+from enum import Enum
+from datetime import date, datetime
+from typing import Any, List, Union, ClassVar, Dict, Optional, TYPE_CHECKING
+from pydantic import Field, StrictStr, ValidationError, field_validator, BaseModel, SecretStr, StrictFloat, StrictInt, StrictBytes, StrictBool
+from decimal import Decimal
+from typing_extensions import Annotated, Literal
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
+class SomeObject(BaseModel):
+    """
+    SomeObject
+    """ # noqa: E501
+    a: Optional[StrictStr] = None
+    __properties: ClassVar[List[str]] = ["a"]
+
+
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True
+    }
+
+    def to_str(self) -> str:
+        """Returns the string representation of the model using alias"""
+        return pprint.pformat(self.model_dump(by_alias=True))
+
+    def to_json(self) -> str:
+        """Returns the JSON representation of the model using alias"""
+        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_json(cls, json_str: str) -> Self:
+        """Create an instance of SomeObject from a JSON string"""
+        return cls.from_dict(json.loads(json_str))
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the dictionary representation of the model using alias.
+
+        This has the following differences from calling pydantic's
+        \`self.model_dump(by_alias=True)\`:
+
+        * \`None\` is only added to the output dict for nullable fields that
+          were set at model initialization. Other fields with value \`None\`
+          are ignored.
+        """
+        _dict = self.model_dump(
+            by_alias=True,
+            exclude={
+            },
+            exclude_none=True,
+        )
+        return _dict
+
+    @classmethod
+    def from_dict(cls, obj: Dict) -> Self:
+        """Create an instance of SomeObject from a dict"""
+
+        if obj is None:
+            return None
+
+        if not isinstance(obj, dict):
+            return cls.model_validate(obj)
+
+        _obj = cls.model_validate({
+            "a": obj.get("a")
+        })
+        return _obj
 
 ",
   "test_project/py.typed": "",

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript.test.ts.snap
@@ -8237,10 +8237,14 @@ src/apis/DefaultApi.ts
 src/apis/index.ts
 src/models/index.ts
 src/models/model-utils.ts
+src/models/AnotherNamedOneOf.ts
+src/models/ArrayOfOneOfs.ts
 src/models/InlineEnum200Response.ts
 src/models/InlineEnum200ResponseCategoryEnum.ts
 src/models/InlineRequestBodyRequestContent.ts
-src/models/MyEnum.ts",
+src/models/MyEnum.ts
+src/models/NamedOneOf.ts
+src/models/NamedOneOfUnion.ts",
   "src/apis/DefaultApi.ts": "/* tslint:disable */
 /* eslint-disable */
 /**
@@ -8256,18 +8260,25 @@ src/models/MyEnum.ts",
 
 import * as runtime from '../runtime';
 import type {
+  ArrayOfOneOfs,
   InlineEnum200Response,
   InlineRequestBodyRequestContent,
   MyEnum,
+  NamedOneOfUnion,
 } from '../models';
 import {
+    ArrayOfOneOfsFromJSON,
+    ArrayOfOneOfsToJSON,
     InlineEnum200ResponseFromJSON,
     InlineEnum200ResponseToJSON,
     InlineRequestBodyRequestContentFromJSON,
     InlineRequestBodyRequestContentToJSON,
     MyEnumFromJSON,
     MyEnumToJSON,
+    NamedOneOfUnionFromJSON,
+    NamedOneOfUnionToJSON,
 } from '../models';
+
 
 export interface ArrayRequestParametersRequest {
     myStringArrayRequestParams?: Array<string>;
@@ -8286,6 +8297,7 @@ export interface InlineRequestBodyRequest {
     inlineRequestBodyRequestContent?: InlineRequestBodyRequestContent;
 }
 
+
 export interface ReservedKeywordsRequest {
     _with?: string;
     _if?: string;
@@ -8296,6 +8308,35 @@ export interface ReservedKeywordsRequest {
  * 
  */
 export class DefaultApi extends runtime.BaseAPI {
+    /**
+     * 
+     */
+    async arrayOfOneOfsRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ArrayOfOneOfs>> {
+        const queryParameters: any = {};
+
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+
+
+        const response = await this.request({
+            path: \`/array-of-one-ofs\`,
+            method: 'POST',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => ArrayOfOneOfsFromJSON(jsonValue));
+    }
+
+    /**
+     * 
+     */
+    async arrayOfOneOfs(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<ArrayOfOneOfs> {
+        const response = await this.arrayOfOneOfsRaw(initOverrides);
+        return await response.value();
+    }
+
     /**
      * 
      */
@@ -8422,6 +8463,35 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * 
      */
+    async namedOneOfRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<NamedOneOfUnion>> {
+        const queryParameters: any = {};
+
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+
+
+        const response = await this.request({
+            path: \`/named-one-of\`,
+            method: 'POST',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => NamedOneOfUnionFromJSON(jsonValue));
+    }
+
+    /**
+     * 
+     */
+    async namedOneOf(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<NamedOneOfUnion> {
+        const response = await this.namedOneOfRaw(initOverrides);
+        return await response.value();
+    }
+
+    /**
+     * 
+     */
     async reservedKeywordsRaw(requestParameters: ReservedKeywordsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
         const queryParameters: any = {};
 
@@ -8464,6 +8534,12 @@ export class DefaultApi extends runtime.BaseAPI {
 ",
   "src/apis/DefaultApi/OperationConfig.ts": "// Import models
 import {
+    AnotherNamedOneOf,
+    AnotherNamedOneOfFromJSON,
+    AnotherNamedOneOfToJSON,
+    ArrayOfOneOfs,
+    ArrayOfOneOfsFromJSON,
+    ArrayOfOneOfsToJSON,
     InlineEnum200Response,
     InlineEnum200ResponseFromJSON,
     InlineEnum200ResponseToJSON,
@@ -8476,6 +8552,12 @@ import {
     MyEnum,
     MyEnumFromJSON,
     MyEnumToJSON,
+    NamedOneOf,
+    NamedOneOfFromJSON,
+    NamedOneOfToJSON,
+    NamedOneOfUnion,
+    NamedOneOfUnionFromJSON,
+    NamedOneOfUnionToJSON,
 } from '../../models';
 // Import request parameter interfaces
 import {
@@ -8489,14 +8571,21 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from "aws-lambda
 
 // Generic type for object keyed by operation names
 export interface OperationConfig<T> {
+    arrayOfOneOfs: T;
     arrayRequestParameters: T;
     inlineEnum: T;
     inlineRequestBody: T;
+    namedOneOf: T;
     reservedKeywords: T;
 }
 
 // Look up path and http method for a given operation name
 export const OperationLookup = {
+    arrayOfOneOfs: {
+        path: '/array-of-one-ofs',
+        method: 'POST',
+        contentTypes: ['application/json'],
+    },
     arrayRequestParameters: {
         path: '/array-request-parameters',
         method: 'GET',
@@ -8509,6 +8598,11 @@ export const OperationLookup = {
     },
     inlineRequestBody: {
         path: '/inline-request-body',
+        method: 'POST',
+        contentTypes: ['application/json'],
+    },
+    namedOneOf: {
+        path: '/named-one-of',
         method: 'POST',
         contentTypes: ['application/json'],
     },
@@ -8633,7 +8727,7 @@ const extractResponseHeadersFromInterceptors = (interceptors: any[]): { [key: st
   }), {} as { [key: string]: string });
 };
 
-export type OperationIds = | 'arrayRequestParameters' | 'inlineEnum' | 'inlineRequestBody' | 'reservedKeywords';
+export type OperationIds = | 'arrayOfOneOfs' | 'arrayRequestParameters' | 'inlineEnum' | 'inlineRequestBody' | 'namedOneOf' | 'reservedKeywords';
 export type OperationApiGatewayProxyResult<T extends OperationIds> = APIGatewayProxyResult & { __operationId?: T };
 
 // Api gateway lambda handler type
@@ -8709,6 +8803,115 @@ const buildHandlerChain = <RequestParameters, RequestBody, Response>(
   };
 };
 
+/**
+ * Path, Query and Header parameters for ArrayOfOneOfs
+ */
+export interface ArrayOfOneOfsRequestParameters {
+}
+
+/**
+ * Request body parameter for ArrayOfOneOfs
+ */
+export type ArrayOfOneOfsRequestBody = never;
+
+export type ArrayOfOneOfs200OperationResponse = OperationResponse<200, ArrayOfOneOfs>;
+
+export type ArrayOfOneOfsOperationResponses = | ArrayOfOneOfs200OperationResponse ;
+
+// Type that the handler function provided to the wrapper must conform to
+export type ArrayOfOneOfsHandlerFunction = LambdaHandlerFunction<ArrayOfOneOfsRequestParameters, ArrayOfOneOfsRequestBody, ArrayOfOneOfsOperationResponses>;
+export type ArrayOfOneOfsChainedHandlerFunction = ChainedLambdaHandlerFunction<ArrayOfOneOfsRequestParameters, ArrayOfOneOfsRequestBody, ArrayOfOneOfsOperationResponses>;
+export type ArrayOfOneOfsChainedRequestInput = ChainedRequestInput<ArrayOfOneOfsRequestParameters, ArrayOfOneOfsRequestBody, ArrayOfOneOfsOperationResponses>;
+
+/**
+ * Lambda handler wrapper to provide typed interface for the implementation of arrayOfOneOfs
+ */
+export const arrayOfOneOfsHandler = (
+    ...handlers: [ArrayOfOneOfsChainedHandlerFunction, ...ArrayOfOneOfsChainedHandlerFunction[]]
+): OperationApiGatewayLambdaHandler<'arrayOfOneOfs'> => async (event: any, context: any, _callback?: any, additionalInterceptors: ArrayOfOneOfsChainedHandlerFunction[] = []): Promise<any> => {
+    const operationId = "arrayOfOneOfs";
+
+    const rawSingleValueParameters = decodeRequestParameters({
+      ...(event.pathParameters || {}),
+      ...(event.queryStringParameters || {}),
+      ...(event.headers || {}),
+    }) as { [key: string]: string | undefined };
+    const rawMultiValueParameters = decodeRequestParameters({
+      ...(event.multiValueQueryStringParameters || {}),
+      ...(event.multiValueHeaders || {}),
+    }) as { [key: string]: string[] | undefined };
+
+    const marshal = (statusCode: number, responseBody: any): string => {
+        let marshalledBody = responseBody;
+        switch(statusCode) {
+            case 200:
+                marshalledBody = JSON.stringify(ArrayOfOneOfsToJSON(marshalledBody));
+                break;
+            default:
+                break;
+        }
+
+        return marshalledBody;
+    };
+
+    const errorHeaders = (statusCode: number): { [key: string]: string } => {
+        let headers = {};
+
+        switch(statusCode) {
+            default:
+                break;
+        }
+
+        return headers;
+    };
+
+    let requestParameters: ArrayOfOneOfsRequestParameters | undefined = undefined;
+
+    try {
+      requestParameters = {
+
+      };
+    } catch (e: any) {
+      const res = {
+        statusCode: 400,
+        body: { message: e.message },
+        headers: extractResponseHeadersFromInterceptors(handlers),
+      };
+      return {
+        ...res,
+        headers: {
+          ...errorHeaders(res.statusCode),
+          ...res.headers,
+        },
+        body: res.body ? marshal(res.statusCode, res.body) : '',
+      };
+    }
+
+    const demarshal = (bodyString: string): any => {
+        return {};
+    };
+    const body = parseBody(event.body, demarshal, ['application/json']) as ArrayOfOneOfsRequestBody;
+
+    const chain = buildHandlerChain(...additionalInterceptors, ...handlers);
+    const response = await chain.next({
+        input: {
+            requestParameters,
+            body,
+        },
+        event,
+        context,
+        interceptorContext: { operationId },
+    });
+
+    return {
+        ...response,
+        headers: {
+          ...errorHeaders(response.statusCode),
+          ...response.headers,
+        },
+        body: response.body ? marshal(response.statusCode, response.body) : '',
+    };
+};
 /**
  * Path, Query and Header parameters for ArrayRequestParameters
  */
@@ -9053,6 +9256,115 @@ export const inlineRequestBodyHandler = (
     };
 };
 /**
+ * Path, Query and Header parameters for NamedOneOf
+ */
+export interface NamedOneOfRequestParameters {
+}
+
+/**
+ * Request body parameter for NamedOneOf
+ */
+export type NamedOneOfRequestBody = never;
+
+export type NamedOneOf200OperationResponse = OperationResponse<200, NamedOneOfUnion>;
+
+export type NamedOneOfOperationResponses = | NamedOneOf200OperationResponse ;
+
+// Type that the handler function provided to the wrapper must conform to
+export type NamedOneOfHandlerFunction = LambdaHandlerFunction<NamedOneOfRequestParameters, NamedOneOfRequestBody, NamedOneOfOperationResponses>;
+export type NamedOneOfChainedHandlerFunction = ChainedLambdaHandlerFunction<NamedOneOfRequestParameters, NamedOneOfRequestBody, NamedOneOfOperationResponses>;
+export type NamedOneOfChainedRequestInput = ChainedRequestInput<NamedOneOfRequestParameters, NamedOneOfRequestBody, NamedOneOfOperationResponses>;
+
+/**
+ * Lambda handler wrapper to provide typed interface for the implementation of namedOneOf
+ */
+export const namedOneOfHandler = (
+    ...handlers: [NamedOneOfChainedHandlerFunction, ...NamedOneOfChainedHandlerFunction[]]
+): OperationApiGatewayLambdaHandler<'namedOneOf'> => async (event: any, context: any, _callback?: any, additionalInterceptors: NamedOneOfChainedHandlerFunction[] = []): Promise<any> => {
+    const operationId = "namedOneOf";
+
+    const rawSingleValueParameters = decodeRequestParameters({
+      ...(event.pathParameters || {}),
+      ...(event.queryStringParameters || {}),
+      ...(event.headers || {}),
+    }) as { [key: string]: string | undefined };
+    const rawMultiValueParameters = decodeRequestParameters({
+      ...(event.multiValueQueryStringParameters || {}),
+      ...(event.multiValueHeaders || {}),
+    }) as { [key: string]: string[] | undefined };
+
+    const marshal = (statusCode: number, responseBody: any): string => {
+        let marshalledBody = responseBody;
+        switch(statusCode) {
+            case 200:
+                marshalledBody = JSON.stringify(NamedOneOfUnionToJSON(marshalledBody));
+                break;
+            default:
+                break;
+        }
+
+        return marshalledBody;
+    };
+
+    const errorHeaders = (statusCode: number): { [key: string]: string } => {
+        let headers = {};
+
+        switch(statusCode) {
+            default:
+                break;
+        }
+
+        return headers;
+    };
+
+    let requestParameters: NamedOneOfRequestParameters | undefined = undefined;
+
+    try {
+      requestParameters = {
+
+      };
+    } catch (e: any) {
+      const res = {
+        statusCode: 400,
+        body: { message: e.message },
+        headers: extractResponseHeadersFromInterceptors(handlers),
+      };
+      return {
+        ...res,
+        headers: {
+          ...errorHeaders(res.statusCode),
+          ...res.headers,
+        },
+        body: res.body ? marshal(res.statusCode, res.body) : '',
+      };
+    }
+
+    const demarshal = (bodyString: string): any => {
+        return {};
+    };
+    const body = parseBody(event.body, demarshal, ['application/json']) as NamedOneOfRequestBody;
+
+    const chain = buildHandlerChain(...additionalInterceptors, ...handlers);
+    const response = await chain.next({
+        input: {
+            requestParameters,
+            body,
+        },
+        event,
+        context,
+        interceptorContext: { operationId },
+    });
+
+    return {
+        ...response,
+        headers: {
+          ...errorHeaders(response.statusCode),
+          ...response.headers,
+        },
+        body: response.body ? marshal(response.statusCode, response.body) : '',
+    };
+};
+/**
  * Path, Query and Header parameters for ReservedKeywords
  */
 export interface ReservedKeywordsRequestParameters {
@@ -9168,15 +9480,17 @@ export const reservedKeywordsHandler = (
 };
 
 export interface HandlerRouterHandlers {
+  readonly arrayOfOneOfs: OperationApiGatewayLambdaHandler<'arrayOfOneOfs'>;
   readonly arrayRequestParameters: OperationApiGatewayLambdaHandler<'arrayRequestParameters'>;
   readonly inlineEnum: OperationApiGatewayLambdaHandler<'inlineEnum'>;
   readonly inlineRequestBody: OperationApiGatewayLambdaHandler<'inlineRequestBody'>;
+  readonly namedOneOf: OperationApiGatewayLambdaHandler<'namedOneOf'>;
   readonly reservedKeywords: OperationApiGatewayLambdaHandler<'reservedKeywords'>;
 }
 
-export type AnyOperationRequestParameters = | ArrayRequestParametersRequestParameters| InlineEnumRequestParameters| InlineRequestBodyRequestParameters| ReservedKeywordsRequestParameters;
-export type AnyOperationRequestBodies = | ArrayRequestParametersRequestBody| InlineEnumRequestBody| InlineRequestBodyRequestBody| ReservedKeywordsRequestBody;
-export type AnyOperationResponses = | ArrayRequestParametersOperationResponses| InlineEnumOperationResponses| InlineRequestBodyOperationResponses| ReservedKeywordsOperationResponses;
+export type AnyOperationRequestParameters = | ArrayOfOneOfsRequestParameters| ArrayRequestParametersRequestParameters| InlineEnumRequestParameters| InlineRequestBodyRequestParameters| NamedOneOfRequestParameters| ReservedKeywordsRequestParameters;
+export type AnyOperationRequestBodies = | ArrayOfOneOfsRequestBody| ArrayRequestParametersRequestBody| InlineEnumRequestBody| InlineRequestBodyRequestBody| NamedOneOfRequestBody| ReservedKeywordsRequestBody;
+export type AnyOperationResponses = | ArrayOfOneOfsOperationResponses| ArrayRequestParametersOperationResponses| InlineEnumOperationResponses| InlineRequestBodyOperationResponses| NamedOneOfOperationResponses| ReservedKeywordsOperationResponses;
 
 export interface HandlerRouterProps<
   RequestParameters,
@@ -9521,6 +9835,143 @@ export const buildTryCatchInterceptor = <TStatus extends number, ErrorResponseBo
  */
 export const tryCatchInterceptor = buildTryCatchInterceptor(500, { message: 'Internal Error' });
 ",
+  "src/models/AnotherNamedOneOf.ts": "/* tslint:disable */
+/* eslint-disable */
+/**
+ * Edge Cases
+ * 
+ *
+ * The version of the OpenAPI document: 1.0.0
+ *
+ *
+ * NOTE: This class is auto generated.
+ * Do not edit the class manually.
+ */
+import { exists, mapValues } from './model-utils';
+
+/**
+ * 
+ * @export
+ * @interface AnotherNamedOneOf
+ */
+export interface AnotherNamedOneOf {
+    /**
+     * 
+     * @type {string}
+     * @memberof AnotherNamedOneOf
+     */
+    bar?: string;
+}
+
+
+/**
+ * Check if a given object implements the AnotherNamedOneOf interface.
+ */
+export function instanceOfAnotherNamedOneOf(value: object): boolean {
+    let isInstance = true;
+    return isInstance;
+}
+
+export function AnotherNamedOneOfFromJSON(json: any): AnotherNamedOneOf {
+    return AnotherNamedOneOfFromJSONTyped(json, false);
+}
+
+export function AnotherNamedOneOfFromJSONTyped(json: any, ignoreDiscriminator: boolean): AnotherNamedOneOf {
+    if ((json === undefined) || (json === null)) {
+        return json;
+    }
+    return {
+
+        'bar': !exists(json, 'bar') ? undefined : json['bar'],
+    };
+}
+
+export function AnotherNamedOneOfToJSON(value?: AnotherNamedOneOf | null): any {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (value === null) {
+        return null;
+    }
+    return {
+
+        'bar': value.bar,
+    };
+}
+
+",
+  "src/models/ArrayOfOneOfs.ts": "/* tslint:disable */
+/* eslint-disable */
+/**
+ * Edge Cases
+ * 
+ *
+ * The version of the OpenAPI document: 1.0.0
+ *
+ *
+ * NOTE: This class is auto generated.
+ * Do not edit the class manually.
+ */
+import { exists, mapValues } from './model-utils';
+import type { NamedOneOfUnion } from './NamedOneOfUnion';
+import {
+    NamedOneOfUnionFromJSON,
+    NamedOneOfUnionFromJSONTyped,
+    NamedOneOfUnionToJSON,
+    instanceOfNamedOneOfUnion,
+} from './NamedOneOfUnion';
+
+/**
+ * 
+ * @export
+ * @interface ArrayOfOneOfs
+ */
+export interface ArrayOfOneOfs {
+    /**
+     * 
+     * @type {Array<NamedOneOfUnion>}
+     * @memberof ArrayOfOneOfs
+     */
+    oneOfs?: Array<NamedOneOfUnion>;
+}
+
+
+/**
+ * Check if a given object implements the ArrayOfOneOfs interface.
+ */
+export function instanceOfArrayOfOneOfs(value: object): boolean {
+    let isInstance = true;
+    return isInstance;
+}
+
+export function ArrayOfOneOfsFromJSON(json: any): ArrayOfOneOfs {
+    return ArrayOfOneOfsFromJSONTyped(json, false);
+}
+
+export function ArrayOfOneOfsFromJSONTyped(json: any, ignoreDiscriminator: boolean): ArrayOfOneOfs {
+    if ((json === undefined) || (json === null)) {
+        return json;
+    }
+    return {
+
+        'oneOfs': !exists(json, 'oneOfs') ? undefined : ((json['oneOfs'] as Array<any>).map(NamedOneOfUnionFromJSON)),
+    };
+}
+
+export function ArrayOfOneOfsToJSON(value?: ArrayOfOneOfs | null): any {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (value === null) {
+        return null;
+    }
+    return {
+
+        'oneOfs': value.oneOfs === undefined ? undefined : ((value.oneOfs as Array<any>).map(NamedOneOfUnionToJSON)),
+    };
+}
+
+",
   "src/models/InlineEnum200Response.ts": "/* tslint:disable */
 /* eslint-disable */
 /**
@@ -9737,12 +10188,152 @@ export function MyEnumToJSON(value?: MyEnum | null): any {
 }
 
 ",
+  "src/models/NamedOneOf.ts": "/* tslint:disable */
+/* eslint-disable */
+/**
+ * Edge Cases
+ * 
+ *
+ * The version of the OpenAPI document: 1.0.0
+ *
+ *
+ * NOTE: This class is auto generated.
+ * Do not edit the class manually.
+ */
+import { exists, mapValues } from './model-utils';
+
+/**
+ * 
+ * @export
+ * @interface NamedOneOf
+ */
+export interface NamedOneOf {
+    /**
+     * 
+     * @type {string}
+     * @memberof NamedOneOf
+     */
+    foo?: string;
+}
+
+
+/**
+ * Check if a given object implements the NamedOneOf interface.
+ */
+export function instanceOfNamedOneOf(value: object): boolean {
+    let isInstance = true;
+    return isInstance;
+}
+
+export function NamedOneOfFromJSON(json: any): NamedOneOf {
+    return NamedOneOfFromJSONTyped(json, false);
+}
+
+export function NamedOneOfFromJSONTyped(json: any, ignoreDiscriminator: boolean): NamedOneOf {
+    if ((json === undefined) || (json === null)) {
+        return json;
+    }
+    return {
+
+        'foo': !exists(json, 'foo') ? undefined : json['foo'],
+    };
+}
+
+export function NamedOneOfToJSON(value?: NamedOneOf | null): any {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (value === null) {
+        return null;
+    }
+    return {
+
+        'foo': value.foo,
+    };
+}
+
+",
+  "src/models/NamedOneOfUnion.ts": "/* tslint:disable */
+/* eslint-disable */
+/**
+ * Edge Cases
+ * 
+ *
+ * The version of the OpenAPI document: 1.0.0
+ *
+ *
+ * NOTE: This class is auto generated.
+ * Do not edit the class manually.
+ */
+import { exists, mapValues } from './model-utils';
+import type { AnotherNamedOneOf } from './AnotherNamedOneOf';
+import {
+    AnotherNamedOneOfFromJSON,
+    AnotherNamedOneOfFromJSONTyped,
+    AnotherNamedOneOfToJSON,
+    instanceOfAnotherNamedOneOf,
+} from './AnotherNamedOneOf';
+import type { NamedOneOf } from './NamedOneOf';
+import {
+    NamedOneOfFromJSON,
+    NamedOneOfFromJSONTyped,
+    NamedOneOfToJSON,
+    instanceOfNamedOneOf,
+} from './NamedOneOf';
+
+/**
+ * @type NamedOneOfUnion
+ * 
+ * @export
+ */
+export type NamedOneOfUnion = NamedOneOf | AnotherNamedOneOf;
+
+
+/**
+ * Check if a given object implements the NamedOneOfUnion interface.
+ */
+export function instanceOfNamedOneOfUnion(value: object): boolean {
+    return instanceOfNamedOneOf(value) || instanceOfAnotherNamedOneOf(value)
+}
+
+export function NamedOneOfUnionFromJSON(json: any): NamedOneOfUnion {
+    return NamedOneOfUnionFromJSONTyped(json, false);
+}
+
+export function NamedOneOfUnionFromJSONTyped(json: any, ignoreDiscriminator: boolean): NamedOneOfUnion {
+    if ((json === undefined) || (json === null)) {
+        return json;
+    }
+    return {
+        ...NamedOneOfFromJSONTyped(json, true),
+        ...AnotherNamedOneOfFromJSONTyped(json, true),
+    };
+}
+
+export function NamedOneOfUnionToJSON(value?: NamedOneOfUnion | null): any {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (value === null) {
+        return null;
+    }
+    return {
+        ...NamedOneOfToJSON(value as any),
+        ...AnotherNamedOneOfToJSON(value as any),
+    };
+}
+
+",
   "src/models/index.ts": "/* tslint:disable */
 /* eslint-disable */
+export * from './AnotherNamedOneOf';
+export * from './ArrayOfOneOfs';
 export * from './InlineEnum200Response';
 export * from './InlineEnum200ResponseCategoryEnum';
 export * from './InlineRequestBodyRequestContent';
 export * from './MyEnum';
+export * from './NamedOneOf';
+export * from './NamedOneOfUnion';
 ",
   "src/models/model-utils.ts": "/* tslint:disable */
 /* eslint-disable */

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript.test.ts.snap
@@ -8237,14 +8237,17 @@ src/apis/DefaultApi.ts
 src/apis/index.ts
 src/models/index.ts
 src/models/model-utils.ts
+src/models/AdditionalPropertiesResponse.ts
 src/models/AnotherNamedOneOf.ts
 src/models/ArrayOfOneOfs.ts
+src/models/Dictionary.ts
 src/models/InlineEnum200Response.ts
 src/models/InlineEnum200ResponseCategoryEnum.ts
 src/models/InlineRequestBodyRequestContent.ts
 src/models/MyEnum.ts
 src/models/NamedOneOf.ts
-src/models/NamedOneOfUnion.ts",
+src/models/NamedOneOfUnion.ts
+src/models/SomeObject.ts",
   "src/apis/DefaultApi.ts": "/* tslint:disable */
 /* eslint-disable */
 /**
@@ -8260,6 +8263,7 @@ src/models/NamedOneOfUnion.ts",
 
 import * as runtime from '../runtime';
 import type {
+  AdditionalPropertiesResponse,
   ArrayOfOneOfs,
   InlineEnum200Response,
   InlineRequestBodyRequestContent,
@@ -8267,6 +8271,8 @@ import type {
   NamedOneOfUnion,
 } from '../models';
 import {
+    AdditionalPropertiesResponseFromJSON,
+    AdditionalPropertiesResponseToJSON,
     ArrayOfOneOfsFromJSON,
     ArrayOfOneOfsToJSON,
     InlineEnum200ResponseFromJSON,
@@ -8291,6 +8297,7 @@ export interface ArrayRequestParametersRequest {
     myDoubleArrayRequestParams?: Array<number>;
     myEnumRequestParam?: MyEnum;
 }
+
 
 
 export interface InlineRequestBodyRequest {
@@ -8399,6 +8406,35 @@ export class DefaultApi extends runtime.BaseAPI {
      */
     async arrayRequestParameters(requestParameters: ArrayRequestParametersRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<void> {
         await this.arrayRequestParametersRaw(requestParameters, initOverrides);
+    }
+
+    /**
+     * 
+     */
+    async dictionaryRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<AdditionalPropertiesResponse>> {
+        const queryParameters: any = {};
+
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+
+
+        const response = await this.request({
+            path: \`/additional-properties\`,
+            method: 'POST',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => AdditionalPropertiesResponseFromJSON(jsonValue));
+    }
+
+    /**
+     * 
+     */
+    async dictionary(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<AdditionalPropertiesResponse> {
+        const response = await this.dictionaryRaw(initOverrides);
+        return await response.value();
     }
 
     /**
@@ -8534,12 +8570,18 @@ export class DefaultApi extends runtime.BaseAPI {
 ",
   "src/apis/DefaultApi/OperationConfig.ts": "// Import models
 import {
+    AdditionalPropertiesResponse,
+    AdditionalPropertiesResponseFromJSON,
+    AdditionalPropertiesResponseToJSON,
     AnotherNamedOneOf,
     AnotherNamedOneOfFromJSON,
     AnotherNamedOneOfToJSON,
     ArrayOfOneOfs,
     ArrayOfOneOfsFromJSON,
     ArrayOfOneOfsToJSON,
+    Dictionary,
+    DictionaryFromJSON,
+    DictionaryToJSON,
     InlineEnum200Response,
     InlineEnum200ResponseFromJSON,
     InlineEnum200ResponseToJSON,
@@ -8558,6 +8600,9 @@ import {
     NamedOneOfUnion,
     NamedOneOfUnionFromJSON,
     NamedOneOfUnionToJSON,
+    SomeObject,
+    SomeObjectFromJSON,
+    SomeObjectToJSON,
 } from '../../models';
 // Import request parameter interfaces
 import {
@@ -8573,6 +8618,7 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from "aws-lambda
 export interface OperationConfig<T> {
     arrayOfOneOfs: T;
     arrayRequestParameters: T;
+    dictionary: T;
     inlineEnum: T;
     inlineRequestBody: T;
     namedOneOf: T;
@@ -8589,6 +8635,11 @@ export const OperationLookup = {
     arrayRequestParameters: {
         path: '/array-request-parameters',
         method: 'GET',
+        contentTypes: ['application/json'],
+    },
+    dictionary: {
+        path: '/additional-properties',
+        method: 'POST',
         contentTypes: ['application/json'],
     },
     inlineEnum: {
@@ -8727,7 +8778,7 @@ const extractResponseHeadersFromInterceptors = (interceptors: any[]): { [key: st
   }), {} as { [key: string]: string });
 };
 
-export type OperationIds = | 'arrayOfOneOfs' | 'arrayRequestParameters' | 'inlineEnum' | 'inlineRequestBody' | 'namedOneOf' | 'reservedKeywords';
+export type OperationIds = | 'arrayOfOneOfs' | 'arrayRequestParameters' | 'dictionary' | 'inlineEnum' | 'inlineRequestBody' | 'namedOneOf' | 'reservedKeywords';
 export type OperationApiGatewayProxyResult<T extends OperationIds> = APIGatewayProxyResult & { __operationId?: T };
 
 // Api gateway lambda handler type
@@ -9017,6 +9068,115 @@ export const arrayRequestParametersHandler = (
         return {};
     };
     const body = parseBody(event.body, demarshal, ['application/json']) as ArrayRequestParametersRequestBody;
+
+    const chain = buildHandlerChain(...additionalInterceptors, ...handlers);
+    const response = await chain.next({
+        input: {
+            requestParameters,
+            body,
+        },
+        event,
+        context,
+        interceptorContext: { operationId },
+    });
+
+    return {
+        ...response,
+        headers: {
+          ...errorHeaders(response.statusCode),
+          ...response.headers,
+        },
+        body: response.body ? marshal(response.statusCode, response.body) : '',
+    };
+};
+/**
+ * Path, Query and Header parameters for Dictionary
+ */
+export interface DictionaryRequestParameters {
+}
+
+/**
+ * Request body parameter for Dictionary
+ */
+export type DictionaryRequestBody = never;
+
+export type Dictionary200OperationResponse = OperationResponse<200, AdditionalPropertiesResponse>;
+
+export type DictionaryOperationResponses = | Dictionary200OperationResponse ;
+
+// Type that the handler function provided to the wrapper must conform to
+export type DictionaryHandlerFunction = LambdaHandlerFunction<DictionaryRequestParameters, DictionaryRequestBody, DictionaryOperationResponses>;
+export type DictionaryChainedHandlerFunction = ChainedLambdaHandlerFunction<DictionaryRequestParameters, DictionaryRequestBody, DictionaryOperationResponses>;
+export type DictionaryChainedRequestInput = ChainedRequestInput<DictionaryRequestParameters, DictionaryRequestBody, DictionaryOperationResponses>;
+
+/**
+ * Lambda handler wrapper to provide typed interface for the implementation of dictionary
+ */
+export const dictionaryHandler = (
+    ...handlers: [DictionaryChainedHandlerFunction, ...DictionaryChainedHandlerFunction[]]
+): OperationApiGatewayLambdaHandler<'dictionary'> => async (event: any, context: any, _callback?: any, additionalInterceptors: DictionaryChainedHandlerFunction[] = []): Promise<any> => {
+    const operationId = "dictionary";
+
+    const rawSingleValueParameters = decodeRequestParameters({
+      ...(event.pathParameters || {}),
+      ...(event.queryStringParameters || {}),
+      ...(event.headers || {}),
+    }) as { [key: string]: string | undefined };
+    const rawMultiValueParameters = decodeRequestParameters({
+      ...(event.multiValueQueryStringParameters || {}),
+      ...(event.multiValueHeaders || {}),
+    }) as { [key: string]: string[] | undefined };
+
+    const marshal = (statusCode: number, responseBody: any): string => {
+        let marshalledBody = responseBody;
+        switch(statusCode) {
+            case 200:
+                marshalledBody = JSON.stringify(AdditionalPropertiesResponseToJSON(marshalledBody));
+                break;
+            default:
+                break;
+        }
+
+        return marshalledBody;
+    };
+
+    const errorHeaders = (statusCode: number): { [key: string]: string } => {
+        let headers = {};
+
+        switch(statusCode) {
+            default:
+                break;
+        }
+
+        return headers;
+    };
+
+    let requestParameters: DictionaryRequestParameters | undefined = undefined;
+
+    try {
+      requestParameters = {
+
+      };
+    } catch (e: any) {
+      const res = {
+        statusCode: 400,
+        body: { message: e.message },
+        headers: extractResponseHeadersFromInterceptors(handlers),
+      };
+      return {
+        ...res,
+        headers: {
+          ...errorHeaders(res.statusCode),
+          ...res.headers,
+        },
+        body: res.body ? marshal(res.statusCode, res.body) : '',
+      };
+    }
+
+    const demarshal = (bodyString: string): any => {
+        return {};
+    };
+    const body = parseBody(event.body, demarshal, ['application/json']) as DictionaryRequestBody;
 
     const chain = buildHandlerChain(...additionalInterceptors, ...handlers);
     const response = await chain.next({
@@ -9482,15 +9642,16 @@ export const reservedKeywordsHandler = (
 export interface HandlerRouterHandlers {
   readonly arrayOfOneOfs: OperationApiGatewayLambdaHandler<'arrayOfOneOfs'>;
   readonly arrayRequestParameters: OperationApiGatewayLambdaHandler<'arrayRequestParameters'>;
+  readonly dictionary: OperationApiGatewayLambdaHandler<'dictionary'>;
   readonly inlineEnum: OperationApiGatewayLambdaHandler<'inlineEnum'>;
   readonly inlineRequestBody: OperationApiGatewayLambdaHandler<'inlineRequestBody'>;
   readonly namedOneOf: OperationApiGatewayLambdaHandler<'namedOneOf'>;
   readonly reservedKeywords: OperationApiGatewayLambdaHandler<'reservedKeywords'>;
 }
 
-export type AnyOperationRequestParameters = | ArrayOfOneOfsRequestParameters| ArrayRequestParametersRequestParameters| InlineEnumRequestParameters| InlineRequestBodyRequestParameters| NamedOneOfRequestParameters| ReservedKeywordsRequestParameters;
-export type AnyOperationRequestBodies = | ArrayOfOneOfsRequestBody| ArrayRequestParametersRequestBody| InlineEnumRequestBody| InlineRequestBodyRequestBody| NamedOneOfRequestBody| ReservedKeywordsRequestBody;
-export type AnyOperationResponses = | ArrayOfOneOfsOperationResponses| ArrayRequestParametersOperationResponses| InlineEnumOperationResponses| InlineRequestBodyOperationResponses| NamedOneOfOperationResponses| ReservedKeywordsOperationResponses;
+export type AnyOperationRequestParameters = | ArrayOfOneOfsRequestParameters| ArrayRequestParametersRequestParameters| DictionaryRequestParameters| InlineEnumRequestParameters| InlineRequestBodyRequestParameters| NamedOneOfRequestParameters| ReservedKeywordsRequestParameters;
+export type AnyOperationRequestBodies = | ArrayOfOneOfsRequestBody| ArrayRequestParametersRequestBody| DictionaryRequestBody| InlineEnumRequestBody| InlineRequestBodyRequestBody| NamedOneOfRequestBody| ReservedKeywordsRequestBody;
+export type AnyOperationResponses = | ArrayOfOneOfsOperationResponses| ArrayRequestParametersOperationResponses| DictionaryOperationResponses| InlineEnumOperationResponses| InlineRequestBodyOperationResponses| NamedOneOfOperationResponses| ReservedKeywordsOperationResponses;
 
 export interface HandlerRouterProps<
   RequestParameters,
@@ -9835,6 +9996,86 @@ export const buildTryCatchInterceptor = <TStatus extends number, ErrorResponseBo
  */
 export const tryCatchInterceptor = buildTryCatchInterceptor(500, { message: 'Internal Error' });
 ",
+  "src/models/AdditionalPropertiesResponse.ts": "/* tslint:disable */
+/* eslint-disable */
+/**
+ * Edge Cases
+ * 
+ *
+ * The version of the OpenAPI document: 1.0.0
+ *
+ *
+ * NOTE: This class is auto generated.
+ * Do not edit the class manually.
+ */
+import { exists, mapValues } from './model-utils';
+import type { Dictionary } from './Dictionary';
+import {
+    DictionaryFromJSON,
+    DictionaryFromJSONTyped,
+    DictionaryToJSON,
+    instanceOfDictionary,
+} from './Dictionary';
+
+/**
+ * 
+ * @export
+ * @interface AdditionalPropertiesResponse
+ */
+export interface AdditionalPropertiesResponse {
+    /**
+     * 
+     * @type {Dictionary}
+     * @memberof AdditionalPropertiesResponse
+     */
+    dictionaryOfObjects?: Dictionary;
+    /**
+     * 
+     * @type {{ [key: string]: string; }}
+     * @memberof AdditionalPropertiesResponse
+     */
+    dictionaryOfPrimitives?: { [key: string]: string; };
+}
+
+
+/**
+ * Check if a given object implements the AdditionalPropertiesResponse interface.
+ */
+export function instanceOfAdditionalPropertiesResponse(value: object): boolean {
+    let isInstance = true;
+    return isInstance;
+}
+
+export function AdditionalPropertiesResponseFromJSON(json: any): AdditionalPropertiesResponse {
+    return AdditionalPropertiesResponseFromJSONTyped(json, false);
+}
+
+export function AdditionalPropertiesResponseFromJSONTyped(json: any, ignoreDiscriminator: boolean): AdditionalPropertiesResponse {
+    if ((json === undefined) || (json === null)) {
+        return json;
+    }
+    return {
+
+        'dictionaryOfObjects': !exists(json, 'dictionaryOfObjects') ? undefined : DictionaryFromJSON(json['dictionaryOfObjects']),
+        'dictionaryOfPrimitives': !exists(json, 'dictionaryOfPrimitives') ? undefined : json['dictionaryOfPrimitives'],
+    };
+}
+
+export function AdditionalPropertiesResponseToJSON(value?: AdditionalPropertiesResponse | null): any {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (value === null) {
+        return null;
+    }
+    return {
+
+        'dictionaryOfObjects': DictionaryToJSON(value.dictionaryOfObjects),
+        'dictionaryOfPrimitives': value.dictionaryOfPrimitives,
+    };
+}
+
+",
   "src/models/AnotherNamedOneOf.ts": "/* tslint:disable */
 /* eslint-disable */
 /**
@@ -9969,6 +10210,58 @@ export function ArrayOfOneOfsToJSON(value?: ArrayOfOneOfs | null): any {
 
         'oneOfs': value.oneOfs === undefined ? undefined : ((value.oneOfs as Array<any>).map(NamedOneOfUnionToJSON)),
     };
+}
+
+",
+  "src/models/Dictionary.ts": "/* tslint:disable */
+/* eslint-disable */
+/**
+ * Edge Cases
+ * 
+ *
+ * The version of the OpenAPI document: 1.0.0
+ *
+ *
+ * NOTE: This class is auto generated.
+ * Do not edit the class manually.
+ */
+import { exists, mapValues } from './model-utils';
+import type { SomeObject } from './SomeObject';
+import {
+    SomeObjectFromJSON,
+    SomeObjectFromJSONTyped,
+    SomeObjectToJSON,
+    instanceOfSomeObject,
+} from './SomeObject';
+
+/**
+ * 
+ * @export
+ * @interface Dictionary
+ */
+export interface Dictionary {
+    [key: string]: Array<SomeObject>;
+}
+
+
+/**
+ * Check if a given object implements the Dictionary interface.
+ */
+export function instanceOfDictionary(value: object): boolean {
+    let isInstance = true;
+    return isInstance;
+}
+
+export function DictionaryFromJSON(json: any): Dictionary {
+    return DictionaryFromJSONTyped(json, false);
+}
+
+export function DictionaryFromJSONTyped(json: any, ignoreDiscriminator: boolean): Dictionary {
+    return json;
+}
+
+export function DictionaryToJSON(value?: Dictionary | null): any {
+    return value;
 }
 
 ",
@@ -10324,16 +10617,84 @@ export function NamedOneOfUnionToJSON(value?: NamedOneOfUnion | null): any {
 }
 
 ",
+  "src/models/SomeObject.ts": "/* tslint:disable */
+/* eslint-disable */
+/**
+ * Edge Cases
+ * 
+ *
+ * The version of the OpenAPI document: 1.0.0
+ *
+ *
+ * NOTE: This class is auto generated.
+ * Do not edit the class manually.
+ */
+import { exists, mapValues } from './model-utils';
+
+/**
+ * 
+ * @export
+ * @interface SomeObject
+ */
+export interface SomeObject {
+    /**
+     * 
+     * @type {string}
+     * @memberof SomeObject
+     */
+    a?: string;
+}
+
+
+/**
+ * Check if a given object implements the SomeObject interface.
+ */
+export function instanceOfSomeObject(value: object): boolean {
+    let isInstance = true;
+    return isInstance;
+}
+
+export function SomeObjectFromJSON(json: any): SomeObject {
+    return SomeObjectFromJSONTyped(json, false);
+}
+
+export function SomeObjectFromJSONTyped(json: any, ignoreDiscriminator: boolean): SomeObject {
+    if ((json === undefined) || (json === null)) {
+        return json;
+    }
+    return {
+
+        'a': !exists(json, 'a') ? undefined : json['a'],
+    };
+}
+
+export function SomeObjectToJSON(value?: SomeObject | null): any {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (value === null) {
+        return null;
+    }
+    return {
+
+        'a': value.a,
+    };
+}
+
+",
   "src/models/index.ts": "/* tslint:disable */
 /* eslint-disable */
+export * from './AdditionalPropertiesResponse';
 export * from './AnotherNamedOneOf';
 export * from './ArrayOfOneOfs';
+export * from './Dictionary';
 export * from './InlineEnum200Response';
 export * from './InlineEnum200ResponseCategoryEnum';
 export * from './InlineRequestBodyRequestContent';
 export * from './MyEnum';
 export * from './NamedOneOf';
 export * from './NamedOneOfUnion';
+export * from './SomeObject';
 ",
   "src/models/model-utils.ts": "/* tslint:disable */
 /* eslint-disable */


### PR DESCRIPTION
Smithy uses the `title` field in OpenAPI to name composite models (all-of, one-of, any-of), which OpenAPI generator also used to produce more readable generated code. This change updates to use the title to name composite models if present for parity with OpenAPI generator.

Additionally, nested composite model properties were typed as `any`. Since we know that we always hoist and generate a type for composite models, we use the model name as the type for these.
