### PR TITLE
fix: address issues with release of react 19

### DIFF
--- a/packages/cloudscape-react-ts-website/samples/cloudscape-react-ts-website/src/layouts/App/index.tsx.mustache
+++ b/packages/cloudscape-react-ts-website/samples/cloudscape-react-ts-website/src/layouts/App/index.tsx.mustache
@@ -78,7 +78,7 @@ const App: React.FC = () => {
           splitPanelSize: undefined,
           splitPanelPreferences: undefined,
         });
-        navigate(e.detail.href);
+        void navigate(e.detail.href);
       }
     },
     [navigate],

--- a/packages/cloudscape-react-ts-website/samples/cloudscape-react-ts-website/src/pages/Home/index.tsx.mustache
+++ b/packages/cloudscape-react-ts-website/samples/cloudscape-react-ts-website/src/pages/Home/index.tsx.mustache
@@ -26,7 +26,7 @@ import { useNavigate } from "react-router-dom";
 const Home: React.FC = () => {
   {{#hasApis}}
   const navigate = useNavigate();
-  useEffect(() => navigate("/apiExplorer"), []);
+  useEffect(() => void navigate("/apiExplorer"), []);
   {{/hasApis}}
 
   {{#typeSafeApis.0}}

--- a/packages/cloudscape-react-ts-website/test/__snapshots__/cloudscape-react-ts-website-project.test.ts.snap
+++ b/packages/cloudscape-react-ts-website/test/__snapshots__/cloudscape-react-ts-website-project.test.ts.snap
@@ -1361,7 +1361,7 @@ const App: React.FC = () => {
           splitPanelSize: undefined,
           splitPanelPreferences: undefined,
         });
-        navigate(e.detail.href);
+        void navigate(e.detail.href);
       }
     },
     [navigate],
@@ -2929,7 +2929,7 @@ const App: React.FC = () => {
           splitPanelSize: undefined,
           splitPanelPreferences: undefined,
         });
-        navigate(e.detail.href);
+        void navigate(e.detail.href);
       }
     },
     [navigate],
@@ -5022,7 +5022,7 @@ const App: React.FC = () => {
           splitPanelSize: undefined,
           splitPanelPreferences: undefined,
         });
-        navigate(e.detail.href);
+        void navigate(e.detail.href);
       }
     },
     [navigate],
@@ -5247,7 +5247,7 @@ import { useNavigate } from "react-router-dom";
  */
 const Home: React.FC = () => {
   const navigate = useNavigate();
-  useEffect(() => navigate("/apiExplorer"), []);
+  useEffect(() => void navigate("/apiExplorer"), []);
 
   // const sayHello = useSayHello({ name: "World" });
 

--- a/packages/type-safe-api/scripts/type-safe-api/generators/typescript-react-query-hooks/templates/clientProvider.ejs
+++ b/packages/type-safe-api/scripts/type-safe-api/generators/typescript-react-query-hooks/templates/clientProvider.ejs
@@ -48,7 +48,7 @@ export const <%- service.className %>ClientProvider = ({
   context = <%- service.className %>DefaultContext,
   <%_ } _%>
   children,
-}: <%- service.className %>ClientProviderProps): JSX.Element => {
+}: <%- service.className %>ClientProviderProps): React.JSX.Element => {
   return (
     <QueryClientProvider client={client}<% if (!metadata.queryV5) { %> context={context}<% } %>>
       <<%- service.className %>ClientContext.Provider value={apiClient}>

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript-esm.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript-esm.test.ts.snap
@@ -4265,7 +4265,7 @@ export const DefaultApiClientProvider = ({
   client = queryClient,
   context = DefaultApiDefaultContext,
   children,
-}: DefaultApiClientProviderProps): JSX.Element => {
+}: DefaultApiClientProviderProps): React.JSX.Element => {
   return (
     <QueryClientProvider client={client} context={context}>
       <DefaultApiClientContext.Provider value={apiClient}>

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript-react-query-hooks.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript-react-query-hooks.test.ts.snap
@@ -183,7 +183,7 @@ export const DefaultApiClientProvider = ({
   client = queryClient,
   context = DefaultApiDefaultContext,
   children,
-}: DefaultApiClientProviderProps): JSX.Element => {
+}: DefaultApiClientProviderProps): React.JSX.Element => {
   return (
     <QueryClientProvider client={client} context={context}>
       <DefaultApiClientContext.Provider value={apiClient}>
@@ -355,7 +355,7 @@ export const Tag1ApiClientProvider = ({
   client = queryClient,
   context = Tag1ApiDefaultContext,
   children,
-}: Tag1ApiClientProviderProps): JSX.Element => {
+}: Tag1ApiClientProviderProps): React.JSX.Element => {
   return (
     <QueryClientProvider client={client} context={context}>
       <Tag1ApiClientContext.Provider value={apiClient}>
@@ -514,7 +514,7 @@ export const Tag2ApiClientProvider = ({
   client = queryClient,
   context = Tag2ApiDefaultContext,
   children,
-}: Tag2ApiClientProviderProps): JSX.Element => {
+}: Tag2ApiClientProviderProps): React.JSX.Element => {
   return (
     <QueryClientProvider client={client} context={context}>
       <Tag2ApiClientContext.Provider value={apiClient}>
@@ -1465,7 +1465,7 @@ export const DefaultApiClientProvider = ({
   client = queryClient,
   context = DefaultApiDefaultContext,
   children,
-}: DefaultApiClientProviderProps): JSX.Element => {
+}: DefaultApiClientProviderProps): React.JSX.Element => {
   return (
     <QueryClientProvider client={client} context={context}>
       <DefaultApiClientContext.Provider value={apiClient}>
@@ -2935,7 +2935,7 @@ export const DefaultApiClientProvider = ({
   apiClient,
   client = queryClient,
   children,
-}: DefaultApiClientProviderProps): JSX.Element => {
+}: DefaultApiClientProviderProps): React.JSX.Element => {
   return (
     <QueryClientProvider client={client}>
       <DefaultApiClientContext.Provider value={apiClient}>


### PR DESCRIPTION
React 19 removes the global JSX namespace - replace with React.JSX which works with both React 19 and 18. Additionally address type error with new versions of react-router-dom's `navigate` function returning a promise.

Fixes #895
Fixes #896
