### PR TITLE
fix(type-safe-api): silence warnings for mock data generation for fields with pattern constraints

### DIFF
--- a/packages/type-safe-api/scripts/type-safe-api/custom/mock-data/generate-mock-data.ts
+++ b/packages/type-safe-api/scripts/type-safe-api/custom/mock-data/generate-mock-data.ts
@@ -178,14 +178,18 @@ export const generateMockDataForSchema = (
 
 const generateStringFromRegex = (pattern: string): string | undefined => {
   const random = Math.random;
+  const warn = console.warn;
   try {
     // Fix random to ensure mocked data is deterministic
     Math.random = () => 0.5;
+    // ReRegExp prints warnings to the console which add unnecessary noise
+    console.warn = () => {};
     return new ReRegExp(pattern).build();
   } catch {
     // Couldn't convert regex to string, don't fail, just be less strict
   } finally {
     Math.random = random;
+    console.warn = warn;
   }
   return undefined;
 }


### PR DESCRIPTION
ReRegExp is used to generate mock data for fields with regex patterns. ReRegExp is quite noisy with its warnings, printing directly to the console. This change silences these warnings.

Fixes #891
