### PR TITLE
fix(type-safe-api): fix reversed pydantic minimum and maximum

### DIFF
--- a/packages/type-safe-api/scripts/type-safe-api/generators/python/templates/types/pydanticType.partial.ejs
+++ b/packages/type-safe-api/scripts/type-safe-api/generators/python/templates/types/pydanticType.partial.ejs
@@ -9,10 +9,10 @@ const getPythonPydanticConstraints = (property) => {
     constraints.max_length = property.maxLength ?? property.maxItems;
   }
   if (property.minimum !== undefined) {
-    constraints[property.exclusiveMinimum ? 'lt' : 'le'] = property.minimum;
+    constraints[property.exclusiveMinimum ? 'gt' : 'ge'] = property.minimum;
   }
   if (property.maximum !== undefined) {
-    constraints[property.exclusiveMaximum ? 'gt' : 'ge'] = property.maximum;
+    constraints[property.exclusiveMaximum ? 'lt' : 'le'] = property.maximum;
   }
 
   if (Object.keys(constraints).length > 0) {

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/python.test.ts.snap
@@ -12633,8 +12633,8 @@ class DataTypes200Response(BaseModel):
     """
     DataTypes200Response
     """ # noqa: E501
-    my_int: Optional[Annotated[int, Field(strict=True, le=3, ge=7)]] = Field(default=None, alias="myInt")
-    my_exclusive_int: Optional[Annotated[int, Field(strict=True, lt=3, gt=7)]] = Field(default=None, alias="myExclusiveInt")
+    my_int: Optional[Annotated[int, Field(strict=True, ge=3, le=7)]] = Field(default=None, alias="myInt")
+    my_exclusive_int: Optional[Annotated[int, Field(strict=True, gt=3, lt=7)]] = Field(default=None, alias="myExclusiveInt")
     my_string: Optional[StrictStr] = Field(default=None, alias="myString")
     my_string_length: Optional[Annotated[str, Field(strict=True, min_length=4, max_length=5)]] = Field(default=None, alias="myStringLength")
     my_long_min_string_length: Optional[Annotated[str, Field(strict=True, min_length=1000)]] = Field(default=None, alias="myLongMinStringLength")
@@ -12656,7 +12656,7 @@ class DataTypes200Response(BaseModel):
     my_all_of: Optional[DataTypes200ResponseMyAllOf] = Field(default=None, alias="myAllOf")
     my_not: Optional[Any] = Field(default=None, alias="myNot")
     my_not_string: Optional[Any] = Field(default=None, alias="myNotString")
-    my_additional_properties: Optional[Dict[str, Annotated[List[Annotated[int, Field(strict=True, le=10, ge=20)]], Field(strict=True, min_length=2, max_length=5)]]] = Field(default=None, alias="myAdditionalProperties")
+    my_additional_properties: Optional[Dict[str, Annotated[List[Annotated[int, Field(strict=True, ge=10, le=20)]], Field(strict=True, min_length=2, max_length=5)]]] = Field(default=None, alias="myAdditionalProperties")
     my_object: Optional[DataTypes200ResponseMyObject] = Field(default=None, alias="myObject")
     __properties: ClassVar[List[str]] = ["myInt", "myExclusiveInt", "myString", "myStringLength", "myLongMinStringLength", "myBool", "myNumber", "myDateArray", "myEmail", "myUrl", "myHostname", "myIpv4", "myIpv6", "myUuid", "myByte", "myConstrainedByte", "myDateTime", "myRegexPattern", "myOneOf", "myAnyOf", "myAllOf", "myNot", "myNotString", "myAdditionalProperties", "myObject"]
 


### PR DESCRIPTION
Correct the generated Pydantic fields so that `minimum` is greater than and `maximum` is less than.

fix #907