### PR TITLE
feat(type-safe-api): handlers default to python 3.13 and node 22

### DIFF
--- a/packages/type-safe-api/src/project/codegen/handlers/generated-python-handlers-base-project.ts
+++ b/packages/type-safe-api/src/project/codegen/handlers/generated-python-handlers-base-project.ts
@@ -58,7 +58,7 @@ export abstract class GeneratedPythonHandlersBaseProject extends PythonProject {
     });
     TypeSafeApiCommandEnvironment.ensure(this);
     this.options = options;
-    this.runtimeVersion = options.runtimeVersion ?? PythonVersion.PYTHON_3_11;
+    this.runtimeVersion = options.runtimeVersion ?? PythonVersion.PYTHON_3_13;
     this.tstDir = "test";
 
     if (options.pytest ?? true) {

--- a/packages/type-safe-api/src/project/codegen/handlers/generated-typescript-handlers-base-project.ts
+++ b/packages/type-safe-api/src/project/codegen/handlers/generated-typescript-handlers-base-project.ts
@@ -63,7 +63,7 @@ export abstract class GeneratedTypescriptHandlersBaseProject extends TypeScriptP
       npmignoreEnabled: false,
     });
     this.options = options;
-    this.runtimeVersion = options.runtimeVersion ?? NodeVersion.NODE_18;
+    this.runtimeVersion = options.runtimeVersion ?? NodeVersion.NODE_22;
 
     TypeSafeApiCommandEnvironment.ensure(this);
 

--- a/packages/type-safe-api/src/project/types.ts
+++ b/packages/type-safe-api/src/project/types.ts
@@ -210,7 +210,7 @@ export interface GeneratedTypeScriptHandlersOptions
 
   /**
    * Runtime version to target for the handlers
-   * @default NodeVersion.NODE_18
+   * @default NodeVersion.NODE_22
    */
   readonly runtimeVersion?: NodeVersion;
 }
@@ -231,7 +231,7 @@ export interface GeneratedPythonHandlersOptions
 
   /**
    * Runtime version to target for the handlers
-   * @default PythonVersion.PYTHON_3_11
+   * @default PythonVersion.PYTHON_3_13
    */
   readonly runtimeVersion?: PythonVersion;
 }

--- a/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
@@ -25781,7 +25781,7 @@ resolution-mode=highest
         "name": "generate",
         "steps": [
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api generate --specPath ../../../model/.api.json --outputPath . --templateDirs "typescript-cdk-infrastructure" --metadata '{"srcDir":"src","runtimePackageName":"smithy-handlers-typescript-runtime","relativeSpecPath":"../assets/api.json","enableMockIntegrations":true,"x-handlers-python-module":"smithy_handlers_python_handlers","x-handlers-java-package":"com.generated.api.smithyhandlersjavahandlers.handlers","x-handlers-typescript-asset-path":"../../../handlers/typescript/dist/lambda","x-handlers-python-asset-path":"../../../handlers/python/dist/lambda","x-handlers-java-asset-path":"../../../handlers/java/dist/java/com/generated/api/smithy-handlers-java-handlers/0.0.0/smithy-handlers-java-handlers-0.0.0.jar","x-handlers-node-lambda-runtime-version":"NODEJS_18_X","x-handlers-python-lambda-runtime-version":"PYTHON_3_11","x-handlers-java-lambda-runtime-version":"JAVA_17"}'",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api generate --specPath ../../../model/.api.json --outputPath . --templateDirs "typescript-cdk-infrastructure" --metadata '{"srcDir":"src","runtimePackageName":"smithy-handlers-typescript-runtime","relativeSpecPath":"../assets/api.json","enableMockIntegrations":true,"x-handlers-python-module":"smithy_handlers_python_handlers","x-handlers-java-package":"com.generated.api.smithyhandlersjavahandlers.handlers","x-handlers-typescript-asset-path":"../../../handlers/typescript/dist/lambda","x-handlers-python-asset-path":"../../../handlers/python/dist/lambda","x-handlers-java-asset-path":"../../../handlers/java/dist/java/com/generated/api/smithy-handlers-java-handlers/0.0.0/smithy-handlers-java-handlers-0.0.0.jar","x-handlers-node-lambda-runtime-version":"NODEJS_22_X","x-handlers-python-lambda-runtime-version":"PYTHON_3_13","x-handlers-java-lambda-runtime-version":"JAVA_17"}'",
           },
           {
             "exec": "mkdir -p assets",
@@ -28333,7 +28333,7 @@ cython_debug/
       {
         "name": "python",
         "type": "runtime",
-        "version": "^3.11",
+        "version": "^3.13",
       },
       {
         "name": "smithy-handlers-python-runtime",
@@ -28446,7 +28446,7 @@ cython_debug/
             "exec": "poetry export --without-hashes --format=requirements.txt | sed -E 's/^-e[[:space:]]+//' > dist/lambda/requirements.txt",
           },
           {
-            "exec": "pip install -r dist/lambda/requirements.txt --target dist/lambda --upgrade --platform manylinux2014_x86_64 --only-binary :all: --python-version 3.11",
+            "exec": "pip install -r dist/lambda/requirements.txt --target dist/lambda --upgrade --platform manylinux2014_x86_64 --only-binary :all: --python-version 3.13",
           },
         ],
       },
@@ -28609,7 +28609,7 @@ include = [
   include = "smithy_handlers_python_handlers"
 
   [tool.poetry.dependencies]
-  python = "^3.11"
+  python = "^3.13"
 
     [tool.poetry.dependencies.smithy-handlers-python-runtime]
     path = "../../generated/runtime/python"
@@ -29104,7 +29104,7 @@ resolution-mode=highest
             "exec": "mkdir -p dist/lambda && rm -rf dist/lambda/*",
           },
           {
-            "exec": "esbuild --bundle src/*.ts --platform=node --outdir=dist/lambda --target=node18",
+            "exec": "esbuild --bundle src/*.ts --platform=node --outdir=dist/lambda --target=node22",
           },
           {
             "exec": "for f in $(ls dist/lambda); do mkdir dist/lambda/$(basename $f .js) && mv dist/lambda/$f dist/lambda/$(basename $f .js)/index.js; done",
@@ -85140,7 +85140,7 @@ dist/java
         "name": "generate",
         "steps": [
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api generate --specPath ../../../model/.api.json --outputPath . --templateDirs "java-cdk-infrastructure" --metadata '{"srcDir":"src/main/java/com/generated/api/typespecjavajavainfra/infra","packageName":"com.generated.api.typespecjavajavainfra.infra","runtimePackageName":"com.generated.api.typespecjavajavaruntime.runtime","enableMockIntegrations":true,"x-handlers-python-module":"typespec_java_python_handlers","x-handlers-java-package":"com.generated.api.typespecjavajavahandlers.handlers","x-handlers-typescript-asset-path":"../../../handlers/typescript/dist/lambda","x-handlers-python-asset-path":"../../../handlers/python/dist/lambda","x-handlers-java-asset-path":"../../../handlers/java/dist/java/com/generated/api/typespec-java-java-handlers/0.0.0/typespec-java-java-handlers-0.0.0.jar","x-handlers-node-lambda-runtime-version":"NODEJS_18_X","x-handlers-python-lambda-runtime-version":"PYTHON_3_11","x-handlers-java-lambda-runtime-version":"JAVA_17"}'",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api generate --specPath ../../../model/.api.json --outputPath . --templateDirs "java-cdk-infrastructure" --metadata '{"srcDir":"src/main/java/com/generated/api/typespecjavajavainfra/infra","packageName":"com.generated.api.typespecjavajavainfra.infra","runtimePackageName":"com.generated.api.typespecjavajavaruntime.runtime","enableMockIntegrations":true,"x-handlers-python-module":"typespec_java_python_handlers","x-handlers-java-package":"com.generated.api.typespecjavajavahandlers.handlers","x-handlers-typescript-asset-path":"../../../handlers/typescript/dist/lambda","x-handlers-python-asset-path":"../../../handlers/python/dist/lambda","x-handlers-java-asset-path":"../../../handlers/java/dist/java/com/generated/api/typespec-java-java-handlers/0.0.0/typespec-java-java-handlers-0.0.0.jar","x-handlers-node-lambda-runtime-version":"NODEJS_22_X","x-handlers-python-lambda-runtime-version":"PYTHON_3_13","x-handlers-java-lambda-runtime-version":"JAVA_17"}'",
           },
           {
             "exec": "mkdir -p src/main/resources",
@@ -87445,7 +87445,7 @@ cython_debug/
       {
         "name": "python",
         "type": "runtime",
-        "version": "^3.11",
+        "version": "^3.13",
       },
       {
         "name": "typespec-java-python-runtime",
@@ -87558,7 +87558,7 @@ cython_debug/
             "exec": "poetry export --without-hashes --format=requirements.txt | sed -E 's/^-e[[:space:]]+//' > dist/lambda/requirements.txt",
           },
           {
-            "exec": "pip install -r dist/lambda/requirements.txt --target dist/lambda --upgrade --platform manylinux2014_x86_64 --only-binary :all: --python-version 3.11",
+            "exec": "pip install -r dist/lambda/requirements.txt --target dist/lambda --upgrade --platform manylinux2014_x86_64 --only-binary :all: --python-version 3.13",
           },
         ],
       },
@@ -87721,7 +87721,7 @@ include = [
   include = "typespec_java_python_handlers"
 
   [tool.poetry.dependencies]
-  python = "^3.11"
+  python = "^3.13"
 
     [tool.poetry.dependencies.typespec-java-python-runtime]
     path = "../../generated/runtime/python"
@@ -88216,7 +88216,7 @@ resolution-mode=highest
             "exec": "mkdir -p dist/lambda && rm -rf dist/lambda/*",
           },
           {
-            "exec": "esbuild --bundle src/*.ts --platform=node --outdir=dist/lambda --target=node18",
+            "exec": "esbuild --bundle src/*.ts --platform=node --outdir=dist/lambda --target=node22",
           },
           {
             "exec": "for f in $(ls dist/lambda); do mkdir dist/lambda/$(basename $f .js) && mv dist/lambda/$f dist/lambda/$(basename $f .js)/index.js; done",
@@ -89767,7 +89767,7 @@ mocks
         "name": "generate",
         "steps": [
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api generate --specPath ../../../model/.api.json --outputPath . --templateDirs "python-cdk-infrastructure" --metadata '{"srcDir":"typespec_python_python_infra","runtimeModuleName":"typespec_python_python_runtime","relativeSpecPath":"../../../../model/.api.json","enableMockIntegrations":true,"x-handlers-python-module":"typespec_python_python_handlers","x-handlers-java-package":"com.generated.api.typespecpythonjavahandlers.handlers","x-handlers-typescript-asset-path":"../../../handlers/typescript/dist/lambda","x-handlers-python-asset-path":"../../../handlers/python/dist/lambda","x-handlers-java-asset-path":"../../../handlers/java/dist/java/com/generated/api/typespec-python-java-handlers/0.0.0/typespec-python-java-handlers-0.0.0.jar","x-handlers-node-lambda-runtime-version":"NODEJS_18_X","x-handlers-python-lambda-runtime-version":"PYTHON_3_11","x-handlers-java-lambda-runtime-version":"JAVA_17"}'",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api generate --specPath ../../../model/.api.json --outputPath . --templateDirs "python-cdk-infrastructure" --metadata '{"srcDir":"typespec_python_python_infra","runtimeModuleName":"typespec_python_python_runtime","relativeSpecPath":"../../../../model/.api.json","enableMockIntegrations":true,"x-handlers-python-module":"typespec_python_python_handlers","x-handlers-java-package":"com.generated.api.typespecpythonjavahandlers.handlers","x-handlers-typescript-asset-path":"../../../handlers/typescript/dist/lambda","x-handlers-python-asset-path":"../../../handlers/python/dist/lambda","x-handlers-java-asset-path":"../../../handlers/java/dist/java/com/generated/api/typespec-python-java-handlers/0.0.0/typespec-python-java-handlers-0.0.0.jar","x-handlers-node-lambda-runtime-version":"NODEJS_22_X","x-handlers-python-lambda-runtime-version":"PYTHON_3_13","x-handlers-java-lambda-runtime-version":"JAVA_17"}'",
           },
           {
             "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api generate-mock-data --specPath ../../../model/.api.json --outputPath .",
@@ -92023,7 +92023,7 @@ cython_debug/
       {
         "name": "python",
         "type": "runtime",
-        "version": "^3.11",
+        "version": "^3.13",
       },
       {
         "name": "typespec-python-python-runtime",
@@ -92136,7 +92136,7 @@ cython_debug/
             "exec": "poetry export --without-hashes --format=requirements.txt | sed -E 's/^-e[[:space:]]+//' > dist/lambda/requirements.txt",
           },
           {
-            "exec": "pip install -r dist/lambda/requirements.txt --target dist/lambda --upgrade --platform manylinux2014_x86_64 --only-binary :all: --python-version 3.11",
+            "exec": "pip install -r dist/lambda/requirements.txt --target dist/lambda --upgrade --platform manylinux2014_x86_64 --only-binary :all: --python-version 3.13",
           },
         ],
       },
@@ -92299,7 +92299,7 @@ include = [
   include = "typespec_python_python_handlers"
 
   [tool.poetry.dependencies]
-  python = "^3.11"
+  python = "^3.13"
 
     [tool.poetry.dependencies.typespec-python-python-runtime]
     path = "../../generated/runtime/python"
@@ -92794,7 +92794,7 @@ resolution-mode=highest
             "exec": "mkdir -p dist/lambda && rm -rf dist/lambda/*",
           },
           {
-            "exec": "esbuild --bundle src/*.ts --platform=node --outdir=dist/lambda --target=node18",
+            "exec": "esbuild --bundle src/*.ts --platform=node --outdir=dist/lambda --target=node22",
           },
           {
             "exec": "for f in $(ls dist/lambda); do mkdir dist/lambda/$(basename $f .js) && mv dist/lambda/$f dist/lambda/$(basename $f .js)/index.js; done",
@@ -94344,7 +94344,7 @@ resolution-mode=highest
         "name": "generate",
         "steps": [
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api generate --specPath ../../../model/.api.json --outputPath . --templateDirs "typescript-cdk-infrastructure" --metadata '{"srcDir":"src","runtimePackageName":"typespec-typescript-typescript-runtime","relativeSpecPath":"../assets/api.json","enableMockIntegrations":true,"x-handlers-python-module":"typespec_typescript_python_handlers","x-handlers-java-package":"com.generated.api.typespectypescriptjavahandlers.handlers","x-handlers-typescript-asset-path":"../../../handlers/typescript/dist/lambda","x-handlers-python-asset-path":"../../../handlers/python/dist/lambda","x-handlers-java-asset-path":"../../../handlers/java/dist/java/com/generated/api/typespec-typescript-java-handlers/0.0.0/typespec-typescript-java-handlers-0.0.0.jar","x-handlers-node-lambda-runtime-version":"NODEJS_18_X","x-handlers-python-lambda-runtime-version":"PYTHON_3_11","x-handlers-java-lambda-runtime-version":"JAVA_17"}'",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api generate --specPath ../../../model/.api.json --outputPath . --templateDirs "typescript-cdk-infrastructure" --metadata '{"srcDir":"src","runtimePackageName":"typespec-typescript-typescript-runtime","relativeSpecPath":"../assets/api.json","enableMockIntegrations":true,"x-handlers-python-module":"typespec_typescript_python_handlers","x-handlers-java-package":"com.generated.api.typespectypescriptjavahandlers.handlers","x-handlers-typescript-asset-path":"../../../handlers/typescript/dist/lambda","x-handlers-python-asset-path":"../../../handlers/python/dist/lambda","x-handlers-java-asset-path":"../../../handlers/java/dist/java/com/generated/api/typespec-typescript-java-handlers/0.0.0/typespec-typescript-java-handlers-0.0.0.jar","x-handlers-node-lambda-runtime-version":"NODEJS_22_X","x-handlers-python-lambda-runtime-version":"PYTHON_3_13","x-handlers-java-lambda-runtime-version":"JAVA_17"}'",
           },
           {
             "exec": "mkdir -p assets",
@@ -96896,7 +96896,7 @@ cython_debug/
       {
         "name": "python",
         "type": "runtime",
-        "version": "^3.11",
+        "version": "^3.13",
       },
       {
         "name": "typespec-typescript-python-runtime",
@@ -97009,7 +97009,7 @@ cython_debug/
             "exec": "poetry export --without-hashes --format=requirements.txt | sed -E 's/^-e[[:space:]]+//' > dist/lambda/requirements.txt",
           },
           {
-            "exec": "pip install -r dist/lambda/requirements.txt --target dist/lambda --upgrade --platform manylinux2014_x86_64 --only-binary :all: --python-version 3.11",
+            "exec": "pip install -r dist/lambda/requirements.txt --target dist/lambda --upgrade --platform manylinux2014_x86_64 --only-binary :all: --python-version 3.13",
           },
         ],
       },
@@ -97172,7 +97172,7 @@ include = [
   include = "typespec_typescript_python_handlers"
 
   [tool.poetry.dependencies]
-  python = "^3.11"
+  python = "^3.13"
 
     [tool.poetry.dependencies.typespec-typescript-python-runtime]
     path = "../../generated/runtime/python"
@@ -97667,7 +97667,7 @@ resolution-mode=highest
             "exec": "mkdir -p dist/lambda && rm -rf dist/lambda/*",
           },
           {
-            "exec": "esbuild --bundle src/*.ts --platform=node --outdir=dist/lambda --target=node18",
+            "exec": "esbuild --bundle src/*.ts --platform=node --outdir=dist/lambda --target=node22",
           },
           {
             "exec": "for f in $(ls dist/lambda); do mkdir dist/lambda/$(basename $f .js) && mv dist/lambda/$f dist/lambda/$(basename $f .js)/index.js; done",

--- a/packages/type-safe-api/test/project/__snapshots__/type-safe-websocket-api-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/__snapshots__/type-safe-websocket-api-project.test.ts.snap
@@ -6216,7 +6216,7 @@ resolution-mode=highest
         "name": "generate",
         "steps": [
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api generate --specPath ../../../model/.api.json --outputPath . --templateDirs "typescript-async-cdk-infrastructure" --metadata '{"srcDir":"src","runtimePackageName":"smithy-handlers-typescript-runtime","relativeSpecPath":"../assets/api.json","x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"../../../handlers/typescript/dist/lambda","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"NODEJS_18_X","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}'",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api generate --specPath ../../../model/.api.json --outputPath . --templateDirs "typescript-async-cdk-infrastructure" --metadata '{"srcDir":"src","runtimePackageName":"smithy-handlers-typescript-runtime","relativeSpecPath":"../assets/api.json","x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"../../../handlers/typescript/dist/lambda","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"NODEJS_22_X","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}'",
           },
           {
             "exec": "mkdir -p assets",
@@ -7788,7 +7788,7 @@ resolution-mode=highest
             "exec": "mkdir -p dist/lambda && rm -rf dist/lambda/*",
           },
           {
-            "exec": "esbuild --bundle src/*.ts --platform=node --outdir=dist/lambda --target=node18",
+            "exec": "esbuild --bundle src/*.ts --platform=node --outdir=dist/lambda --target=node22",
           },
           {
             "exec": "for f in $(ls dist/lambda); do mkdir dist/lambda/$(basename $f .js) && mv dist/lambda/$f dist/lambda/$(basename $f .js)/index.js; done",
@@ -45259,7 +45259,7 @@ mocks
         "name": "generate",
         "steps": [
           {
-            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api generate --specPath ../../../model/.api.json --outputPath . --templateDirs "typescript-async-cdk-infrastructure" --metadata '{"srcDir":"src","runtimePackageName":"typespec-typescript-typescript-runtime","relativeSpecPath":"../assets/api.json","x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"../../../handlers/typescript/dist/lambda","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"NODEJS_18_X","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}'",
+            "exec": "npx --yes -p @aws/pdk@$AWS_PDK_VERSION type-safe-api generate --specPath ../../../model/.api.json --outputPath . --templateDirs "typescript-async-cdk-infrastructure" --metadata '{"srcDir":"src","runtimePackageName":"typespec-typescript-typescript-runtime","relativeSpecPath":"../assets/api.json","x-handlers-python-module":"","x-handlers-java-package":"","x-handlers-typescript-asset-path":"../../../handlers/typescript/dist/lambda","x-handlers-python-asset-path":"","x-handlers-java-asset-path":"","x-handlers-node-lambda-runtime-version":"NODEJS_22_X","x-handlers-python-lambda-runtime-version":"","x-handlers-java-lambda-runtime-version":""}'",
           },
           {
             "exec": "mkdir -p assets",
@@ -46886,7 +46886,7 @@ junit.xml
             "exec": "mkdir -p dist/lambda && rm -rf dist/lambda/*",
           },
           {
-            "exec": "esbuild --bundle src/*.ts --platform=node --outdir=dist/lambda --target=node18",
+            "exec": "esbuild --bundle src/*.ts --platform=node --outdir=dist/lambda --target=node22",
           },
           {
             "exec": "for f in $(ls dist/lambda); do mkdir dist/lambda/$(basename $f .js) && mv dist/lambda/$f dist/lambda/$(basename $f .js)/index.js; done",

--- a/packages/type-safe-api/test/project/codegen/handlers/__snapshots__/generated-python-async-handlers-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/codegen/handlers/__snapshots__/generated-python-async-handlers-project.test.ts.snap
@@ -140,7 +140,7 @@ cython_debug/
       {
         "name": "python",
         "type": "runtime",
-        "version": "^3.11",
+        "version": "^3.13",
       },
       {
         "name": "test-python-client",
@@ -299,7 +299,7 @@ cython_debug/
             "exec": "poetry export --without-hashes --format=requirements.txt | sed -E 's/^-e[[:space:]]+//' > dist/lambda/requirements.txt",
           },
           {
-            "exec": "pip install -r dist/lambda/requirements.txt --target dist/lambda --upgrade --platform manylinux2014_x86_64 --only-binary :all: --python-version 3.11",
+            "exec": "pip install -r dist/lambda/requirements.txt --target dist/lambda --upgrade --platform manylinux2014_x86_64 --only-binary :all: --python-version 3.13",
           },
         ],
       },
@@ -365,7 +365,7 @@ include = [ "test_handlers", "test_handlers/**/*.py" ]
   include = "test_handlers"
 
   [tool.poetry.dependencies]
-  python = "^3.11"
+  python = "^3.13"
 
     [tool.poetry.dependencies.test-python-client]
     path = "../python-async-client"

--- a/packages/type-safe-api/test/project/codegen/handlers/__snapshots__/generated-python-handlers-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/codegen/handlers/__snapshots__/generated-python-handlers-project.test.ts.snap
@@ -140,7 +140,7 @@ cython_debug/
       {
         "name": "python",
         "type": "runtime",
-        "version": "^3.11",
+        "version": "^3.13",
       },
       {
         "name": "test-python-client",
@@ -299,7 +299,7 @@ cython_debug/
             "exec": "poetry export --without-hashes --format=requirements.txt | sed -E 's/^-e[[:space:]]+//' > dist/lambda/requirements.txt",
           },
           {
-            "exec": "pip install -r dist/lambda/requirements.txt --target dist/lambda --upgrade --platform manylinux2014_x86_64 --only-binary :all: --python-version 3.11",
+            "exec": "pip install -r dist/lambda/requirements.txt --target dist/lambda --upgrade --platform manylinux2014_x86_64 --only-binary :all: --python-version 3.13",
           },
         ],
       },
@@ -365,7 +365,7 @@ include = [ "test_handlers", "test_handlers/**/*.py" ]
   include = "test_handlers"
 
   [tool.poetry.dependencies]
-  python = "^3.11"
+  python = "^3.13"
 
     [tool.poetry.dependencies.test-python-client]
     path = "../python-client"

--- a/packages/type-safe-api/test/project/codegen/handlers/__snapshots__/generated-typescript-async-handlers-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/codegen/handlers/__snapshots__/generated-typescript-async-handlers-project.test.ts.snap
@@ -882,7 +882,7 @@ pull_request_rules:
             "exec": "mkdir -p dist/lambda && rm -rf dist/lambda/*",
           },
           {
-            "exec": "esbuild --bundle src/*.ts --platform=node --outdir=dist/lambda --target=node18",
+            "exec": "esbuild --bundle src/*.ts --platform=node --outdir=dist/lambda --target=node22",
           },
           {
             "exec": "for f in $(ls dist/lambda); do mkdir dist/lambda/$(basename $f .js) && mv dist/lambda/$f dist/lambda/$(basename $f .js)/index.js; done",

--- a/packages/type-safe-api/test/project/codegen/handlers/__snapshots__/generated-typescript-handlers-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/codegen/handlers/__snapshots__/generated-typescript-handlers-project.test.ts.snap
@@ -882,7 +882,7 @@ pull_request_rules:
             "exec": "mkdir -p dist/lambda && rm -rf dist/lambda/*",
           },
           {
-            "exec": "esbuild --bundle src/*.ts --platform=node --outdir=dist/lambda --target=node18",
+            "exec": "esbuild --bundle src/*.ts --platform=node --outdir=dist/lambda --target=node22",
           },
           {
             "exec": "for f in $(ls dist/lambda); do mkdir dist/lambda/$(basename $f .js) && mv dist/lambda/$f dist/lambda/$(basename $f .js)/index.js; done",

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/java-cdk-infrastructure.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/java-cdk-infrastructure.test.ts.snap
@@ -365,7 +365,7 @@ public class PythonOneFunctionProps implements FunctionProps {
         "../python-handlers/dist/lambda"
     ).toAbsolutePath().toString());
     private final String handler = "test_python_handlers.python_one.handler";
-    private final Runtime runtime = Runtime.PYTHON_3_11;
+    private final Runtime runtime = Runtime.PYTHON_3_13;
 
     // Props with defaults
     @lombok.Builder.Default
@@ -502,7 +502,7 @@ public class PythonTwoFunctionProps implements FunctionProps {
         "../python-handlers/dist/lambda"
     ).toAbsolutePath().toString());
     private final String handler = "test_python_handlers.python_two.handler";
-    private final Runtime runtime = Runtime.PYTHON_3_11;
+    private final Runtime runtime = Runtime.PYTHON_3_13;
 
     // Props with defaults
     @lombok.Builder.Default
@@ -639,7 +639,7 @@ public class TypescriptOneFunctionProps implements FunctionProps {
         "../typescript-handlers/dist/lambda/typescript-one"
     ).toAbsolutePath().toString());
     private final String handler = "index.handler";
-    private final Runtime runtime = Runtime.NODEJS_18_X;
+    private final Runtime runtime = Runtime.NODEJS_22_X;
 
     // Props with defaults
     @lombok.Builder.Default
@@ -776,7 +776,7 @@ public class TypescriptTwoFunctionProps implements FunctionProps {
         "../typescript-handlers/dist/lambda/typescript-two"
     ).toAbsolutePath().toString());
     private final String handler = "index.handler";
-    private final Runtime runtime = Runtime.NODEJS_18_X;
+    private final Runtime runtime = Runtime.NODEJS_22_X;
 
     // Props with defaults
     @lombok.Builder.Default
@@ -1055,7 +1055,7 @@ public class PythonTestFunctionProps implements FunctionProps {
         "../python-handlers/dist/lambda"
     ).toAbsolutePath().toString());
     private final String handler = "test_python_handlers.python_test.handler";
-    private final Runtime runtime = Runtime.PYTHON_3_11;
+    private final Runtime runtime = Runtime.PYTHON_3_13;
 
     // Props with defaults
     @lombok.Builder.Default
@@ -1192,7 +1192,7 @@ public class TypescriptTestFunctionProps implements FunctionProps {
         "../typescript-handlers/dist/lambda/typescript-test"
     ).toAbsolutePath().toString());
     private final String handler = "index.handler";
-    private final Runtime runtime = Runtime.NODEJS_18_X;
+    private final Runtime runtime = Runtime.NODEJS_22_X;
 
     // Props with defaults
     @lombok.Builder.Default

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/python-cdk-infrastructure.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/python-cdk-infrastructure.test.ts.snap
@@ -50,7 +50,7 @@ class PythonOneFunction(Function):
     """
     def __init__(self, scope, id, **kwargs):
         super().__init__(scope, id,
-            runtime=Runtime.PYTHON_3_11,
+            runtime=Runtime.PYTHON_3_13,
             handler="test_python_handlers.python_one.handler",
             code=Code.from_asset(path.join(str(Path(__file__).absolute().parent), "..",
                 "../python-handlers/dist/lambda",
@@ -67,7 +67,7 @@ class PythonTwoFunction(Function):
     """
     def __init__(self, scope, id, **kwargs):
         super().__init__(scope, id,
-            runtime=Runtime.PYTHON_3_11,
+            runtime=Runtime.PYTHON_3_13,
             handler="test_python_handlers.python_two.handler",
             code=Code.from_asset(path.join(str(Path(__file__).absolute().parent), "..",
                 "../python-handlers/dist/lambda",
@@ -84,7 +84,7 @@ class TypescriptOneFunction(Function):
     """
     def __init__(self, scope, id, **kwargs):
         super().__init__(scope, id,
-            runtime=Runtime.NODEJS_18_X,
+            runtime=Runtime.NODEJS_22_X,
             handler="index.handler",
             code=Code.from_asset(path.join(str(Path(__file__).absolute().parent), "..",
                 "../typescript-handlers/dist/lambda",
@@ -102,7 +102,7 @@ class TypescriptTwoFunction(Function):
     """
     def __init__(self, scope, id, **kwargs):
         super().__init__(scope, id,
-            runtime=Runtime.NODEJS_18_X,
+            runtime=Runtime.NODEJS_22_X,
             handler="index.handler",
             code=Code.from_asset(path.join(str(Path(__file__).absolute().parent), "..",
                 "../typescript-handlers/dist/lambda",
@@ -149,7 +149,7 @@ class PythonTestFunction(Function):
     """
     def __init__(self, scope, id, **kwargs):
         super().__init__(scope, id,
-            runtime=Runtime.PYTHON_3_11,
+            runtime=Runtime.PYTHON_3_13,
             handler="test_python_handlers.python_test.handler",
             code=Code.from_asset(path.join(str(Path(__file__).absolute().parent), "..",
                 "../python-handlers/dist/lambda",
@@ -166,7 +166,7 @@ class TypescriptTestFunction(Function):
     """
     def __init__(self, scope, id, **kwargs):
         super().__init__(scope, id,
-            runtime=Runtime.NODEJS_18_X,
+            runtime=Runtime.NODEJS_22_X,
             handler="index.handler",
             code=Code.from_asset(path.join(str(Path(__file__).absolute().parent), "..",
                 "../typescript-handlers/dist/lambda",

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript-cdk-infrastructure.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript-cdk-infrastructure.test.ts.snap
@@ -64,7 +64,7 @@ export interface PythonOneFunctionProps extends Omit<FunctionProps, 'code' | 'ha
 export class PythonOneFunction extends Function {
   constructor(scope: Construct, id: string, props?: PythonOneFunctionProps) {
     super(scope, id, {
-      runtime: Runtime.PYTHON_3_11,
+      runtime: Runtime.PYTHON_3_13,
       handler: "test_python_handlers.python_one.handler",
       code: Code.fromAsset(path.resolve(__dirname, "..",
         "../python-handlers/dist/lambda",
@@ -87,7 +87,7 @@ export interface PythonTwoFunctionProps extends Omit<FunctionProps, 'code' | 'ha
 export class PythonTwoFunction extends Function {
   constructor(scope: Construct, id: string, props?: PythonTwoFunctionProps) {
     super(scope, id, {
-      runtime: Runtime.PYTHON_3_11,
+      runtime: Runtime.PYTHON_3_13,
       handler: "test_python_handlers.python_two.handler",
       code: Code.fromAsset(path.resolve(__dirname, "..",
         "../python-handlers/dist/lambda",
@@ -110,7 +110,7 @@ export interface TypescriptOneFunctionProps extends Omit<FunctionProps, 'code' |
 export class TypescriptOneFunction extends Function {
   constructor(scope: Construct, id: string, props?: TypescriptOneFunctionProps) {
     super(scope, id, {
-      runtime: Runtime.NODEJS_18_X,
+      runtime: Runtime.NODEJS_22_X,
       handler: "index.handler",
       code: Code.fromAsset(path.resolve(__dirname, "..",
         "../typescript-handlers/dist/lambda",
@@ -134,7 +134,7 @@ export interface TypescriptTwoFunctionProps extends Omit<FunctionProps, 'code' |
 export class TypescriptTwoFunction extends Function {
   constructor(scope: Construct, id: string, props?: TypescriptTwoFunctionProps) {
     super(scope, id, {
-      runtime: Runtime.NODEJS_18_X,
+      runtime: Runtime.NODEJS_22_X,
       handler: "index.handler",
       code: Code.fromAsset(path.resolve(__dirname, "..",
         "../typescript-handlers/dist/lambda",
@@ -191,7 +191,7 @@ export interface PythonTestFunctionProps extends Omit<FunctionProps, 'code' | 'h
 export class PythonTestFunction extends Function {
   constructor(scope: Construct, id: string, props?: PythonTestFunctionProps) {
     super(scope, id, {
-      runtime: Runtime.PYTHON_3_11,
+      runtime: Runtime.PYTHON_3_13,
       handler: "test_python_handlers.python_test.handler",
       code: Code.fromAsset(path.resolve(__dirname, "..",
         "../python-handlers/dist/lambda",
@@ -214,7 +214,7 @@ export interface TypescriptTestFunctionProps extends Omit<FunctionProps, 'code' 
 export class TypescriptTestFunction extends Function {
   constructor(scope: Construct, id: string, props?: TypescriptTestFunctionProps) {
     super(scope, id, {
-      runtime: Runtime.NODEJS_18_X,
+      runtime: Runtime.NODEJS_22_X,
       handler: "index.handler",
       code: Code.fromAsset(path.resolve(__dirname, "..",
         "../typescript-handlers/dist/lambda",

--- a/packages/type-safe-api/test/scripts/generators/async/__snapshots__/java-cdk-infrastructure.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/async/__snapshots__/java-cdk-infrastructure.test.ts.snap
@@ -365,7 +365,7 @@ public class PythonOneFunctionProps implements FunctionProps {
         "../python-handlers/dist/lambda"
     ).toAbsolutePath().toString());
     private final String handler = "test_python_handlers.python_one.handler";
-    private final Runtime runtime = Runtime.PYTHON_3_11;
+    private final Runtime runtime = Runtime.PYTHON_3_13;
 
     // Props with defaults
     @lombok.Builder.Default
@@ -502,7 +502,7 @@ public class PythonTwoFunctionProps implements FunctionProps {
         "../python-handlers/dist/lambda"
     ).toAbsolutePath().toString());
     private final String handler = "test_python_handlers.python_two.handler";
-    private final Runtime runtime = Runtime.PYTHON_3_11;
+    private final Runtime runtime = Runtime.PYTHON_3_13;
 
     // Props with defaults
     @lombok.Builder.Default
@@ -639,7 +639,7 @@ public class TypescriptOneFunctionProps implements FunctionProps {
         "../typescript-handlers/dist/lambda/typescript-one"
     ).toAbsolutePath().toString());
     private final String handler = "index.handler";
-    private final Runtime runtime = Runtime.NODEJS_18_X;
+    private final Runtime runtime = Runtime.NODEJS_22_X;
 
     // Props with defaults
     @lombok.Builder.Default
@@ -776,7 +776,7 @@ public class TypescriptTwoFunctionProps implements FunctionProps {
         "../typescript-handlers/dist/lambda/typescript-two"
     ).toAbsolutePath().toString());
     private final String handler = "index.handler";
-    private final Runtime runtime = Runtime.NODEJS_18_X;
+    private final Runtime runtime = Runtime.NODEJS_22_X;
 
     // Props with defaults
     @lombok.Builder.Default
@@ -1055,7 +1055,7 @@ public class PythonFunctionProps implements FunctionProps {
         "../python-handlers/dist/lambda"
     ).toAbsolutePath().toString());
     private final String handler = "test_python_handlers.python.handler";
-    private final Runtime runtime = Runtime.PYTHON_3_11;
+    private final Runtime runtime = Runtime.PYTHON_3_13;
 
     // Props with defaults
     @lombok.Builder.Default
@@ -1192,7 +1192,7 @@ public class TypeScriptFunctionProps implements FunctionProps {
         "../typescript-handlers/dist/lambda/type-script"
     ).toAbsolutePath().toString());
     private final String handler = "index.handler";
-    private final Runtime runtime = Runtime.NODEJS_18_X;
+    private final Runtime runtime = Runtime.NODEJS_22_X;
 
     // Props with defaults
     @lombok.Builder.Default

--- a/packages/type-safe-api/test/scripts/generators/async/__snapshots__/python-cdk-infrastructure.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/async/__snapshots__/python-cdk-infrastructure.test.ts.snap
@@ -50,7 +50,7 @@ class PythonOneFunction(Function):
     """
     def __init__(self, scope, id, **kwargs):
         super().__init__(scope, id,
-            runtime=Runtime.PYTHON_3_11,
+            runtime=Runtime.PYTHON_3_13,
             handler="test_python_handlers.python_one.handler",
             code=Code.from_asset(path.join(str(Path(__file__).absolute().parent), "..",
                 "../python-handlers/dist/lambda",
@@ -67,7 +67,7 @@ class PythonTwoFunction(Function):
     """
     def __init__(self, scope, id, **kwargs):
         super().__init__(scope, id,
-            runtime=Runtime.PYTHON_3_11,
+            runtime=Runtime.PYTHON_3_13,
             handler="test_python_handlers.python_two.handler",
             code=Code.from_asset(path.join(str(Path(__file__).absolute().parent), "..",
                 "../python-handlers/dist/lambda",
@@ -84,7 +84,7 @@ class TypescriptOneFunction(Function):
     """
     def __init__(self, scope, id, **kwargs):
         super().__init__(scope, id,
-            runtime=Runtime.NODEJS_18_X,
+            runtime=Runtime.NODEJS_22_X,
             handler="index.handler",
             code=Code.from_asset(path.join(str(Path(__file__).absolute().parent), "..",
                 "../typescript-handlers/dist/lambda",
@@ -102,7 +102,7 @@ class TypescriptTwoFunction(Function):
     """
     def __init__(self, scope, id, **kwargs):
         super().__init__(scope, id,
-            runtime=Runtime.NODEJS_18_X,
+            runtime=Runtime.NODEJS_22_X,
             handler="index.handler",
             code=Code.from_asset(path.join(str(Path(__file__).absolute().parent), "..",
                 "../typescript-handlers/dist/lambda",
@@ -149,7 +149,7 @@ class PythonFunction(Function):
     """
     def __init__(self, scope, id, **kwargs):
         super().__init__(scope, id,
-            runtime=Runtime.PYTHON_3_11,
+            runtime=Runtime.PYTHON_3_13,
             handler="test_python_handlers.python.handler",
             code=Code.from_asset(path.join(str(Path(__file__).absolute().parent), "..",
                 "../python-handlers/dist/lambda",
@@ -166,7 +166,7 @@ class TypeScriptFunction(Function):
     """
     def __init__(self, scope, id, **kwargs):
         super().__init__(scope, id,
-            runtime=Runtime.NODEJS_18_X,
+            runtime=Runtime.NODEJS_22_X,
             handler="index.handler",
             code=Code.from_asset(path.join(str(Path(__file__).absolute().parent), "..",
                 "../typescript-handlers/dist/lambda",

--- a/packages/type-safe-api/test/scripts/generators/async/__snapshots__/typescript-cdk-infrastructure.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/async/__snapshots__/typescript-cdk-infrastructure.test.ts.snap
@@ -18,7 +18,7 @@ export interface $ConnectFunctionProps extends Omit<FunctionProps, 'code' | 'han
 export class $ConnectFunction extends Function {
   constructor(scope: Construct, id: string, props?: $ConnectFunctionProps) {
     super(scope, id, {
-      runtime: Runtime.NODEJS_18_X,
+      runtime: Runtime.NODEJS_22_X,
       handler: "index.handler",
       code: Code.fromAsset(path.resolve(__dirname, "..",
         "../typescript-handlers/dist/lambda",
@@ -113,7 +113,7 @@ export interface PythonOneFunctionProps extends Omit<FunctionProps, 'code' | 'ha
 export class PythonOneFunction extends Function {
   constructor(scope: Construct, id: string, props?: PythonOneFunctionProps) {
     super(scope, id, {
-      runtime: Runtime.PYTHON_3_11,
+      runtime: Runtime.PYTHON_3_13,
       handler: "test_python_handlers.python_one.handler",
       code: Code.fromAsset(path.resolve(__dirname, "..",
         "../python-handlers/dist/lambda",
@@ -137,7 +137,7 @@ export interface PythonTwoFunctionProps extends Omit<FunctionProps, 'code' | 'ha
 export class PythonTwoFunction extends Function {
   constructor(scope: Construct, id: string, props?: PythonTwoFunctionProps) {
     super(scope, id, {
-      runtime: Runtime.PYTHON_3_11,
+      runtime: Runtime.PYTHON_3_13,
       handler: "test_python_handlers.python_two.handler",
       code: Code.fromAsset(path.resolve(__dirname, "..",
         "../python-handlers/dist/lambda",
@@ -161,7 +161,7 @@ export interface TypescriptOneFunctionProps extends Omit<FunctionProps, 'code' |
 export class TypescriptOneFunction extends Function {
   constructor(scope: Construct, id: string, props?: TypescriptOneFunctionProps) {
     super(scope, id, {
-      runtime: Runtime.NODEJS_18_X,
+      runtime: Runtime.NODEJS_22_X,
       handler: "index.handler",
       code: Code.fromAsset(path.resolve(__dirname, "..",
         "../typescript-handlers/dist/lambda",
@@ -186,7 +186,7 @@ export interface TypescriptTwoFunctionProps extends Omit<FunctionProps, 'code' |
 export class TypescriptTwoFunction extends Function {
   constructor(scope: Construct, id: string, props?: TypescriptTwoFunctionProps) {
     super(scope, id, {
-      runtime: Runtime.NODEJS_18_X,
+      runtime: Runtime.NODEJS_22_X,
       handler: "index.handler",
       code: Code.fromAsset(path.resolve(__dirname, "..",
         "../typescript-handlers/dist/lambda",
@@ -246,7 +246,7 @@ export interface PythonFunctionProps extends Omit<FunctionProps, 'code' | 'handl
 export class PythonFunction extends Function {
   constructor(scope: Construct, id: string, props?: PythonFunctionProps) {
     super(scope, id, {
-      runtime: Runtime.PYTHON_3_11,
+      runtime: Runtime.PYTHON_3_13,
       handler: "test_python_handlers.python.handler",
       code: Code.fromAsset(path.resolve(__dirname, "..",
         "../python-handlers/dist/lambda",
@@ -270,7 +270,7 @@ export interface TypeScriptFunctionProps extends Omit<FunctionProps, 'code' | 'h
 export class TypeScriptFunction extends Function {
   constructor(scope: Construct, id: string, props?: TypeScriptFunctionProps) {
     super(scope, id, {
-      runtime: Runtime.NODEJS_18_X,
+      runtime: Runtime.NODEJS_22_X,
       handler: "index.handler",
       code: Code.fromAsset(path.resolve(__dirname, "..",
         "../typescript-handlers/dist/lambda",


### PR DESCRIPTION
In order to default to the most secure configuration, handler functions now default to the latest
supported AWS Lambda runtimes for Python and Node.

BREAKING CHANGE: API handlers that don't specify the runtime version need to be validated with
Python 3.13 or Node 22.

Depends on #899 