### PR TITLE
fix(pdk-nag): remove reference to deleted sns encrypted kms rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@mrgrain/jsii-struct-builder": "0.7.43",
     "@pnpm/types": "^9.0.0",
     "aws-cdk-lib": "2.163.1",
-    "cdk-nag": "2.29.14",
+    "cdk-nag": "2.31.0",
     "fast-xml-parser": "4.5.0",
     "projen": "0.82.8"
   },

--- a/packages/cdk-graph-plugin-threat-composer/package.json
+++ b/packages/cdk-graph-plugin-threat-composer/package.json
@@ -38,7 +38,7 @@
     "@typescript-eslint/eslint-plugin": "^7",
     "@typescript-eslint/parser": "^7",
     "aws-cdk-lib": "2.163.1",
-    "cdk-nag": "2.29.14",
+    "cdk-nag": "2.31.0",
     "constructs": "10.4.2",
     "eslint": "^8",
     "eslint-config-prettier": "8.10.0",
@@ -64,7 +64,7 @@
     "@aws/cdk-graph": "^0.x",
     "@aws/pdk-nag": "^0.x",
     "aws-cdk-lib": "^2.163.1",
-    "cdk-nag": "2.29.14",
+    "cdk-nag": "2.31.0",
     "constructs": "10.4.2",
     "projen": "^0.82.8"
   },

--- a/packages/cdk-graph-plugin-threat-composer/src/model-generator/base-model/threat-composer-base-model.tc.json
+++ b/packages/cdk-graph-plugin-threat-composer/src/model-generator/base-model/threat-composer-base-model.tc.json
@@ -69,15 +69,6 @@
       "content": "cdk-nag rule: SNSTopicSSLPublishOnly"
     },
     {
-      "id": "35eefa29-d011-4b50-a7a8-a204a2b01b34",
-      "numericId": 101,
-      "displayOrder": 101,
-      "tags": [
-        "SNS"
-      ],
-      "content": "cdk-nag rule: SNSEncryptedKMS"
-    },
-    {
       "id": "fff9fac4-1512-4a49-81a3-88e420f6c110",
       "numericId": 100,
       "displayOrder": 100,
@@ -1401,10 +1392,6 @@
       "linkedId": "90619d5b-6450-4108-8013-2eaafc5788b5"
     },
     {
-      "mitigationId": "35eefa29-d011-4b50-a7a8-a204a2b01b34",
-      "linkedId": "7f17d020-6368-48ee-b934-c9272de71242"
-    },
-    {
       "mitigationId": "7e9478e3-4571-4c36-bb7c-bb33acf4ec08",
       "linkedId": "9d47bd52-9dbc-4eee-8e55-04a3fc8064c4"
     },
@@ -1561,26 +1548,6 @@
         "this application's data"
       ],
       "statement": "A threat actor who is in a person-in-the-middle position between the publisher and the Amazon SNS endpoint can view plaintext requests and responses, which leads to them being able manipulate view or modify the requests or responses, negatively impacting this application's data"
-    },
-    {
-      "id": "7f17d020-6368-48ee-b934-c9272de71242",
-      "numericId": 88,
-      "displayOrder": 88,
-      "tags": [
-        "SNS",
-        "SSE"
-      ],
-      "threatSource": "threat actor",
-      "prerequisites": "with access to underlying storage used for the SNS (Simple Notification Service) topic",
-      "threatAction": "view the SNS messages",
-      "impactedGoal": [
-        "confidentiality",
-        "integrity"
-      ],
-      "impactedAssets": [
-        "this application's data"
-      ],
-      "statement": "A threat actor with access to underlying storage used for the SNS (Simple Notification Service) topic can view the SNS messages, resulting in reduced confidentiality and/or integrity of this application's data"
     },
     {
       "id": "90619d5b-6450-4108-8013-2eaafc5788b5",

--- a/packages/cdk-graph/package.json
+++ b/packages/cdk-graph/package.json
@@ -46,7 +46,7 @@
     "@typescript-eslint/eslint-plugin": "^7",
     "@typescript-eslint/parser": "^7",
     "aws-cdk-lib": "2.163.1",
-    "cdk-nag": "2.29.14",
+    "cdk-nag": "2.31.0",
     "constructs": "10.4.2",
     "eslint": "^8",
     "eslint-config-prettier": "8.10.0",

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -35,7 +35,7 @@
     "@typescript-eslint/eslint-plugin": "^7",
     "@typescript-eslint/parser": "^7",
     "aws-cdk-lib": "2.163.1",
-    "cdk-nag": "2.29.14",
+    "cdk-nag": "2.31.0",
     "constructs": "10.4.2",
     "eslint": "^8",
     "eslint-config-prettier": "8.10.0",
@@ -58,7 +58,7 @@
   "peerDependencies": {
     "@aws-cdk/aws-cognito-identitypool-alpha": "^2.163.1-alpha.0",
     "aws-cdk-lib": "^2.163.1",
-    "cdk-nag": "2.29.14",
+    "cdk-nag": "2.31.0",
     "constructs": "10.4.2",
     "projen": "^0.82.8"
   },

--- a/packages/pdk-nag/package.json
+++ b/packages/pdk-nag/package.json
@@ -37,7 +37,7 @@
     "@typescript-eslint/eslint-plugin": "^7",
     "@typescript-eslint/parser": "^7",
     "aws-cdk-lib": "2.163.1",
-    "cdk-nag": "2.29.14",
+    "cdk-nag": "2.31.0",
     "constructs": "10.4.2",
     "eslint": "^8",
     "eslint-config-prettier": "8.10.0",
@@ -61,7 +61,7 @@
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.163.1",
-    "cdk-nag": "2.29.14",
+    "cdk-nag": "2.31.0",
     "constructs": "10.4.2"
   },
   "main": "lib/index.js",

--- a/packages/pdk-nag/src/packs/README.md
+++ b/packages/pdk-nag/src/packs/README.md
@@ -111,7 +111,7 @@ Total: `35`
 
 ### Warnings
 
-Total: `74`
+Total: `73`
 
 | Rule ID | Cause | Explanation |
 | ------------------ | ------------------ | ------------------ |
@@ -183,7 +183,6 @@ Total: `74`
 | SageMakerNotebookInVPC | The SageMaker notebook instance is not provisioned inside a VPC. | Provisioning the notebook instances inside a VPC enables the notebook to access VPC-only resources such as EFS file systems. |
 | SageMakerNotebookNoDirectInternetAccess | The SageMaker notebook does not disable direct internet access. | By preventing direct internet access, you can keep sensitive data from being accessed by unauthorized users. |
 | SecretsManagerRotationEnabled | The secret does not have automatic rotation scheduled. | Rotating secrets on a regular schedule can shorten the period a secret is active, and potentially reduce the business impact if the secret is compromised. |
-| SNSEncryptedKMS | The SNS topic does not have KMS encryption enabled. | To help protect data at rest, ensure that your Amazon Simple Notification Service (Amazon SNS) topics require encryption using AWS Key Management Service (AWS KMS). Because sensitive data can exist at rest in published messages, enable encryption at rest to help protect that data. |
 | SNSTopicSSLPublishOnly | The SNS Topic does not require publishers to use SSL. | Without HTTPS (TLS), a network-based attacker can eavesdrop on network traffic or manipulate it, using an attack such as man-in-the-middle. Allow only encrypted connections over HTTPS (TLS) using the aws:SecureTransport condition and the 'sns:Publish' action in the topic policy to force publishers to use SSL. If SSE is already enabled then this control is auto enforced. |
 | SQSQueueSSE | The SQS Queue does not have server-side encryption enabled. | Server side encryption adds additional protection of sensitive data delivered as messages to subscribers. |
 | SQSQueueSSLRequestsOnly | The SQS queue does not require requests to use SSL. | Without HTTPS (TLS), a network-based attacker can eavesdrop on network traffic or manipulate it, using an attack such as man-in-the-middle. Allow only encrypted connections over HTTPS (TLS) using the aws:SecureTransport condition in the queue policy to force requests to use SSL. |

--- a/packages/pdk-nag/src/packs/aws-prototyping-rules.ts
+++ b/packages/pdk-nag/src/packs/aws-prototyping-rules.ts
@@ -727,13 +727,6 @@ export let RuleMetadata = [
     rule: rules.secretsmanager.SecretsManagerRotationEnabled,
   },
   {
-    info: "The SNS topic does not have KMS encryption enabled.",
-    explanation:
-      "To help protect data at rest, ensure that your Amazon Simple Notification Service (Amazon SNS) topics require encryption using AWS Key Management Service (AWS KMS). Because sensitive data can exist at rest in published messages, enable encryption at rest to help protect that data.",
-    level: NagMessageLevel.WARN,
-    rule: rules.sns.SNSEncryptedKMS,
-  },
-  {
     info: "The SNS Topic does not require publishers to use SSL.",
     explanation:
       "Without HTTPS (TLS), a network-based attacker can eavesdrop on network traffic or manipulate it, using an attack such as man-in-the-middle. Allow only encrypted connections over HTTPS (TLS) using the aws:SecureTransport condition and the 'sns:Publish' action in the topic policy to force publishers to use SSL. If SSE is already enabled then this control is auto enforced.",

--- a/packages/pdk-nag/test/prototyping-nag-pack.test.ts
+++ b/packages/pdk-nag/test/prototyping-nag-pack.test.ts
@@ -113,7 +113,6 @@ const expectedWarnings = [
   "AwsPrototyping-SageMakerNotebookInVPC",
   "AwsPrototyping-SageMakerNotebookNoDirectInternetAccess",
   "AwsPrototyping-SecretsManagerRotationEnabled",
-  "AwsPrototyping-SNSEncryptedKMS",
   "AwsPrototyping-SNSTopicSSLPublishOnly",
   "AwsPrototyping-SQSQueueSSE",
   "AwsPrototyping-SQSQueueSSLRequestsOnly",

--- a/packages/pdk/package.json
+++ b/packages/pdk/package.json
@@ -69,7 +69,7 @@
     "@typescript-eslint/eslint-plugin": "^7",
     "@typescript-eslint/parser": "^7",
     "aws-cdk-lib": "2.163.1",
-    "cdk-nag": "2.29.14",
+    "cdk-nag": "2.31.0",
     "constructs": "10.4.2",
     "downlevel-dts": "0.11.0",
     "ejs": "3.1.10",
@@ -106,7 +106,7 @@
   "peerDependencies": {
     "@aws-cdk/aws-cognito-identitypool-alpha": "^2.163.1-alpha.0",
     "aws-cdk-lib": "^2.163.1",
-    "cdk-nag": "2.29.14",
+    "cdk-nag": "2.31.0",
     "constructs": "10.4.2",
     "projen": "^0.82.8"
   },

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -34,7 +34,7 @@
     "@typescript-eslint/eslint-plugin": "^7",
     "@typescript-eslint/parser": "^7",
     "aws-cdk-lib": "2.163.1",
-    "cdk-nag": "2.29.14",
+    "cdk-nag": "2.31.0",
     "constructs": "10.4.2",
     "eslint": "^8",
     "eslint-config-prettier": "8.10.0",
@@ -56,7 +56,7 @@
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.163.1",
-    "cdk-nag": "2.29.14",
+    "cdk-nag": "2.31.0",
     "constructs": "10.4.2",
     "projen": "^0.82.8"
   },

--- a/packages/static-website/package.json
+++ b/packages/static-website/package.json
@@ -35,7 +35,7 @@
     "@typescript-eslint/eslint-plugin": "^7",
     "@typescript-eslint/parser": "^7",
     "aws-cdk-lib": "2.163.1",
-    "cdk-nag": "2.29.14",
+    "cdk-nag": "2.31.0",
     "constructs": "10.4.2",
     "eslint": "^8",
     "eslint-config-prettier": "8.10.0",
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.163.1",
-    "cdk-nag": "2.29.14",
+    "cdk-nag": "2.31.0",
     "constructs": "10.4.2",
     "projen": "^0.82.8"
   },

--- a/packages/type-safe-api/package.json
+++ b/packages/type-safe-api/package.json
@@ -45,7 +45,7 @@
     "@typescript-eslint/eslint-plugin": "^7",
     "@typescript-eslint/parser": "^7",
     "aws-cdk-lib": "2.163.1",
-    "cdk-nag": "2.29.14",
+    "cdk-nag": "2.31.0",
     "constructs": "10.4.2",
     "ejs": "3.1.10",
     "esbuild": "0.24.0",
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.163.1",
-    "cdk-nag": "2.29.14",
+    "cdk-nag": "2.31.0",
     "constructs": "10.4.2",
     "projen": "^0.82.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         specifier: 2.163.1
         version: 2.163.1(constructs@10.4.2)
       cdk-nag:
-        specifier: 2.29.14
-        version: 2.29.14(aws-cdk-lib@2.163.1)(constructs@10.4.2)
+        specifier: 2.31.0
+        version: 2.31.0(aws-cdk-lib@2.163.1)(constructs@10.4.2)
       fast-xml-parser:
         specifier: 4.5.0
         version: 4.5.0
@@ -364,8 +364,8 @@ importers:
         specifier: 2.163.1
         version: 2.163.1(constructs@10.4.2)
       cdk-nag:
-        specifier: 2.29.14
-        version: 2.29.14(aws-cdk-lib@2.163.1)(constructs@10.4.2)
+        specifier: 2.31.0
+        version: 2.31.0(aws-cdk-lib@2.163.1)(constructs@10.4.2)
       constructs:
         specifier: 10.4.2
         version: 10.4.2
@@ -612,8 +612,8 @@ importers:
         specifier: 2.163.1
         version: 2.163.1(constructs@10.4.2)
       cdk-nag:
-        specifier: 2.29.14
-        version: 2.29.14(aws-cdk-lib@2.163.1)(constructs@10.4.2)
+        specifier: 2.31.0
+        version: 2.31.0(aws-cdk-lib@2.163.1)(constructs@10.4.2)
       constructs:
         specifier: 10.4.2
         version: 10.4.2
@@ -779,8 +779,8 @@ importers:
         specifier: 2.163.1
         version: 2.163.1(constructs@10.4.2)
       cdk-nag:
-        specifier: 2.29.14
-        version: 2.29.14(aws-cdk-lib@2.163.1)(constructs@10.4.2)
+        specifier: 2.31.0
+        version: 2.31.0(aws-cdk-lib@2.163.1)(constructs@10.4.2)
       constructs:
         specifier: 10.4.2
         version: 10.4.2
@@ -1214,8 +1214,8 @@ importers:
         specifier: 2.163.1
         version: 2.163.1(constructs@10.4.2)
       cdk-nag:
-        specifier: 2.29.14
-        version: 2.29.14(aws-cdk-lib@2.163.1)(constructs@10.4.2)
+        specifier: 2.31.0
+        version: 2.31.0(aws-cdk-lib@2.163.1)(constructs@10.4.2)
       constructs:
         specifier: 10.4.2
         version: 10.4.2
@@ -1340,8 +1340,8 @@ importers:
         specifier: 2.163.1
         version: 2.163.1(constructs@10.4.2)
       cdk-nag:
-        specifier: 2.29.14
-        version: 2.29.14(aws-cdk-lib@2.163.1)(constructs@10.4.2)
+        specifier: 2.31.0
+        version: 2.31.0(aws-cdk-lib@2.163.1)(constructs@10.4.2)
       constructs:
         specifier: 10.4.2
         version: 10.4.2
@@ -1425,8 +1425,8 @@ importers:
         specifier: 2.163.1
         version: 2.163.1(constructs@10.4.2)
       cdk-nag:
-        specifier: 2.29.14
-        version: 2.29.14(aws-cdk-lib@2.163.1)(constructs@10.4.2)
+        specifier: 2.31.0
+        version: 2.31.0(aws-cdk-lib@2.163.1)(constructs@10.4.2)
       constructs:
         specifier: 10.4.2
         version: 10.4.2
@@ -1507,8 +1507,8 @@ importers:
         specifier: 2.163.1
         version: 2.163.1(constructs@10.4.2)
       cdk-nag:
-        specifier: 2.29.14
-        version: 2.29.14(aws-cdk-lib@2.163.1)(constructs@10.4.2)
+        specifier: 2.31.0
+        version: 2.31.0(aws-cdk-lib@2.163.1)(constructs@10.4.2)
       constructs:
         specifier: 10.4.2
         version: 10.4.2
@@ -1622,8 +1622,8 @@ importers:
         specifier: 2.163.1
         version: 2.163.1(constructs@10.4.2)
       cdk-nag:
-        specifier: 2.29.14
-        version: 2.29.14(aws-cdk-lib@2.163.1)(constructs@10.4.2)
+        specifier: 2.31.0
+        version: 2.31.0(aws-cdk-lib@2.163.1)(constructs@10.4.2)
       constructs:
         specifier: 10.4.2
         version: 10.4.2
@@ -6853,8 +6853,8 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /cdk-nag@2.29.14(aws-cdk-lib@2.163.1)(constructs@10.4.2):
-    resolution: {integrity: sha512-Nt9YxqRH6jOJSRB7E0Yc/upDgB9QCTEu0i1yah+fnyA3nZZSImQelVy+Q3JkjeBa1BSGrtRXCcheOoQBoe1PrQ==}
+  /cdk-nag@2.31.0(aws-cdk-lib@2.163.1)(constructs@10.4.2):
+    resolution: {integrity: sha512-/f2K4SUJp1hZKLjhQvJxQGc/qQw0JguJL21B+IqVNkKgrAXFuIjDlzSqQ6neZgJWQUP+zr1dA1KxUy9/QFhplA==}
     peerDependencies:
       aws-cdk-lib: ^2.156.0
       constructs: ^10.0.5
@@ -7817,7 +7817,7 @@ packages:
     dependencies:
       semver: 7.6.2
       shelljs: 0.8.5
-      typescript: 5.7.0-dev.20241023
+      typescript: 5.7.0-dev.20241031
     dev: true
 
   /duplexer2@0.1.4:
@@ -14244,8 +14244,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript@5.7.0-dev.20241023:
-    resolution: {integrity: sha512-HB6rRd9ySnFMoQUuDasWnBtvOg1P4CFG3nRfs2ZvFbenUkxSzoeeZ0PUwJJ7MKJp5zz7uMTZamGt7zdj0tP9YA==}
+  /typescript@5.7.0-dev.20241031:
+    resolution: {integrity: sha512-CR0uSMNCzLCXjptJ38ESiEpTMEYJiplIe9jmZLQuTp5nrxwOE2ljMg5z1XyPI+Uss1saZOdpwkPxXU3mDIASEg==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true


### PR DESCRIPTION
The SNSEncryptedKMS cdk nag rule has been removed since [2.30.0](https://github.com/cdklabs/cdk-nag/releases/tag/v2.30.0). We remove this from the prototyping nag pack and upgrade cdk nag to the latest version.
