### PR TITLE
fix(type-safe-api): stop calling to_dict on lists in python runtime

### DIFF
--- a/packages/type-safe-api/scripts/type-safe-api/generators/python/templates/client/models/models.ejs
+++ b/packages/type-safe-api/scripts/type-safe-api/generators/python/templates/client/models/models.ejs
@@ -462,7 +462,7 @@ class <%- model.name %>(BaseModel):
                 if self.<%- property.pythonName %>[_key]:
                     _field_dict[_key] = self.<%- property.pythonName %>[_key].to_dict()
             _dict['<%- property.name %>'] = _field_dict
-        <%_ } else if (!property.isPrimitive) { _%>
+        <%_ } else if (property.export !== 'array' && !property.isPrimitive) { _%>
         # override the default output from pydantic by calling `to_dict()` of <%- property.pythonName %>
         if self.<%- property.pythonName %>:
             _dict['<%- property.name %>'] = self.<%- property.pythonName %>.to_dict()

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
@@ -12705,9 +12705,6 @@ class DataTypes200Response(BaseModel):
             },
             exclude_none=True,
         )
-        # override the default output from pydantic by calling \`to_dict()\` of my_date_array
-        if self.my_date_array:
-            _dict['myDateArray'] = self.my_date_array.to_dict()
         # override the default output from pydantic by calling \`to_dict()\` of my_one_of
         if self.my_one_of:
             _dict['myOneOf'] = self.my_one_of.to_dict()


### PR DESCRIPTION
The template wasn't handling models with arrays of primitives properly, and it was getting handled by the last else if statement for non-primitives. This change excludes arrays from the case.

fix #904
