### PR TITLE
feat(type-safe-api): add argument to exclude templates in generate command

### DIFF
--- a/packages/pdk/.projen/deps.json
+++ b/packages/pdk/.projen/deps.json
@@ -235,6 +235,11 @@
       "type": "build"
     },
     {
+      "name": "minimatch",
+      "version": "10.0.1",
+      "type": "build"
+    },
+    {
       "name": "node-fetch",
       "version": "^2.6.7",
       "type": "build"

--- a/packages/pdk/package.json
+++ b/packages/pdk/package.json
@@ -89,6 +89,7 @@
     "jsii-pacmak": "1.104.0",
     "jsii-rosetta": "1.104.0",
     "license-checker": "25.0.1",
+    "minimatch": "10.0.1",
     "node-fetch": "^2.6.7",
     "nx": "19",
     "parse-openapi": "0.0.1",

--- a/packages/type-safe-api/.projen/deps.json
+++ b/packages/type-safe-api/.projen/deps.json
@@ -131,6 +131,11 @@
       "type": "build"
     },
     {
+      "name": "minimatch",
+      "version": "10.0.1",
+      "type": "build"
+    },
+    {
       "name": "parse-openapi",
       "version": "0.0.1",
       "type": "build"

--- a/packages/type-safe-api/package.json
+++ b/packages/type-safe-api/package.json
@@ -62,6 +62,7 @@
     "jsii-docgen": "8.0.56",
     "jsii-pacmak": "1.104.0",
     "jsii-rosetta": "1.104.0",
+    "minimatch": "10.0.1",
     "parse-openapi": "0.0.1",
     "prettier": "2.8.8",
     "projen": "0.82.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1273,6 +1273,9 @@ importers:
       license-checker:
         specifier: 25.0.1
         version: 25.0.1
+      minimatch:
+        specifier: 10.0.1
+        version: 10.0.1
       node-fetch:
         specifier: ^2.6.7
         version: 2.7.0
@@ -1672,6 +1675,9 @@ importers:
       jsii-rosetta:
         specifier: 1.104.0
         version: 1.104.0
+      minimatch:
+        specifier: 10.0.1
+        version: 10.0.1
       parse-openapi:
         specifier: 0.0.1
         version: 0.0.1
@@ -7817,7 +7823,7 @@ packages:
     dependencies:
       semver: 7.6.2
       shelljs: 0.8.5
-      typescript: 5.7.0-dev.20241031
+      typescript: 5.8.0-dev.20241127
     dev: true
 
   /duplexer2@0.1.4:
@@ -11249,6 +11255,13 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /minimatch@10.0.1:
+    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
+    engines: {node: 20 || >=22}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: true
+
   /minimatch@3.0.5:
     resolution: {integrity: sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==}
     dependencies:
@@ -14244,8 +14257,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /typescript@5.7.0-dev.20241031:
-    resolution: {integrity: sha512-CR0uSMNCzLCXjptJ38ESiEpTMEYJiplIe9jmZLQuTp5nrxwOE2ljMg5z1XyPI+Uss1saZOdpwkPxXU3mDIASEg==}
+  /typescript@5.8.0-dev.20241127:
+    resolution: {integrity: sha512-TGb4/mmMCY5GOBuEry4xaOcDonyPwnxPc2zaR/8jgA6twK+iGEPsB6EeT+lSSrpOP906WPlFAn3XVQfQm4d7TQ==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true

--- a/projenrc/projects/type-safe-api-project.ts
+++ b/projenrc/projects/type-safe-api-project.ts
@@ -47,6 +47,7 @@ export class TypeSafeApiProject extends PDKProject {
         "ejs@3.1.10", // Used by scripts
         "@types/ejs@3.1.5", // Used by scripts
         "parse-openapi@0.0.1", // Used by scripts
+        "minimatch@10.0.1", // Used by scripts
         "esbuild",
       ],
       deps: [


### PR DESCRIPTION
Allow excluding specific templates from code generation.
