### PR TITLE
fix(type-safe-api): fix model serialisation for nested collections in typescript

### DIFF
--- a/packages/type-safe-api/scripts/type-safe-api/generators/typescript/templates/client/models/models.ejs
+++ b/packages/type-safe-api/scripts/type-safe-api/generators/typescript/templates/client/models/models.ejs
@@ -33,6 +33,16 @@ import {
 } from './<%= importName %>';
 <%_ }); _%>
 <%_ const isComposite = model.export === "one-of" || model.export === "any-of" || model.export === "all-of"; _%>
+<%_
+// Nested arrays of primitives (besides dates) don't need to have .map(...) called to convert them as the base case will be a noop
+// eg. an array of arrays of strings doesn't need to be rendered as `value.map(item0 => item0.map(item1 => item1))`
+const canShortCircuitConversion = (property) => {
+  if (["array", "dictionary"].includes(property.export)) {
+    return canShortCircuitConversion(property.link);
+  }
+  return property.isPrimitive && !["date", "date-time"].includes(property.format);
+};
+_%>
 
 <%_ if (model.export === "enum") { _%>
 /**
@@ -126,19 +136,45 @@ export function <%= model.name %>FromJSONTyped(json: any, ignoreDiscriminator: b
 <%_ } else { _%>
     return {
 
+<%_
+// Renders the appropriate nested function for .map() or mapValues() for arrays and dictionaries for the given type
+const renderNestedFromJsonValue = (type, depth = 0) => {
+    const itemIdentifier = `item${depth}`;
+    if (type.isPrimitive) {
+        return `(${itemIdentifier}) => ${["date", "date-time"].includes(type.format) ? `new Date(${itemIdentifier})` : itemIdentifier}`;
+    } else if (type.export === "array") {
+        return `(${itemIdentifier}) => ${itemIdentifier}.map(${renderNestedFromJsonValue(type.link, depth + 1)})`;
+    } else if (type.export === "dictionary") {
+        return `(${itemIdentifier}) => mapValues(${itemIdentifier}, ${renderNestedFromJsonValue(type.link, depth + 1)})`;
+    }
+    return `${type.name || type.type}FromJSON`;
+};
+// Renders the code to transform a property of the model from its json representation into the model types
+const renderFromJsonValue = (property) => {
+    const value = `json['${property.name}']`;
+    let rendered = '';
+    if (canShortCircuitConversion(property)) {
+        rendered = value;
+    } else if (property.isPrimitive) {
+        rendered = ["date", "date-time"].includes(property.format) ? `(new Date(${value}))` : value;
+    } else if (property.export === "array") {
+        rendered = `((${value} as Array<any>).map(${renderNestedFromJsonValue(property.link)}))`;
+        rendered = property.uniqueItems ? `new Set(${rendered})` : rendered;
+    } else if (property.export === "dictionary") {
+        rendered = `(mapValues(${value}, ${renderNestedFromJsonValue(property.link)}))`;
+    } else {
+        rendered = `${property.type}FromJSON(${value})`;
+    }
+    rendered = property.isNullable ? `${value} === null ? null : ${rendered}` : rendered;
+    rendered = !property.isRequired ? `!exists(json, '${property.name}') ? undefined : ${rendered}` : rendered;
+    return rendered;
+};
+_%>
 <%_ if (model.export === "dictionary") { _%>
             ...json,
 <%_ } _%>
 <%_ model.properties.forEach((property) => { _%>
-    <%_ if (property.isPrimitive) { _%>
-        '<%= property.typescriptName %>': <% if (!property.isRequired) { %>!exists(json, '<%- property.name %>') ? undefined : <% } %><% if (["date", "date-time"].includes(property.format) && property.isNullable) { %>json['<%- property.name %>'] === null ? null : <% } %><% if (["date", "date-time"].includes(property.format)) { %>(new Date(json['<%= property.name %>']))<% } else { %>json['<%= property.name %>']<% } %>,
-    <%_ } else if (property.export === 'array') { _%>
-        '<%= property.typescriptName %>': <% if (!property.isRequired) { %>!exists(json, '<%- property.name %>') ? undefined : <% } %><% if (property.isNullable) { %>json['<%- property.name %>'] === null ? null : <% } %><%= property.uniqueItems ? 'new Set(' : '' %>((json['<%= property.name %>'] as Array<any>).map(<%= property.type %>FromJSON))<%= property.uniqueItems ? ')' : '' %>,
-    <%_ } else if (property.export === 'dictionary') { _%>
-        '<%= property.typescriptName %>': <% if (!property.isRequired) { %>!exists(json, '<%- property.name %>') ? undefined : <% } %><% if (property.isNullable) { %>json['<%- property.name %>'] === null ? null : <% } %>(mapValues(json['<%= property.name %>'], <%= property.type %>FromJSON)),
-    <%_ } else { _%>
-        '<%= property.typescriptName %>': <% if (!property.isRequired) { %>!exists(json, '<%- property.name %>') ? undefined : <% } %><% if (property.isNullable) { %>json['<%- property.name %>'] === null ? null : <% } %><%= property.type %>FromJSON(json['<%= property.name %>']),
-    <%_ } _%>
+        '<%= property.typescriptName %>': <%- renderFromJsonValue(property) %>,
 <%_ }); _%>
     };
 <%_ } _%>
@@ -173,24 +209,56 @@ export function <%= model.name %>ToJSON(value?: <%= model.name %> | null): any {
 <%_ } else { _%>
     return {
 
+<%_
+// Render code to convert a date to its string representation
+const renderToJsonDateValue = (identifier, format) => {
+    return `${identifier}.toISOString()${format === 'date' ? '.substr(0,10)' : ''}`;
+};
+// Renders the appropriate nested function for .map() or mapValues() for arrays and dictionaries for the given type
+const renderNestedToJsonValue = (type, depth = 0) => {
+    const itemIdentifier = `item${depth}`;
+    if (type.isPrimitive) {
+        return `(${itemIdentifier}) => ${["date", "date-time"].includes(type.format) ? renderToJsonDateValue(itemIdentifier, type.format) : itemIdentifier}`;
+    } else if (type.export === "array") {
+        return `(${itemIdentifier}) => ${itemIdentifier}.map(${renderNestedToJsonValue(type.link, depth + 1)})`;
+    } else if (type.export === "dictionary") {
+        return `(${itemIdentifier}) => mapValues(${itemIdentifier}, ${renderNestedToJsonValue(type.link, depth + 1)})`;
+    }
+    return `${type.name || type.type}ToJSON`;
+};
+// Renders the code to transform a property of the model to its json representation from the model types
+const renderToJsonValue = (property) => {
+    const value = `value.${property.typescriptName}`;
+    let rendered = '';
+
+    if (canShortCircuitConversion(property)) {
+        rendered = value;
+    } else if (property.isPrimitive) {
+        rendered = ["date", "date-time"].includes(property.format) ? `(${renderToJsonDateValue(value, property.format)})` : value;
+    } else if (property.export === "array") {
+        const prefix = property.uniqueItems ? `Array.from(${value} as Array<any>)` : `(${value} as Array<any>)`;
+        rendered = `(${prefix}.map(${renderNestedToJsonValue(property.link)}))`;
+    } else if (property.export === "dictionary") {
+        rendered = `(mapValues(${value}, ${renderNestedToJsonValue(property.link)}))`;
+    } else if (property.type !== "any") {
+        rendered = `${property.type}ToJSON(${value})`;
+    } else {
+        rendered = value;
+    }
+
+    if ((property.isPrimitive && ["date", "date-time"].includes(property.format)) || (!property.isPrimitive && ["array", "dictionary"].includes(property.export))) {
+        rendered = property.isNullable ? `${value} === null ? null : ${rendered}` : rendered;
+        rendered = !property.isRequired ? `${value} === undefined ? undefined : ${rendered}` : rendered;
+    }
+    return rendered;
+};
+_%>
 <%_ if (model.export === "dictionary") { _%>
             ...value,
 <%_ } _%>
 <%_ model.properties.forEach((property) => { _%>
 <%_ if (!property.isReadOnly) { _%>
-    <%_ if (property.isPrimitive && ["date", "date-time"].includes(property.format)) { _%>
-        '<%= property.name %>': <% if (!property.isRequired) { %>value.<%- property.typescriptName %> === undefined ? undefined : <% } %>(<% if (property.isNullable) { %>value.<%- property.typescriptName %> === null ? null : <% } %>value.<%- property.typescriptName %>.toISOString()<% if (property.format === 'date') { %>.substr(0,10)<% } %>),
-    <%_ } else if (property.isPrimitive) { _%>
-        '<%= property.name %>': value.<%- property.typescriptName %>,
-    <%_ } else if (property.export === 'array') { _%>
-        '<%= property.name %>': <% if (!property.isRequired) { %>value.<%- property.typescriptName %> === undefined ? undefined : <% } %>(<% if (property.isNullable) { %>value.<%- property.typescriptName %> === null ? null : <% } %><% if (property.uniqueItems) { %>Array.from(value.<%- property.typescriptName %> as Set<any>)<% } else { %>(value.<%- property.typescriptName %> as Array<any>)<% } %>.map(<%- property.type %>ToJSON)),
-    <%_ } else if (property.export === 'dictionary') { _%>
-        '<%= property.name %>': <% if (!property.isRequired) { %>value.<%- property.typescriptName %> === undefined ? undefined : <% } %>(<% if (property.isNullable) { %>value.<%- property.typescriptName %> === null ? null : <% } %>mapValues(value.<%- property.typescriptName %>, <%- property.type %>ToJSON)),
-    <%_ } else if (property.type !== 'any') { _%>
-        '<%= property.name %>': <%- property.type %>ToJSON(value.<%- property.typescriptName %>),
-    <%_ } else { _%>
-        '<%= property.name %>': value.<%- property.typescriptName %>,
-    <%_ } _%>
+        '<%= property.name %>': <%- renderToJsonValue(property) %>,
 <%_ } _%>
 <%_ }); _%>
     };

--- a/packages/type-safe-api/test/resources/specs/edge-cases.yaml
+++ b/packages/type-safe-api/test/resources/specs/edge-cases.yaml
@@ -138,6 +138,16 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ArrayOfOneOfs"
+  /nested-collections:
+    post:
+      operationId: nestedCollections
+      responses:
+        200:
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NestedCollections"
   /additional-properties:
     post:
       operationId: dictionary
@@ -175,6 +185,96 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/NamedOneOfUnion"
+    NestedCollections:
+      type: object
+      properties:
+        nestedArrayOfStrings:
+          type: array
+          items:
+            type: array
+            items:
+              type: string
+        nestedArrayOfDates:
+          type: array
+          items:
+            type: array
+            items:
+              type: string
+              format: date
+        nestedArrayOfObjects:
+          type: array
+          items:
+            type: array
+            items:
+              $ref: "#/components/schemas/SomeObject"
+        fourDimensionalNestedArrayOfObjects:
+          type: array
+          items:
+            type: array
+            items:
+              type: array
+              items:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SomeObject"
+        nestedDictionaryOfStrings:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: string
+        nestedDictionaryOfObjects:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              $ref: "#/components/schemas/SomeObject"
+        fourDimensionalNestedDictionaryOfObjects:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: object
+              additionalProperties:
+                type: object
+                additionalProperties:
+                  $ref: "#/components/schemas/SomeObject"
+        nestedMixOfDictionariesAndArrays:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              type: array
+              items:
+                type: array
+                items:
+                  type: object
+                  additionalProperties:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/SomeObject"
+        cycleArray:
+          $ref: "#/components/schemas/CycleArray"
+        cycleDictionary:
+          $ref: "#/components/schemas/CycleDictionary"
+    CycleArray:
+      type: array
+      items:
+        $ref: "#/components/schemas/CycleArrayNode"
+    CycleArrayNode:
+      type: object
+      properties:
+        nodes:
+          $ref: "#/components/schemas/CycleArray"
+    CycleDictionary:
+      type: object
+      additionalProperties:
+        $ref: "#/components/schemas/CycleDictionaryNode"
+    CycleDictionaryNode:
+      type: object
+      properties:
+        nodes:
+          $ref: "#/components/schemas/CycleDictionary"
     AdditionalPropertiesResponse:
       type: object
       properties:

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/java.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/java.test.ts.snap
@@ -22835,9 +22835,6 @@ public class DataTypes200Response {
       if (jsonObj.get("myDateArray") != null && !jsonObj.get("myDateArray").isJsonArray()) {
         throw new IllegalArgumentException(String.format("Expected the field \`myDateArray\` to be an array in the JSON string but got \`%s\`", jsonObj.get("myDateArray").toString()));
       }
-      if ((jsonObj.get("myDateArray") != null && !jsonObj.get("myDateArray").isJsonNull()) && !jsonObj.get("myDateArray").isJsonPrimitive()) {
-        throw new IllegalArgumentException(String.format("Expected the field \`myDateArray\` to be a primitive type in the JSON string but got \`%s\`", jsonObj.get("myDateArray").toString()));
-      }
       if ((jsonObj.get("myEmail") != null && !jsonObj.get("myEmail").isJsonNull()) && !jsonObj.get("myEmail").isJsonPrimitive()) {
         throw new IllegalArgumentException(String.format("Expected the field \`myEmail\` to be a primitive type in the JSON string but got \`%s\`", jsonObj.get("myEmail").toString()));
       }
@@ -30345,6 +30342,9 @@ src/main/java/test/test/runtime/model/AbstractOpenApiSchema.java
 src/main/java/test/test/runtime/model/AdditionalPropertiesResponse.java
 src/main/java/test/test/runtime/model/AnotherNamedOneOf.java
 src/main/java/test/test/runtime/model/ArrayOfOneOfs.java
+src/main/java/test/test/runtime/model/CycleArrayNode.java
+src/main/java/test/test/runtime/model/CycleDictionary.java
+src/main/java/test/test/runtime/model/CycleDictionaryNode.java
 src/main/java/test/test/runtime/model/Dictionary.java
 src/main/java/test/test/runtime/model/InlineEnum200Response.java
 src/main/java/test/test/runtime/model/InlineEnum200ResponseCategoryEnum.java
@@ -30352,6 +30352,7 @@ src/main/java/test/test/runtime/model/InlineRequestBodyRequestContent.java
 src/main/java/test/test/runtime/model/MyEnum.java
 src/main/java/test/test/runtime/model/NamedOneOf.java
 src/main/java/test/test/runtime/model/NamedOneOfUnion.java
+src/main/java/test/test/runtime/model/NestedCollections.java
 src/main/java/test/test/runtime/model/SomeObject.java
 src/main/java/test/test/runtime/api/handlers/Handlers.java
 src/main/java/test/test/runtime/api/handlers/Response.java
@@ -30369,6 +30370,7 @@ src/main/java/test/test/runtime/api/handlers/dictionary/DictionaryResponse.java
 src/main/java/test/test/runtime/api/handlers/inline_enum/InlineEnumResponse.java
 src/main/java/test/test/runtime/api/handlers/inline_request_body/InlineRequestBodyResponse.java
 src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOfResponse.java
+src/main/java/test/test/runtime/api/handlers/nested_collections/NestedCollectionsResponse.java
 src/main/java/test/test/runtime/api/handlers/reserved_keywords/ReservedKeywordsResponse.java
 src/main/java/test/test/runtime/api/handlers/array_of_one_ofs/ArrayOfOneOfs200Response.java
 src/main/java/test/test/runtime/api/handlers/array_request_parameters/ArrayRequestParameters200Response.java
@@ -30376,6 +30378,7 @@ src/main/java/test/test/runtime/api/handlers/dictionary/Dictionary200Response.ja
 src/main/java/test/test/runtime/api/handlers/inline_enum/InlineEnum200Response.java
 src/main/java/test/test/runtime/api/handlers/inline_request_body/InlineRequestBody204Response.java
 src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOf200Response.java
+src/main/java/test/test/runtime/api/handlers/nested_collections/NestedCollections200Response.java
 src/main/java/test/test/runtime/api/handlers/reserved_keywords/ReservedKeywords200Response.java
 src/main/java/test/test/runtime/api/handlers/array_of_one_ofs/ArrayOfOneOfsRequestParameters.java
 src/main/java/test/test/runtime/api/handlers/array_request_parameters/ArrayRequestParametersRequestParameters.java
@@ -30383,6 +30386,7 @@ src/main/java/test/test/runtime/api/handlers/dictionary/DictionaryRequestParamet
 src/main/java/test/test/runtime/api/handlers/inline_enum/InlineEnumRequestParameters.java
 src/main/java/test/test/runtime/api/handlers/inline_request_body/InlineRequestBodyRequestParameters.java
 src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOfRequestParameters.java
+src/main/java/test/test/runtime/api/handlers/nested_collections/NestedCollectionsRequestParameters.java
 src/main/java/test/test/runtime/api/handlers/reserved_keywords/ReservedKeywordsRequestParameters.java
 src/main/java/test/test/runtime/api/handlers/array_of_one_ofs/ArrayOfOneOfsInput.java
 src/main/java/test/test/runtime/api/handlers/array_request_parameters/ArrayRequestParametersInput.java
@@ -30390,6 +30394,7 @@ src/main/java/test/test/runtime/api/handlers/dictionary/DictionaryInput.java
 src/main/java/test/test/runtime/api/handlers/inline_enum/InlineEnumInput.java
 src/main/java/test/test/runtime/api/handlers/inline_request_body/InlineRequestBodyInput.java
 src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOfInput.java
+src/main/java/test/test/runtime/api/handlers/nested_collections/NestedCollectionsInput.java
 src/main/java/test/test/runtime/api/handlers/reserved_keywords/ReservedKeywordsInput.java
 src/main/java/test/test/runtime/api/handlers/array_of_one_ofs/ArrayOfOneOfsRequestInput.java
 src/main/java/test/test/runtime/api/handlers/array_request_parameters/ArrayRequestParametersRequestInput.java
@@ -30397,6 +30402,7 @@ src/main/java/test/test/runtime/api/handlers/dictionary/DictionaryRequestInput.j
 src/main/java/test/test/runtime/api/handlers/inline_enum/InlineEnumRequestInput.java
 src/main/java/test/test/runtime/api/handlers/inline_request_body/InlineRequestBodyRequestInput.java
 src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOfRequestInput.java
+src/main/java/test/test/runtime/api/handlers/nested_collections/NestedCollectionsRequestInput.java
 src/main/java/test/test/runtime/api/handlers/reserved_keywords/ReservedKeywordsRequestInput.java
 src/main/java/test/test/runtime/api/handlers/array_of_one_ofs/ArrayOfOneOfs.java
 src/main/java/test/test/runtime/api/handlers/array_request_parameters/ArrayRequestParameters.java
@@ -30404,6 +30410,7 @@ src/main/java/test/test/runtime/api/handlers/dictionary/Dictionary.java
 src/main/java/test/test/runtime/api/handlers/inline_enum/InlineEnum.java
 src/main/java/test/test/runtime/api/handlers/inline_request_body/InlineRequestBody.java
 src/main/java/test/test/runtime/api/handlers/named_one_of/NamedOneOf.java
+src/main/java/test/test/runtime/api/handlers/nested_collections/NestedCollections.java
 src/main/java/test/test/runtime/api/handlers/reserved_keywords/ReservedKeywords.java
 src/main/java/test/test/runtime/api/handlers/HandlerRouter.java
 src/main/java/test/test/runtime/api/interceptors/TryCatchInterceptor.java
@@ -32484,11 +32491,15 @@ public class JSON {
         gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.AdditionalPropertiesResponse.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.AnotherNamedOneOf.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.ArrayOfOneOfs.CustomTypeAdapterFactory());
+        gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.CycleArrayNode.CustomTypeAdapterFactory());
+        gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.CycleDictionary.CustomTypeAdapterFactory());
+        gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.CycleDictionaryNode.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.Dictionary.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.InlineEnum200Response.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.InlineRequestBodyRequestContent.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.NamedOneOf.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.NamedOneOfUnion.CustomTypeAdapterFactory());
+        gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.NestedCollections.CustomTypeAdapterFactory());
         gsonBuilder.registerTypeAdapterFactory(new test.test.runtime.model.SomeObject.CustomTypeAdapterFactory());
         gson = gsonBuilder.create();
     }
@@ -33196,6 +33207,7 @@ import test.test.runtime.model.InlineEnum200Response;
 import test.test.runtime.model.InlineRequestBodyRequestContent;
 import test.test.runtime.model.MyEnum;
 import test.test.runtime.model.NamedOneOfUnion;
+import test.test.runtime.model.NestedCollections;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -34248,6 +34260,151 @@ public class DefaultApi {
     public APInamedOneOfRequest namedOneOf() {
         return new APInamedOneOfRequest();
     }
+    private okhttp3.Call nestedCollectionsCall(final ApiCallback _callback) throws ApiException {
+        String basePath = null;
+        // Operation Servers
+        String[] localBasePaths = new String[] {  };
+
+        // Determine Base Path to Use
+        if (localCustomBaseUrl != null){
+            basePath = localCustomBaseUrl;
+        } else if ( localBasePaths.length > 0 ) {
+            basePath = localBasePaths[localHostIndex];
+        } else {
+            basePath = null;
+        }
+
+        Object localVarPostBody = null;
+
+        // create path and map variables
+        String localVarPath = "/nested-collections";
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        final String[] localVarAccepts = {
+            "application/json"
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        if (localVarContentType != null) {
+            localVarHeaderParams.put("Content-Type", localVarContentType);
+        }
+
+        String[] localVarAuthNames = new String[] {  };
+        return localVarApiClient.buildCall(basePath, localVarPath, "POST", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call nestedCollectionsValidateBeforeCall(final ApiCallback _callback) throws ApiException {
+        return nestedCollectionsCall(_callback);
+
+    }
+
+    private ApiResponse<NestedCollections> nestedCollectionsWithHttpInfo() throws ApiException {
+        okhttp3.Call localVarCall = nestedCollectionsValidateBeforeCall(null);
+        Type localVarReturnType = new TypeToken<NestedCollections>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+
+    private okhttp3.Call nestedCollectionsAsync(final ApiCallback<NestedCollections> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = nestedCollectionsValidateBeforeCall(_callback);
+        Type localVarReturnType = new TypeToken<NestedCollections>(){}.getType();
+        localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+        return localVarCall;
+    }
+
+    public class APInestedCollectionsRequest {
+
+        private APInestedCollectionsRequest() {
+        }
+
+        /**
+         * Build call for nestedCollections
+         * @param _callback ApiCallback API callback
+         * @return Call to execute
+         * @throws ApiException If fail to serialize the request body object
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> ok </td><td>  -  </td></tr>
+         </table>
+         */
+        public okhttp3.Call buildCall(final ApiCallback _callback) throws ApiException {
+            return nestedCollectionsCall(_callback);
+        }
+
+        /**
+         * Execute nestedCollections request
+         * @return NestedCollections
+         * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> ok </td><td>  -  </td></tr>
+         </table>
+         */
+        public NestedCollections execute() throws ApiException {
+            ApiResponse<NestedCollections> localVarResp = nestedCollectionsWithHttpInfo();
+            return localVarResp.getData();
+        }
+
+        /**
+         * Execute nestedCollections request with HTTP info returned
+         * @return ApiResponse&lt;NestedCollections&gt;
+         * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> ok </td><td>  -  </td></tr>
+         </table>
+         */
+        public ApiResponse<NestedCollections> executeWithHttpInfo() throws ApiException {
+            return nestedCollectionsWithHttpInfo();
+        }
+
+        /**
+         * Execute nestedCollections request (asynchronously)
+         * @param _callback The callback to be executed when the API call finishes
+         * @return The request call
+         * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> ok </td><td>  -  </td></tr>
+         </table>
+         */
+        public okhttp3.Call executeAsync(final ApiCallback<NestedCollections> _callback) throws ApiException {
+            return nestedCollectionsAsync(_callback);
+        }
+    }
+
+    /**
+     * 
+     * 
+     * @return APInestedCollectionsRequest
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> ok </td><td>  -  </td></tr>
+     </table>
+     */
+    
+    public APInestedCollectionsRequest nestedCollections() {
+        return new APInestedCollectionsRequest();
+    }
     private okhttp3.Call reservedKeywordsCall(String with, String _if, String propertyClass, final ApiCallback _callback) throws ApiException {
         String basePath = null;
         // Operation Servers
@@ -34487,6 +34644,7 @@ import test.test.runtime.api.handlers.dictionary.*;
 import test.test.runtime.api.handlers.inline_enum.*;
 import test.test.runtime.api.handlers.inline_request_body.*;
 import test.test.runtime.api.handlers.named_one_of.*;
+import test.test.runtime.api.handlers.nested_collections.*;
 import test.test.runtime.api.handlers.reserved_keywords.*;
 
 import test.test.runtime.api.handlers.Handlers;
@@ -34511,6 +34669,7 @@ public abstract class HandlerRouter implements RequestHandler<APIGatewayProxyReq
     private static final String inlineEnumMethodAndPath = Handlers.concatMethodAndPath("GET", "/inline-enum");
     private static final String inlineRequestBodyMethodAndPath = Handlers.concatMethodAndPath("POST", "/inline-request-body");
     private static final String namedOneOfMethodAndPath = Handlers.concatMethodAndPath("POST", "/named-one-of");
+    private static final String nestedCollectionsMethodAndPath = Handlers.concatMethodAndPath("POST", "/nested-collections");
     private static final String reservedKeywordsMethodAndPath = Handlers.concatMethodAndPath("GET", "/reserved-keywords");
 
     private final ArrayOfOneOfs constructedArrayOfOneOfs;
@@ -34519,6 +34678,7 @@ public abstract class HandlerRouter implements RequestHandler<APIGatewayProxyReq
     private final InlineEnum constructedInlineEnum;
     private final InlineRequestBody constructedInlineRequestBody;
     private final NamedOneOf constructedNamedOneOf;
+    private final NestedCollections constructedNestedCollections;
     private final ReservedKeywords constructedReservedKeywords;
 
     /**
@@ -34546,6 +34706,10 @@ public abstract class HandlerRouter implements RequestHandler<APIGatewayProxyReq
      */
     public abstract NamedOneOf namedOneOf();
     /**
+     * This method must return your implementation of the NestedCollections operation
+     */
+    public abstract NestedCollections nestedCollections();
+    /**
      * This method must return your implementation of the ReservedKeywords operation
      */
     public abstract ReservedKeywords reservedKeywords();
@@ -34557,6 +34721,7 @@ public abstract class HandlerRouter implements RequestHandler<APIGatewayProxyReq
         inlineEnumRoute,
         inlineRequestBodyRoute,
         namedOneOfRoute,
+        nestedCollectionsRoute,
         reservedKeywordsRoute,
     }
 
@@ -34572,6 +34737,7 @@ public abstract class HandlerRouter implements RequestHandler<APIGatewayProxyReq
         this.routes.put(inlineEnumMethodAndPath, Route.inlineEnumRoute);
         this.routes.put(inlineRequestBodyMethodAndPath, Route.inlineRequestBodyRoute);
         this.routes.put(namedOneOfMethodAndPath, Route.namedOneOfRoute);
+        this.routes.put(nestedCollectionsMethodAndPath, Route.nestedCollectionsRoute);
         this.routes.put(reservedKeywordsMethodAndPath, Route.reservedKeywordsRoute);
         // Handlers are all constructed in the router's constructor such that lambda behaviour remains consistent;
         // ie resources created in the constructor remain in memory between invocations.
@@ -34582,6 +34748,7 @@ public abstract class HandlerRouter implements RequestHandler<APIGatewayProxyReq
         this.constructedInlineEnum = this.inlineEnum();
         this.constructedInlineRequestBody = this.inlineRequestBody();
         this.constructedNamedOneOf = this.namedOneOf();
+        this.constructedNestedCollections = this.nestedCollections();
         this.constructedReservedKeywords = this.reservedKeywords();
     }
 
@@ -34626,6 +34793,10 @@ public abstract class HandlerRouter implements RequestHandler<APIGatewayProxyReq
                 List<Interceptor<NamedOneOfInput>> namedOneOfInterceptors = Handlers.getAnnotationInterceptors(this.getClass());
                 namedOneOfInterceptors.addAll(this.getInterceptors());
                 return this.constructedNamedOneOf.handleRequestWithAdditionalInterceptors(event, context, namedOneOfInterceptors);
+            case nestedCollectionsRoute:
+                List<Interceptor<NestedCollectionsInput>> nestedCollectionsInterceptors = Handlers.getAnnotationInterceptors(this.getClass());
+                nestedCollectionsInterceptors.addAll(this.getInterceptors());
+                return this.constructedNestedCollections.handleRequestWithAdditionalInterceptors(event, context, nestedCollectionsInterceptors);
             case reservedKeywordsRoute:
                 List<Interceptor<ReservedKeywordsInput>> reservedKeywordsInterceptors = Handlers.getAnnotationInterceptors(this.getClass());
                 reservedKeywordsInterceptors.addAll(this.getInterceptors());
@@ -37782,6 +37953,413 @@ import test.test.runtime.api.handlers.Response;
  */
 public interface NamedOneOfResponse extends Response {}
 ",
+  "src/main/java/test/test/runtime/api/handlers/nested_collections/NestedCollections.java": "
+package test.test.runtime.api.handlers.nested_collections;
+
+import test.test.runtime.model.*;
+import test.test.runtime.JSON;
+import test.test.runtime.api.handlers.Interceptor;
+import test.test.runtime.api.handlers.Handlers;
+import test.test.runtime.api.handlers.*;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Collections;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import java.io.IOException;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import org.crac.Core;
+import org.crac.Resource;
+
+
+/**
+ * Lambda handler wrapper for the nestedCollections operation
+ */
+public abstract class NestedCollections implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent>, Resource {
+    {
+        Core.getGlobalContext().register(this);
+    }
+
+    /**
+     * Handle the request for the nestedCollections operation
+     */
+    public abstract NestedCollectionsResponse handle(final NestedCollectionsRequestInput request);
+
+    /**
+     * Interceptors that the handler class has been decorated with
+     */
+    private List<Interceptor<NestedCollectionsInput>> annotationInterceptors = Handlers.getAnnotationInterceptors(NestedCollections.class);
+
+    /**
+     * For more complex interceptors that require instantiation with parameters, you may override this method to
+     * return a list of instantiated interceptors. For simple interceptors with no need for constructor arguments,
+     * prefer the @Interceptors annotation.
+     */
+    public List<Interceptor<NestedCollectionsInput>> getInterceptors() {
+        return Collections.emptyList();
+    }
+
+    private List<Interceptor<NestedCollectionsInput>> getHandlerInterceptors() {
+        List<Interceptor<NestedCollectionsInput>> interceptors = new ArrayList<>();
+        interceptors.addAll(annotationInterceptors);
+        interceptors.addAll(this.getInterceptors());
+        return interceptors;
+    }
+
+    private HandlerChain<NestedCollectionsInput> buildChain(List<Interceptor<NestedCollectionsInput>> interceptors) {
+        return Handlers.buildHandlerChain(interceptors, new HandlerChain<NestedCollectionsInput>() {
+            @Override
+            public Response next(ChainedRequestInput<NestedCollectionsInput> input) {
+                return handle(new NestedCollectionsRequestInput(input.getEvent(), input.getContext(), input.getInterceptorContext(), input.getInput()));
+            }
+        });
+    }
+
+    private ChainedRequestInput<NestedCollectionsInput> buildChainedRequestInput(final APIGatewayProxyRequestEvent event, final Context context, final NestedCollectionsInput input, final Map<String, Object> interceptorContext) {
+        return new ChainedRequestInput<NestedCollectionsInput>() {
+            @Override
+            public HandlerChain getChain() {
+                // The chain's next method ignores the chain given as input, and is pre-built to follow the remaining
+                // chain.
+                return null;
+            }
+
+            @Override
+            public APIGatewayProxyRequestEvent getEvent() {
+                return event;
+            }
+
+            @Override
+            public Context getContext() {
+                return context;
+            }
+
+            @Override
+            public NestedCollectionsInput getInput() {
+                return input;
+            }
+
+            @Override
+            public Map<String, Object> getInterceptorContext() {
+                return interceptorContext;
+            }
+        };
+    }
+
+    @Override
+    public void beforeCheckpoint(org.crac.Context<? extends Resource> context) {
+        // Prime building the handler chain which can take a few 100ms to JIT.
+        this.buildChain(this.getHandlerInterceptors());
+        this.buildChainedRequestInput(null, null, null, null);
+
+        // Initialise instance of Gson and prime serialisation and deserialisation
+        new JSON();
+        JSON.getGson().fromJson(JSON.getGson().toJson(new ApiResponse("", 0, new HashMap<>(), new HashMap<>())), ApiResponse.class);
+
+        try {
+            // Prime input validation - this will likely fail for the fake event but ensures the code path is optimised
+            // ready for a real invocation
+            new NestedCollectionsInput(new APIGatewayProxyRequestEvent()
+                    .withBody("{}")
+                    .withPathParameters(new HashMap<>())
+                    .withQueryStringParameters(new HashMap<>())
+                    .withMultiValueQueryStringParameters(new HashMap<>())
+                    .withHeaders(new HashMap<>())
+                    .withMultiValueHeaders(new HashMap<>())
+            );
+        } catch (Exception e) {
+
+        }
+
+        this.warmUp();
+    }
+
+    @Override
+    public void afterRestore(org.crac.Context<? extends Resource> context) {
+
+    }
+
+    /**
+     * Override this method to perform any warmup activities which will be executed prior to the snap-start snapshot.
+     */
+    public void warmUp() {
+
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent event, final Context context) {
+        return this.handleRequestWithAdditionalInterceptors(event, context, new ArrayList<>());
+    }
+
+    private Map<String, String> getErrorResponseHeaders(final int statusCode) {
+        Map<String, String> headers = new HashMap<>();
+        return headers;
+    }
+
+    public APIGatewayProxyResponseEvent handleRequestWithAdditionalInterceptors(final APIGatewayProxyRequestEvent event, final Context context, final List<Interceptor<NestedCollectionsInput>> additionalInterceptors) {
+        final Map<String, Object> interceptorContext = new HashMap<>();
+        interceptorContext.put("operationId", "nestedCollections");
+
+        List<Interceptor<NestedCollectionsInput>> interceptors = new ArrayList<>();
+        interceptors.addAll(additionalInterceptors);
+        interceptors.addAll(this.getHandlerInterceptors());
+
+        final HandlerChain chain = this.buildChain(interceptors);
+
+        NestedCollectionsInput input;
+
+        try {
+            input = new NestedCollectionsInput(event);
+        } catch (RuntimeException e) {
+            Map<String, String> headers = new HashMap<>();
+            headers.putAll(Handlers.extractResponseHeadersFromInterceptors(interceptors));
+            headers.putAll(this.getErrorResponseHeaders(400));
+            return new APIGatewayProxyResponseEvent()
+                .withStatusCode(400)
+                .withHeaders(headers)
+                .withBody("{\\"message\\": \\"" + e.getMessage() + "\\"}");
+        }
+
+        final Response response = chain.next(this.buildChainedRequestInput(event, context, input, interceptorContext));
+
+        Map<String, String> responseHeaders = new HashMap<>();
+        responseHeaders.putAll(this.getErrorResponseHeaders(response.getStatusCode()));
+        responseHeaders.putAll(response.getHeaders());
+
+        return new APIGatewayProxyResponseEvent()
+                .withStatusCode(response.getStatusCode())
+                .withHeaders(responseHeaders)
+                .withMultiValueHeaders(response.getMultiValueHeaders())
+                .withBody(response.getBody());
+    }
+}
+",
+  "src/main/java/test/test/runtime/api/handlers/nested_collections/NestedCollections200Response.java": "
+package test.test.runtime.api.handlers.nested_collections;
+
+import test.test.runtime.model.*;
+import test.test.runtime.JSON;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Response with status code 200 for the nestedCollections operation
+ */
+public class NestedCollections200Response extends RuntimeException implements NestedCollectionsResponse {
+    static {
+        // JSON has a static instance of Gson which is instantiated lazily the first time it is initialised.
+        // Create an instance here if required to ensure that the static Gson instance is always available.
+        if (JSON.getGson() == null) {
+            new JSON();
+        }
+    }
+
+    private final String body;
+    private final NestedCollections typedBody;
+    private final Map<String, String> headers;
+    private final Map<String, List<String>> multiValueHeaders;
+
+    private NestedCollections200Response(final NestedCollections body, final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
+        this.typedBody = body;
+        this.body = body.toJson();
+        this.headers = headers;
+        this.multiValueHeaders = multiValueHeaders;
+    }
+
+    @Override
+    public int getStatusCode() {
+        return 200;
+    }
+
+    @Override
+    public String getBody() {
+        return this.body;
+    }
+
+    public NestedCollections getTypedBody() {
+        return this.typedBody;
+    }
+
+    @Override
+    public Map<String, String> getHeaders() {
+        return this.headers;
+    }
+
+    @Override
+    public Map<String, List<String>> getMultiValueHeaders() {
+        return this.multiValueHeaders;
+    }
+
+    /**
+     * Create a NestedCollections200Response with a body
+     */
+    public static NestedCollections200Response of(final NestedCollections body) {
+        return new NestedCollections200Response(body, new HashMap<>(), new HashMap<>());
+    }
+
+    /**
+     * Create a NestedCollections200Response with a body and headers
+     */
+    public static NestedCollections200Response of(final NestedCollections body, final Map<String, String> headers) {
+        return new NestedCollections200Response(body, headers, new HashMap<>());
+    }
+
+    /**
+     * Create a NestedCollections200Response with a body, headers and multi-value headers
+     */
+    public static NestedCollections200Response of(final NestedCollections body, final Map<String, String> headers, final Map<String, List<String>> multiValueHeaders) {
+        return new NestedCollections200Response(body, headers, multiValueHeaders);
+    }
+}
+",
+  "src/main/java/test/test/runtime/api/handlers/nested_collections/NestedCollectionsInput.java": "
+package test.test.runtime.api.handlers.nested_collections;
+
+import test.test.runtime.model.*;
+import test.test.runtime.JSON;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.Map;
+import java.util.HashMap;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import java.io.IOException;
+
+/**
+ * Input for the nestedCollections operation
+ */
+@lombok.Builder
+@lombok.AllArgsConstructor
+public class NestedCollectionsInput {
+    static {
+        // JSON has a static instance of Gson which is instantiated lazily the first time it is initialised.
+        // Create an instance here if required to ensure that the static Gson instance is always available.
+        if (JSON.getGson() == null) {
+            new JSON();
+        }
+    }
+
+    private final NestedCollectionsRequestParameters requestParameters;
+
+    public NestedCollectionsInput(final APIGatewayProxyRequestEvent event) {
+        this.requestParameters = new NestedCollectionsRequestParameters(event);
+    }
+
+    public NestedCollectionsRequestParameters getRequestParameters() {
+        return this.requestParameters;
+    }
+
+}
+",
+  "src/main/java/test/test/runtime/api/handlers/nested_collections/NestedCollectionsRequestInput.java": "
+package test.test.runtime.api.handlers.nested_collections;
+
+import test.test.runtime.model.*;
+import test.test.runtime.api.handlers.RequestInput;
+import java.util.List;
+import java.util.Optional;
+import java.util.Map;
+import java.util.HashMap;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import java.io.IOException;
+import com.amazonaws.services.lambda.runtime.Context;
+
+/**
+ * Full request input for the nestedCollections operation, including the raw API Gateway event
+ */
+@lombok.Builder
+@lombok.AllArgsConstructor
+public class NestedCollectionsRequestInput implements RequestInput<NestedCollectionsInput> {
+    private final APIGatewayProxyRequestEvent event;
+    private final Context context;
+    private final Map<String, Object> interceptorContext;
+    private final NestedCollectionsInput input;
+
+    /**
+     * Returns the typed request input, with path, query and body parameters
+     */
+    public NestedCollectionsInput getInput() {
+        return this.input;
+    }
+
+    /**
+     * Returns the raw API Gateway event
+     */
+    public APIGatewayProxyRequestEvent getEvent() {
+        return this.event;
+    }
+
+    /**
+     * Returns the lambda context
+     */
+    public Context getContext() {
+        return this.context;
+    }
+
+    /**
+     * Returns the interceptor context, which may contain values set by request interceptors
+     */
+    public Map<String, Object> getInterceptorContext() {
+        return this.interceptorContext;
+    }
+}
+",
+  "src/main/java/test/test/runtime/api/handlers/nested_collections/NestedCollectionsRequestParameters.java": "
+package test.test.runtime.api.handlers.nested_collections;
+
+import test.test.runtime.api.handlers.Handlers;
+import java.util.Optional;
+import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.time.OffsetDateTime;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.stream.Collectors;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+
+import test.test.runtime.model.*;
+
+/**
+ * Query, path and header parameters for the NestedCollections operation
+ */
+@lombok.Builder
+@lombok.AllArgsConstructor
+public class NestedCollectionsRequestParameters {
+
+    public NestedCollectionsRequestParameters(final APIGatewayProxyRequestEvent event) {
+        Map<String, String> rawStringParameters = new HashMap<>();
+        Handlers.putAllFromNullableMap(event.getPathParameters(), rawStringParameters);
+        Handlers.putAllFromNullableMap(event.getQueryStringParameters(), rawStringParameters);
+        Handlers.putAllFromNullableMap(event.getHeaders(), rawStringParameters);
+        Map<String, String> decodedStringParameters = Handlers.decodeRequestParameters(rawStringParameters);
+
+        Map<String, List<String>> rawStringArrayParameters = new HashMap<>();
+        Handlers.putAllFromNullableMap(event.getMultiValueQueryStringParameters(), rawStringArrayParameters);
+        Handlers.putAllFromNullableMap(event.getMultiValueHeaders(), rawStringArrayParameters);
+        Map<String, List<String>> decodedStringArrayParameters = Handlers.decodeRequestArrayParameters(rawStringArrayParameters);
+
+    }
+
+}
+",
+  "src/main/java/test/test/runtime/api/handlers/nested_collections/NestedCollectionsResponse.java": "
+package test.test.runtime.api.handlers.nested_collections;
+
+import test.test.runtime.api.handlers.Response;
+
+/**
+ * Response for the nestedCollections operation
+ */
+public interface NestedCollectionsResponse extends Response {}
+",
   "src/main/java/test/test/runtime/api/handlers/reserved_keywords/ReservedKeywords.java": "
 package test.test.runtime.api.handlers.reserved_keywords;
 
@@ -38558,6 +39136,7 @@ public class OperationConfig<T> {
     private T inlineEnum;
     private T inlineRequestBody;
     private T namedOneOf;
+    private T nestedCollections;
     private T reservedKeywords;
 
     public Map<String, T> asMap() {
@@ -38568,6 +39147,7 @@ public class OperationConfig<T> {
         map.put("inlineEnum", this.inlineEnum);
         map.put("inlineRequestBody", this.inlineRequestBody);
         map.put("namedOneOf", this.namedOneOf);
+        map.put("nestedCollections", this.nestedCollections);
         map.put("reservedKeywords", this.reservedKeywords);
         return map;
     }
@@ -38628,6 +39208,11 @@ public class OperationLookup {
             .method("POST")
             .contentTypes(Arrays.asList("application/json"))
             .build());
+        config.put("nestedCollections", OperationLookupEntry.builder()
+            .path("/nested-collections")
+            .method("POST")
+            .contentTypes(Arrays.asList("application/json"))
+            .build());
         config.put("reservedKeywords", OperationLookupEntry.builder()
             .path("/reserved-keywords")
             .method("GET")
@@ -38654,6 +39239,7 @@ public class Operations {
                 .inlineEnum(value)
                 .inlineRequestBody(value)
                 .namedOneOf(value)
+                .nestedCollections(value)
                 .reservedKeywords(value)
                 ;
     }
@@ -39252,9 +39838,6 @@ public class AdditionalPropertiesResponse {
       if (jsonObj.get("dictionaryOfObjects") != null && !jsonObj.get("dictionaryOfObjects").isJsonNull()) {
         Dictionary.validateJsonObject(jsonObj.getAsJsonObject("dictionaryOfObjects"));
       }
-      if ((jsonObj.get("dictionaryOfPrimitives") != null && !jsonObj.get("dictionaryOfPrimitives").isJsonNull()) && !jsonObj.get("dictionaryOfPrimitives").isJsonPrimitive()) {
-        throw new IllegalArgumentException(String.format("Expected the field \`dictionaryOfPrimitives\` to be a primitive type in the JSON string but got \`%s\`", jsonObj.get("dictionaryOfPrimitives").toString()));
-      }
   }
 
   public static class CustomTypeAdapterFactory implements TypeAdapterFactory {
@@ -39711,9 +40294,19 @@ public class ArrayOfOneOfs {
           throw new IllegalArgumentException(String.format("The field \`%s\` in the JSON string is not defined in the \`ArrayOfOneOfs\` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
         }
       }
-      // ensure the optional json data is an array if present
-      if (jsonObj.get("oneOfs") != null && !jsonObj.get("oneOfs").isJsonArray()) {
-        throw new IllegalArgumentException(String.format("Expected the field \`oneOfs\` to be an array in the JSON string but got \`%s\`", jsonObj.get("oneOfs").toString()));
+      if (jsonObj.get("oneOfs") != null && !jsonObj.get("oneOfs").isJsonNull()) {
+        JsonArray jsonArrayoneOfs = jsonObj.getAsJsonArray("oneOfs");
+        if (jsonArrayoneOfs != null) {
+          // ensure the json data is an array
+          if (!jsonObj.get("oneOfs").isJsonArray()) {
+            throw new IllegalArgumentException(String.format("Expected the field \`oneOfs\` to be an array in the JSON string but got \`%s\`", jsonObj.get("oneOfs").toString()));
+          }
+
+          // validate the optional field \`oneOfs\` (array)
+          for (int i = 0; i < jsonArrayoneOfs.size(); i++) {
+            NamedOneOfUnion.validateJsonObject(jsonArrayoneOfs.get(i).getAsJsonObject());
+          };
+        }
       }
   }
 
@@ -39759,6 +40352,672 @@ public class ArrayOfOneOfs {
 
  /**
   * Convert an instance of ArrayOfOneOfs to an JSON string
+  *
+  * @return JSON string
+  */
+  public String toJson() {
+    return JSON.getGson().toJson(this);
+  }
+}
+",
+  "src/main/java/test/test/runtime/model/CycleArrayNode.java": "/*
+ * Edge Cases
+ * 
+ *
+ * The version of the OpenAPI document: 1.0.0
+ *
+ *
+ * NOTE: This class is auto generated.
+ * Do not edit the class manually.
+ */
+
+
+package test.test.runtime.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+
+import javax.ws.rs.core.GenericType;
+
+import java.io.IOException;
+import java.io.File;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import java.lang.reflect.Type;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.List;
+import java.util.Set;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import test.test.runtime.JSON;
+
+/**
+ * CycleArrayNode
+ */
+@lombok.AllArgsConstructor @lombok.experimental.SuperBuilder
+public class CycleArrayNode {
+  public static final String SERIALIZED_NAME_NODES = "nodes";
+  @SerializedName(SERIALIZED_NAME_NODES)
+  private List<CycleArrayNode> nodes = null;
+
+  public CycleArrayNode() {
+  }
+
+  public CycleArrayNode nodes(List<CycleArrayNode> nodes) {
+
+    this.nodes = nodes;
+    return this;
+  }
+
+  public CycleArrayNode addNodesItem(CycleArrayNode nodesItem) {
+    if (this.nodes == null) {
+      this.nodes = new ArrayList<>();
+    }
+    this.nodes.add(nodesItem);
+    return this;
+  }
+
+   /**
+   * Get nodes
+   * @return nodes
+  **/
+  @javax.annotation.Nullable
+  public List<CycleArrayNode> getNodes() {
+    return nodes;
+  }
+
+
+  public void setNodes(List<CycleArrayNode> nodes) {
+    this.nodes = nodes;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CycleArrayNode cycleArrayNode = (CycleArrayNode) o;
+    return Objects.equals(this.nodes, cycleArrayNode.nodes);
+        
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(nodes);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class CycleArrayNode {\\n");
+    sb.append("    nodes: ").append(toIndentedString(nodes)).append("\\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\\n", "\\n    ");
+  }
+
+
+  public static HashSet<String> openapiFields;
+  public static HashSet<String> openapiRequiredFields;
+
+  static {
+    // a set of all properties/fields (JSON key names)
+    openapiFields = new HashSet<String>();
+    openapiFields.add("nodes");
+
+    // a set of required properties/fields (JSON key names)
+    openapiRequiredFields = new HashSet<String>();
+  }
+
+ /**
+  * Validates the JSON Object and throws an exception if issues found
+  *
+  * @param jsonObj JSON Object
+  * @throws IOException if the JSON Object is invalid with respect to CycleArrayNode
+  */
+  public static void validateJsonObject(JsonObject jsonObj) throws IOException {
+      if (jsonObj == null) {
+        if (!CycleArrayNode.openapiRequiredFields.isEmpty()) { // has required fields but JSON object is null
+          throw new IllegalArgumentException(String.format("The required field(s) %s in CycleArrayNode is not found in the empty JSON string", CycleArrayNode.openapiRequiredFields.toString()));
+        }
+      }
+
+      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
+      // check to see if the JSON string contains additional fields
+      for (Entry<String, JsonElement> entry : entries) {
+        if (!CycleArrayNode.openapiFields.contains(entry.getKey())) {
+          throw new IllegalArgumentException(String.format("The field \`%s\` in the JSON string is not defined in the \`CycleArrayNode\` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
+        }
+      }
+      if (jsonObj.get("nodes") != null && !jsonObj.get("nodes").isJsonNull()) {
+        JsonArray jsonArraynodes = jsonObj.getAsJsonArray("nodes");
+        if (jsonArraynodes != null) {
+          // ensure the json data is an array
+          if (!jsonObj.get("nodes").isJsonArray()) {
+            throw new IllegalArgumentException(String.format("Expected the field \`nodes\` to be an array in the JSON string but got \`%s\`", jsonObj.get("nodes").toString()));
+          }
+
+          // validate the optional field \`nodes\` (array)
+          for (int i = 0; i < jsonArraynodes.size(); i++) {
+            CycleArrayNode.validateJsonObject(jsonArraynodes.get(i).getAsJsonObject());
+          };
+        }
+      }
+  }
+
+  public static class CustomTypeAdapterFactory implements TypeAdapterFactory {
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+       if (!CycleArrayNode.class.isAssignableFrom(type.getRawType())) {
+         return null; // this class only serializes 'CycleArrayNode' and its subtypes
+       }
+       final TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
+       final TypeAdapter<CycleArrayNode> thisAdapter
+                        = gson.getDelegateAdapter(this, TypeToken.get(CycleArrayNode.class));
+
+       return (TypeAdapter<T>) new TypeAdapter<CycleArrayNode>() {
+           @Override
+           public void write(JsonWriter out, CycleArrayNode value) throws IOException {
+             JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             elementAdapter.write(out, obj);
+           }
+
+           @Override
+           public CycleArrayNode read(JsonReader in) throws IOException {
+             JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
+             validateJsonObject(jsonObj);
+             return thisAdapter.fromJsonTree(jsonObj);
+           }
+
+       }.nullSafe();
+    }
+  }
+
+ /**
+  * Create an instance of CycleArrayNode given an JSON string
+  *
+  * @param jsonString JSON string
+  * @return An instance of CycleArrayNode
+  * @throws IOException if the JSON string is invalid with respect to CycleArrayNode
+  */
+  public static CycleArrayNode fromJson(String jsonString) throws IOException {
+    return JSON.getGson().fromJson(jsonString, CycleArrayNode.class);
+  }
+
+ /**
+  * Convert an instance of CycleArrayNode to an JSON string
+  *
+  * @return JSON string
+  */
+  public String toJson() {
+    return JSON.getGson().toJson(this);
+  }
+}
+",
+  "src/main/java/test/test/runtime/model/CycleDictionary.java": "/*
+ * Edge Cases
+ * 
+ *
+ * The version of the OpenAPI document: 1.0.0
+ *
+ *
+ * NOTE: This class is auto generated.
+ * Do not edit the class manually.
+ */
+
+
+package test.test.runtime.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+
+import javax.ws.rs.core.GenericType;
+
+import java.io.IOException;
+import java.io.File;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import java.lang.reflect.Type;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.List;
+import java.util.Set;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import test.test.runtime.JSON;
+
+/**
+ * CycleDictionary
+ */
+@lombok.AllArgsConstructor @lombok.experimental.SuperBuilder
+public class CycleDictionary {
+  public CycleDictionary() {
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CycleDictionary cycleDictionary = (CycleDictionary) o;
+    return 
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash();
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class CycleDictionary {\\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\\n", "\\n    ");
+  }
+
+
+  public static HashSet<String> openapiFields;
+  public static HashSet<String> openapiRequiredFields;
+
+  static {
+    // a set of all properties/fields (JSON key names)
+    openapiFields = new HashSet<String>();
+
+    // a set of required properties/fields (JSON key names)
+    openapiRequiredFields = new HashSet<String>();
+  }
+
+ /**
+  * Validates the JSON Object and throws an exception if issues found
+  *
+  * @param jsonObj JSON Object
+  * @throws IOException if the JSON Object is invalid with respect to CycleDictionary
+  */
+  public static void validateJsonObject(JsonObject jsonObj) throws IOException {
+      if (jsonObj == null) {
+        if (!CycleDictionary.openapiRequiredFields.isEmpty()) { // has required fields but JSON object is null
+          throw new IllegalArgumentException(String.format("The required field(s) %s in CycleDictionary is not found in the empty JSON string", CycleDictionary.openapiRequiredFields.toString()));
+        }
+      }
+
+      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
+      // check to see if the JSON string contains additional fields
+      for (Entry<String, JsonElement> entry : entries) {
+        if (!CycleDictionary.openapiFields.contains(entry.getKey())) {
+          throw new IllegalArgumentException(String.format("The field \`%s\` in the JSON string is not defined in the \`CycleDictionary\` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
+        }
+      }
+  }
+
+  public static class CustomTypeAdapterFactory implements TypeAdapterFactory {
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+       if (!CycleDictionary.class.isAssignableFrom(type.getRawType())) {
+         return null; // this class only serializes 'CycleDictionary' and its subtypes
+       }
+       final TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
+       final TypeAdapter<CycleDictionary> thisAdapter
+                        = gson.getDelegateAdapter(this, TypeToken.get(CycleDictionary.class));
+
+       return (TypeAdapter<T>) new TypeAdapter<CycleDictionary>() {
+           @Override
+           public void write(JsonWriter out, CycleDictionary value) throws IOException {
+             JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             elementAdapter.write(out, obj);
+           }
+
+           @Override
+           public CycleDictionary read(JsonReader in) throws IOException {
+             JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
+             validateJsonObject(jsonObj);
+             return thisAdapter.fromJsonTree(jsonObj);
+           }
+
+       }.nullSafe();
+    }
+  }
+
+ /**
+  * Create an instance of CycleDictionary given an JSON string
+  *
+  * @param jsonString JSON string
+  * @return An instance of CycleDictionary
+  * @throws IOException if the JSON string is invalid with respect to CycleDictionary
+  */
+  public static CycleDictionary fromJson(String jsonString) throws IOException {
+    return JSON.getGson().fromJson(jsonString, CycleDictionary.class);
+  }
+
+ /**
+  * Convert an instance of CycleDictionary to an JSON string
+  *
+  * @return JSON string
+  */
+  public String toJson() {
+    return JSON.getGson().toJson(this);
+  }
+}
+",
+  "src/main/java/test/test/runtime/model/CycleDictionaryNode.java": "/*
+ * Edge Cases
+ * 
+ *
+ * The version of the OpenAPI document: 1.0.0
+ *
+ *
+ * NOTE: This class is auto generated.
+ * Do not edit the class manually.
+ */
+
+
+package test.test.runtime.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import test.test.runtime.model.CycleDictionary;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+
+import javax.ws.rs.core.GenericType;
+
+import java.io.IOException;
+import java.io.File;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import java.lang.reflect.Type;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.List;
+import java.util.Set;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import test.test.runtime.JSON;
+
+/**
+ * CycleDictionaryNode
+ */
+@lombok.AllArgsConstructor @lombok.experimental.SuperBuilder
+public class CycleDictionaryNode {
+  public static final String SERIALIZED_NAME_NODES = "nodes";
+  @SerializedName(SERIALIZED_NAME_NODES)
+  private CycleDictionary nodes;
+
+  public CycleDictionaryNode() {
+  }
+
+  public CycleDictionaryNode nodes(CycleDictionary nodes) {
+
+    this.nodes = nodes;
+    return this;
+  }
+
+   /**
+   * Get nodes
+   * @return nodes
+  **/
+  @javax.annotation.Nullable
+  public CycleDictionary getNodes() {
+    return nodes;
+  }
+
+
+  public void setNodes(CycleDictionary nodes) {
+    this.nodes = nodes;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CycleDictionaryNode cycleDictionaryNode = (CycleDictionaryNode) o;
+    return Objects.equals(this.nodes, cycleDictionaryNode.nodes);
+        
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(nodes);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class CycleDictionaryNode {\\n");
+    sb.append("    nodes: ").append(toIndentedString(nodes)).append("\\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\\n", "\\n    ");
+  }
+
+
+  public static HashSet<String> openapiFields;
+  public static HashSet<String> openapiRequiredFields;
+
+  static {
+    // a set of all properties/fields (JSON key names)
+    openapiFields = new HashSet<String>();
+    openapiFields.add("nodes");
+
+    // a set of required properties/fields (JSON key names)
+    openapiRequiredFields = new HashSet<String>();
+  }
+
+ /**
+  * Validates the JSON Object and throws an exception if issues found
+  *
+  * @param jsonObj JSON Object
+  * @throws IOException if the JSON Object is invalid with respect to CycleDictionaryNode
+  */
+  public static void validateJsonObject(JsonObject jsonObj) throws IOException {
+      if (jsonObj == null) {
+        if (!CycleDictionaryNode.openapiRequiredFields.isEmpty()) { // has required fields but JSON object is null
+          throw new IllegalArgumentException(String.format("The required field(s) %s in CycleDictionaryNode is not found in the empty JSON string", CycleDictionaryNode.openapiRequiredFields.toString()));
+        }
+      }
+
+      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
+      // check to see if the JSON string contains additional fields
+      for (Entry<String, JsonElement> entry : entries) {
+        if (!CycleDictionaryNode.openapiFields.contains(entry.getKey())) {
+          throw new IllegalArgumentException(String.format("The field \`%s\` in the JSON string is not defined in the \`CycleDictionaryNode\` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
+        }
+      }
+      // validate the optional field \`nodes\`
+      if (jsonObj.get("nodes") != null && !jsonObj.get("nodes").isJsonNull()) {
+        CycleDictionary.validateJsonObject(jsonObj.getAsJsonObject("nodes"));
+      }
+  }
+
+  public static class CustomTypeAdapterFactory implements TypeAdapterFactory {
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+       if (!CycleDictionaryNode.class.isAssignableFrom(type.getRawType())) {
+         return null; // this class only serializes 'CycleDictionaryNode' and its subtypes
+       }
+       final TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
+       final TypeAdapter<CycleDictionaryNode> thisAdapter
+                        = gson.getDelegateAdapter(this, TypeToken.get(CycleDictionaryNode.class));
+
+       return (TypeAdapter<T>) new TypeAdapter<CycleDictionaryNode>() {
+           @Override
+           public void write(JsonWriter out, CycleDictionaryNode value) throws IOException {
+             JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             elementAdapter.write(out, obj);
+           }
+
+           @Override
+           public CycleDictionaryNode read(JsonReader in) throws IOException {
+             JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
+             validateJsonObject(jsonObj);
+             return thisAdapter.fromJsonTree(jsonObj);
+           }
+
+       }.nullSafe();
+    }
+  }
+
+ /**
+  * Create an instance of CycleDictionaryNode given an JSON string
+  *
+  * @param jsonString JSON string
+  * @return An instance of CycleDictionaryNode
+  * @throws IOException if the JSON string is invalid with respect to CycleDictionaryNode
+  */
+  public static CycleDictionaryNode fromJson(String jsonString) throws IOException {
+    return JSON.getGson().fromJson(jsonString, CycleDictionaryNode.class);
+  }
+
+ /**
+  * Convert an instance of CycleDictionaryNode to an JSON string
   *
   * @return JSON string
   */
@@ -41169,6 +42428,634 @@ public class NamedOneOfUnion extends AbstractOpenApiSchema {
     return JSON.getGson().toJson(this);
   }
 
+}
+",
+  "src/main/java/test/test/runtime/model/NestedCollections.java": "/*
+ * Edge Cases
+ * 
+ *
+ * The version of the OpenAPI document: 1.0.0
+ *
+ *
+ * NOTE: This class is auto generated.
+ * Do not edit the class manually.
+ */
+
+
+package test.test.runtime.model;
+
+import java.util.Objects;
+import java.util.Arrays;
+import test.test.runtime.model.CycleArrayNode;
+import test.test.runtime.model.CycleDictionary;
+import test.test.runtime.model.SomeObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+
+import javax.ws.rs.core.GenericType;
+
+import java.io.IOException;
+import java.io.File;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import java.lang.reflect.Type;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.List;
+import java.util.Set;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParseException;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import test.test.runtime.JSON;
+
+/**
+ * NestedCollections
+ */
+@lombok.AllArgsConstructor @lombok.experimental.SuperBuilder
+public class NestedCollections {
+  public static final String SERIALIZED_NAME_NESTED_ARRAY_OF_STRINGS = "nestedArrayOfStrings";
+  @SerializedName(SERIALIZED_NAME_NESTED_ARRAY_OF_STRINGS)
+  private List<List<String>> nestedArrayOfStrings = null;
+
+  public static final String SERIALIZED_NAME_NESTED_ARRAY_OF_DATES = "nestedArrayOfDates";
+  @SerializedName(SERIALIZED_NAME_NESTED_ARRAY_OF_DATES)
+  private List<List<LocalDate>> nestedArrayOfDates = null;
+
+  public static final String SERIALIZED_NAME_NESTED_ARRAY_OF_OBJECTS = "nestedArrayOfObjects";
+  @SerializedName(SERIALIZED_NAME_NESTED_ARRAY_OF_OBJECTS)
+  private List<List<SomeObject>> nestedArrayOfObjects = null;
+
+  public static final String SERIALIZED_NAME_FOUR_DIMENSIONAL_NESTED_ARRAY_OF_OBJECTS = "fourDimensionalNestedArrayOfObjects";
+  @SerializedName(SERIALIZED_NAME_FOUR_DIMENSIONAL_NESTED_ARRAY_OF_OBJECTS)
+  private List<List<List<List<SomeObject>>>> fourDimensionalNestedArrayOfObjects = null;
+
+  public static final String SERIALIZED_NAME_NESTED_DICTIONARY_OF_STRINGS = "nestedDictionaryOfStrings";
+  @SerializedName(SERIALIZED_NAME_NESTED_DICTIONARY_OF_STRINGS)
+  private Map<String, Map<String, String>> nestedDictionaryOfStrings = null;
+
+  public static final String SERIALIZED_NAME_NESTED_DICTIONARY_OF_OBJECTS = "nestedDictionaryOfObjects";
+  @SerializedName(SERIALIZED_NAME_NESTED_DICTIONARY_OF_OBJECTS)
+  private Map<String, Map<String, SomeObject>> nestedDictionaryOfObjects = null;
+
+  public static final String SERIALIZED_NAME_FOUR_DIMENSIONAL_NESTED_DICTIONARY_OF_OBJECTS = "fourDimensionalNestedDictionaryOfObjects";
+  @SerializedName(SERIALIZED_NAME_FOUR_DIMENSIONAL_NESTED_DICTIONARY_OF_OBJECTS)
+  private Map<String, Map<String, Map<String, Map<String, SomeObject>>>> fourDimensionalNestedDictionaryOfObjects = null;
+
+  public static final String SERIALIZED_NAME_NESTED_MIX_OF_DICTIONARIES_AND_ARRAYS = "nestedMixOfDictionariesAndArrays";
+  @SerializedName(SERIALIZED_NAME_NESTED_MIX_OF_DICTIONARIES_AND_ARRAYS)
+  private List<Map<String, List<List<Map<String, List<SomeObject>>>>>> nestedMixOfDictionariesAndArrays = null;
+
+  public static final String SERIALIZED_NAME_CYCLE_ARRAY = "cycleArray";
+  @SerializedName(SERIALIZED_NAME_CYCLE_ARRAY)
+  private List<CycleArrayNode> cycleArray = null;
+
+  public static final String SERIALIZED_NAME_CYCLE_DICTIONARY = "cycleDictionary";
+  @SerializedName(SERIALIZED_NAME_CYCLE_DICTIONARY)
+  private CycleDictionary cycleDictionary;
+
+  public NestedCollections() {
+  }
+
+  public NestedCollections nestedArrayOfStrings(List<List<String>> nestedArrayOfStrings) {
+
+    this.nestedArrayOfStrings = nestedArrayOfStrings;
+    return this;
+  }
+
+  public NestedCollections addNestedArrayOfStringsItem(List<String> nestedArrayOfStringsItem) {
+    if (this.nestedArrayOfStrings == null) {
+      this.nestedArrayOfStrings = new ArrayList<>();
+    }
+    this.nestedArrayOfStrings.add(nestedArrayOfStringsItem);
+    return this;
+  }
+
+   /**
+   * Get nestedArrayOfStrings
+   * @return nestedArrayOfStrings
+  **/
+  @javax.annotation.Nullable
+  public List<List<String>> getNestedArrayOfStrings() {
+    return nestedArrayOfStrings;
+  }
+
+
+  public void setNestedArrayOfStrings(List<List<String>> nestedArrayOfStrings) {
+    this.nestedArrayOfStrings = nestedArrayOfStrings;
+  }
+
+  public NestedCollections nestedArrayOfDates(List<List<LocalDate>> nestedArrayOfDates) {
+
+    this.nestedArrayOfDates = nestedArrayOfDates;
+    return this;
+  }
+
+  public NestedCollections addNestedArrayOfDatesItem(List<LocalDate> nestedArrayOfDatesItem) {
+    if (this.nestedArrayOfDates == null) {
+      this.nestedArrayOfDates = new ArrayList<>();
+    }
+    this.nestedArrayOfDates.add(nestedArrayOfDatesItem);
+    return this;
+  }
+
+   /**
+   * Get nestedArrayOfDates
+   * @return nestedArrayOfDates
+  **/
+  @javax.annotation.Nullable
+  public List<List<LocalDate>> getNestedArrayOfDates() {
+    return nestedArrayOfDates;
+  }
+
+
+  public void setNestedArrayOfDates(List<List<LocalDate>> nestedArrayOfDates) {
+    this.nestedArrayOfDates = nestedArrayOfDates;
+  }
+
+  public NestedCollections nestedArrayOfObjects(List<List<SomeObject>> nestedArrayOfObjects) {
+
+    this.nestedArrayOfObjects = nestedArrayOfObjects;
+    return this;
+  }
+
+  public NestedCollections addNestedArrayOfObjectsItem(List<SomeObject> nestedArrayOfObjectsItem) {
+    if (this.nestedArrayOfObjects == null) {
+      this.nestedArrayOfObjects = new ArrayList<>();
+    }
+    this.nestedArrayOfObjects.add(nestedArrayOfObjectsItem);
+    return this;
+  }
+
+   /**
+   * Get nestedArrayOfObjects
+   * @return nestedArrayOfObjects
+  **/
+  @javax.annotation.Nullable
+  public List<List<SomeObject>> getNestedArrayOfObjects() {
+    return nestedArrayOfObjects;
+  }
+
+
+  public void setNestedArrayOfObjects(List<List<SomeObject>> nestedArrayOfObjects) {
+    this.nestedArrayOfObjects = nestedArrayOfObjects;
+  }
+
+  public NestedCollections fourDimensionalNestedArrayOfObjects(List<List<List<List<SomeObject>>>> fourDimensionalNestedArrayOfObjects) {
+
+    this.fourDimensionalNestedArrayOfObjects = fourDimensionalNestedArrayOfObjects;
+    return this;
+  }
+
+  public NestedCollections addFourDimensionalNestedArrayOfObjectsItem(List<List<List<SomeObject>>> fourDimensionalNestedArrayOfObjectsItem) {
+    if (this.fourDimensionalNestedArrayOfObjects == null) {
+      this.fourDimensionalNestedArrayOfObjects = new ArrayList<>();
+    }
+    this.fourDimensionalNestedArrayOfObjects.add(fourDimensionalNestedArrayOfObjectsItem);
+    return this;
+  }
+
+   /**
+   * Get fourDimensionalNestedArrayOfObjects
+   * @return fourDimensionalNestedArrayOfObjects
+  **/
+  @javax.annotation.Nullable
+  public List<List<List<List<SomeObject>>>> getFourDimensionalNestedArrayOfObjects() {
+    return fourDimensionalNestedArrayOfObjects;
+  }
+
+
+  public void setFourDimensionalNestedArrayOfObjects(List<List<List<List<SomeObject>>>> fourDimensionalNestedArrayOfObjects) {
+    this.fourDimensionalNestedArrayOfObjects = fourDimensionalNestedArrayOfObjects;
+  }
+
+  public NestedCollections nestedDictionaryOfStrings(Map<String, Map<String, String>> nestedDictionaryOfStrings) {
+
+    this.nestedDictionaryOfStrings = nestedDictionaryOfStrings;
+    return this;
+  }
+
+  public NestedCollections putNestedDictionaryOfStringsItem(String key, Map<String, String> nestedDictionaryOfStringsItem) {
+    if (this.nestedDictionaryOfStrings == null) {
+      this.nestedDictionaryOfStrings = new HashMap<>();
+    }
+    this.nestedDictionaryOfStrings.put(key, nestedDictionaryOfStringsItem);
+    return this;
+  }
+
+   /**
+   * Get nestedDictionaryOfStrings
+   * @return nestedDictionaryOfStrings
+  **/
+  @javax.annotation.Nullable
+  public Map<String, Map<String, String>> getNestedDictionaryOfStrings() {
+    return nestedDictionaryOfStrings;
+  }
+
+
+  public void setNestedDictionaryOfStrings(Map<String, Map<String, String>> nestedDictionaryOfStrings) {
+    this.nestedDictionaryOfStrings = nestedDictionaryOfStrings;
+  }
+
+  public NestedCollections nestedDictionaryOfObjects(Map<String, Map<String, SomeObject>> nestedDictionaryOfObjects) {
+
+    this.nestedDictionaryOfObjects = nestedDictionaryOfObjects;
+    return this;
+  }
+
+  public NestedCollections putNestedDictionaryOfObjectsItem(String key, Map<String, SomeObject> nestedDictionaryOfObjectsItem) {
+    if (this.nestedDictionaryOfObjects == null) {
+      this.nestedDictionaryOfObjects = new HashMap<>();
+    }
+    this.nestedDictionaryOfObjects.put(key, nestedDictionaryOfObjectsItem);
+    return this;
+  }
+
+   /**
+   * Get nestedDictionaryOfObjects
+   * @return nestedDictionaryOfObjects
+  **/
+  @javax.annotation.Nullable
+  public Map<String, Map<String, SomeObject>> getNestedDictionaryOfObjects() {
+    return nestedDictionaryOfObjects;
+  }
+
+
+  public void setNestedDictionaryOfObjects(Map<String, Map<String, SomeObject>> nestedDictionaryOfObjects) {
+    this.nestedDictionaryOfObjects = nestedDictionaryOfObjects;
+  }
+
+  public NestedCollections fourDimensionalNestedDictionaryOfObjects(Map<String, Map<String, Map<String, Map<String, SomeObject>>>> fourDimensionalNestedDictionaryOfObjects) {
+
+    this.fourDimensionalNestedDictionaryOfObjects = fourDimensionalNestedDictionaryOfObjects;
+    return this;
+  }
+
+  public NestedCollections putFourDimensionalNestedDictionaryOfObjectsItem(String key, Map<String, Map<String, Map<String, SomeObject>>> fourDimensionalNestedDictionaryOfObjectsItem) {
+    if (this.fourDimensionalNestedDictionaryOfObjects == null) {
+      this.fourDimensionalNestedDictionaryOfObjects = new HashMap<>();
+    }
+    this.fourDimensionalNestedDictionaryOfObjects.put(key, fourDimensionalNestedDictionaryOfObjectsItem);
+    return this;
+  }
+
+   /**
+   * Get fourDimensionalNestedDictionaryOfObjects
+   * @return fourDimensionalNestedDictionaryOfObjects
+  **/
+  @javax.annotation.Nullable
+  public Map<String, Map<String, Map<String, Map<String, SomeObject>>>> getFourDimensionalNestedDictionaryOfObjects() {
+    return fourDimensionalNestedDictionaryOfObjects;
+  }
+
+
+  public void setFourDimensionalNestedDictionaryOfObjects(Map<String, Map<String, Map<String, Map<String, SomeObject>>>> fourDimensionalNestedDictionaryOfObjects) {
+    this.fourDimensionalNestedDictionaryOfObjects = fourDimensionalNestedDictionaryOfObjects;
+  }
+
+  public NestedCollections nestedMixOfDictionariesAndArrays(List<Map<String, List<List<Map<String, List<SomeObject>>>>>> nestedMixOfDictionariesAndArrays) {
+
+    this.nestedMixOfDictionariesAndArrays = nestedMixOfDictionariesAndArrays;
+    return this;
+  }
+
+  public NestedCollections addNestedMixOfDictionariesAndArraysItem(Map<String, List<List<Map<String, List<SomeObject>>>>> nestedMixOfDictionariesAndArraysItem) {
+    if (this.nestedMixOfDictionariesAndArrays == null) {
+      this.nestedMixOfDictionariesAndArrays = new ArrayList<>();
+    }
+    this.nestedMixOfDictionariesAndArrays.add(nestedMixOfDictionariesAndArraysItem);
+    return this;
+  }
+
+   /**
+   * Get nestedMixOfDictionariesAndArrays
+   * @return nestedMixOfDictionariesAndArrays
+  **/
+  @javax.annotation.Nullable
+  public List<Map<String, List<List<Map<String, List<SomeObject>>>>>> getNestedMixOfDictionariesAndArrays() {
+    return nestedMixOfDictionariesAndArrays;
+  }
+
+
+  public void setNestedMixOfDictionariesAndArrays(List<Map<String, List<List<Map<String, List<SomeObject>>>>>> nestedMixOfDictionariesAndArrays) {
+    this.nestedMixOfDictionariesAndArrays = nestedMixOfDictionariesAndArrays;
+  }
+
+  public NestedCollections cycleArray(List<CycleArrayNode> cycleArray) {
+
+    this.cycleArray = cycleArray;
+    return this;
+  }
+
+  public NestedCollections addCycleArrayItem(CycleArrayNode cycleArrayItem) {
+    if (this.cycleArray == null) {
+      this.cycleArray = new ArrayList<>();
+    }
+    this.cycleArray.add(cycleArrayItem);
+    return this;
+  }
+
+   /**
+   * Get cycleArray
+   * @return cycleArray
+  **/
+  @javax.annotation.Nullable
+  public List<CycleArrayNode> getCycleArray() {
+    return cycleArray;
+  }
+
+
+  public void setCycleArray(List<CycleArrayNode> cycleArray) {
+    this.cycleArray = cycleArray;
+  }
+
+  public NestedCollections cycleDictionary(CycleDictionary cycleDictionary) {
+
+    this.cycleDictionary = cycleDictionary;
+    return this;
+  }
+
+   /**
+   * Get cycleDictionary
+   * @return cycleDictionary
+  **/
+  @javax.annotation.Nullable
+  public CycleDictionary getCycleDictionary() {
+    return cycleDictionary;
+  }
+
+
+  public void setCycleDictionary(CycleDictionary cycleDictionary) {
+    this.cycleDictionary = cycleDictionary;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    NestedCollections nestedCollections = (NestedCollections) o;
+    return Objects.equals(this.nestedArrayOfStrings, nestedCollections.nestedArrayOfStrings) &&
+        Objects.equals(this.nestedArrayOfDates, nestedCollections.nestedArrayOfDates) &&
+        Objects.equals(this.nestedArrayOfObjects, nestedCollections.nestedArrayOfObjects) &&
+        Objects.equals(this.fourDimensionalNestedArrayOfObjects, nestedCollections.fourDimensionalNestedArrayOfObjects) &&
+        Objects.equals(this.nestedDictionaryOfStrings, nestedCollections.nestedDictionaryOfStrings) &&
+        Objects.equals(this.nestedDictionaryOfObjects, nestedCollections.nestedDictionaryOfObjects) &&
+        Objects.equals(this.fourDimensionalNestedDictionaryOfObjects, nestedCollections.fourDimensionalNestedDictionaryOfObjects) &&
+        Objects.equals(this.nestedMixOfDictionariesAndArrays, nestedCollections.nestedMixOfDictionariesAndArrays) &&
+        Objects.equals(this.cycleArray, nestedCollections.cycleArray) &&
+        Objects.equals(this.cycleDictionary, nestedCollections.cycleDictionary);
+        
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(nestedArrayOfStrings, nestedArrayOfDates, nestedArrayOfObjects, fourDimensionalNestedArrayOfObjects, nestedDictionaryOfStrings, nestedDictionaryOfObjects, fourDimensionalNestedDictionaryOfObjects, nestedMixOfDictionariesAndArrays, cycleArray, cycleDictionary);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class NestedCollections {\\n");
+    sb.append("    nestedArrayOfStrings: ").append(toIndentedString(nestedArrayOfStrings)).append("\\n");
+    sb.append("    nestedArrayOfDates: ").append(toIndentedString(nestedArrayOfDates)).append("\\n");
+    sb.append("    nestedArrayOfObjects: ").append(toIndentedString(nestedArrayOfObjects)).append("\\n");
+    sb.append("    fourDimensionalNestedArrayOfObjects: ").append(toIndentedString(fourDimensionalNestedArrayOfObjects)).append("\\n");
+    sb.append("    nestedDictionaryOfStrings: ").append(toIndentedString(nestedDictionaryOfStrings)).append("\\n");
+    sb.append("    nestedDictionaryOfObjects: ").append(toIndentedString(nestedDictionaryOfObjects)).append("\\n");
+    sb.append("    fourDimensionalNestedDictionaryOfObjects: ").append(toIndentedString(fourDimensionalNestedDictionaryOfObjects)).append("\\n");
+    sb.append("    nestedMixOfDictionariesAndArrays: ").append(toIndentedString(nestedMixOfDictionariesAndArrays)).append("\\n");
+    sb.append("    cycleArray: ").append(toIndentedString(cycleArray)).append("\\n");
+    sb.append("    cycleDictionary: ").append(toIndentedString(cycleDictionary)).append("\\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\\n", "\\n    ");
+  }
+
+
+  public static HashSet<String> openapiFields;
+  public static HashSet<String> openapiRequiredFields;
+
+  static {
+    // a set of all properties/fields (JSON key names)
+    openapiFields = new HashSet<String>();
+    openapiFields.add("nestedArrayOfStrings");
+    openapiFields.add("nestedArrayOfDates");
+    openapiFields.add("nestedArrayOfObjects");
+    openapiFields.add("fourDimensionalNestedArrayOfObjects");
+    openapiFields.add("nestedDictionaryOfStrings");
+    openapiFields.add("nestedDictionaryOfObjects");
+    openapiFields.add("fourDimensionalNestedDictionaryOfObjects");
+    openapiFields.add("nestedMixOfDictionariesAndArrays");
+    openapiFields.add("cycleArray");
+    openapiFields.add("cycleDictionary");
+
+    // a set of required properties/fields (JSON key names)
+    openapiRequiredFields = new HashSet<String>();
+  }
+
+ /**
+  * Validates the JSON Object and throws an exception if issues found
+  *
+  * @param jsonObj JSON Object
+  * @throws IOException if the JSON Object is invalid with respect to NestedCollections
+  */
+  public static void validateJsonObject(JsonObject jsonObj) throws IOException {
+      if (jsonObj == null) {
+        if (!NestedCollections.openapiRequiredFields.isEmpty()) { // has required fields but JSON object is null
+          throw new IllegalArgumentException(String.format("The required field(s) %s in NestedCollections is not found in the empty JSON string", NestedCollections.openapiRequiredFields.toString()));
+        }
+      }
+
+      Set<Entry<String, JsonElement>> entries = jsonObj.entrySet();
+      // check to see if the JSON string contains additional fields
+      for (Entry<String, JsonElement> entry : entries) {
+        if (!NestedCollections.openapiFields.contains(entry.getKey())) {
+          throw new IllegalArgumentException(String.format("The field \`%s\` in the JSON string is not defined in the \`NestedCollections\` properties. JSON: %s", entry.getKey(), jsonObj.toString()));
+        }
+      }
+      if (jsonObj.get("nestedArrayOfStrings") != null && !jsonObj.get("nestedArrayOfStrings").isJsonNull()) {
+        JsonArray jsonArraynestedArrayOfStrings = jsonObj.getAsJsonArray("nestedArrayOfStrings");
+        if (jsonArraynestedArrayOfStrings != null) {
+          // ensure the json data is an array
+          if (!jsonObj.get("nestedArrayOfStrings").isJsonArray()) {
+            throw new IllegalArgumentException(String.format("Expected the field \`nestedArrayOfStrings\` to be an array in the JSON string but got \`%s\`", jsonObj.get("nestedArrayOfStrings").toString()));
+          }
+
+          // validate the optional field \`nestedArrayOfStrings\` (array)
+          for (int i = 0; i < jsonArraynestedArrayOfStrings.size(); i++) {
+            List<String>.validateJsonObject(jsonArraynestedArrayOfStrings.get(i).getAsJsonObject());
+          };
+        }
+      }
+      if (jsonObj.get("nestedArrayOfDates") != null && !jsonObj.get("nestedArrayOfDates").isJsonNull()) {
+        JsonArray jsonArraynestedArrayOfDates = jsonObj.getAsJsonArray("nestedArrayOfDates");
+        if (jsonArraynestedArrayOfDates != null) {
+          // ensure the json data is an array
+          if (!jsonObj.get("nestedArrayOfDates").isJsonArray()) {
+            throw new IllegalArgumentException(String.format("Expected the field \`nestedArrayOfDates\` to be an array in the JSON string but got \`%s\`", jsonObj.get("nestedArrayOfDates").toString()));
+          }
+
+          // validate the optional field \`nestedArrayOfDates\` (array)
+          for (int i = 0; i < jsonArraynestedArrayOfDates.size(); i++) {
+            List<LocalDate>.validateJsonObject(jsonArraynestedArrayOfDates.get(i).getAsJsonObject());
+          };
+        }
+      }
+      if (jsonObj.get("nestedArrayOfObjects") != null && !jsonObj.get("nestedArrayOfObjects").isJsonNull()) {
+        JsonArray jsonArraynestedArrayOfObjects = jsonObj.getAsJsonArray("nestedArrayOfObjects");
+        if (jsonArraynestedArrayOfObjects != null) {
+          // ensure the json data is an array
+          if (!jsonObj.get("nestedArrayOfObjects").isJsonArray()) {
+            throw new IllegalArgumentException(String.format("Expected the field \`nestedArrayOfObjects\` to be an array in the JSON string but got \`%s\`", jsonObj.get("nestedArrayOfObjects").toString()));
+          }
+
+          // validate the optional field \`nestedArrayOfObjects\` (array)
+          for (int i = 0; i < jsonArraynestedArrayOfObjects.size(); i++) {
+            List<SomeObject>.validateJsonObject(jsonArraynestedArrayOfObjects.get(i).getAsJsonObject());
+          };
+        }
+      }
+      if (jsonObj.get("fourDimensionalNestedArrayOfObjects") != null && !jsonObj.get("fourDimensionalNestedArrayOfObjects").isJsonNull()) {
+        JsonArray jsonArrayfourDimensionalNestedArrayOfObjects = jsonObj.getAsJsonArray("fourDimensionalNestedArrayOfObjects");
+        if (jsonArrayfourDimensionalNestedArrayOfObjects != null) {
+          // ensure the json data is an array
+          if (!jsonObj.get("fourDimensionalNestedArrayOfObjects").isJsonArray()) {
+            throw new IllegalArgumentException(String.format("Expected the field \`fourDimensionalNestedArrayOfObjects\` to be an array in the JSON string but got \`%s\`", jsonObj.get("fourDimensionalNestedArrayOfObjects").toString()));
+          }
+
+          // validate the optional field \`fourDimensionalNestedArrayOfObjects\` (array)
+          for (int i = 0; i < jsonArrayfourDimensionalNestedArrayOfObjects.size(); i++) {
+            List<List<List<SomeObject>>>.validateJsonObject(jsonArrayfourDimensionalNestedArrayOfObjects.get(i).getAsJsonObject());
+          };
+        }
+      }
+      if (jsonObj.get("nestedMixOfDictionariesAndArrays") != null && !jsonObj.get("nestedMixOfDictionariesAndArrays").isJsonNull()) {
+        JsonArray jsonArraynestedMixOfDictionariesAndArrays = jsonObj.getAsJsonArray("nestedMixOfDictionariesAndArrays");
+        if (jsonArraynestedMixOfDictionariesAndArrays != null) {
+          // ensure the json data is an array
+          if (!jsonObj.get("nestedMixOfDictionariesAndArrays").isJsonArray()) {
+            throw new IllegalArgumentException(String.format("Expected the field \`nestedMixOfDictionariesAndArrays\` to be an array in the JSON string but got \`%s\`", jsonObj.get("nestedMixOfDictionariesAndArrays").toString()));
+          }
+
+          // validate the optional field \`nestedMixOfDictionariesAndArrays\` (array)
+          for (int i = 0; i < jsonArraynestedMixOfDictionariesAndArrays.size(); i++) {
+            Map<String, List<List<Map<String, List<SomeObject>>>>>.validateJsonObject(jsonArraynestedMixOfDictionariesAndArrays.get(i).getAsJsonObject());
+          };
+        }
+      }
+      if (jsonObj.get("cycleArray") != null && !jsonObj.get("cycleArray").isJsonNull()) {
+        JsonArray jsonArraycycleArray = jsonObj.getAsJsonArray("cycleArray");
+        if (jsonArraycycleArray != null) {
+          // ensure the json data is an array
+          if (!jsonObj.get("cycleArray").isJsonArray()) {
+            throw new IllegalArgumentException(String.format("Expected the field \`cycleArray\` to be an array in the JSON string but got \`%s\`", jsonObj.get("cycleArray").toString()));
+          }
+
+          // validate the optional field \`cycleArray\` (array)
+          for (int i = 0; i < jsonArraycycleArray.size(); i++) {
+            CycleArrayNode.validateJsonObject(jsonArraycycleArray.get(i).getAsJsonObject());
+          };
+        }
+      }
+      // validate the optional field \`cycleDictionary\`
+      if (jsonObj.get("cycleDictionary") != null && !jsonObj.get("cycleDictionary").isJsonNull()) {
+        CycleDictionary.validateJsonObject(jsonObj.getAsJsonObject("cycleDictionary"));
+      }
+  }
+
+  public static class CustomTypeAdapterFactory implements TypeAdapterFactory {
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+       if (!NestedCollections.class.isAssignableFrom(type.getRawType())) {
+         return null; // this class only serializes 'NestedCollections' and its subtypes
+       }
+       final TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
+       final TypeAdapter<NestedCollections> thisAdapter
+                        = gson.getDelegateAdapter(this, TypeToken.get(NestedCollections.class));
+
+       return (TypeAdapter<T>) new TypeAdapter<NestedCollections>() {
+           @Override
+           public void write(JsonWriter out, NestedCollections value) throws IOException {
+             JsonObject obj = thisAdapter.toJsonTree(value).getAsJsonObject();
+             elementAdapter.write(out, obj);
+           }
+
+           @Override
+           public NestedCollections read(JsonReader in) throws IOException {
+             JsonObject jsonObj = elementAdapter.read(in).getAsJsonObject();
+             validateJsonObject(jsonObj);
+             return thisAdapter.fromJsonTree(jsonObj);
+           }
+
+       }.nullSafe();
+    }
+  }
+
+ /**
+  * Create an instance of NestedCollections given an JSON string
+  *
+  * @param jsonString JSON string
+  * @return An instance of NestedCollections
+  * @throws IOException if the JSON string is invalid with respect to NestedCollections
+  */
+  public static NestedCollections fromJson(String jsonString) throws IOException {
+    return JSON.getGson().fromJson(jsonString, NestedCollections.class);
+  }
+
+ /**
+  * Convert an instance of NestedCollections to an JSON string
+  *
+  * @return JSON string
+  */
+  public String toJson() {
+    return JSON.getGson().toJson(this);
+  }
 }
 ",
   "src/main/java/test/test/runtime/model/SomeObject.java": "/*

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
@@ -12705,6 +12705,9 @@ class DataTypes200Response(BaseModel):
             },
             exclude_none=True,
         )
+        # override the default output from pydantic by calling \`to_dict()\` of my_date_array
+        if self.my_date_array:
+            _dict['myDateArray'] = self.my_date_array.to_dict()
         # override the default output from pydantic by calling \`to_dict()\` of my_one_of
         if self.my_one_of:
             _dict['myOneOf'] = self.my_one_of.to_dict()
@@ -12714,6 +12717,13 @@ class DataTypes200Response(BaseModel):
         # override the default output from pydantic by calling \`to_dict()\` of my_all_of
         if self.my_all_of:
             _dict['myAllOf'] = self.my_all_of.to_dict()
+        # override the default output from pydantic by calling \`to_dict()\` of each value in my_additional_properties (dict)
+        _field_dict = {}
+        if self.my_additional_properties:
+            for _key in self.my_additional_properties:
+                if self.my_additional_properties[_key]:
+                    _field_dict[_key] = self.my_additional_properties[_key].to_dict()
+            _dict['myAdditionalProperties'] = _field_dict
         # override the default output from pydantic by calling \`to_dict()\` of my_object
         if self.my_object:
             _dict['myObject'] = self.my_object.to_dict()
@@ -12747,7 +12757,7 @@ class DataTypes200Response(BaseModel):
             "myLongMinStringLength": obj.get("myLongMinStringLength"),
             "myBool": obj.get("myBool"),
             "myNumber": obj.get("myNumber"),
-            "myDateArray": obj.get("myDateArray"),
+            "myDateArray": List[date].from_dict(obj.get("myDateArray")) if obj.get("myDateArray") is not None else None,
             "myEmail": obj.get("myEmail"),
             "myUrl": obj.get("myUrl"),
             "myHostname": obj.get("myHostname"),
@@ -12763,7 +12773,12 @@ class DataTypes200Response(BaseModel):
             "myAllOf": DataTypes200ResponseMyAllOf.from_dict(obj.get("myAllOf")) if obj.get("myAllOf") is not None else None,
             "myNot": obj.get("myNot"),
             "myNotString": obj.get("myNotString"),
-            "myAdditionalProperties": obj.get("myAdditionalProperties"),
+            "myAdditionalProperties": dict(
+                (_k, List[int].from_dict(_v))
+                for _k, _v in obj.get("myAdditionalProperties").items()
+            )
+            if obj.get("myAdditionalProperties") is not None
+            else None,
             "myObject": DataTypes200ResponseMyObject.from_dict(obj.get("myObject")) if obj.get("myObject") is not None else None
         })
         return _obj
@@ -17431,6 +17446,9 @@ test_project/models/__init__.py
 test_project/models/additional_properties_response.py
 test_project/models/another_named_one_of.py
 test_project/models/array_of_one_ofs.py
+test_project/models/cycle_array_node.py
+test_project/models/cycle_dictionary.py
+test_project/models/cycle_dictionary_node.py
 test_project/models/dictionary.py
 test_project/models/inline_enum200_response.py
 test_project/models/inline_enum200_response_category_enum.py
@@ -17438,6 +17456,7 @@ test_project/models/inline_request_body_request_content.py
 test_project/models/my_enum.py
 test_project/models/named_one_of.py
 test_project/models/named_one_of_union.py
+test_project/models/nested_collections.py
 test_project/models/some_object.py
 test_project/py.typed
 test_project/rest.py
@@ -17445,6 +17464,9 @@ docs/DefaultApi.md
 docs/AdditionalPropertiesResponse.md
 docs/AnotherNamedOneOf.md
 docs/ArrayOfOneOfs.md
+docs/CycleArrayNode.md
+docs/CycleDictionary.md
+docs/CycleDictionaryNode.md
 docs/Dictionary.md
 docs/InlineEnum200Response.md
 docs/InlineEnum200ResponseCategoryEnum.md
@@ -17452,6 +17474,7 @@ docs/InlineRequestBodyRequestContent.md
 docs/MyEnum.md
 docs/NamedOneOf.md
 docs/NamedOneOfUnion.md
+docs/NestedCollections.md
 docs/SomeObject.md
 README.md
 test_project/interceptors/try_catch.py
@@ -17512,6 +17535,7 @@ Class | Method | HTTP request | Description
 *DefaultApi* | [**inline_enum**](docs/DefaultApi.md#inline_enum) | **GET** /inline-enum | 
 *DefaultApi* | [**inline_request_body**](docs/DefaultApi.md#inline_request_body) | **POST** /inline-request-body | 
 *DefaultApi* | [**named_one_of**](docs/DefaultApi.md#named_one_of) | **POST** /named-one-of | 
+*DefaultApi* | [**nested_collections**](docs/DefaultApi.md#nested_collections) | **POST** /nested-collections | 
 *DefaultApi* | [**reserved_keywords**](docs/DefaultApi.md#reserved_keywords) | **GET** /reserved-keywords | 
 
 ## Documentation For Models
@@ -17519,6 +17543,9 @@ Class | Method | HTTP request | Description
  - [AdditionalPropertiesResponse](docs/AdditionalPropertiesResponse.md)
  - [AnotherNamedOneOf](docs/AnotherNamedOneOf.md)
  - [ArrayOfOneOfs](docs/ArrayOfOneOfs.md)
+ - [CycleArrayNode](docs/CycleArrayNode.md)
+ - [CycleDictionary](docs/CycleDictionary.md)
+ - [CycleDictionaryNode](docs/CycleDictionaryNode.md)
  - [Dictionary](docs/Dictionary.md)
  - [InlineEnum200Response](docs/InlineEnum200Response.md)
  - [InlineEnum200ResponseCategoryEnum](docs/InlineEnum200ResponseCategoryEnum.md)
@@ -17526,6 +17553,7 @@ Class | Method | HTTP request | Description
  - [MyEnum](docs/MyEnum.md)
  - [NamedOneOf](docs/NamedOneOf.md)
  - [NamedOneOfUnion](docs/NamedOneOfUnion.md)
+ - [NestedCollections](docs/NestedCollections.md)
  - [SomeObject](docs/SomeObject.md)
 ",
   "docs/AdditionalPropertiesResponse.md": "# AdditionalPropertiesResponse
@@ -17610,6 +17638,86 @@ array_of_one_ofs_form_dict = array_of_one_ofs.from_dict(array_of_one_ofs_dict)
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 
 ",
+  "docs/CycleArrayNode.md": "# CycleArrayNode
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**nodes** | **List[CycleArrayNode]** |  | [optional] 
+
+## Example
+
+\`\`\`python
+from test_project.models.cycle_array_node import CycleArrayNode
+
+# TODO update the JSON string below
+json = "{}"
+# create an instance of CycleArrayNode from a JSON string
+cycle_array_node_instance = CycleArrayNode.from_json(json)
+# print the JSON string representation of the object
+print(CycleArrayNode.to_json())
+
+# convert the object into a dict
+cycle_array_node_dict = cycle_array_node_instance.to_dict()
+# create an instance of CycleArrayNode from a dict
+cycle_array_node_form_dict = cycle_array_node.from_dict(cycle_array_node_dict)
+\`\`\`
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+",
+  "docs/CycleDictionary.md": "# CycleDictionary
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+## Example
+
+\`\`\`python
+from test_project.models.cycle_dictionary import CycleDictionary
+
+# TODO update the JSON string below
+json = "{}"
+# create an instance of CycleDictionary from a JSON string
+cycle_dictionary_instance = CycleDictionary.from_json(json)
+# print the JSON string representation of the object
+print(CycleDictionary.to_json())
+
+# convert the object into a dict
+cycle_dictionary_dict = cycle_dictionary_instance.to_dict()
+# create an instance of CycleDictionary from a dict
+cycle_dictionary_form_dict = cycle_dictionary.from_dict(cycle_dictionary_dict)
+\`\`\`
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+",
+  "docs/CycleDictionaryNode.md": "# CycleDictionaryNode
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**nodes** | [**CycleDictionary**](CycleDictionary.md) |  | [optional] 
+
+## Example
+
+\`\`\`python
+from test_project.models.cycle_dictionary_node import CycleDictionaryNode
+
+# TODO update the JSON string below
+json = "{}"
+# create an instance of CycleDictionaryNode from a JSON string
+cycle_dictionary_node_instance = CycleDictionaryNode.from_json(json)
+# print the JSON string representation of the object
+print(CycleDictionaryNode.to_json())
+
+# convert the object into a dict
+cycle_dictionary_node_dict = cycle_dictionary_node_instance.to_dict()
+# create an instance of CycleDictionaryNode from a dict
+cycle_dictionary_node_form_dict = cycle_dictionary_node.from_dict(cycle_dictionary_node_dict)
+\`\`\`
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+",
   "docs/DefaultApi.md": "# test_project.DefaultApi
 
 Method | HTTP request | Description
@@ -17620,6 +17728,7 @@ Method | HTTP request | Description
 [**inline_enum**](DefaultApi.md#inline_enum) | **GET** /inline-enum | 
 [**inline_request_body**](DefaultApi.md#inline_request_body) | **POST** /inline-request-body | 
 [**named_one_of**](DefaultApi.md#named_one_of) | **POST** /named-one-of | 
+[**nested_collections**](DefaultApi.md#nested_collections) | **POST** /nested-collections | 
 [**reserved_keywords**](DefaultApi.md#reserved_keywords) | **GET** /reserved-keywords | 
 
 # **array_of_one_ofs**
@@ -17940,6 +18049,56 @@ This endpoint does not need any parameters.
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
+# **nested_collections**
+> NestedCollections nested_collections()
+
+
+### Example
+
+\`\`\`python
+import time
+import test_project
+from test_project.rest import ApiException
+from pprint import pprint
+
+# Defining the host is optional and defaults to http://localhost
+# See configuration.py for a list of all supported configuration parameters.
+configuration = test_project.Configuration(
+    host = "http://localhost"
+)
+
+# Enter a context with an instance of the API client
+with test_project.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = test_project.DefaultApi(api_client)
+
+    try:
+        api_response = api_instance.nested_collections()
+        print("The response of DefaultApi->nested_collections:\\n")
+        pprint(api_response)
+    except ApiException as e:
+        print("Exception when calling DefaultApi->nested_collections: %s\\n" % e)
+\`\`\`
+
+### Parameters
+This endpoint does not need any parameters.
+
+### Return type
+
+[**NestedCollections**](NestedCollections.md)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | ok |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
 # **reserved_keywords**
 > reserved_keywords(var_with=var_with, var_if=var_if, var_class=var_class)
 
@@ -18152,6 +18311,42 @@ named_one_of_union_form_dict = named_one_of_union.from_dict(named_one_of_union_d
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 
 ",
+  "docs/NestedCollections.md": "# NestedCollections
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**nested_array_of_strings** | **List[List[str]]** |  | [optional] 
+**nested_array_of_dates** | **List[List[date]]** |  | [optional] 
+**nested_array_of_objects** | **List[List[SomeObject]]** |  | [optional] 
+**four_dimensional_nested_array_of_objects** | **List[List[List[List[SomeObject]]]]** |  | [optional] 
+**nested_dictionary_of_strings** | **Dict[str, Dict[str, str]]** |  | [optional] 
+**nested_dictionary_of_objects** | **Dict[str, Dict[str, SomeObject]]** |  | [optional] 
+**four_dimensional_nested_dictionary_of_objects** | **Dict[str, Dict[str, Dict[str, Dict[str, SomeObject]]]]** |  | [optional] 
+**nested_mix_of_dictionaries_and_arrays** | **List[Dict[str, List[List[Dict[str, List[SomeObject]]]]]]** |  | [optional] 
+**cycle_array** | **List[CycleArrayNode]** |  | [optional] 
+**cycle_dictionary** | [**CycleDictionary**](CycleDictionary.md) |  | [optional] 
+
+## Example
+
+\`\`\`python
+from test_project.models.nested_collections import NestedCollections
+
+# TODO update the JSON string below
+json = "{}"
+# create an instance of NestedCollections from a JSON string
+nested_collections_instance = NestedCollections.from_json(json)
+# print the JSON string representation of the object
+print(NestedCollections.to_json())
+
+# convert the object into a dict
+nested_collections_dict = nested_collections_instance.to_dict()
+# create an instance of NestedCollections from a dict
+nested_collections_form_dict = nested_collections.from_dict(nested_collections_dict)
+\`\`\`
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+",
   "docs/SomeObject.md": "# SomeObject
 
 ## Properties
@@ -18250,6 +18445,9 @@ from test_project.exceptions import ApiException
 from test_project.models.additional_properties_response import AdditionalPropertiesResponse
 from test_project.models.another_named_one_of import AnotherNamedOneOf
 from test_project.models.array_of_one_ofs import ArrayOfOneOfs
+from test_project.models.cycle_array_node import CycleArrayNode
+from test_project.models.cycle_dictionary import CycleDictionary
+from test_project.models.cycle_dictionary_node import CycleDictionaryNode
 from test_project.models.dictionary import Dictionary
 from test_project.models.inline_enum200_response import InlineEnum200Response
 from test_project.models.inline_enum200_response_category_enum import InlineEnum200ResponseCategoryEnum
@@ -18257,6 +18455,7 @@ from test_project.models.inline_request_body_request_content import InlineReques
 from test_project.models.my_enum import MyEnum
 from test_project.models.named_one_of import NamedOneOf
 from test_project.models.named_one_of_union import NamedOneOfUnion
+from test_project.models.nested_collections import NestedCollections
 from test_project.models.some_object import SomeObject
 ",
   "test_project/api/__init__.py": "# flake8: noqa
@@ -18294,6 +18493,7 @@ from test_project.models.inline_enum200_response import InlineEnum200Response
 from test_project.models.inline_request_body_request_content import InlineRequestBodyRequestContent
 from test_project.models.my_enum import MyEnum
 from test_project.models.named_one_of_union import NamedOneOfUnion
+from test_project.models.nested_collections import NestedCollections
 
 from test_project.api_client import ApiClient
 from test_project.api_response import ApiResponse
@@ -19875,6 +20075,241 @@ class DefaultApi:
 
 
     @validate_call
+    def nested_collections(
+        self,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> NestedCollections:
+        """nested_collections
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._nested_collections_serialize(
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "NestedCollections"
+        }
+
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        ).data
+
+
+    @validate_call
+    def nested_collections_with_http_info(
+        self,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> ApiResponse[NestedCollections]:
+        """nested_collections
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._nested_collections_serialize(
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "NestedCollections"
+        }
+
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        response_data.read()
+        return self.api_client.response_deserialize(
+            response_data=response_data,
+            response_types_map=_response_types_map,
+        )
+
+
+    @validate_call
+    def nested_collections_without_preload_content(
+        self,
+        _request_timeout: Union[
+            None,
+            Annotated[StrictFloat, Field(gt=0)],
+            Tuple[
+                Annotated[StrictFloat, Field(gt=0)],
+                Annotated[StrictFloat, Field(gt=0)]
+            ]
+        ] = None,
+        _request_auth: Optional[Dict[StrictStr, Any]] = None,
+        _content_type: Optional[StrictStr] = None,
+        _headers: Optional[Dict[StrictStr, Any]] = None,
+        _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
+    ) -> RESTResponseType:
+        """nested_collections
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :type _request_timeout: int, tuple(int, int), optional
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the
+                              authentication in the spec for a single request.
+        :type _request_auth: dict, optional
+        :param _content_type: force content-type for the request.
+        :type _content_type: str, Optional
+        :param _headers: set to override the headers for a single
+                         request; this effectively ignores the headers
+                         in the spec for a single request.
+        :type _headers: dict, optional
+        :param _host_index: set to override the host_index for a single
+                            request; this effectively ignores the host_index
+                            in the spec for a single request.
+        :type _host_index: int, optional
+        :return: Returns the result object.
+        """ # noqa: E501
+
+        _param = self._nested_collections_serialize(
+            _request_auth=_request_auth,
+            _content_type=_content_type,
+            _headers=_headers,
+            _host_index=_host_index
+        )
+
+        _response_types_map: Dict[str, Optional[str]] = {
+            '200': "NestedCollections"
+        }
+
+        response_data = self.api_client.call_api(
+            *_param,
+            _request_timeout=_request_timeout
+        )
+        return response_data.response
+
+
+    def _nested_collections_serialize(
+        self,
+        _request_auth,
+        _content_type,
+        _headers,
+        _host_index,
+    ) -> Tuple:
+
+        _host = None
+
+        _collection_formats: Dict[str, str] = {
+        }
+
+        _path_params: Dict[str, str] = {}
+        _query_params: List[Tuple[str, str]] = []
+        _header_params: Dict[str, Optional[str]] = _headers or {}
+        _form_params: List[Tuple[str, str]] = []
+        _files: Dict[str, str] = {}
+        _body_params: Optional[bytes] = None
+
+        # process the path parameters
+        # process the query parameters
+        # process the header parameters
+        # process the form parameters
+        # process the body parameter
+
+
+        # set the HTTP header \`Accept\`
+        _header_params['Accept'] = self.api_client.select_header_accept(
+            [
+                'application/json'
+            ]
+        )
+
+
+        # authentication setting
+        _auth_settings: List[str] = [
+        ]
+
+        return self.api_client.param_serialize(
+            method='POST',
+            resource_path='/nested-collections',
+            path_params=_path_params,
+            query_params=_query_params,
+            header_params=_header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            auth_settings=_auth_settings,
+            collection_formats=_collection_formats,
+            _host=_host,
+            _request_auth=_request_auth
+        )
+
+
+
+    @validate_call
     def reserved_keywords(
         self,
         var_with: Optional[StrictStr] = None,
@@ -20168,6 +20603,7 @@ class OperationConfig(Generic[T]):
     inline_enum: T
     inline_request_body: T
     named_one_of: T
+    nested_collections: T
     reserved_keywords: T
     ...
 
@@ -20200,6 +20636,11 @@ OperationLookup = {
     },
     "named_one_of": {
         "path": "/named-one-of",
+        "method": "POST",
+        "contentTypes": ["application/json"]
+    },
+    "nested_collections": {
+        "path": "/nested-collections",
         "method": "POST",
         "contentTypes": ["application/json"]
     },
@@ -21082,6 +21523,121 @@ def named_one_of_handler(_handler: NamedOneOfHandlerFunction = None, interceptor
     else:
         raise Exception("Positional arguments are not supported by named_one_of_handler.")
 
+class NestedCollectionsRequestParameters(BaseModel):
+    """
+    Query, path and header parameters for the NestedCollections operation
+    """
+
+    class Config:
+        """Pydantic configuration"""
+        populate_by_name = True
+        validate_assignment = True
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_json(cls, json_str: str) -> NestedCollectionsRequestParameters:
+        return cls.from_dict(json.loads(json_str))
+
+    def to_dict(self):
+        return self.model_dump(exclude={}, exclude_none=True)
+
+    @classmethod
+    def from_dict(cls, obj: dict) -> NestedCollectionsRequestParameters:
+        if obj is None:
+            return None
+        return NestedCollectionsRequestParameters.model_validate(obj)
+
+
+# Request body type (default to Any when no body parameters exist, or leave unchanged as str if it's a primitive type)
+NestedCollectionsRequestBody = Any
+
+NestedCollections200OperationResponse = ApiResponse[Literal[200], NestedCollections]
+
+NestedCollectionsOperationResponses = Union[NestedCollections200OperationResponse, ]
+
+# Request type for nested_collections
+NestedCollectionsRequest = ApiRequest[NestedCollectionsRequestParameters, NestedCollectionsRequestBody]
+NestedCollectionsChainedRequest = ChainedApiRequest[NestedCollectionsRequestParameters, NestedCollectionsRequestBody]
+
+class NestedCollectionsHandlerFunction(Protocol):
+    def __call__(self, input: NestedCollectionsRequest, **kwargs) -> NestedCollectionsOperationResponses:
+        ...
+
+NestedCollectionsInterceptor = Callable[[NestedCollectionsChainedRequest], NestedCollectionsOperationResponses]
+
+def nested_collections_handler(_handler: NestedCollectionsHandlerFunction = None, interceptors: List[NestedCollectionsInterceptor] = []):
+    """
+    Decorator for an api handler for the nested_collections operation, providing a typed interface for inputs and outputs
+    """
+    def _handler_wrapper(handler: NestedCollectionsHandlerFunction):
+        @wraps(handler)
+        def wrapper(event, context, additional_interceptors = [], **kwargs):
+            all_interceptors = additional_interceptors + interceptors
+
+            raw_string_parameters = decode_request_parameters({
+                **(event.get('pathParameters', {}) or {}),
+                **(event.get('queryStringParameters', {}) or {}),
+                **(event.get('headers', {}) or {}),
+            })
+            raw_string_array_parameters = decode_request_parameters({
+                **(event.get('multiValueQueryStringParameters', {}) or {}),
+                **(event.get('multiValueHeaders', {}) or {}),
+            })
+
+            def response_headers_for_status_code(status_code):
+                headers_for_status = {}
+                return headers_for_status
+
+            request_parameters = None
+            try:
+                request_parameters = NestedCollectionsRequestParameters.from_dict({
+                })
+            except Exception as e:
+                return {
+                    'statusCode': 400,
+                    'headers': {**response_headers_for_status_code(400), **extract_response_headers_from_interceptors(all_interceptors)},
+                    'body': '{"message": "' + str(e) + '"}',
+                }
+
+            body = {}
+            interceptor_context = {
+                "operationId": "nested_collections",
+            }
+
+            chain = _build_handler_chain(all_interceptors, handler)
+            response = chain.next(ApiRequest(
+                request_parameters,
+                body,
+                event,
+                context,
+                interceptor_context,
+            ), **kwargs)
+
+            response_headers = {** (response.headers or {}), **response_headers_for_status_code(response.status_code)}
+            response_body = ''
+            if response.body is None:
+                pass
+            elif response.status_code == 200:
+                response_body = response.body.to_json()
+
+            return {
+                'statusCode': response.status_code,
+                'headers': response_headers,
+                'multiValueHeaders': response.multi_value_headers or {},
+                'body': response_body,
+            }
+        return wrapper
+
+    # Support use as a decorator with no arguments, or with interceptor arguments
+    if callable(_handler):
+        return _handler_wrapper(_handler)
+    elif _handler is None:
+        return _handler_wrapper
+    else:
+        raise Exception("Positional arguments are not supported by nested_collections_handler.")
+
 class ReservedKeywordsRequestParameters(BaseModel):
     """
     Query, path and header parameters for the ReservedKeywords operation
@@ -21218,6 +21774,7 @@ class HandlerRouterHandlers:
   inline_enum: Callable[[Dict, Any], Dict]
   inline_request_body: Callable[[Dict, Any], Dict]
   named_one_of: Callable[[Dict, Any], Dict]
+  nested_collections: Callable[[Dict, Any], Dict]
   reserved_keywords: Callable[[Dict, Any], Dict]
 
 def handler_router(handlers: HandlerRouterHandlers, interceptors: List[Interceptor] = []):
@@ -22790,6 +23347,9 @@ def try_catch_interceptor(request: ChainedApiRequest) -> ApiResponse:
 from test_project.models.additional_properties_response import AdditionalPropertiesResponse
 from test_project.models.another_named_one_of import AnotherNamedOneOf
 from test_project.models.array_of_one_ofs import ArrayOfOneOfs
+from test_project.models.cycle_array_node import CycleArrayNode
+from test_project.models.cycle_dictionary import CycleDictionary
+from test_project.models.cycle_dictionary_node import CycleDictionaryNode
 from test_project.models.dictionary import Dictionary
 from test_project.models.inline_enum200_response import InlineEnum200Response
 from test_project.models.inline_enum200_response_category_enum import InlineEnum200ResponseCategoryEnum
@@ -22797,6 +23357,7 @@ from test_project.models.inline_request_body_request_content import InlineReques
 from test_project.models.my_enum import MyEnum
 from test_project.models.named_one_of import NamedOneOf
 from test_project.models.named_one_of_union import NamedOneOfUnion
+from test_project.models.nested_collections import NestedCollections
 from test_project.models.some_object import SomeObject
 ",
   "test_project/models/additional_properties_response.py": "# coding: utf-8
@@ -22875,6 +23436,9 @@ class AdditionalPropertiesResponse(BaseModel):
         # override the default output from pydantic by calling \`to_dict()\` of dictionary_of_objects
         if self.dictionary_of_objects:
             _dict['dictionaryOfObjects'] = self.dictionary_of_objects.to_dict()
+        # override the default output from pydantic by calling \`to_dict()\` of dictionary_of_primitives
+        if self.dictionary_of_primitives:
+            _dict['dictionaryOfPrimitives'] = self.dictionary_of_primitives.to_dict()
         return _dict
 
     @classmethod
@@ -22889,7 +23453,7 @@ class AdditionalPropertiesResponse(BaseModel):
 
         _obj = cls.model_validate({
             "dictionaryOfObjects": Dictionary.from_dict(obj.get("dictionaryOfObjects")) if obj.get("dictionaryOfObjects") is not None else None,
-            "dictionaryOfPrimitives": obj.get("dictionaryOfPrimitives")
+            "dictionaryOfPrimitives": Dict[str, str].from_dict(obj.get("dictionaryOfPrimitives")) if obj.get("dictionaryOfPrimitives") is not None else None
         })
         return _obj
 
@@ -23016,7 +23580,7 @@ class ArrayOfOneOfs(BaseModel):
     """
     ArrayOfOneOfs
     """ # noqa: E501
-    one_ofs: Optional[List[Any]] = Field(default=None, alias="oneOfs")
+    one_ofs: Optional[List[any]] = Field(default=None, alias="oneOfs")
     __properties: ClassVar[List[str]] = ["oneOfs"]
 
 
@@ -23055,9 +23619,13 @@ class ArrayOfOneOfs(BaseModel):
             },
             exclude_none=True,
         )
-        # override the default output from pydantic by calling \`to_dict()\` of one_ofs
+        # override the default output from pydantic by calling \`to_dict()\` of each item in one_ofs (list)
+        _items = []
         if self.one_ofs:
-            _dict['oneOfs'] = self.one_ofs.to_dict()
+            for _item in self.one_ofs:
+                if _item:
+                    _items.append(_item.to_dict())
+            _dict['oneOfs'] = _items
         return _dict
 
     @classmethod
@@ -23071,7 +23639,296 @@ class ArrayOfOneOfs(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
-            "oneOfs": List[NamedOneOfUnion].from_dict(obj.get("oneOfs")) if obj.get("oneOfs") is not None else None
+            "oneOfs": [NamedOneOfUnion.from_dict(_item) for _item in obj.get("oneOfs")] if obj.get("oneOfs") is not None else None
+        })
+        return _obj
+
+",
+  "test_project/models/cycle_array_node.py": "# coding: utf-8
+
+"""
+    Edge Cases
+
+    No description provided
+
+    The version of the OpenAPI document: 1.0.0
+
+    NOTE: This class is auto generated.
+    Do not edit the class manually.
+"""  # noqa: E501
+
+from __future__ import annotations
+import pprint
+import re  # noqa: F401
+import json
+from enum import Enum
+from datetime import date, datetime
+from typing import Any, List, Union, ClassVar, Dict, Optional, TYPE_CHECKING
+from pydantic import Field, StrictStr, ValidationError, field_validator, BaseModel, SecretStr, StrictFloat, StrictInt, StrictBytes, StrictBool
+from decimal import Decimal
+from typing_extensions import Annotated, Literal
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
+class CycleArrayNode(BaseModel):
+    """
+    CycleArrayNode
+    """ # noqa: E501
+    nodes: Optional[List[CycleArrayNode]] = None
+    __properties: ClassVar[List[str]] = ["nodes"]
+
+
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True
+    }
+
+    def to_str(self) -> str:
+        """Returns the string representation of the model using alias"""
+        return pprint.pformat(self.model_dump(by_alias=True))
+
+    def to_json(self) -> str:
+        """Returns the JSON representation of the model using alias"""
+        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_json(cls, json_str: str) -> Self:
+        """Create an instance of CycleArrayNode from a JSON string"""
+        return cls.from_dict(json.loads(json_str))
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the dictionary representation of the model using alias.
+
+        This has the following differences from calling pydantic's
+        \`self.model_dump(by_alias=True)\`:
+
+        * \`None\` is only added to the output dict for nullable fields that
+          were set at model initialization. Other fields with value \`None\`
+          are ignored.
+        """
+        _dict = self.model_dump(
+            by_alias=True,
+            exclude={
+            },
+            exclude_none=True,
+        )
+        # override the default output from pydantic by calling \`to_dict()\` of each item in nodes (list)
+        _items = []
+        if self.nodes:
+            for _item in self.nodes:
+                if _item:
+                    _items.append(_item.to_dict())
+            _dict['nodes'] = _items
+        return _dict
+
+    @classmethod
+    def from_dict(cls, obj: Dict) -> Self:
+        """Create an instance of CycleArrayNode from a dict"""
+
+        if obj is None:
+            return None
+
+        if not isinstance(obj, dict):
+            return cls.model_validate(obj)
+
+        _obj = cls.model_validate({
+            "nodes": [CycleArrayNode.from_dict(_item) for _item in obj.get("nodes")] if obj.get("nodes") is not None else None
+        })
+        return _obj
+
+",
+  "test_project/models/cycle_dictionary.py": "# coding: utf-8
+
+"""
+    Edge Cases
+
+    No description provided
+
+    The version of the OpenAPI document: 1.0.0
+
+    NOTE: This class is auto generated.
+    Do not edit the class manually.
+"""  # noqa: E501
+
+from __future__ import annotations
+import pprint
+import re  # noqa: F401
+import json
+from enum import Enum
+from datetime import date, datetime
+from typing import Any, List, Union, ClassVar, Dict, Optional, TYPE_CHECKING
+from pydantic import Field, StrictStr, ValidationError, field_validator, BaseModel, SecretStr, StrictFloat, StrictInt, StrictBytes, StrictBool
+from decimal import Decimal
+from typing_extensions import Annotated, Literal
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
+class CycleDictionary(BaseModel):
+    """
+    CycleDictionary
+    """ # noqa: E501
+    additional_properties: Dict[str, Any] = {}
+    __properties: ClassVar[List[str]] = []
+
+
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True
+    }
+
+    def to_str(self) -> str:
+        """Returns the string representation of the model using alias"""
+        return pprint.pformat(self.model_dump(by_alias=True))
+
+    def to_json(self) -> str:
+        """Returns the JSON representation of the model using alias"""
+        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_json(cls, json_str: str) -> Self:
+        """Create an instance of CycleDictionary from a JSON string"""
+        return cls.from_dict(json.loads(json_str))
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the dictionary representation of the model using alias.
+
+        This has the following differences from calling pydantic's
+        \`self.model_dump(by_alias=True)\`:
+
+        * \`None\` is only added to the output dict for nullable fields that
+          were set at model initialization. Other fields with value \`None\`
+          are ignored.
+        * Fields in \`self.additional_properties\` are added to the output dict.
+        """
+        _dict = self.model_dump(
+            by_alias=True,
+            exclude={
+                "additional_properties",
+            },
+            exclude_none=True,
+        )
+        # puts key-value pairs in additional_properties in the top level
+        if self.additional_properties is not None:
+            for _key, _value in self.additional_properties.items():
+                _dict[_key] = _value
+
+        return _dict
+
+    @classmethod
+    def from_dict(cls, obj: Dict) -> Self:
+        """Create an instance of CycleDictionary from a dict"""
+
+        if obj is None:
+            return None
+
+        if not isinstance(obj, dict):
+            return cls.model_validate(obj)
+
+        _obj = cls.model_validate({
+        })
+        # store additional fields in additional_properties
+        for _key in obj.keys():
+            if _key not in cls.__properties:
+                _obj.additional_properties[_key] = obj.get(_key)
+
+        return _obj
+
+",
+  "test_project/models/cycle_dictionary_node.py": "# coding: utf-8
+
+"""
+    Edge Cases
+
+    No description provided
+
+    The version of the OpenAPI document: 1.0.0
+
+    NOTE: This class is auto generated.
+    Do not edit the class manually.
+"""  # noqa: E501
+
+from __future__ import annotations
+import pprint
+import re  # noqa: F401
+import json
+from enum import Enum
+from datetime import date, datetime
+from typing import Any, List, Union, ClassVar, Dict, Optional, TYPE_CHECKING
+from pydantic import Field, StrictStr, ValidationError, field_validator, BaseModel, SecretStr, StrictFloat, StrictInt, StrictBytes, StrictBool
+from decimal import Decimal
+from typing_extensions import Annotated, Literal
+from test_project.models.cycle_dictionary import CycleDictionary
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
+class CycleDictionaryNode(BaseModel):
+    """
+    CycleDictionaryNode
+    """ # noqa: E501
+    nodes: Optional[CycleDictionary] = None
+    __properties: ClassVar[List[str]] = ["nodes"]
+
+
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True
+    }
+
+    def to_str(self) -> str:
+        """Returns the string representation of the model using alias"""
+        return pprint.pformat(self.model_dump(by_alias=True))
+
+    def to_json(self) -> str:
+        """Returns the JSON representation of the model using alias"""
+        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_json(cls, json_str: str) -> Self:
+        """Create an instance of CycleDictionaryNode from a JSON string"""
+        return cls.from_dict(json.loads(json_str))
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the dictionary representation of the model using alias.
+
+        This has the following differences from calling pydantic's
+        \`self.model_dump(by_alias=True)\`:
+
+        * \`None\` is only added to the output dict for nullable fields that
+          were set at model initialization. Other fields with value \`None\`
+          are ignored.
+        """
+        _dict = self.model_dump(
+            by_alias=True,
+            exclude={
+            },
+            exclude_none=True,
+        )
+        # override the default output from pydantic by calling \`to_dict()\` of nodes
+        if self.nodes:
+            _dict['nodes'] = self.nodes.to_dict()
+        return _dict
+
+    @classmethod
+    def from_dict(cls, obj: Dict) -> Self:
+        """Create an instance of CycleDictionaryNode from a dict"""
+
+        if obj is None:
+            return None
+
+        if not isinstance(obj, dict):
+            return cls.model_validate(obj)
+
+        _obj = cls.model_validate({
+            "nodes": CycleDictionary.from_dict(obj.get("nodes")) if obj.get("nodes") is not None else None
         })
         return _obj
 
@@ -23682,6 +24539,219 @@ class NamedOneOfUnion(BaseModel):
     def to_str(self) -> str:
         """Returns the string representation of the actual instance"""
         return pprint.pformat(self.model_dump())
+
+",
+  "test_project/models/nested_collections.py": "# coding: utf-8
+
+"""
+    Edge Cases
+
+    No description provided
+
+    The version of the OpenAPI document: 1.0.0
+
+    NOTE: This class is auto generated.
+    Do not edit the class manually.
+"""  # noqa: E501
+
+from __future__ import annotations
+import pprint
+import re  # noqa: F401
+import json
+from enum import Enum
+from datetime import date, datetime
+from typing import Any, List, Union, ClassVar, Dict, Optional, TYPE_CHECKING
+from pydantic import Field, StrictStr, ValidationError, field_validator, BaseModel, SecretStr, StrictFloat, StrictInt, StrictBytes, StrictBool
+from decimal import Decimal
+from typing_extensions import Annotated, Literal
+from test_project.models.cycle_array_node import CycleArrayNode
+from test_project.models.cycle_dictionary import CycleDictionary
+from test_project.models.some_object import SomeObject
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
+
+class NestedCollections(BaseModel):
+    """
+    NestedCollections
+    """ # noqa: E501
+    nested_array_of_strings: Optional[List[List[StrictStr]]] = Field(default=None, alias="nestedArrayOfStrings")
+    nested_array_of_dates: Optional[List[List[date]]] = Field(default=None, alias="nestedArrayOfDates")
+    nested_array_of_objects: Optional[List[List[SomeObject]]] = Field(default=None, alias="nestedArrayOfObjects")
+    four_dimensional_nested_array_of_objects: Optional[List[List[List[List[SomeObject]]]]] = Field(default=None, alias="fourDimensionalNestedArrayOfObjects")
+    nested_dictionary_of_strings: Optional[Dict[str, Dict[str, StrictStr]]] = Field(default=None, alias="nestedDictionaryOfStrings")
+    nested_dictionary_of_objects: Optional[Dict[str, Dict[str, SomeObject]]] = Field(default=None, alias="nestedDictionaryOfObjects")
+    four_dimensional_nested_dictionary_of_objects: Optional[Dict[str, Dict[str, Dict[str, Dict[str, SomeObject]]]]] = Field(default=None, alias="fourDimensionalNestedDictionaryOfObjects")
+    nested_mix_of_dictionaries_and_arrays: Optional[List[Dict[str, List[List[Dict[str, List[SomeObject]]]]]]] = Field(default=None, alias="nestedMixOfDictionariesAndArrays")
+    cycle_array: Optional[List[CycleArrayNode]] = Field(default=None, alias="cycleArray")
+    cycle_dictionary: Optional[CycleDictionary] = Field(default=None, alias="cycleDictionary")
+    __properties: ClassVar[List[str]] = ["nestedArrayOfStrings", "nestedArrayOfDates", "nestedArrayOfObjects", "fourDimensionalNestedArrayOfObjects", "nestedDictionaryOfStrings", "nestedDictionaryOfObjects", "fourDimensionalNestedDictionaryOfObjects", "nestedMixOfDictionariesAndArrays", "cycleArray", "cycleDictionary"]
+
+
+    model_config = {
+        "populate_by_name": True,
+        "validate_assignment": True
+    }
+
+    def to_str(self) -> str:
+        """Returns the string representation of the model using alias"""
+        return pprint.pformat(self.model_dump(by_alias=True))
+
+    def to_json(self) -> str:
+        """Returns the JSON representation of the model using alias"""
+        # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_json(cls, json_str: str) -> Self:
+        """Create an instance of NestedCollections from a JSON string"""
+        return cls.from_dict(json.loads(json_str))
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the dictionary representation of the model using alias.
+
+        This has the following differences from calling pydantic's
+        \`self.model_dump(by_alias=True)\`:
+
+        * \`None\` is only added to the output dict for nullable fields that
+          were set at model initialization. Other fields with value \`None\`
+          are ignored.
+        """
+        _dict = self.model_dump(
+            by_alias=True,
+            exclude={
+            },
+            exclude_none=True,
+        )
+        # override the default output from pydantic by calling \`to_dict()\` of each item in nested_array_of_strings (list)
+        _items = []
+        if self.nested_array_of_strings:
+            for _item in self.nested_array_of_strings:
+                if _item:
+                    _items.append(_item.to_dict())
+            _dict['nestedArrayOfStrings'] = _items
+        # override the default output from pydantic by calling \`to_dict()\` of each item in nested_array_of_dates (list)
+        _items = []
+        if self.nested_array_of_dates:
+            for _item in self.nested_array_of_dates:
+                if _item:
+                    _items.append(_item.to_dict())
+            _dict['nestedArrayOfDates'] = _items
+        # override the default output from pydantic by calling \`to_dict()\` of each item in nested_array_of_objects (list of list)
+        _items = []
+        if self.nested_array_of_objects:
+            for _item in self.nested_array_of_objects:
+                if _item:
+                    _items.append(
+                         [_inner_item.to_dict() for _inner_item in _item if _inner_item is not None]
+                    )
+            _dict['nestedArrayOfObjects'] = _items
+        # override the default output from pydantic by calling \`to_dict()\` of each item in four_dimensional_nested_array_of_objects (list of list)
+        _items = []
+        if self.four_dimensional_nested_array_of_objects:
+            for _item in self.four_dimensional_nested_array_of_objects:
+                if _item:
+                    _items.append(
+                         [_inner_item.to_dict() for _inner_item in _item if _inner_item is not None]
+                    )
+            _dict['fourDimensionalNestedArrayOfObjects'] = _items
+        # override the default output from pydantic by calling \`to_dict()\` of each value in nested_dictionary_of_strings (dict)
+        _field_dict = {}
+        if self.nested_dictionary_of_strings:
+            for _key in self.nested_dictionary_of_strings:
+                if self.nested_dictionary_of_strings[_key]:
+                    _field_dict[_key] = self.nested_dictionary_of_strings[_key].to_dict()
+            _dict['nestedDictionaryOfStrings'] = _field_dict
+        # override the default output from pydantic by calling \`to_dict()\` of each value in nested_dictionary_of_objects (dict)
+        _field_dict = {}
+        if self.nested_dictionary_of_objects:
+            for _key in self.nested_dictionary_of_objects:
+                if self.nested_dictionary_of_objects[_key]:
+                    _field_dict[_key] = self.nested_dictionary_of_objects[_key].to_dict()
+            _dict['nestedDictionaryOfObjects'] = _field_dict
+        # override the default output from pydantic by calling \`to_dict()\` of each value in four_dimensional_nested_dictionary_of_objects (dict)
+        _field_dict = {}
+        if self.four_dimensional_nested_dictionary_of_objects:
+            for _key in self.four_dimensional_nested_dictionary_of_objects:
+                if self.four_dimensional_nested_dictionary_of_objects[_key]:
+                    _field_dict[_key] = self.four_dimensional_nested_dictionary_of_objects[_key].to_dict()
+            _dict['fourDimensionalNestedDictionaryOfObjects'] = _field_dict
+        # override the default output from pydantic by calling \`to_dict()\` of each item in nested_mix_of_dictionaries_and_arrays (list)
+        _items = []
+        if self.nested_mix_of_dictionaries_and_arrays:
+            for _item in self.nested_mix_of_dictionaries_and_arrays:
+                if _item:
+                    _items.append(_item.to_dict())
+            _dict['nestedMixOfDictionariesAndArrays'] = _items
+        # override the default output from pydantic by calling \`to_dict()\` of each item in cycle_array (list)
+        _items = []
+        if self.cycle_array:
+            for _item in self.cycle_array:
+                if _item:
+                    _items.append(_item.to_dict())
+            _dict['cycleArray'] = _items
+        # override the default output from pydantic by calling \`to_dict()\` of cycle_dictionary
+        if self.cycle_dictionary:
+            _dict['cycleDictionary'] = self.cycle_dictionary.to_dict()
+        return _dict
+
+    @classmethod
+    def from_dict(cls, obj: Dict) -> Self:
+        """Create an instance of NestedCollections from a dict"""
+
+        if obj is None:
+            return None
+
+        if not isinstance(obj, dict):
+            return cls.model_validate(obj)
+
+        _obj = cls.model_validate({
+            "nestedArrayOfStrings": obj.get("nestedArrayOfStrings"),
+            "nestedArrayOfDates": obj.get("nestedArrayOfDates"),
+            "nestedArrayOfObjects": [
+                    [SomeObject.from_dict(_inner_item) for _inner_item in _item]
+                    for _item in obj.get("nestedArrayOfObjects")
+                ] if obj.get("nestedArrayOfObjects") is not None else None,
+            "fourDimensionalNestedArrayOfObjects": [
+                    [List[List[SomeObject]].from_dict(_inner_item) for _inner_item in _item]
+                    for _item in obj.get("fourDimensionalNestedArrayOfObjects")
+                ] if obj.get("fourDimensionalNestedArrayOfObjects") is not None else None,
+            "nestedDictionaryOfStrings": dict(
+                (_k, Dict[str, str].from_dict(_v))
+                for _k, _v in obj.get("nestedDictionaryOfStrings").items()
+            )
+            if obj.get("nestedDictionaryOfStrings") is not None
+            else None,
+            "nestedDictionaryOfObjects": dict(
+                (_k, dict(
+                    (_ik, SomeObject.from_dict(_iv))
+                        for _ik, _iv in _v.items()
+                    )
+                    if _v is not None
+                    else None
+                )
+                for _k, _v in obj.get("nestedDictionaryOfObjects").items()
+            )
+            if obj.get("nestedDictionaryOfObjects") is not None
+            else None,
+            "fourDimensionalNestedDictionaryOfObjects": dict(
+                (_k, dict(
+                    (_ik, Dict[str, Dict[str, SomeObject]].from_dict(_iv))
+                        for _ik, _iv in _v.items()
+                    )
+                    if _v is not None
+                    else None
+                )
+                for _k, _v in obj.get("fourDimensionalNestedDictionaryOfObjects").items()
+            )
+            if obj.get("fourDimensionalNestedDictionaryOfObjects") is not None
+            else None,
+            "nestedMixOfDictionariesAndArrays": [Dict[str, List[List[Dict[str, List[SomeObject]]]]].from_dict(_item) for _item in obj.get("nestedMixOfDictionariesAndArrays")] if obj.get("nestedMixOfDictionariesAndArrays") is not None else None,
+            "cycleArray": [CycleArrayNode.from_dict(_item) for _item in obj.get("cycleArray")] if obj.get("cycleArray") is not None else None,
+            "cycleDictionary": CycleDictionary.from_dict(obj.get("cycleDictionary")) if obj.get("cycleDictionary") is not None else None
+        })
+        return _obj
 
 ",
   "test_project/models/some_object.py": "# coding: utf-8

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript-react-query-hooks.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript-react-query-hooks.test.ts.snap
@@ -1775,7 +1775,7 @@ export function PaginatedGet200ResponseToJSON(value?: PaginatedGet200Response | 
     return {
 
         'outputNextToken': value.outputNextToken,
-        'results': value.results,
+        'results': value.results === undefined ? undefined : value.results,
     };
 }
 

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript.test.ts.snap
@@ -5638,7 +5638,7 @@ export function DataTypes200ResponseFromJSONTyped(json: any, ignoreDiscriminator
         'myLongMinStringLength': !exists(json, 'myLongMinStringLength') ? undefined : json['myLongMinStringLength'],
         'myBool': !exists(json, 'myBool') ? undefined : json['myBool'],
         'myNumber': !exists(json, 'myNumber') ? undefined : json['myNumber'],
-        'myDateArray': !exists(json, 'myDateArray') ? undefined : json['myDateArray'],
+        'myDateArray': !exists(json, 'myDateArray') ? undefined : ((json['myDateArray'] as Array<any>).map((item0) => new Date(item0))),
         'myEmail': !exists(json, 'myEmail') ? undefined : json['myEmail'],
         'myUrl': !exists(json, 'myUrl') ? undefined : json['myUrl'],
         'myHostname': !exists(json, 'myHostname') ? undefined : json['myHostname'],
@@ -5675,7 +5675,7 @@ export function DataTypes200ResponseToJSON(value?: DataTypes200Response | null):
         'myLongMinStringLength': value.myLongMinStringLength,
         'myBool': value.myBool,
         'myNumber': value.myNumber,
-        'myDateArray': value.myDateArray,
+        'myDateArray': value.myDateArray === undefined ? undefined : ((value.myDateArray as Array<any>).map((item0) => item0.toISOString().substr(0,10))),
         'myEmail': value.myEmail,
         'myUrl': value.myUrl,
         'myHostname': value.myHostname,
@@ -5691,7 +5691,7 @@ export function DataTypes200ResponseToJSON(value?: DataTypes200Response | null):
         'myAllOf': DataTypes200ResponseMyAllOfToJSON(value.myAllOf),
         'myNot': value.myNot,
         'myNotString': value.myNotString,
-        'myAdditionalProperties': value.myAdditionalProperties,
+        'myAdditionalProperties': value.myAdditionalProperties === undefined ? undefined : value.myAdditionalProperties,
         'myObject': DataTypes200ResponseMyObjectToJSON(value.myObject),
     };
 }
@@ -8230,6 +8230,9 @@ src/models/model-utils.ts
 src/models/AdditionalPropertiesResponse.ts
 src/models/AnotherNamedOneOf.ts
 src/models/ArrayOfOneOfs.ts
+src/models/CycleArrayNode.ts
+src/models/CycleDictionary.ts
+src/models/CycleDictionaryNode.ts
 src/models/Dictionary.ts
 src/models/InlineEnum200Response.ts
 src/models/InlineEnum200ResponseCategoryEnum.ts
@@ -8237,6 +8240,7 @@ src/models/InlineRequestBodyRequestContent.ts
 src/models/MyEnum.ts
 src/models/NamedOneOf.ts
 src/models/NamedOneOfUnion.ts
+src/models/NestedCollections.ts
 src/models/SomeObject.ts
 src/runtime.ts
 src/index.ts
@@ -8269,6 +8273,7 @@ import type {
   InlineRequestBodyRequestContent,
   MyEnum,
   NamedOneOfUnion,
+  NestedCollections,
 } from '../models';
 import {
     AdditionalPropertiesResponseFromJSON,
@@ -8283,6 +8288,8 @@ import {
     MyEnumToJSON,
     NamedOneOfUnionFromJSON,
     NamedOneOfUnionToJSON,
+    NestedCollectionsFromJSON,
+    NestedCollectionsToJSON,
 } from '../models';
 
 
@@ -8303,6 +8310,7 @@ export interface ArrayRequestParametersRequest {
 export interface InlineRequestBodyRequest {
     inlineRequestBodyRequestContent?: InlineRequestBodyRequestContent;
 }
+
 
 
 export interface ReservedKeywordsRequest {
@@ -8528,6 +8536,35 @@ export class DefaultApi extends runtime.BaseAPI {
     /**
      * 
      */
+    async nestedCollectionsRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<NestedCollections>> {
+        const queryParameters: any = {};
+
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+
+
+        const response = await this.request({
+            path: \`/nested-collections\`,
+            method: 'POST',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => NestedCollectionsFromJSON(jsonValue));
+    }
+
+    /**
+     * 
+     */
+    async nestedCollections(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<NestedCollections> {
+        const response = await this.nestedCollectionsRaw(initOverrides);
+        return await response.value();
+    }
+
+    /**
+     * 
+     */
     async reservedKeywordsRaw(requestParameters: ReservedKeywordsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<void>> {
         const queryParameters: any = {};
 
@@ -8579,6 +8616,15 @@ import {
     ArrayOfOneOfs,
     ArrayOfOneOfsFromJSON,
     ArrayOfOneOfsToJSON,
+    CycleArrayNode,
+    CycleArrayNodeFromJSON,
+    CycleArrayNodeToJSON,
+    CycleDictionary,
+    CycleDictionaryFromJSON,
+    CycleDictionaryToJSON,
+    CycleDictionaryNode,
+    CycleDictionaryNodeFromJSON,
+    CycleDictionaryNodeToJSON,
     Dictionary,
     DictionaryFromJSON,
     DictionaryToJSON,
@@ -8600,6 +8646,9 @@ import {
     NamedOneOfUnion,
     NamedOneOfUnionFromJSON,
     NamedOneOfUnionToJSON,
+    NestedCollections,
+    NestedCollectionsFromJSON,
+    NestedCollectionsToJSON,
     SomeObject,
     SomeObjectFromJSON,
     SomeObjectToJSON,
@@ -8622,6 +8671,7 @@ export interface OperationConfig<T> {
     inlineEnum: T;
     inlineRequestBody: T;
     namedOneOf: T;
+    nestedCollections: T;
     reservedKeywords: T;
 }
 
@@ -8654,6 +8704,11 @@ export const OperationLookup = {
     },
     namedOneOf: {
         path: '/named-one-of',
+        method: 'POST',
+        contentTypes: ['application/json'],
+    },
+    nestedCollections: {
+        path: '/nested-collections',
         method: 'POST',
         contentTypes: ['application/json'],
     },
@@ -8778,7 +8833,7 @@ const extractResponseHeadersFromInterceptors = (interceptors: any[]): { [key: st
   }), {} as { [key: string]: string });
 };
 
-export type OperationIds = | 'arrayOfOneOfs' | 'arrayRequestParameters' | 'dictionary' | 'inlineEnum' | 'inlineRequestBody' | 'namedOneOf' | 'reservedKeywords';
+export type OperationIds = | 'arrayOfOneOfs' | 'arrayRequestParameters' | 'dictionary' | 'inlineEnum' | 'inlineRequestBody' | 'namedOneOf' | 'nestedCollections' | 'reservedKeywords';
 export type OperationApiGatewayProxyResult<T extends OperationIds> = APIGatewayProxyResult & { __operationId?: T };
 
 // Api gateway lambda handler type
@@ -9525,6 +9580,115 @@ export const namedOneOfHandler = (
     };
 };
 /**
+ * Path, Query and Header parameters for NestedCollections
+ */
+export interface NestedCollectionsRequestParameters {
+}
+
+/**
+ * Request body parameter for NestedCollections
+ */
+export type NestedCollectionsRequestBody = never;
+
+export type NestedCollections200OperationResponse = OperationResponse<200, NestedCollections>;
+
+export type NestedCollectionsOperationResponses = | NestedCollections200OperationResponse ;
+
+// Type that the handler function provided to the wrapper must conform to
+export type NestedCollectionsHandlerFunction = LambdaHandlerFunction<NestedCollectionsRequestParameters, NestedCollectionsRequestBody, NestedCollectionsOperationResponses>;
+export type NestedCollectionsChainedHandlerFunction = ChainedLambdaHandlerFunction<NestedCollectionsRequestParameters, NestedCollectionsRequestBody, NestedCollectionsOperationResponses>;
+export type NestedCollectionsChainedRequestInput = ChainedRequestInput<NestedCollectionsRequestParameters, NestedCollectionsRequestBody, NestedCollectionsOperationResponses>;
+
+/**
+ * Lambda handler wrapper to provide typed interface for the implementation of nestedCollections
+ */
+export const nestedCollectionsHandler = (
+    ...handlers: [NestedCollectionsChainedHandlerFunction, ...NestedCollectionsChainedHandlerFunction[]]
+): OperationApiGatewayLambdaHandler<'nestedCollections'> => async (event: any, context: any, _callback?: any, additionalInterceptors: NestedCollectionsChainedHandlerFunction[] = []): Promise<any> => {
+    const operationId = "nestedCollections";
+
+    const rawSingleValueParameters = decodeRequestParameters({
+      ...(event.pathParameters || {}),
+      ...(event.queryStringParameters || {}),
+      ...(event.headers || {}),
+    }) as { [key: string]: string | undefined };
+    const rawMultiValueParameters = decodeRequestParameters({
+      ...(event.multiValueQueryStringParameters || {}),
+      ...(event.multiValueHeaders || {}),
+    }) as { [key: string]: string[] | undefined };
+
+    const marshal = (statusCode: number, responseBody: any): string => {
+        let marshalledBody = responseBody;
+        switch(statusCode) {
+            case 200:
+                marshalledBody = JSON.stringify(NestedCollectionsToJSON(marshalledBody));
+                break;
+            default:
+                break;
+        }
+
+        return marshalledBody;
+    };
+
+    const errorHeaders = (statusCode: number): { [key: string]: string } => {
+        let headers = {};
+
+        switch(statusCode) {
+            default:
+                break;
+        }
+
+        return headers;
+    };
+
+    let requestParameters: NestedCollectionsRequestParameters | undefined = undefined;
+
+    try {
+      requestParameters = {
+
+      };
+    } catch (e: any) {
+      const res = {
+        statusCode: 400,
+        body: { message: e.message },
+        headers: extractResponseHeadersFromInterceptors(handlers),
+      };
+      return {
+        ...res,
+        headers: {
+          ...errorHeaders(res.statusCode),
+          ...res.headers,
+        },
+        body: res.body ? marshal(res.statusCode, res.body) : '',
+      };
+    }
+
+    const demarshal = (bodyString: string): any => {
+        return {};
+    };
+    const body = parseBody(event.body, demarshal, ['application/json']) as NestedCollectionsRequestBody;
+
+    const chain = buildHandlerChain(...additionalInterceptors, ...handlers);
+    const response = await chain.next({
+        input: {
+            requestParameters,
+            body,
+        },
+        event,
+        context,
+        interceptorContext: { operationId },
+    });
+
+    return {
+        ...response,
+        headers: {
+          ...errorHeaders(response.statusCode),
+          ...response.headers,
+        },
+        body: response.body ? marshal(response.statusCode, response.body) : '',
+    };
+};
+/**
  * Path, Query and Header parameters for ReservedKeywords
  */
 export interface ReservedKeywordsRequestParameters {
@@ -9646,12 +9810,13 @@ export interface HandlerRouterHandlers {
   readonly inlineEnum: OperationApiGatewayLambdaHandler<'inlineEnum'>;
   readonly inlineRequestBody: OperationApiGatewayLambdaHandler<'inlineRequestBody'>;
   readonly namedOneOf: OperationApiGatewayLambdaHandler<'namedOneOf'>;
+  readonly nestedCollections: OperationApiGatewayLambdaHandler<'nestedCollections'>;
   readonly reservedKeywords: OperationApiGatewayLambdaHandler<'reservedKeywords'>;
 }
 
-export type AnyOperationRequestParameters = | ArrayOfOneOfsRequestParameters| ArrayRequestParametersRequestParameters| DictionaryRequestParameters| InlineEnumRequestParameters| InlineRequestBodyRequestParameters| NamedOneOfRequestParameters| ReservedKeywordsRequestParameters;
-export type AnyOperationRequestBodies = | ArrayOfOneOfsRequestBody| ArrayRequestParametersRequestBody| DictionaryRequestBody| InlineEnumRequestBody| InlineRequestBodyRequestBody| NamedOneOfRequestBody| ReservedKeywordsRequestBody;
-export type AnyOperationResponses = | ArrayOfOneOfsOperationResponses| ArrayRequestParametersOperationResponses| DictionaryOperationResponses| InlineEnumOperationResponses| InlineRequestBodyOperationResponses| NamedOneOfOperationResponses| ReservedKeywordsOperationResponses;
+export type AnyOperationRequestParameters = | ArrayOfOneOfsRequestParameters| ArrayRequestParametersRequestParameters| DictionaryRequestParameters| InlineEnumRequestParameters| InlineRequestBodyRequestParameters| NamedOneOfRequestParameters| NestedCollectionsRequestParameters| ReservedKeywordsRequestParameters;
+export type AnyOperationRequestBodies = | ArrayOfOneOfsRequestBody| ArrayRequestParametersRequestBody| DictionaryRequestBody| InlineEnumRequestBody| InlineRequestBodyRequestBody| NamedOneOfRequestBody| NestedCollectionsRequestBody| ReservedKeywordsRequestBody;
+export type AnyOperationResponses = | ArrayOfOneOfsOperationResponses| ArrayRequestParametersOperationResponses| DictionaryOperationResponses| InlineEnumOperationResponses| InlineRequestBodyOperationResponses| NamedOneOfOperationResponses| NestedCollectionsOperationResponses| ReservedKeywordsOperationResponses;
 
 export interface HandlerRouterProps<
   RequestParameters,
@@ -10071,7 +10236,7 @@ export function AdditionalPropertiesResponseToJSON(value?: AdditionalPropertiesR
     return {
 
         'dictionaryOfObjects': DictionaryToJSON(value.dictionaryOfObjects),
-        'dictionaryOfPrimitives': value.dictionaryOfPrimitives,
+        'dictionaryOfPrimitives': value.dictionaryOfPrimitives === undefined ? undefined : value.dictionaryOfPrimitives,
     };
 }
 
@@ -10209,6 +10374,195 @@ export function ArrayOfOneOfsToJSON(value?: ArrayOfOneOfs | null): any {
     return {
 
         'oneOfs': value.oneOfs === undefined ? undefined : ((value.oneOfs as Array<any>).map(NamedOneOfUnionToJSON)),
+    };
+}
+
+",
+  "src/models/CycleArrayNode.ts": "/* tslint:disable */
+/* eslint-disable */
+/**
+ * Edge Cases
+ * 
+ *
+ * The version of the OpenAPI document: 1.0.0
+ *
+ *
+ * NOTE: This class is auto generated.
+ * Do not edit the class manually.
+ */
+import { exists, mapValues } from './model-utils';
+
+/**
+ * 
+ * @export
+ * @interface CycleArrayNode
+ */
+export interface CycleArrayNode {
+    /**
+     * 
+     * @type {Array<CycleArrayNode>}
+     * @memberof CycleArrayNode
+     */
+    nodes?: Array<CycleArrayNode>;
+}
+
+
+/**
+ * Check if a given object implements the CycleArrayNode interface.
+ */
+export function instanceOfCycleArrayNode(value: object): boolean {
+    let isInstance = true;
+    return isInstance;
+}
+
+export function CycleArrayNodeFromJSON(json: any): CycleArrayNode {
+    return CycleArrayNodeFromJSONTyped(json, false);
+}
+
+export function CycleArrayNodeFromJSONTyped(json: any, ignoreDiscriminator: boolean): CycleArrayNode {
+    if ((json === undefined) || (json === null)) {
+        return json;
+    }
+    return {
+
+        'nodes': !exists(json, 'nodes') ? undefined : ((json['nodes'] as Array<any>).map(CycleArrayNodeFromJSON)),
+    };
+}
+
+export function CycleArrayNodeToJSON(value?: CycleArrayNode | null): any {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (value === null) {
+        return null;
+    }
+    return {
+
+        'nodes': value.nodes === undefined ? undefined : ((value.nodes as Array<any>).map(CycleArrayNodeToJSON)),
+    };
+}
+
+",
+  "src/models/CycleDictionary.ts": "/* tslint:disable */
+/* eslint-disable */
+/**
+ * Edge Cases
+ * 
+ *
+ * The version of the OpenAPI document: 1.0.0
+ *
+ *
+ * NOTE: This class is auto generated.
+ * Do not edit the class manually.
+ */
+import { exists, mapValues } from './model-utils';
+import type { CycleDictionaryNode } from './CycleDictionaryNode';
+import {
+    CycleDictionaryNodeFromJSON,
+    CycleDictionaryNodeFromJSONTyped,
+    CycleDictionaryNodeToJSON,
+    instanceOfCycleDictionaryNode,
+} from './CycleDictionaryNode';
+
+/**
+ * 
+ * @export
+ * @interface CycleDictionary
+ */
+export interface CycleDictionary {
+    [key: string]: CycleDictionaryNode;
+}
+
+
+/**
+ * Check if a given object implements the CycleDictionary interface.
+ */
+export function instanceOfCycleDictionary(value: object): boolean {
+    let isInstance = true;
+    return isInstance;
+}
+
+export function CycleDictionaryFromJSON(json: any): CycleDictionary {
+    return CycleDictionaryFromJSONTyped(json, false);
+}
+
+export function CycleDictionaryFromJSONTyped(json: any, ignoreDiscriminator: boolean): CycleDictionary {
+    return json;
+}
+
+export function CycleDictionaryToJSON(value?: CycleDictionary | null): any {
+    return value;
+}
+
+",
+  "src/models/CycleDictionaryNode.ts": "/* tslint:disable */
+/* eslint-disable */
+/**
+ * Edge Cases
+ * 
+ *
+ * The version of the OpenAPI document: 1.0.0
+ *
+ *
+ * NOTE: This class is auto generated.
+ * Do not edit the class manually.
+ */
+import { exists, mapValues } from './model-utils';
+import type { CycleDictionary } from './CycleDictionary';
+import {
+    CycleDictionaryFromJSON,
+    CycleDictionaryFromJSONTyped,
+    CycleDictionaryToJSON,
+    instanceOfCycleDictionary,
+} from './CycleDictionary';
+
+/**
+ * 
+ * @export
+ * @interface CycleDictionaryNode
+ */
+export interface CycleDictionaryNode {
+    /**
+     * 
+     * @type {CycleDictionary}
+     * @memberof CycleDictionaryNode
+     */
+    nodes?: CycleDictionary;
+}
+
+
+/**
+ * Check if a given object implements the CycleDictionaryNode interface.
+ */
+export function instanceOfCycleDictionaryNode(value: object): boolean {
+    let isInstance = true;
+    return isInstance;
+}
+
+export function CycleDictionaryNodeFromJSON(json: any): CycleDictionaryNode {
+    return CycleDictionaryNodeFromJSONTyped(json, false);
+}
+
+export function CycleDictionaryNodeFromJSONTyped(json: any, ignoreDiscriminator: boolean): CycleDictionaryNode {
+    if ((json === undefined) || (json === null)) {
+        return json;
+    }
+    return {
+
+        'nodes': !exists(json, 'nodes') ? undefined : CycleDictionaryFromJSON(json['nodes']),
+    };
+}
+
+export function CycleDictionaryNodeToJSON(value?: CycleDictionaryNode | null): any {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (value === null) {
+        return null;
+    }
+    return {
+
+        'nodes': CycleDictionaryToJSON(value.nodes),
     };
 }
 
@@ -10617,6 +10971,164 @@ export function NamedOneOfUnionToJSON(value?: NamedOneOfUnion | null): any {
 }
 
 ",
+  "src/models/NestedCollections.ts": "/* tslint:disable */
+/* eslint-disable */
+/**
+ * Edge Cases
+ * 
+ *
+ * The version of the OpenAPI document: 1.0.0
+ *
+ *
+ * NOTE: This class is auto generated.
+ * Do not edit the class manually.
+ */
+import { exists, mapValues } from './model-utils';
+import type { CycleArrayNode } from './CycleArrayNode';
+import {
+    CycleArrayNodeFromJSON,
+    CycleArrayNodeFromJSONTyped,
+    CycleArrayNodeToJSON,
+    instanceOfCycleArrayNode,
+} from './CycleArrayNode';
+import type { CycleDictionary } from './CycleDictionary';
+import {
+    CycleDictionaryFromJSON,
+    CycleDictionaryFromJSONTyped,
+    CycleDictionaryToJSON,
+    instanceOfCycleDictionary,
+} from './CycleDictionary';
+import type { SomeObject } from './SomeObject';
+import {
+    SomeObjectFromJSON,
+    SomeObjectFromJSONTyped,
+    SomeObjectToJSON,
+    instanceOfSomeObject,
+} from './SomeObject';
+
+/**
+ * 
+ * @export
+ * @interface NestedCollections
+ */
+export interface NestedCollections {
+    /**
+     * 
+     * @type {Array<Array<string>>}
+     * @memberof NestedCollections
+     */
+    nestedArrayOfStrings?: Array<Array<string>>;
+    /**
+     * 
+     * @type {Array<Array<Date>>}
+     * @memberof NestedCollections
+     */
+    nestedArrayOfDates?: Array<Array<Date>>;
+    /**
+     * 
+     * @type {Array<Array<SomeObject>>}
+     * @memberof NestedCollections
+     */
+    nestedArrayOfObjects?: Array<Array<SomeObject>>;
+    /**
+     * 
+     * @type {Array<Array<Array<Array<SomeObject>>>>}
+     * @memberof NestedCollections
+     */
+    fourDimensionalNestedArrayOfObjects?: Array<Array<Array<Array<SomeObject>>>>;
+    /**
+     * 
+     * @type {{ [key: string]: { [key: string]: string; }; }}
+     * @memberof NestedCollections
+     */
+    nestedDictionaryOfStrings?: { [key: string]: { [key: string]: string; }; };
+    /**
+     * 
+     * @type {{ [key: string]: { [key: string]: SomeObject; }; }}
+     * @memberof NestedCollections
+     */
+    nestedDictionaryOfObjects?: { [key: string]: { [key: string]: SomeObject; }; };
+    /**
+     * 
+     * @type {{ [key: string]: { [key: string]: { [key: string]: { [key: string]: SomeObject; }; }; }; }}
+     * @memberof NestedCollections
+     */
+    fourDimensionalNestedDictionaryOfObjects?: { [key: string]: { [key: string]: { [key: string]: { [key: string]: SomeObject; }; }; }; };
+    /**
+     * 
+     * @type {Array<{ [key: string]: Array<Array<{ [key: string]: Array<SomeObject>; }>>; }>}
+     * @memberof NestedCollections
+     */
+    nestedMixOfDictionariesAndArrays?: Array<{ [key: string]: Array<Array<{ [key: string]: Array<SomeObject>; }>>; }>;
+    /**
+     * 
+     * @type {Array<CycleArrayNode>}
+     * @memberof NestedCollections
+     */
+    cycleArray?: Array<CycleArrayNode>;
+    /**
+     * 
+     * @type {CycleDictionary}
+     * @memberof NestedCollections
+     */
+    cycleDictionary?: CycleDictionary;
+}
+
+
+/**
+ * Check if a given object implements the NestedCollections interface.
+ */
+export function instanceOfNestedCollections(value: object): boolean {
+    let isInstance = true;
+    return isInstance;
+}
+
+export function NestedCollectionsFromJSON(json: any): NestedCollections {
+    return NestedCollectionsFromJSONTyped(json, false);
+}
+
+export function NestedCollectionsFromJSONTyped(json: any, ignoreDiscriminator: boolean): NestedCollections {
+    if ((json === undefined) || (json === null)) {
+        return json;
+    }
+    return {
+
+        'nestedArrayOfStrings': !exists(json, 'nestedArrayOfStrings') ? undefined : json['nestedArrayOfStrings'],
+        'nestedArrayOfDates': !exists(json, 'nestedArrayOfDates') ? undefined : ((json['nestedArrayOfDates'] as Array<any>).map((item0) => item0.map((item1) => new Date(item1)))),
+        'nestedArrayOfObjects': !exists(json, 'nestedArrayOfObjects') ? undefined : ((json['nestedArrayOfObjects'] as Array<any>).map((item0) => item0.map(SomeObjectFromJSON))),
+        'fourDimensionalNestedArrayOfObjects': !exists(json, 'fourDimensionalNestedArrayOfObjects') ? undefined : ((json['fourDimensionalNestedArrayOfObjects'] as Array<any>).map((item0) => item0.map((item1) => item1.map((item2) => item2.map(SomeObjectFromJSON))))),
+        'nestedDictionaryOfStrings': !exists(json, 'nestedDictionaryOfStrings') ? undefined : json['nestedDictionaryOfStrings'],
+        'nestedDictionaryOfObjects': !exists(json, 'nestedDictionaryOfObjects') ? undefined : (mapValues(json['nestedDictionaryOfObjects'], (item0) => mapValues(item0, SomeObjectFromJSON))),
+        'fourDimensionalNestedDictionaryOfObjects': !exists(json, 'fourDimensionalNestedDictionaryOfObjects') ? undefined : (mapValues(json['fourDimensionalNestedDictionaryOfObjects'], (item0) => mapValues(item0, (item1) => mapValues(item1, (item2) => mapValues(item2, SomeObjectFromJSON))))),
+        'nestedMixOfDictionariesAndArrays': !exists(json, 'nestedMixOfDictionariesAndArrays') ? undefined : ((json['nestedMixOfDictionariesAndArrays'] as Array<any>).map((item0) => mapValues(item0, (item1) => item1.map((item2) => item2.map((item3) => mapValues(item3, (item4) => item4.map(SomeObjectFromJSON))))))),
+        'cycleArray': !exists(json, 'cycleArray') ? undefined : ((json['cycleArray'] as Array<any>).map(CycleArrayNodeFromJSON)),
+        'cycleDictionary': !exists(json, 'cycleDictionary') ? undefined : CycleDictionaryFromJSON(json['cycleDictionary']),
+    };
+}
+
+export function NestedCollectionsToJSON(value?: NestedCollections | null): any {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (value === null) {
+        return null;
+    }
+    return {
+
+        'nestedArrayOfStrings': value.nestedArrayOfStrings === undefined ? undefined : value.nestedArrayOfStrings,
+        'nestedArrayOfDates': value.nestedArrayOfDates === undefined ? undefined : ((value.nestedArrayOfDates as Array<any>).map((item0) => item0.map((item1) => item1.toISOString().substr(0,10)))),
+        'nestedArrayOfObjects': value.nestedArrayOfObjects === undefined ? undefined : ((value.nestedArrayOfObjects as Array<any>).map((item0) => item0.map(SomeObjectToJSON))),
+        'fourDimensionalNestedArrayOfObjects': value.fourDimensionalNestedArrayOfObjects === undefined ? undefined : ((value.fourDimensionalNestedArrayOfObjects as Array<any>).map((item0) => item0.map((item1) => item1.map((item2) => item2.map(SomeObjectToJSON))))),
+        'nestedDictionaryOfStrings': value.nestedDictionaryOfStrings === undefined ? undefined : value.nestedDictionaryOfStrings,
+        'nestedDictionaryOfObjects': value.nestedDictionaryOfObjects === undefined ? undefined : (mapValues(value.nestedDictionaryOfObjects, (item0) => mapValues(item0, SomeObjectToJSON))),
+        'fourDimensionalNestedDictionaryOfObjects': value.fourDimensionalNestedDictionaryOfObjects === undefined ? undefined : (mapValues(value.fourDimensionalNestedDictionaryOfObjects, (item0) => mapValues(item0, (item1) => mapValues(item1, (item2) => mapValues(item2, SomeObjectToJSON))))),
+        'nestedMixOfDictionariesAndArrays': value.nestedMixOfDictionariesAndArrays === undefined ? undefined : ((value.nestedMixOfDictionariesAndArrays as Array<any>).map((item0) => mapValues(item0, (item1) => item1.map((item2) => item2.map((item3) => mapValues(item3, (item4) => item4.map(SomeObjectToJSON))))))),
+        'cycleArray': value.cycleArray === undefined ? undefined : ((value.cycleArray as Array<any>).map(CycleArrayNodeToJSON)),
+        'cycleDictionary': CycleDictionaryToJSON(value.cycleDictionary),
+    };
+}
+
+",
   "src/models/SomeObject.ts": "/* tslint:disable */
 /* eslint-disable */
 /**
@@ -10687,6 +11199,9 @@ export function SomeObjectToJSON(value?: SomeObject | null): any {
 export * from './AdditionalPropertiesResponse';
 export * from './AnotherNamedOneOf';
 export * from './ArrayOfOneOfs';
+export * from './CycleArrayNode';
+export * from './CycleDictionary';
+export * from './CycleDictionaryNode';
 export * from './Dictionary';
 export * from './InlineEnum200Response';
 export * from './InlineEnum200ResponseCategoryEnum';
@@ -10694,6 +11209,7 @@ export * from './InlineRequestBodyRequestContent';
 export * from './MyEnum';
 export * from './NamedOneOf';
 export * from './NamedOneOfUnion';
+export * from './NestedCollections';
 export * from './SomeObject';
 ",
   "src/models/model-utils.ts": "/* tslint:disable */


### PR DESCRIPTION
Previously, arrays of arrays or dictionaries of dictionaries (or any combination) were not serialising/deserialising correctly. There were 2 main problems:

1. Nested arrays/dictionaries of models would be treated as if they were a single array/dictionary
2. Nested dates (even under single level arrays) weren't being serialised/deserialised at all which could lead to runtime errors

Note that OpenAPI generator would not attempt to recursively serialise/deserialise nested arrays which mean that problem 2 was present prior to moving to the new code generator.
