### PR TITLE
fix(type-safe-api): fix template discovery on node 18.17.x

### DIFF
--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/java.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/java.test.ts.snap
@@ -2,7 +2,29 @@
 
 exports[`Java Client Code Generation Script Unit Tests Generates With allof-model.yaml 1`] = `
 {
-  ".tsapi-manifest": "src/main/java/test/test/runtime/api/handlers/Handlers.java
+  ".tsapi-manifest": "src/main/java/test/test/runtime/api/DefaultApi.java
+src/main/java/test/test/runtime/auth/ApiKeyAuth.java
+src/main/java/test/test/runtime/auth/Authentication.java
+src/main/java/test/test/runtime/auth/HttpBasicAuth.java
+src/main/java/test/test/runtime/auth/HttpBearerAuth.java
+src/main/java/test/test/runtime/ApiCallback.java
+src/main/java/test/test/runtime/ApiClient.java
+src/main/java/test/test/runtime/ApiException.java
+src/main/java/test/test/runtime/ApiResponse.java
+src/main/java/test/test/runtime/Configuration.java
+src/main/java/test/test/runtime/GzipRequestInterceptor.java
+src/main/java/test/test/runtime/JSON.java
+src/main/java/test/test/runtime/Pair.java
+src/main/java/test/test/runtime/ProgressRequestBody.java
+src/main/java/test/test/runtime/ProgressResponseBody.java
+src/main/java/test/test/runtime/ServerConfiguration.java
+src/main/java/test/test/runtime/ServerVariable.java
+src/main/java/test/test/runtime/StringUtil.java
+src/main/java/test/test/runtime/model/AbstractOpenApiSchema.java
+src/main/java/test/test/runtime/model/Template.java
+src/main/java/test/test/runtime/model/TemplateBase.java
+src/main/java/test/test/runtime/model/TemplateBody.java
+src/main/java/test/test/runtime/api/handlers/Handlers.java
 src/main/java/test/test/runtime/api/handlers/Response.java
 src/main/java/test/test/runtime/api/handlers/ApiResponse.java
 src/main/java/test/test/runtime/api/handlers/Interceptor.java
@@ -27,29 +49,7 @@ src/main/java/test/test/runtime/api/interceptors/powertools/MetricsInterceptor.j
 src/main/java/test/test/runtime/api/interceptors/DefaultInterceptors.java
 src/main/java/test/test/runtime/api/operation_config/OperationConfig.java
 src/main/java/test/test/runtime/api/operation_config/OperationLookup.java
-src/main/java/test/test/runtime/api/operation_config/Operations.java
-src/main/java/test/test/runtime/api/DefaultApi.java
-src/main/java/test/test/runtime/auth/ApiKeyAuth.java
-src/main/java/test/test/runtime/auth/Authentication.java
-src/main/java/test/test/runtime/auth/HttpBasicAuth.java
-src/main/java/test/test/runtime/auth/HttpBearerAuth.java
-src/main/java/test/test/runtime/ApiCallback.java
-src/main/java/test/test/runtime/ApiClient.java
-src/main/java/test/test/runtime/ApiException.java
-src/main/java/test/test/runtime/ApiResponse.java
-src/main/java/test/test/runtime/Configuration.java
-src/main/java/test/test/runtime/GzipRequestInterceptor.java
-src/main/java/test/test/runtime/JSON.java
-src/main/java/test/test/runtime/Pair.java
-src/main/java/test/test/runtime/ProgressRequestBody.java
-src/main/java/test/test/runtime/ProgressResponseBody.java
-src/main/java/test/test/runtime/ServerConfiguration.java
-src/main/java/test/test/runtime/ServerVariable.java
-src/main/java/test/test/runtime/StringUtil.java
-src/main/java/test/test/runtime/model/AbstractOpenApiSchema.java
-src/main/java/test/test/runtime/model/Template.java
-src/main/java/test/test/runtime/model/TemplateBase.java
-src/main/java/test/test/runtime/model/TemplateBody.java",
+src/main/java/test/test/runtime/api/operation_config/Operations.java",
   "src/main/java/test/test/runtime/ApiCallback.java": "/*
  * My API
  * See https://github.com/aws/aws-pdk/issues/841
@@ -5767,33 +5767,7 @@ public class TemplateBody {
 
 exports[`Java Client Code Generation Script Unit Tests Generates With composite-models.yaml 1`] = `
 {
-  ".tsapi-manifest": "src/main/java/test/test/runtime/api/handlers/Handlers.java
-src/main/java/test/test/runtime/api/handlers/Response.java
-src/main/java/test/test/runtime/api/handlers/ApiResponse.java
-src/main/java/test/test/runtime/api/handlers/Interceptor.java
-src/main/java/test/test/runtime/api/handlers/Interceptors.java
-src/main/java/test/test/runtime/api/handlers/HandlerChain.java
-src/main/java/test/test/runtime/api/handlers/RequestInput.java
-src/main/java/test/test/runtime/api/handlers/ChainedRequestInput.java
-src/main/java/test/test/runtime/api/handlers/InterceptorWarmupChainedRequestInput.java
-src/main/java/test/test/runtime/api/handlers/InterceptorWithWarmup.java
-src/main/java/test/test/runtime/api/handlers/op_get/OpGetResponse.java
-src/main/java/test/test/runtime/api/handlers/op_get/OpGet200Response.java
-src/main/java/test/test/runtime/api/handlers/op_get/OpGetRequestParameters.java
-src/main/java/test/test/runtime/api/handlers/op_get/OpGetInput.java
-src/main/java/test/test/runtime/api/handlers/op_get/OpGetRequestInput.java
-src/main/java/test/test/runtime/api/handlers/op_get/OpGet.java
-src/main/java/test/test/runtime/api/handlers/HandlerRouter.java
-src/main/java/test/test/runtime/api/interceptors/TryCatchInterceptor.java
-src/main/java/test/test/runtime/api/interceptors/ResponseHeadersInterceptor.java
-src/main/java/test/test/runtime/api/interceptors/powertools/LoggingInterceptor.java
-src/main/java/test/test/runtime/api/interceptors/powertools/TracingInterceptor.java
-src/main/java/test/test/runtime/api/interceptors/powertools/MetricsInterceptor.java
-src/main/java/test/test/runtime/api/interceptors/DefaultInterceptors.java
-src/main/java/test/test/runtime/api/operation_config/OperationConfig.java
-src/main/java/test/test/runtime/api/operation_config/OperationLookup.java
-src/main/java/test/test/runtime/api/operation_config/Operations.java
-src/main/java/test/test/runtime/api/DefaultApi.java
+  ".tsapi-manifest": "src/main/java/test/test/runtime/api/DefaultApi.java
 src/main/java/test/test/runtime/auth/ApiKeyAuth.java
 src/main/java/test/test/runtime/auth/Authentication.java
 src/main/java/test/test/runtime/auth/HttpBasicAuth.java
@@ -5832,7 +5806,33 @@ src/main/java/test/test/runtime/model/OneOfRefs.java
 src/main/java/test/test/runtime/model/Wrapper.java
 src/main/java/test/test/runtime/model/WrapperAllOf.java
 src/main/java/test/test/runtime/model/WrapperAnyOf.java
-src/main/java/test/test/runtime/model/WrapperOneOf.java",
+src/main/java/test/test/runtime/model/WrapperOneOf.java
+src/main/java/test/test/runtime/api/handlers/Handlers.java
+src/main/java/test/test/runtime/api/handlers/Response.java
+src/main/java/test/test/runtime/api/handlers/ApiResponse.java
+src/main/java/test/test/runtime/api/handlers/Interceptor.java
+src/main/java/test/test/runtime/api/handlers/Interceptors.java
+src/main/java/test/test/runtime/api/handlers/HandlerChain.java
+src/main/java/test/test/runtime/api/handlers/RequestInput.java
+src/main/java/test/test/runtime/api/handlers/ChainedRequestInput.java
+src/main/java/test/test/runtime/api/handlers/InterceptorWarmupChainedRequestInput.java
+src/main/java/test/test/runtime/api/handlers/InterceptorWithWarmup.java
+src/main/java/test/test/runtime/api/handlers/op_get/OpGetResponse.java
+src/main/java/test/test/runtime/api/handlers/op_get/OpGet200Response.java
+src/main/java/test/test/runtime/api/handlers/op_get/OpGetRequestParameters.java
+src/main/java/test/test/runtime/api/handlers/op_get/OpGetInput.java
+src/main/java/test/test/runtime/api/handlers/op_get/OpGetRequestInput.java
+src/main/java/test/test/runtime/api/handlers/op_get/OpGet.java
+src/main/java/test/test/runtime/api/handlers/HandlerRouter.java
+src/main/java/test/test/runtime/api/interceptors/TryCatchInterceptor.java
+src/main/java/test/test/runtime/api/interceptors/ResponseHeadersInterceptor.java
+src/main/java/test/test/runtime/api/interceptors/powertools/LoggingInterceptor.java
+src/main/java/test/test/runtime/api/interceptors/powertools/TracingInterceptor.java
+src/main/java/test/test/runtime/api/interceptors/powertools/MetricsInterceptor.java
+src/main/java/test/test/runtime/api/interceptors/DefaultInterceptors.java
+src/main/java/test/test/runtime/api/operation_config/OperationConfig.java
+src/main/java/test/test/runtime/api/operation_config/OperationLookup.java
+src/main/java/test/test/runtime/api/operation_config/Operations.java",
   "src/main/java/test/test/runtime/ApiCallback.java": "/*
  * composite models
  * 
@@ -16989,33 +16989,7 @@ public class WrapperOneOf {
 
 exports[`Java Client Code Generation Script Unit Tests Generates With data-types.yaml 1`] = `
 {
-  ".tsapi-manifest": "src/main/java/test/test/runtime/api/handlers/Handlers.java
-src/main/java/test/test/runtime/api/handlers/Response.java
-src/main/java/test/test/runtime/api/handlers/ApiResponse.java
-src/main/java/test/test/runtime/api/handlers/Interceptor.java
-src/main/java/test/test/runtime/api/handlers/Interceptors.java
-src/main/java/test/test/runtime/api/handlers/HandlerChain.java
-src/main/java/test/test/runtime/api/handlers/RequestInput.java
-src/main/java/test/test/runtime/api/handlers/ChainedRequestInput.java
-src/main/java/test/test/runtime/api/handlers/InterceptorWarmupChainedRequestInput.java
-src/main/java/test/test/runtime/api/handlers/InterceptorWithWarmup.java
-src/main/java/test/test/runtime/api/handlers/data_types/DataTypesResponse.java
-src/main/java/test/test/runtime/api/handlers/data_types/DataTypes200Response.java
-src/main/java/test/test/runtime/api/handlers/data_types/DataTypesRequestParameters.java
-src/main/java/test/test/runtime/api/handlers/data_types/DataTypesInput.java
-src/main/java/test/test/runtime/api/handlers/data_types/DataTypesRequestInput.java
-src/main/java/test/test/runtime/api/handlers/data_types/DataTypes.java
-src/main/java/test/test/runtime/api/handlers/HandlerRouter.java
-src/main/java/test/test/runtime/api/interceptors/TryCatchInterceptor.java
-src/main/java/test/test/runtime/api/interceptors/ResponseHeadersInterceptor.java
-src/main/java/test/test/runtime/api/interceptors/powertools/LoggingInterceptor.java
-src/main/java/test/test/runtime/api/interceptors/powertools/TracingInterceptor.java
-src/main/java/test/test/runtime/api/interceptors/powertools/MetricsInterceptor.java
-src/main/java/test/test/runtime/api/interceptors/DefaultInterceptors.java
-src/main/java/test/test/runtime/api/operation_config/OperationConfig.java
-src/main/java/test/test/runtime/api/operation_config/OperationLookup.java
-src/main/java/test/test/runtime/api/operation_config/Operations.java
-src/main/java/test/test/runtime/api/DefaultApi.java
+  ".tsapi-manifest": "src/main/java/test/test/runtime/api/DefaultApi.java
 src/main/java/test/test/runtime/auth/ApiKeyAuth.java
 src/main/java/test/test/runtime/auth/Authentication.java
 src/main/java/test/test/runtime/auth/HttpBasicAuth.java
@@ -17041,7 +17015,33 @@ src/main/java/test/test/runtime/model/DataTypes200ResponseMyNotNot.java
 src/main/java/test/test/runtime/model/DataTypes200ResponseMyObject.java
 src/main/java/test/test/runtime/model/DataTypes200ResponseMyObjectOne.java
 src/main/java/test/test/runtime/model/DataTypes200ResponseMyObjectOneTwo.java
-src/main/java/test/test/runtime/model/DataTypes200ResponseMyOneOf.java",
+src/main/java/test/test/runtime/model/DataTypes200ResponseMyOneOf.java
+src/main/java/test/test/runtime/api/handlers/Handlers.java
+src/main/java/test/test/runtime/api/handlers/Response.java
+src/main/java/test/test/runtime/api/handlers/ApiResponse.java
+src/main/java/test/test/runtime/api/handlers/Interceptor.java
+src/main/java/test/test/runtime/api/handlers/Interceptors.java
+src/main/java/test/test/runtime/api/handlers/HandlerChain.java
+src/main/java/test/test/runtime/api/handlers/RequestInput.java
+src/main/java/test/test/runtime/api/handlers/ChainedRequestInput.java
+src/main/java/test/test/runtime/api/handlers/InterceptorWarmupChainedRequestInput.java
+src/main/java/test/test/runtime/api/handlers/InterceptorWithWarmup.java
+src/main/java/test/test/runtime/api/handlers/data_types/DataTypesResponse.java
+src/main/java/test/test/runtime/api/handlers/data_types/DataTypes200Response.java
+src/main/java/test/test/runtime/api/handlers/data_types/DataTypesRequestParameters.java
+src/main/java/test/test/runtime/api/handlers/data_types/DataTypesInput.java
+src/main/java/test/test/runtime/api/handlers/data_types/DataTypesRequestInput.java
+src/main/java/test/test/runtime/api/handlers/data_types/DataTypes.java
+src/main/java/test/test/runtime/api/handlers/HandlerRouter.java
+src/main/java/test/test/runtime/api/interceptors/TryCatchInterceptor.java
+src/main/java/test/test/runtime/api/interceptors/ResponseHeadersInterceptor.java
+src/main/java/test/test/runtime/api/interceptors/powertools/LoggingInterceptor.java
+src/main/java/test/test/runtime/api/interceptors/powertools/TracingInterceptor.java
+src/main/java/test/test/runtime/api/interceptors/powertools/MetricsInterceptor.java
+src/main/java/test/test/runtime/api/interceptors/DefaultInterceptors.java
+src/main/java/test/test/runtime/api/operation_config/OperationConfig.java
+src/main/java/test/test/runtime/api/operation_config/OperationLookup.java
+src/main/java/test/test/runtime/api/operation_config/Operations.java",
   "src/main/java/test/test/runtime/ApiCallback.java": "/*
  * Data Types
  * 
@@ -24735,7 +24735,28 @@ public class DataTypes200ResponseMyOneOf extends AbstractOpenApiSchema {
 
 exports[`Java Client Code Generation Script Unit Tests Generates With default-response.yaml 1`] = `
 {
-  ".tsapi-manifest": "src/main/java/test/test/runtime/api/handlers/Handlers.java
+  ".tsapi-manifest": "src/main/java/test/test/runtime/api/DefaultApi.java
+src/main/java/test/test/runtime/auth/ApiKeyAuth.java
+src/main/java/test/test/runtime/auth/Authentication.java
+src/main/java/test/test/runtime/auth/HttpBasicAuth.java
+src/main/java/test/test/runtime/auth/HttpBearerAuth.java
+src/main/java/test/test/runtime/ApiCallback.java
+src/main/java/test/test/runtime/ApiClient.java
+src/main/java/test/test/runtime/ApiException.java
+src/main/java/test/test/runtime/ApiResponse.java
+src/main/java/test/test/runtime/Configuration.java
+src/main/java/test/test/runtime/GzipRequestInterceptor.java
+src/main/java/test/test/runtime/JSON.java
+src/main/java/test/test/runtime/Pair.java
+src/main/java/test/test/runtime/ProgressRequestBody.java
+src/main/java/test/test/runtime/ProgressResponseBody.java
+src/main/java/test/test/runtime/ServerConfiguration.java
+src/main/java/test/test/runtime/ServerVariable.java
+src/main/java/test/test/runtime/StringUtil.java
+src/main/java/test/test/runtime/model/AbstractOpenApiSchema.java
+src/main/java/test/test/runtime/model/SayHelloResponseContent.java
+src/main/java/test/test/runtime/model/ServiceUnavailableErrorResponseContent.java
+src/main/java/test/test/runtime/api/handlers/Handlers.java
 src/main/java/test/test/runtime/api/handlers/Response.java
 src/main/java/test/test/runtime/api/handlers/ApiResponse.java
 src/main/java/test/test/runtime/api/handlers/Interceptor.java
@@ -24761,28 +24782,7 @@ src/main/java/test/test/runtime/api/interceptors/powertools/MetricsInterceptor.j
 src/main/java/test/test/runtime/api/interceptors/DefaultInterceptors.java
 src/main/java/test/test/runtime/api/operation_config/OperationConfig.java
 src/main/java/test/test/runtime/api/operation_config/OperationLookup.java
-src/main/java/test/test/runtime/api/operation_config/Operations.java
-src/main/java/test/test/runtime/api/DefaultApi.java
-src/main/java/test/test/runtime/auth/ApiKeyAuth.java
-src/main/java/test/test/runtime/auth/Authentication.java
-src/main/java/test/test/runtime/auth/HttpBasicAuth.java
-src/main/java/test/test/runtime/auth/HttpBearerAuth.java
-src/main/java/test/test/runtime/ApiCallback.java
-src/main/java/test/test/runtime/ApiClient.java
-src/main/java/test/test/runtime/ApiException.java
-src/main/java/test/test/runtime/ApiResponse.java
-src/main/java/test/test/runtime/Configuration.java
-src/main/java/test/test/runtime/GzipRequestInterceptor.java
-src/main/java/test/test/runtime/JSON.java
-src/main/java/test/test/runtime/Pair.java
-src/main/java/test/test/runtime/ProgressRequestBody.java
-src/main/java/test/test/runtime/ProgressResponseBody.java
-src/main/java/test/test/runtime/ServerConfiguration.java
-src/main/java/test/test/runtime/ServerVariable.java
-src/main/java/test/test/runtime/StringUtil.java
-src/main/java/test/test/runtime/model/AbstractOpenApiSchema.java
-src/main/java/test/test/runtime/model/SayHelloResponseContent.java
-src/main/java/test/test/runtime/model/ServiceUnavailableErrorResponseContent.java",
+src/main/java/test/test/runtime/api/operation_config/Operations.java",
   "src/main/java/test/test/runtime/ApiCallback.java": "/*
  * My API
  * See https://github.com/aws/aws-pdk/issues/841
@@ -30323,7 +30323,37 @@ public class ServiceUnavailableErrorResponseContent {
 
 exports[`Java Client Code Generation Script Unit Tests Generates With edge-cases.yaml 1`] = `
 {
-  ".tsapi-manifest": "src/main/java/test/test/runtime/api/handlers/Handlers.java
+  ".tsapi-manifest": "src/main/java/test/test/runtime/api/DefaultApi.java
+src/main/java/test/test/runtime/auth/ApiKeyAuth.java
+src/main/java/test/test/runtime/auth/Authentication.java
+src/main/java/test/test/runtime/auth/HttpBasicAuth.java
+src/main/java/test/test/runtime/auth/HttpBearerAuth.java
+src/main/java/test/test/runtime/ApiCallback.java
+src/main/java/test/test/runtime/ApiClient.java
+src/main/java/test/test/runtime/ApiException.java
+src/main/java/test/test/runtime/ApiResponse.java
+src/main/java/test/test/runtime/Configuration.java
+src/main/java/test/test/runtime/GzipRequestInterceptor.java
+src/main/java/test/test/runtime/JSON.java
+src/main/java/test/test/runtime/Pair.java
+src/main/java/test/test/runtime/ProgressRequestBody.java
+src/main/java/test/test/runtime/ProgressResponseBody.java
+src/main/java/test/test/runtime/ServerConfiguration.java
+src/main/java/test/test/runtime/ServerVariable.java
+src/main/java/test/test/runtime/StringUtil.java
+src/main/java/test/test/runtime/model/AbstractOpenApiSchema.java
+src/main/java/test/test/runtime/model/AdditionalPropertiesResponse.java
+src/main/java/test/test/runtime/model/AnotherNamedOneOf.java
+src/main/java/test/test/runtime/model/ArrayOfOneOfs.java
+src/main/java/test/test/runtime/model/Dictionary.java
+src/main/java/test/test/runtime/model/InlineEnum200Response.java
+src/main/java/test/test/runtime/model/InlineEnum200ResponseCategoryEnum.java
+src/main/java/test/test/runtime/model/InlineRequestBodyRequestContent.java
+src/main/java/test/test/runtime/model/MyEnum.java
+src/main/java/test/test/runtime/model/NamedOneOf.java
+src/main/java/test/test/runtime/model/NamedOneOfUnion.java
+src/main/java/test/test/runtime/model/SomeObject.java
+src/main/java/test/test/runtime/api/handlers/Handlers.java
 src/main/java/test/test/runtime/api/handlers/Response.java
 src/main/java/test/test/runtime/api/handlers/ApiResponse.java
 src/main/java/test/test/runtime/api/handlers/Interceptor.java
@@ -30384,37 +30414,7 @@ src/main/java/test/test/runtime/api/interceptors/powertools/MetricsInterceptor.j
 src/main/java/test/test/runtime/api/interceptors/DefaultInterceptors.java
 src/main/java/test/test/runtime/api/operation_config/OperationConfig.java
 src/main/java/test/test/runtime/api/operation_config/OperationLookup.java
-src/main/java/test/test/runtime/api/operation_config/Operations.java
-src/main/java/test/test/runtime/api/DefaultApi.java
-src/main/java/test/test/runtime/auth/ApiKeyAuth.java
-src/main/java/test/test/runtime/auth/Authentication.java
-src/main/java/test/test/runtime/auth/HttpBasicAuth.java
-src/main/java/test/test/runtime/auth/HttpBearerAuth.java
-src/main/java/test/test/runtime/ApiCallback.java
-src/main/java/test/test/runtime/ApiClient.java
-src/main/java/test/test/runtime/ApiException.java
-src/main/java/test/test/runtime/ApiResponse.java
-src/main/java/test/test/runtime/Configuration.java
-src/main/java/test/test/runtime/GzipRequestInterceptor.java
-src/main/java/test/test/runtime/JSON.java
-src/main/java/test/test/runtime/Pair.java
-src/main/java/test/test/runtime/ProgressRequestBody.java
-src/main/java/test/test/runtime/ProgressResponseBody.java
-src/main/java/test/test/runtime/ServerConfiguration.java
-src/main/java/test/test/runtime/ServerVariable.java
-src/main/java/test/test/runtime/StringUtil.java
-src/main/java/test/test/runtime/model/AbstractOpenApiSchema.java
-src/main/java/test/test/runtime/model/AdditionalPropertiesResponse.java
-src/main/java/test/test/runtime/model/AnotherNamedOneOf.java
-src/main/java/test/test/runtime/model/ArrayOfOneOfs.java
-src/main/java/test/test/runtime/model/Dictionary.java
-src/main/java/test/test/runtime/model/InlineEnum200Response.java
-src/main/java/test/test/runtime/model/InlineEnum200ResponseCategoryEnum.java
-src/main/java/test/test/runtime/model/InlineRequestBodyRequestContent.java
-src/main/java/test/test/runtime/model/MyEnum.java
-src/main/java/test/test/runtime/model/NamedOneOf.java
-src/main/java/test/test/runtime/model/NamedOneOfUnion.java
-src/main/java/test/test/runtime/model/SomeObject.java",
+src/main/java/test/test/runtime/api/operation_config/Operations.java",
   "src/main/java/test/test/runtime/ApiCallback.java": "/*
  * Edge Cases
  * 
@@ -41401,7 +41401,28 @@ public class SomeObject {
 
 exports[`Java Client Code Generation Script Unit Tests Generates With multiple-tags.yaml 1`] = `
 {
-  ".tsapi-manifest": "src/main/java/test/test/runtime/api/handlers/Handlers.java
+  ".tsapi-manifest": "src/main/java/test/test/runtime/api/DefaultApi.java
+src/main/java/test/test/runtime/api/Tag1Api.java
+src/main/java/test/test/runtime/api/Tag2Api.java
+src/main/java/test/test/runtime/auth/ApiKeyAuth.java
+src/main/java/test/test/runtime/auth/Authentication.java
+src/main/java/test/test/runtime/auth/HttpBasicAuth.java
+src/main/java/test/test/runtime/auth/HttpBearerAuth.java
+src/main/java/test/test/runtime/ApiCallback.java
+src/main/java/test/test/runtime/ApiClient.java
+src/main/java/test/test/runtime/ApiException.java
+src/main/java/test/test/runtime/ApiResponse.java
+src/main/java/test/test/runtime/Configuration.java
+src/main/java/test/test/runtime/GzipRequestInterceptor.java
+src/main/java/test/test/runtime/JSON.java
+src/main/java/test/test/runtime/Pair.java
+src/main/java/test/test/runtime/ProgressRequestBody.java
+src/main/java/test/test/runtime/ProgressResponseBody.java
+src/main/java/test/test/runtime/ServerConfiguration.java
+src/main/java/test/test/runtime/ServerVariable.java
+src/main/java/test/test/runtime/StringUtil.java
+src/main/java/test/test/runtime/model/AbstractOpenApiSchema.java
+src/main/java/test/test/runtime/api/handlers/Handlers.java
 src/main/java/test/test/runtime/api/handlers/Response.java
 src/main/java/test/test/runtime/api/handlers/ApiResponse.java
 src/main/java/test/test/runtime/api/handlers/Interceptor.java
@@ -41444,28 +41465,7 @@ src/main/java/test/test/runtime/api/interceptors/powertools/MetricsInterceptor.j
 src/main/java/test/test/runtime/api/interceptors/DefaultInterceptors.java
 src/main/java/test/test/runtime/api/operation_config/OperationConfig.java
 src/main/java/test/test/runtime/api/operation_config/OperationLookup.java
-src/main/java/test/test/runtime/api/operation_config/Operations.java
-src/main/java/test/test/runtime/api/DefaultApi.java
-src/main/java/test/test/runtime/api/Tag1Api.java
-src/main/java/test/test/runtime/api/Tag2Api.java
-src/main/java/test/test/runtime/auth/ApiKeyAuth.java
-src/main/java/test/test/runtime/auth/Authentication.java
-src/main/java/test/test/runtime/auth/HttpBasicAuth.java
-src/main/java/test/test/runtime/auth/HttpBearerAuth.java
-src/main/java/test/test/runtime/ApiCallback.java
-src/main/java/test/test/runtime/ApiClient.java
-src/main/java/test/test/runtime/ApiException.java
-src/main/java/test/test/runtime/ApiResponse.java
-src/main/java/test/test/runtime/Configuration.java
-src/main/java/test/test/runtime/GzipRequestInterceptor.java
-src/main/java/test/test/runtime/JSON.java
-src/main/java/test/test/runtime/Pair.java
-src/main/java/test/test/runtime/ProgressRequestBody.java
-src/main/java/test/test/runtime/ProgressResponseBody.java
-src/main/java/test/test/runtime/ServerConfiguration.java
-src/main/java/test/test/runtime/ServerVariable.java
-src/main/java/test/test/runtime/StringUtil.java
-src/main/java/test/test/runtime/model/AbstractOpenApiSchema.java",
+src/main/java/test/test/runtime/api/operation_config/Operations.java",
   "src/main/java/test/test/runtime/ApiCallback.java": "/*
  * Multiple Tags Test
  * 
@@ -48248,7 +48248,27 @@ public abstract class AbstractOpenApiSchema {
 
 exports[`Java Client Code Generation Script Unit Tests Generates With parameter-refs.yaml 1`] = `
 {
-  ".tsapi-manifest": "src/main/java/test/test/runtime/api/handlers/Handlers.java
+  ".tsapi-manifest": "src/main/java/test/test/runtime/api/DefaultApi.java
+src/main/java/test/test/runtime/auth/ApiKeyAuth.java
+src/main/java/test/test/runtime/auth/Authentication.java
+src/main/java/test/test/runtime/auth/HttpBasicAuth.java
+src/main/java/test/test/runtime/auth/HttpBearerAuth.java
+src/main/java/test/test/runtime/ApiCallback.java
+src/main/java/test/test/runtime/ApiClient.java
+src/main/java/test/test/runtime/ApiException.java
+src/main/java/test/test/runtime/ApiResponse.java
+src/main/java/test/test/runtime/Configuration.java
+src/main/java/test/test/runtime/GzipRequestInterceptor.java
+src/main/java/test/test/runtime/JSON.java
+src/main/java/test/test/runtime/Pair.java
+src/main/java/test/test/runtime/ProgressRequestBody.java
+src/main/java/test/test/runtime/ProgressResponseBody.java
+src/main/java/test/test/runtime/ServerConfiguration.java
+src/main/java/test/test/runtime/ServerVariable.java
+src/main/java/test/test/runtime/StringUtil.java
+src/main/java/test/test/runtime/model/AbstractOpenApiSchema.java
+src/main/java/test/test/runtime/model/HelloResponse.java
+src/main/java/test/test/runtime/api/handlers/Handlers.java
 src/main/java/test/test/runtime/api/handlers/Response.java
 src/main/java/test/test/runtime/api/handlers/ApiResponse.java
 src/main/java/test/test/runtime/api/handlers/Interceptor.java
@@ -48273,27 +48293,7 @@ src/main/java/test/test/runtime/api/interceptors/powertools/MetricsInterceptor.j
 src/main/java/test/test/runtime/api/interceptors/DefaultInterceptors.java
 src/main/java/test/test/runtime/api/operation_config/OperationConfig.java
 src/main/java/test/test/runtime/api/operation_config/OperationLookup.java
-src/main/java/test/test/runtime/api/operation_config/Operations.java
-src/main/java/test/test/runtime/api/DefaultApi.java
-src/main/java/test/test/runtime/auth/ApiKeyAuth.java
-src/main/java/test/test/runtime/auth/Authentication.java
-src/main/java/test/test/runtime/auth/HttpBasicAuth.java
-src/main/java/test/test/runtime/auth/HttpBearerAuth.java
-src/main/java/test/test/runtime/ApiCallback.java
-src/main/java/test/test/runtime/ApiClient.java
-src/main/java/test/test/runtime/ApiException.java
-src/main/java/test/test/runtime/ApiResponse.java
-src/main/java/test/test/runtime/Configuration.java
-src/main/java/test/test/runtime/GzipRequestInterceptor.java
-src/main/java/test/test/runtime/JSON.java
-src/main/java/test/test/runtime/Pair.java
-src/main/java/test/test/runtime/ProgressRequestBody.java
-src/main/java/test/test/runtime/ProgressResponseBody.java
-src/main/java/test/test/runtime/ServerConfiguration.java
-src/main/java/test/test/runtime/ServerVariable.java
-src/main/java/test/test/runtime/StringUtil.java
-src/main/java/test/test/runtime/model/AbstractOpenApiSchema.java
-src/main/java/test/test/runtime/model/HelloResponse.java",
+src/main/java/test/test/runtime/api/operation_config/Operations.java",
   "src/main/java/test/test/runtime/ApiCallback.java": "/*
  * Example API
  * 
@@ -53516,7 +53516,27 @@ public class HelloResponse {
 
 exports[`Java Client Code Generation Script Unit Tests Generates With recursive.yaml 1`] = `
 {
-  ".tsapi-manifest": "src/main/java/test/test/runtime/api/handlers/Handlers.java
+  ".tsapi-manifest": "src/main/java/test/test/runtime/api/DefaultApi.java
+src/main/java/test/test/runtime/auth/ApiKeyAuth.java
+src/main/java/test/test/runtime/auth/Authentication.java
+src/main/java/test/test/runtime/auth/HttpBasicAuth.java
+src/main/java/test/test/runtime/auth/HttpBearerAuth.java
+src/main/java/test/test/runtime/ApiCallback.java
+src/main/java/test/test/runtime/ApiClient.java
+src/main/java/test/test/runtime/ApiException.java
+src/main/java/test/test/runtime/ApiResponse.java
+src/main/java/test/test/runtime/Configuration.java
+src/main/java/test/test/runtime/GzipRequestInterceptor.java
+src/main/java/test/test/runtime/JSON.java
+src/main/java/test/test/runtime/Pair.java
+src/main/java/test/test/runtime/ProgressRequestBody.java
+src/main/java/test/test/runtime/ProgressResponseBody.java
+src/main/java/test/test/runtime/ServerConfiguration.java
+src/main/java/test/test/runtime/ServerVariable.java
+src/main/java/test/test/runtime/StringUtil.java
+src/main/java/test/test/runtime/model/AbstractOpenApiSchema.java
+src/main/java/test/test/runtime/model/TreeNode.java
+src/main/java/test/test/runtime/api/handlers/Handlers.java
 src/main/java/test/test/runtime/api/handlers/Response.java
 src/main/java/test/test/runtime/api/handlers/ApiResponse.java
 src/main/java/test/test/runtime/api/handlers/Interceptor.java
@@ -53541,27 +53561,7 @@ src/main/java/test/test/runtime/api/interceptors/powertools/MetricsInterceptor.j
 src/main/java/test/test/runtime/api/interceptors/DefaultInterceptors.java
 src/main/java/test/test/runtime/api/operation_config/OperationConfig.java
 src/main/java/test/test/runtime/api/operation_config/OperationLookup.java
-src/main/java/test/test/runtime/api/operation_config/Operations.java
-src/main/java/test/test/runtime/api/DefaultApi.java
-src/main/java/test/test/runtime/auth/ApiKeyAuth.java
-src/main/java/test/test/runtime/auth/Authentication.java
-src/main/java/test/test/runtime/auth/HttpBasicAuth.java
-src/main/java/test/test/runtime/auth/HttpBearerAuth.java
-src/main/java/test/test/runtime/ApiCallback.java
-src/main/java/test/test/runtime/ApiClient.java
-src/main/java/test/test/runtime/ApiException.java
-src/main/java/test/test/runtime/ApiResponse.java
-src/main/java/test/test/runtime/Configuration.java
-src/main/java/test/test/runtime/GzipRequestInterceptor.java
-src/main/java/test/test/runtime/JSON.java
-src/main/java/test/test/runtime/Pair.java
-src/main/java/test/test/runtime/ProgressRequestBody.java
-src/main/java/test/test/runtime/ProgressResponseBody.java
-src/main/java/test/test/runtime/ServerConfiguration.java
-src/main/java/test/test/runtime/ServerVariable.java
-src/main/java/test/test/runtime/StringUtil.java
-src/main/java/test/test/runtime/model/AbstractOpenApiSchema.java
-src/main/java/test/test/runtime/model/TreeNode.java",
+src/main/java/test/test/runtime/api/operation_config/Operations.java",
   "src/main/java/test/test/runtime/ApiCallback.java": "/*
  * Recursive schema
  * 
@@ -58757,7 +58757,32 @@ public class TreeNode {
 
 exports[`Java Client Code Generation Script Unit Tests Generates With single.yaml 1`] = `
 {
-  ".tsapi-manifest": "src/main/java/test/test/runtime/api/handlers/Handlers.java
+  ".tsapi-manifest": "src/main/java/test/test/runtime/api/DefaultApi.java
+src/main/java/test/test/runtime/auth/ApiKeyAuth.java
+src/main/java/test/test/runtime/auth/Authentication.java
+src/main/java/test/test/runtime/auth/HttpBasicAuth.java
+src/main/java/test/test/runtime/auth/HttpBearerAuth.java
+src/main/java/test/test/runtime/ApiCallback.java
+src/main/java/test/test/runtime/ApiClient.java
+src/main/java/test/test/runtime/ApiException.java
+src/main/java/test/test/runtime/ApiResponse.java
+src/main/java/test/test/runtime/Configuration.java
+src/main/java/test/test/runtime/GzipRequestInterceptor.java
+src/main/java/test/test/runtime/JSON.java
+src/main/java/test/test/runtime/Pair.java
+src/main/java/test/test/runtime/ProgressRequestBody.java
+src/main/java/test/test/runtime/ProgressResponseBody.java
+src/main/java/test/test/runtime/ServerConfiguration.java
+src/main/java/test/test/runtime/ServerVariable.java
+src/main/java/test/test/runtime/StringUtil.java
+src/main/java/test/test/runtime/model/AbstractOpenApiSchema.java
+src/main/java/test/test/runtime/model/ApiError.java
+src/main/java/test/test/runtime/model/MapResponse.java
+src/main/java/test/test/runtime/model/MapResponseMapPropertyValue.java
+src/main/java/test/test/runtime/model/TestRequest.java
+src/main/java/test/test/runtime/model/TestResponse.java
+src/main/java/test/test/runtime/model/TestResponseMessagesInner.java
+src/main/java/test/test/runtime/api/handlers/Handlers.java
 src/main/java/test/test/runtime/api/handlers/Response.java
 src/main/java/test/test/runtime/api/handlers/ApiResponse.java
 src/main/java/test/test/runtime/api/handlers/Interceptor.java
@@ -58819,32 +58844,7 @@ src/main/java/test/test/runtime/api/interceptors/powertools/MetricsInterceptor.j
 src/main/java/test/test/runtime/api/interceptors/DefaultInterceptors.java
 src/main/java/test/test/runtime/api/operation_config/OperationConfig.java
 src/main/java/test/test/runtime/api/operation_config/OperationLookup.java
-src/main/java/test/test/runtime/api/operation_config/Operations.java
-src/main/java/test/test/runtime/api/DefaultApi.java
-src/main/java/test/test/runtime/auth/ApiKeyAuth.java
-src/main/java/test/test/runtime/auth/Authentication.java
-src/main/java/test/test/runtime/auth/HttpBasicAuth.java
-src/main/java/test/test/runtime/auth/HttpBearerAuth.java
-src/main/java/test/test/runtime/ApiCallback.java
-src/main/java/test/test/runtime/ApiClient.java
-src/main/java/test/test/runtime/ApiException.java
-src/main/java/test/test/runtime/ApiResponse.java
-src/main/java/test/test/runtime/Configuration.java
-src/main/java/test/test/runtime/GzipRequestInterceptor.java
-src/main/java/test/test/runtime/JSON.java
-src/main/java/test/test/runtime/Pair.java
-src/main/java/test/test/runtime/ProgressRequestBody.java
-src/main/java/test/test/runtime/ProgressResponseBody.java
-src/main/java/test/test/runtime/ServerConfiguration.java
-src/main/java/test/test/runtime/ServerVariable.java
-src/main/java/test/test/runtime/StringUtil.java
-src/main/java/test/test/runtime/model/AbstractOpenApiSchema.java
-src/main/java/test/test/runtime/model/ApiError.java
-src/main/java/test/test/runtime/model/MapResponse.java
-src/main/java/test/test/runtime/model/MapResponseMapPropertyValue.java
-src/main/java/test/test/runtime/model/TestRequest.java
-src/main/java/test/test/runtime/model/TestResponse.java
-src/main/java/test/test/runtime/model/TestResponseMessagesInner.java",
+src/main/java/test/test/runtime/api/operation_config/Operations.java",
   "src/main/java/test/test/runtime/ApiCallback.java": "/*
  * Example API
  * 

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
@@ -354,9 +354,15 @@ README.md
   },
   ".tsapi-manifest": "test_project/api_client.py
 test_project/api_response.py
+test_project/api/default_api.py
+test_project/api/__init__.py
 test_project/configuration.py
 test_project/exceptions.py
 test_project/__init__.py
+test_project/models/__init__.py
+test_project/models/template.py
+test_project/models/template_base.py
+test_project/models/template_body.py
 test_project/py.typed
 test_project/rest.py
 docs/DefaultApi.md
@@ -371,13 +377,7 @@ test_project/interceptors/powertools/tracer.py
 test_project/interceptors/powertools/metrics.py
 test_project/interceptors/__init__.py
 test_project/api/operation_config.py
-test_project/response.py
-test_project/api/default_api.py
-test_project/api/__init__.py
-test_project/models/__init__.py
-test_project/models/template.py
-test_project/models/template_base.py
-test_project/models/template_body.py",
+test_project/response.py",
   "README.md": "# My API
 See https://github.com/aws/aws-pdk/issues/841
 
@@ -3728,9 +3728,33 @@ README.md
   },
   ".tsapi-manifest": "test_project/api_client.py
 test_project/api_response.py
+test_project/api/default_api.py
+test_project/api/__init__.py
 test_project/configuration.py
 test_project/exceptions.py
 test_project/__init__.py
+test_project/models/__init__.py
+test_project/models/a.py
+test_project/models/all_of_inline_and_refs.py
+test_project/models/all_of_refs.py
+test_project/models/any_of_inline_and_refs.py
+test_project/models/any_of_inline_and_refs_any_of.py
+test_project/models/any_of_inline_and_refs_any_of1.py
+test_project/models/any_of_primitives.py
+test_project/models/any_of_primitives_and_refs.py
+test_project/models/any_of_refs.py
+test_project/models/b.py
+test_project/models/c.py
+test_project/models/one_of_inline_and_refs.py
+test_project/models/one_of_inline_and_refs_one_of.py
+test_project/models/one_of_inline_and_refs_one_of1.py
+test_project/models/one_of_primitives.py
+test_project/models/one_of_primitives_and_refs.py
+test_project/models/one_of_refs.py
+test_project/models/wrapper.py
+test_project/models/wrapper_all_of.py
+test_project/models/wrapper_any_of.py
+test_project/models/wrapper_one_of.py
 test_project/py.typed
 test_project/rest.py
 docs/DefaultApi.md
@@ -3763,31 +3787,7 @@ test_project/interceptors/powertools/tracer.py
 test_project/interceptors/powertools/metrics.py
 test_project/interceptors/__init__.py
 test_project/api/operation_config.py
-test_project/response.py
-test_project/api/default_api.py
-test_project/api/__init__.py
-test_project/models/__init__.py
-test_project/models/a.py
-test_project/models/all_of_inline_and_refs.py
-test_project/models/all_of_refs.py
-test_project/models/any_of_inline_and_refs.py
-test_project/models/any_of_inline_and_refs_any_of.py
-test_project/models/any_of_inline_and_refs_any_of1.py
-test_project/models/any_of_primitives.py
-test_project/models/any_of_primitives_and_refs.py
-test_project/models/any_of_refs.py
-test_project/models/b.py
-test_project/models/c.py
-test_project/models/one_of_inline_and_refs.py
-test_project/models/one_of_inline_and_refs_one_of.py
-test_project/models/one_of_inline_and_refs_one_of1.py
-test_project/models/one_of_primitives.py
-test_project/models/one_of_primitives_and_refs.py
-test_project/models/one_of_refs.py
-test_project/models/wrapper.py
-test_project/models/wrapper_all_of.py
-test_project/models/wrapper_any_of.py
-test_project/models/wrapper_one_of.py",
+test_project/response.py",
   "README.md": "# composite models
 
 
@@ -9943,9 +9943,20 @@ README.md
   },
   ".tsapi-manifest": "test_project/api_client.py
 test_project/api_response.py
+test_project/api/default_api.py
+test_project/api/__init__.py
 test_project/configuration.py
 test_project/exceptions.py
 test_project/__init__.py
+test_project/models/__init__.py
+test_project/models/data_types200_response.py
+test_project/models/data_types200_response_my_all_of.py
+test_project/models/data_types200_response_my_any_of.py
+test_project/models/data_types200_response_my_not_not.py
+test_project/models/data_types200_response_my_object.py
+test_project/models/data_types200_response_my_object_one.py
+test_project/models/data_types200_response_my_object_one_two.py
+test_project/models/data_types200_response_my_one_of.py
 test_project/py.typed
 test_project/rest.py
 docs/DefaultApi.md
@@ -9965,18 +9976,7 @@ test_project/interceptors/powertools/tracer.py
 test_project/interceptors/powertools/metrics.py
 test_project/interceptors/__init__.py
 test_project/api/operation_config.py
-test_project/response.py
-test_project/api/default_api.py
-test_project/api/__init__.py
-test_project/models/__init__.py
-test_project/models/data_types200_response.py
-test_project/models/data_types200_response_my_all_of.py
-test_project/models/data_types200_response_my_any_of.py
-test_project/models/data_types200_response_my_not_not.py
-test_project/models/data_types200_response_my_object.py
-test_project/models/data_types200_response_my_object_one.py
-test_project/models/data_types200_response_my_object_one_two.py
-test_project/models/data_types200_response_my_one_of.py",
+test_project/response.py",
   "README.md": "# Data Types
 
 
@@ -14153,9 +14153,14 @@ README.md
   },
   ".tsapi-manifest": "test_project/api_client.py
 test_project/api_response.py
+test_project/api/default_api.py
+test_project/api/__init__.py
 test_project/configuration.py
 test_project/exceptions.py
 test_project/__init__.py
+test_project/models/__init__.py
+test_project/models/say_hello_response_content.py
+test_project/models/service_unavailable_error_response_content.py
 test_project/py.typed
 test_project/rest.py
 docs/DefaultApi.md
@@ -14169,12 +14174,7 @@ test_project/interceptors/powertools/tracer.py
 test_project/interceptors/powertools/metrics.py
 test_project/interceptors/__init__.py
 test_project/api/operation_config.py
-test_project/response.py
-test_project/api/default_api.py
-test_project/api/__init__.py
-test_project/models/__init__.py
-test_project/models/say_hello_response_content.py
-test_project/models/service_unavailable_error_response_content.py",
+test_project/response.py",
   "README.md": "# My API
 See https://github.com/aws/aws-pdk/issues/841
 
@@ -17422,9 +17422,23 @@ README.md
   },
   ".tsapi-manifest": "test_project/api_client.py
 test_project/api_response.py
+test_project/api/default_api.py
+test_project/api/__init__.py
 test_project/configuration.py
 test_project/exceptions.py
 test_project/__init__.py
+test_project/models/__init__.py
+test_project/models/additional_properties_response.py
+test_project/models/another_named_one_of.py
+test_project/models/array_of_one_ofs.py
+test_project/models/dictionary.py
+test_project/models/inline_enum200_response.py
+test_project/models/inline_enum200_response_category_enum.py
+test_project/models/inline_request_body_request_content.py
+test_project/models/my_enum.py
+test_project/models/named_one_of.py
+test_project/models/named_one_of_union.py
+test_project/models/some_object.py
 test_project/py.typed
 test_project/rest.py
 docs/DefaultApi.md
@@ -17447,21 +17461,7 @@ test_project/interceptors/powertools/tracer.py
 test_project/interceptors/powertools/metrics.py
 test_project/interceptors/__init__.py
 test_project/api/operation_config.py
-test_project/response.py
-test_project/api/default_api.py
-test_project/api/__init__.py
-test_project/models/__init__.py
-test_project/models/additional_properties_response.py
-test_project/models/another_named_one_of.py
-test_project/models/array_of_one_ofs.py
-test_project/models/dictionary.py
-test_project/models/inline_enum200_response.py
-test_project/models/inline_enum200_response_category_enum.py
-test_project/models/inline_request_body_request_content.py
-test_project/models/my_enum.py
-test_project/models/named_one_of.py
-test_project/models/named_one_of_union.py
-test_project/models/some_object.py",
+test_project/response.py",
   "README.md": "# Edge Cases
 
 
@@ -24408,9 +24408,14 @@ README.md
   },
   ".tsapi-manifest": "test_project/api_client.py
 test_project/api_response.py
+test_project/api/default_api.py
+test_project/api/tag1_api.py
+test_project/api/tag2_api.py
+test_project/api/__init__.py
 test_project/configuration.py
 test_project/exceptions.py
 test_project/__init__.py
+test_project/models/__init__.py
 test_project/py.typed
 test_project/rest.py
 docs/DefaultApi.md
@@ -24424,12 +24429,7 @@ test_project/interceptors/powertools/tracer.py
 test_project/interceptors/powertools/metrics.py
 test_project/interceptors/__init__.py
 test_project/api/operation_config.py
-test_project/response.py
-test_project/api/default_api.py
-test_project/api/tag1_api.py
-test_project/api/tag2_api.py
-test_project/api/__init__.py
-test_project/models/__init__.py",
+test_project/response.py",
   "README.md": "# Multiple Tags Test
 
 
@@ -28686,9 +28686,13 @@ README.md
   },
   ".tsapi-manifest": "test_project/api_client.py
 test_project/api_response.py
+test_project/api/default_api.py
+test_project/api/__init__.py
 test_project/configuration.py
 test_project/exceptions.py
 test_project/__init__.py
+test_project/models/__init__.py
+test_project/models/hello_response.py
 test_project/py.typed
 test_project/rest.py
 docs/DefaultApi.md
@@ -28701,11 +28705,7 @@ test_project/interceptors/powertools/tracer.py
 test_project/interceptors/powertools/metrics.py
 test_project/interceptors/__init__.py
 test_project/api/operation_config.py
-test_project/response.py
-test_project/api/default_api.py
-test_project/api/__init__.py
-test_project/models/__init__.py
-test_project/models/hello_response.py",
+test_project/response.py",
   "README.md": "# Example API
 
 
@@ -31830,9 +31830,13 @@ README.md
   },
   ".tsapi-manifest": "test_project/api_client.py
 test_project/api_response.py
+test_project/api/default_api.py
+test_project/api/__init__.py
 test_project/configuration.py
 test_project/exceptions.py
 test_project/__init__.py
+test_project/models/__init__.py
+test_project/models/tree_node.py
 test_project/py.typed
 test_project/rest.py
 docs/DefaultApi.md
@@ -31845,11 +31849,7 @@ test_project/interceptors/powertools/tracer.py
 test_project/interceptors/powertools/metrics.py
 test_project/interceptors/__init__.py
 test_project/api/operation_config.py
-test_project/response.py
-test_project/api/default_api.py
-test_project/api/__init__.py
-test_project/models/__init__.py
-test_project/models/tree_node.py",
+test_project/response.py",
   "README.md": "# Recursive schema
 
 
@@ -34956,9 +34956,18 @@ README.md
   },
   ".tsapi-manifest": "test_project/api_client.py
 test_project/api_response.py
+test_project/api/default_api.py
+test_project/api/__init__.py
 test_project/configuration.py
 test_project/exceptions.py
 test_project/__init__.py
+test_project/models/__init__.py
+test_project/models/api_error.py
+test_project/models/map_response.py
+test_project/models/map_response_map_property_value.py
+test_project/models/test_request.py
+test_project/models/test_response.py
+test_project/models/test_response_messages_inner.py
 test_project/py.typed
 test_project/rest.py
 docs/DefaultApi.md
@@ -34976,16 +34985,7 @@ test_project/interceptors/powertools/tracer.py
 test_project/interceptors/powertools/metrics.py
 test_project/interceptors/__init__.py
 test_project/api/operation_config.py
-test_project/response.py
-test_project/api/default_api.py
-test_project/api/__init__.py
-test_project/models/__init__.py
-test_project/models/api_error.py
-test_project/models/map_response.py
-test_project/models/map_response_map_property_value.py
-test_project/models/test_request.py
-test_project/models/test_response.py
-test_project/models/test_response_messages_inner.py",
+test_project/response.py",
   "README.md": "# Example API
 
 

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript-react-query-hooks.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript-react-query-hooks.test.ts.snap
@@ -2,12 +2,12 @@
 
 exports[`Typescript React Query Hooks Code Generation Script Unit Tests Generates With multiple-tags.yaml 1`] = `
 {
-  ".tsapi-manifest": "src/runtime.ts
-src/apis/DefaultApi.ts
+  ".tsapi-manifest": "src/apis/DefaultApi.ts
 src/apis/Tag1Api.ts
 src/apis/Tag2Api.ts
 src/apis/index.ts
 src/models/model-utils.ts
+src/runtime.ts
 README.md
 src/apis/index.ts
 src/apis/DefaultApiClientProvider.tsx
@@ -1013,8 +1013,7 @@ export class TextApiResponse {
 
 exports[`Typescript React Query Hooks Code Generation Script Unit Tests Generates With single-pagination.yaml 1`] = `
 {
-  ".tsapi-manifest": "src/runtime.ts
-src/apis/DefaultApi.ts
+  ".tsapi-manifest": "src/apis/DefaultApi.ts
 src/apis/index.ts
 src/models/index.ts
 src/models/model-utils.ts
@@ -1024,6 +1023,7 @@ src/models/RegularGet200Response.ts
 src/models/TestRequest.ts
 src/models/TestResponse.ts
 src/models/TestResponseMessagesInner.ts
+src/runtime.ts
 README.md
 src/apis/index.ts
 src/apis/DefaultApiClientProvider.tsx

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript.test.ts.snap
@@ -2,8 +2,15 @@
 
 exports[`Typescript Client Code Generation Script Unit Tests Generates With allof-model.yaml 1`] = `
 {
-  ".tsapi-manifest": "src/index.ts
+  ".tsapi-manifest": "src/apis/DefaultApi.ts
+src/apis/index.ts
+src/models/index.ts
+src/models/model-utils.ts
+src/models/Template.ts
+src/models/TemplateBase.ts
+src/models/TemplateBody.ts
 src/runtime.ts
+src/index.ts
 src/interceptors/try-catch.ts
 src/interceptors/cors.ts
 src/interceptors/powertools/logger.ts
@@ -11,14 +18,7 @@ src/interceptors/powertools/tracer.ts
 src/interceptors/powertools/metrics.ts
 src/interceptors/index.ts
 src/apis/DefaultApi/OperationConfig.ts
-src/response/response.ts
-src/apis/DefaultApi.ts
-src/apis/index.ts
-src/models/index.ts
-src/models/model-utils.ts
-src/models/Template.ts
-src/models/TemplateBase.ts
-src/models/TemplateBody.ts",
+src/response/response.ts",
   "src/apis/DefaultApi.ts": "/* tslint:disable */
 /* eslint-disable */
 /**
@@ -1464,17 +1464,7 @@ export class TextApiResponse {
 
 exports[`Typescript Client Code Generation Script Unit Tests Generates With composite-models.yaml 1`] = `
 {
-  ".tsapi-manifest": "src/index.ts
-src/runtime.ts
-src/interceptors/try-catch.ts
-src/interceptors/cors.ts
-src/interceptors/powertools/logger.ts
-src/interceptors/powertools/tracer.ts
-src/interceptors/powertools/metrics.ts
-src/interceptors/index.ts
-src/apis/DefaultApi/OperationConfig.ts
-src/response/response.ts
-src/apis/DefaultApi.ts
+  ".tsapi-manifest": "src/apis/DefaultApi.ts
 src/apis/index.ts
 src/models/index.ts
 src/models/model-utils.ts
@@ -1500,7 +1490,17 @@ src/models/OneOfRefs.ts
 src/models/Wrapper.ts
 src/models/WrapperAllOf.ts
 src/models/WrapperAnyOf.ts
-src/models/WrapperOneOf.ts",
+src/models/WrapperOneOf.ts
+src/runtime.ts
+src/index.ts
+src/interceptors/try-catch.ts
+src/interceptors/cors.ts
+src/interceptors/powertools/logger.ts
+src/interceptors/powertools/tracer.ts
+src/interceptors/powertools/metrics.ts
+src/interceptors/index.ts
+src/apis/DefaultApi/OperationConfig.ts
+src/response/response.ts",
   "src/apis/DefaultApi.ts": "/* tslint:disable */
 /* eslint-disable */
 /**
@@ -4624,17 +4624,7 @@ export class TextApiResponse {
 
 exports[`Typescript Client Code Generation Script Unit Tests Generates With data-types.yaml 1`] = `
 {
-  ".tsapi-manifest": "src/index.ts
-src/runtime.ts
-src/interceptors/try-catch.ts
-src/interceptors/cors.ts
-src/interceptors/powertools/logger.ts
-src/interceptors/powertools/tracer.ts
-src/interceptors/powertools/metrics.ts
-src/interceptors/index.ts
-src/apis/DefaultApi/OperationConfig.ts
-src/response/response.ts
-src/apis/DefaultApi.ts
+  ".tsapi-manifest": "src/apis/DefaultApi.ts
 src/apis/index.ts
 src/models/index.ts
 src/models/model-utils.ts
@@ -4647,7 +4637,17 @@ src/models/DataTypes200ResponseMyNotNot.ts
 src/models/DataTypes200ResponseMyObject.ts
 src/models/DataTypes200ResponseMyObjectOne.ts
 src/models/DataTypes200ResponseMyObjectOneTwo.ts
-src/models/DataTypes200ResponseMyOneOf.ts",
+src/models/DataTypes200ResponseMyOneOf.ts
+src/runtime.ts
+src/index.ts
+src/interceptors/try-catch.ts
+src/interceptors/cors.ts
+src/interceptors/powertools/logger.ts
+src/interceptors/powertools/tracer.ts
+src/interceptors/powertools/metrics.ts
+src/interceptors/index.ts
+src/apis/DefaultApi/OperationConfig.ts
+src/response/response.ts",
   "src/apis/DefaultApi.ts": "/* tslint:disable */
 /* eslint-disable */
 /**
@@ -6811,8 +6811,14 @@ export class TextApiResponse {
 
 exports[`Typescript Client Code Generation Script Unit Tests Generates With default-response.yaml 1`] = `
 {
-  ".tsapi-manifest": "src/index.ts
+  ".tsapi-manifest": "src/apis/DefaultApi.ts
+src/apis/index.ts
+src/models/index.ts
+src/models/model-utils.ts
+src/models/SayHelloResponseContent.ts
+src/models/ServiceUnavailableErrorResponseContent.ts
 src/runtime.ts
+src/index.ts
 src/interceptors/try-catch.ts
 src/interceptors/cors.ts
 src/interceptors/powertools/logger.ts
@@ -6820,13 +6826,7 @@ src/interceptors/powertools/tracer.ts
 src/interceptors/powertools/metrics.ts
 src/interceptors/index.ts
 src/apis/DefaultApi/OperationConfig.ts
-src/response/response.ts
-src/apis/DefaultApi.ts
-src/apis/index.ts
-src/models/index.ts
-src/models/model-utils.ts
-src/models/SayHelloResponseContent.ts
-src/models/ServiceUnavailableErrorResponseContent.ts",
+src/response/response.ts",
   "src/apis/DefaultApi.ts": "/* tslint:disable */
 /* eslint-disable */
 /**
@@ -8223,17 +8223,7 @@ export class TextApiResponse {
 
 exports[`Typescript Client Code Generation Script Unit Tests Generates With edge-cases.yaml 1`] = `
 {
-  ".tsapi-manifest": "src/index.ts
-src/runtime.ts
-src/interceptors/try-catch.ts
-src/interceptors/cors.ts
-src/interceptors/powertools/logger.ts
-src/interceptors/powertools/tracer.ts
-src/interceptors/powertools/metrics.ts
-src/interceptors/index.ts
-src/apis/DefaultApi/OperationConfig.ts
-src/response/response.ts
-src/apis/DefaultApi.ts
+  ".tsapi-manifest": "src/apis/DefaultApi.ts
 src/apis/index.ts
 src/models/index.ts
 src/models/model-utils.ts
@@ -8247,7 +8237,17 @@ src/models/InlineRequestBodyRequestContent.ts
 src/models/MyEnum.ts
 src/models/NamedOneOf.ts
 src/models/NamedOneOfUnion.ts
-src/models/SomeObject.ts",
+src/models/SomeObject.ts
+src/runtime.ts
+src/index.ts
+src/interceptors/try-catch.ts
+src/interceptors/cors.ts
+src/interceptors/powertools/logger.ts
+src/interceptors/powertools/tracer.ts
+src/interceptors/powertools/metrics.ts
+src/interceptors/index.ts
+src/apis/DefaultApi/OperationConfig.ts
+src/response/response.ts",
   "src/apis/DefaultApi.ts": "/* tslint:disable */
 /* eslint-disable */
 /**
@@ -11180,8 +11180,13 @@ export class TextApiResponse {
 
 exports[`Typescript Client Code Generation Script Unit Tests Generates With multiple-tags.yaml 1`] = `
 {
-  ".tsapi-manifest": "src/index.ts
+  ".tsapi-manifest": "src/apis/DefaultApi.ts
+src/apis/Tag1Api.ts
+src/apis/Tag2Api.ts
+src/apis/index.ts
+src/models/model-utils.ts
 src/runtime.ts
+src/index.ts
 src/interceptors/try-catch.ts
 src/interceptors/cors.ts
 src/interceptors/powertools/logger.ts
@@ -11189,12 +11194,7 @@ src/interceptors/powertools/tracer.ts
 src/interceptors/powertools/metrics.ts
 src/interceptors/index.ts
 src/apis/DefaultApi/OperationConfig.ts
-src/response/response.ts
-src/apis/DefaultApi.ts
-src/apis/Tag1Api.ts
-src/apis/Tag2Api.ts
-src/apis/index.ts
-src/models/model-utils.ts",
+src/response/response.ts",
   "src/apis/DefaultApi.ts": "/* tslint:disable */
 /* eslint-disable */
 /**
@@ -12882,8 +12882,13 @@ export class TextApiResponse {
 
 exports[`Typescript Client Code Generation Script Unit Tests Generates With parameter-refs.yaml 1`] = `
 {
-  ".tsapi-manifest": "src/index.ts
+  ".tsapi-manifest": "src/apis/DefaultApi.ts
+src/apis/index.ts
+src/models/index.ts
+src/models/model-utils.ts
+src/models/HelloResponse.ts
 src/runtime.ts
+src/index.ts
 src/interceptors/try-catch.ts
 src/interceptors/cors.ts
 src/interceptors/powertools/logger.ts
@@ -12891,12 +12896,7 @@ src/interceptors/powertools/tracer.ts
 src/interceptors/powertools/metrics.ts
 src/interceptors/index.ts
 src/apis/DefaultApi/OperationConfig.ts
-src/response/response.ts
-src/apis/DefaultApi.ts
-src/apis/index.ts
-src/models/index.ts
-src/models/model-utils.ts
-src/models/HelloResponse.ts",
+src/response/response.ts",
   "src/apis/DefaultApi.ts": "/* tslint:disable */
 /* eslint-disable */
 /**
@@ -14206,8 +14206,13 @@ export class TextApiResponse {
 
 exports[`Typescript Client Code Generation Script Unit Tests Generates With recursive.yaml 1`] = `
 {
-  ".tsapi-manifest": "src/index.ts
+  ".tsapi-manifest": "src/apis/DefaultApi.ts
+src/apis/index.ts
+src/models/index.ts
+src/models/model-utils.ts
+src/models/TreeNode.ts
 src/runtime.ts
+src/index.ts
 src/interceptors/try-catch.ts
 src/interceptors/cors.ts
 src/interceptors/powertools/logger.ts
@@ -14215,12 +14220,7 @@ src/interceptors/powertools/tracer.ts
 src/interceptors/powertools/metrics.ts
 src/interceptors/index.ts
 src/apis/DefaultApi/OperationConfig.ts
-src/response/response.ts
-src/apis/DefaultApi.ts
-src/apis/index.ts
-src/models/index.ts
-src/models/model-utils.ts
-src/models/TreeNode.ts",
+src/response/response.ts",
   "src/apis/DefaultApi.ts": "/* tslint:disable */
 /* eslint-disable */
 /**
@@ -15519,17 +15519,7 @@ export class TextApiResponse {
 
 exports[`Typescript Client Code Generation Script Unit Tests Generates With single.yaml 1`] = `
 {
-  ".tsapi-manifest": "src/index.ts
-src/runtime.ts
-src/interceptors/try-catch.ts
-src/interceptors/cors.ts
-src/interceptors/powertools/logger.ts
-src/interceptors/powertools/tracer.ts
-src/interceptors/powertools/metrics.ts
-src/interceptors/index.ts
-src/apis/DefaultApi/OperationConfig.ts
-src/response/response.ts
-src/apis/DefaultApi.ts
+  ".tsapi-manifest": "src/apis/DefaultApi.ts
 src/apis/index.ts
 src/models/index.ts
 src/models/model-utils.ts
@@ -15538,7 +15528,17 @@ src/models/MapResponse.ts
 src/models/MapResponseMapPropertyValue.ts
 src/models/TestRequest.ts
 src/models/TestResponse.ts
-src/models/TestResponseMessagesInner.ts",
+src/models/TestResponseMessagesInner.ts
+src/runtime.ts
+src/index.ts
+src/interceptors/try-catch.ts
+src/interceptors/cors.ts
+src/interceptors/powertools/logger.ts
+src/interceptors/powertools/tracer.ts
+src/interceptors/powertools/metrics.ts
+src/interceptors/index.ts
+src/apis/DefaultApi/OperationConfig.ts
+src/response/response.ts",
   "src/apis/DefaultApi.ts": "/* tslint:disable */
 /* eslint-disable */
 /**

--- a/packages/type-safe-api/test/scripts/generators/async/__snapshots__/java.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/async/__snapshots__/java.test.ts.snap
@@ -2,7 +2,32 @@
 
 exports[`Java Async Runtime Code Generation Script Unit Tests Generates With single.yaml 1`] = `
 {
-  ".tsapi-manifest": "src/main/java/test/test/runtime/api/handlers/Handlers.java
+  ".tsapi-manifest": "src/main/java/test/test/runtime/api/DefaultApi.java
+src/main/java/test/test/runtime/auth/ApiKeyAuth.java
+src/main/java/test/test/runtime/auth/Authentication.java
+src/main/java/test/test/runtime/auth/HttpBasicAuth.java
+src/main/java/test/test/runtime/auth/HttpBearerAuth.java
+src/main/java/test/test/runtime/ApiCallback.java
+src/main/java/test/test/runtime/ApiClient.java
+src/main/java/test/test/runtime/ApiException.java
+src/main/java/test/test/runtime/ApiResponse.java
+src/main/java/test/test/runtime/Configuration.java
+src/main/java/test/test/runtime/GzipRequestInterceptor.java
+src/main/java/test/test/runtime/JSON.java
+src/main/java/test/test/runtime/Pair.java
+src/main/java/test/test/runtime/ProgressRequestBody.java
+src/main/java/test/test/runtime/ProgressResponseBody.java
+src/main/java/test/test/runtime/ServerConfiguration.java
+src/main/java/test/test/runtime/ServerVariable.java
+src/main/java/test/test/runtime/StringUtil.java
+src/main/java/test/test/runtime/model/AbstractOpenApiSchema.java
+src/main/java/test/test/runtime/model/ApiError.java
+src/main/java/test/test/runtime/model/MapRequest.java
+src/main/java/test/test/runtime/model/MapRequestMapPropertyValue.java
+src/main/java/test/test/runtime/model/TestRequest.java
+src/main/java/test/test/runtime/model/TestResponse.java
+src/main/java/test/test/runtime/model/TestResponseMessagesInner.java
+src/main/java/test/test/runtime/api/handlers/Handlers.java
 src/main/java/test/test/runtime/api/handlers/Response.java
 src/main/java/test/test/runtime/api/handlers/ApiResponse.java
 src/main/java/test/test/runtime/api/handlers/Interceptor.java
@@ -66,32 +91,7 @@ src/main/java/test/test/runtime/api/interceptors/powertools/MetricsInterceptor.j
 src/main/java/test/test/runtime/api/interceptors/DefaultInterceptors.java
 src/main/java/test/test/runtime/api/operation_config/OperationConfig.java
 src/main/java/test/test/runtime/api/operation_config/OperationLookup.java
-src/main/java/test/test/runtime/api/operation_config/Operations.java
-src/main/java/test/test/runtime/api/DefaultApi.java
-src/main/java/test/test/runtime/auth/ApiKeyAuth.java
-src/main/java/test/test/runtime/auth/Authentication.java
-src/main/java/test/test/runtime/auth/HttpBasicAuth.java
-src/main/java/test/test/runtime/auth/HttpBearerAuth.java
-src/main/java/test/test/runtime/ApiCallback.java
-src/main/java/test/test/runtime/ApiClient.java
-src/main/java/test/test/runtime/ApiException.java
-src/main/java/test/test/runtime/ApiResponse.java
-src/main/java/test/test/runtime/Configuration.java
-src/main/java/test/test/runtime/GzipRequestInterceptor.java
-src/main/java/test/test/runtime/JSON.java
-src/main/java/test/test/runtime/Pair.java
-src/main/java/test/test/runtime/ProgressRequestBody.java
-src/main/java/test/test/runtime/ProgressResponseBody.java
-src/main/java/test/test/runtime/ServerConfiguration.java
-src/main/java/test/test/runtime/ServerVariable.java
-src/main/java/test/test/runtime/StringUtil.java
-src/main/java/test/test/runtime/model/AbstractOpenApiSchema.java
-src/main/java/test/test/runtime/model/ApiError.java
-src/main/java/test/test/runtime/model/MapRequest.java
-src/main/java/test/test/runtime/model/MapRequestMapPropertyValue.java
-src/main/java/test/test/runtime/model/TestRequest.java
-src/main/java/test/test/runtime/model/TestResponse.java
-src/main/java/test/test/runtime/model/TestResponseMessagesInner.java",
+src/main/java/test/test/runtime/api/operation_config/Operations.java",
   "src/main/java/test/test/runtime/ApiCallback.java": "/*
  * Example API
  * 

--- a/packages/type-safe-api/test/scripts/generators/async/__snapshots__/python.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/async/__snapshots__/python.test.ts.snap
@@ -354,9 +354,18 @@ README.md
   },
   ".tsapi-manifest": "test_project/api_client.py
 test_project/api_response.py
+test_project/api/default_api.py
+test_project/api/__init__.py
 test_project/configuration.py
 test_project/exceptions.py
 test_project/__init__.py
+test_project/models/__init__.py
+test_project/models/api_error.py
+test_project/models/map_request.py
+test_project/models/map_request_map_property_value.py
+test_project/models/test_request.py
+test_project/models/test_response.py
+test_project/models/test_response_messages_inner.py
 test_project/py.typed
 test_project/rest.py
 docs/DefaultApi.md
@@ -374,16 +383,7 @@ test_project/interceptors/powertools/tracer.py
 test_project/interceptors/powertools/metrics.py
 test_project/interceptors/__init__.py
 test_project/api/operation_config.py
-test_project/response.py
-test_project/api/default_api.py
-test_project/api/__init__.py
-test_project/models/__init__.py
-test_project/models/api_error.py
-test_project/models/map_request.py
-test_project/models/map_request_map_property_value.py
-test_project/models/test_request.py
-test_project/models/test_response.py
-test_project/models/test_response_messages_inner.py",
+test_project/response.py",
   "README.md": "# Example API
 
 


### PR DESCRIPTION
Node 18.17.x has a bug where `readdirSync` returns invalid entries when both `recursive` and `withFileTypes` is specified:

https://github.com/nodejs/node/issues/48858

We use our own implementation to recursively find template files to ensure we work for older versions of node.

NB the shapshots have changed due to the `.tsapi-manifest` now containing the file names in a different order.