### PR TITLE
fix(type-safe-api): ensure api key auth can be disabled for specific operations

### DIFF
--- a/packages/type-safe-api/src/construct/prepare-spec-event-handler/index.ts
+++ b/packages/type-safe-api/src/construct/prepare-spec-event-handler/index.ts
@@ -53,7 +53,14 @@ interface OnEventRequest {
   /**
    * Properties for preparing the api
    */
-  readonly ResourceProperties: PrepareApiSpecCustomResourceProperties;
+  readonly ResourceProperties: {
+    /**
+     * This is acually of type PrepareApiSpecCustomResourceProperties but JSON stringified to work around A
+     * bug in cloudformation!
+     * @see https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1037
+     */
+    options: string;
+  };
 }
 
 /**
@@ -136,7 +143,9 @@ exports.handler = async (event: OnEventRequest): Promise<OnEventResponse> => {
     case "Create":
     case "Update":
       // Prepare the spec on create
-      const outputLocation = await prepare(event.ResourceProperties);
+      const outputLocation = await prepare(
+        JSON.parse(event.ResourceProperties.options)
+      );
       return {
         PhysicalResourceId: outputLocation.key,
         Status: "SUCCESS",

--- a/packages/type-safe-api/src/construct/type-safe-rest-api.ts
+++ b/packages/type-safe-api/src/construct/type-safe-rest-api.ts
@@ -361,7 +361,9 @@ export class TypeSafeRestApi extends Construct {
       "PrepareSpecCustomResource",
       {
         serviceToken: provider.serviceToken,
-        properties: prepareApiSpecCustomResourceProperties,
+        properties: {
+          options: JSON.stringify(prepareApiSpecCustomResourceProperties),
+        },
       }
     );
 

--- a/packages/type-safe-api/test/construct/__snapshots__/type-safe-rest-api.test.ts.snap
+++ b/packages/type-safe-api/test/construct/__snapshots__/type-safe-rest-api.test.ts.snap
@@ -749,57 +749,37 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
             "Arn",
           ],
         },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "LambdaD247545B",
+                  "Arn",
                 ],
               },
-            },
-          },
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+            ],
+          ],
         },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
       },
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
@@ -845,7 +825,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-85532C36PrepSpec",
         "Handler": "index.handler",
@@ -1881,57 +1861,37 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
             "Arn",
           ],
         },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "LambdaD247545B",
+                  "Arn",
                 ],
               },
-            },
-          },
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+            ],
+          ],
         },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
       },
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
@@ -1977,7 +1937,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-300D0E5FPrepSpec",
         "Handler": "index.handler",
@@ -3351,57 +3311,37 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
             "Arn",
           ],
         },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "LambdaD247545B",
+                  "Arn",
                 ],
               },
-            },
-          },
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+            ],
+          ],
         },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
       },
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
@@ -3447,7 +3387,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -4726,60 +4666,37 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
             "Arn",
           ],
         },
-        "defaultAuthorizerReference": {
-          "authorizerId": "none",
-        },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"defaultAuthorizerReference":{"authorizerId":"none"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "LambdaD247545B",
+                  "Arn",
                 ],
               },
-            },
-          },
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+            ],
+          ],
         },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
       },
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
@@ -4825,7 +4742,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -6399,192 +6316,81 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
             "Arn",
           ],
         },
-        "corsOptions": {
-          "allowHeaders": [
-            "Content-Type",
-            "X-Amz-Date",
-            "Authorization",
-            "X-Api-Key",
-            "X-Amz-Security-Token",
-            "X-Amz-User-Agent",
-            "x-amz-content-sha256",
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"1b379c070728ce6e390dc775a85f16303a2625450133ff14c948409d76eb41c8.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"1b379c070728ce6e390dc775a85f16303a2625450133ff14c948409d76eb41c8.json-prepared"},"defaultAuthorizerReference":{"authorizerId":"aws.auth.sigv4"},"integrations":{"getOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "Lambda1DB8E9965",
+                  "Arn",
+                ],
+              },
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}},"putOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "Lambda217CFB423",
+                  "Arn",
+                ],
+              },
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}},"deleteOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "Lambda35298F1AD",
+                  "Arn",
+                ],
+              },
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}},"postOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "Lambda461E84558",
+                  "Arn",
+                ],
+              },
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{"aws.auth.sigv4":{"type":"apiKey","name":"Authorization","in":"header","x-amazon-apigateway-authtype":"awsSigv4"}},"corsOptions":{"allowHeaders":["Content-Type","X-Amz-Date","Authorization","X-Api-Key","X-Amz-Security-Token","X-Amz-User-Agent","x-amz-content-sha256"],"allowMethods":["OPTIONS","GET","PUT","POST","DELETE","PATCH","HEAD"],"allowOrigins":["*"],"statusCode":200},"operationLookup":{"getOperation":{"method":"get","path":"/test"},"putOperation":{"method":"put","path":"/test"},"postOperation":{"method":"post","path":"/test"},"deleteOperation":{"method":"delete","path":"/test"}}}",
+            ],
           ],
-          "allowMethods": [
-            "OPTIONS",
-            "GET",
-            "PUT",
-            "POST",
-            "DELETE",
-            "PATCH",
-            "HEAD",
-          ],
-          "allowOrigins": [
-            "*",
-          ],
-          "statusCode": 200,
-        },
-        "defaultAuthorizerReference": {
-          "authorizerId": "aws.auth.sigv4",
-        },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "1b379c070728ce6e390dc775a85f16303a2625450133ff14c948409d76eb41c8.json",
-        },
-        "integrations": {
-          "deleteOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "Lambda35298F1AD",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
-                ],
-              },
-            },
-          },
-          "getOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "Lambda1DB8E9965",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
-                ],
-              },
-            },
-          },
-          "postOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "Lambda461E84558",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
-                ],
-              },
-            },
-          },
-          "putOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "Lambda217CFB423",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
-                ],
-              },
-            },
-          },
-        },
-        "operationLookup": {
-          "deleteOperation": {
-            "method": "delete",
-            "path": "/test",
-          },
-          "getOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-          "postOperation": {
-            "method": "post",
-            "path": "/test",
-          },
-          "putOperation": {
-            "method": "put",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "1b379c070728ce6e390dc775a85f16303a2625450133ff14c948409d76eb41c8.json-prepared",
-        },
-        "securitySchemes": {
-          "aws.auth.sigv4": {
-            "in": "header",
-            "name": "Authorization",
-            "type": "apiKey",
-            "x-amazon-apigateway-authtype": "awsSigv4",
-          },
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -6631,7 +6437,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -8520,159 +8326,82 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
             "Arn",
           ],
         },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "59c8d7b10656c48be66a3a7cb22540b5dc6f56cfa67229affa21977c6567f30e.json",
-        },
-        "integrations": {
-          "deleteOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "Lambda1DB8E9965",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"59c8d7b10656c48be66a3a7cb22540b5dc6f56cfa67229affa21977c6567f30e.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"59c8d7b10656c48be66a3a7cb22540b5dc6f56cfa67229affa21977c6567f30e.json-prepared"},"integrations":{"getOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "Lambda1DB8E9965",
+                  "Arn",
                 ],
               },
-            },
-          },
-          "getOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "Lambda1DB8E9965",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}},"putOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "Lambda1DB8E9965",
+                  "Arn",
                 ],
               },
-            },
-          },
-          "postOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "Lambda217CFB423",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}},"postOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "Lambda217CFB423",
+                  "Arn",
                 ],
               },
-            },
-          },
-          "putOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "Lambda1DB8E9965",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}},"deleteOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "Lambda1DB8E9965",
+                  "Arn",
                 ],
               },
-            },
-          },
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"getOperation":{"method":"get","path":"/test"},"putOperation":{"method":"put","path":"/test"},"postOperation":{"method":"post","path":"/test"},"deleteOperation":{"method":"delete","path":"/test"}}}",
+            ],
+          ],
         },
-        "operationLookup": {
-          "deleteOperation": {
-            "method": "delete",
-            "path": "/test",
-          },
-          "getOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-          "postOperation": {
-            "method": "post",
-            "path": "/test",
-          },
-          "putOperation": {
-            "method": "put",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "59c8d7b10656c48be66a3a7cb22540b5dc6f56cfa67229affa21977c6567f30e.json-prepared",
-        },
-        "securitySchemes": {},
       },
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
@@ -8718,7 +8447,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -10048,57 +9777,37 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
             "Arn",
           ],
         },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "LambdaD247545B",
+                  "Arn",
                 ],
               },
-            },
-          },
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+            ],
+          ],
         },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
       },
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
@@ -10144,7 +9853,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -11423,57 +11132,37 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
             "Arn",
           ],
         },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "LambdaD247545B",
+                  "Arn",
                 ],
               },
-            },
-          },
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+            ],
+          ],
         },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
       },
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
@@ -11519,7 +11208,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -13897,57 +13586,37 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth with dedicated prepareSpe
             "Arn",
           ],
         },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Ref": "PrepareSpecBucket95FB609F",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "LambdaD247545B",
+                  "Arn",
                 ],
               },
-            },
-          },
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+            ],
+          ],
         },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Ref": "PrepareSpecBucket95FB609F",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
       },
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
@@ -13993,7 +13662,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth with dedicated prepareSpe
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -15370,77 +15039,43 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
             "Arn",
           ],
         },
-        "defaultAuthorizerReference": {
-          "authorizerId": "myCognitoAuthorizer",
-        },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"defaultAuthorizerReference":{"authorizerId":"myCognitoAuthorizer"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "LambdaD247545B",
+                  "Arn",
                 ],
               },
-            },
-          },
-        },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {
-          "myCognitoAuthorizer": {
-            "in": "header",
-            "name": "Authorization",
-            "type": "apiKey",
-            "x-amazon-apigateway-authorizer": {
-              "providerARNs": [
-                {
-                  "Fn::GetAtt": [
-                    "pool056F3F7E",
-                    "Arn",
-                  ],
-                },
-              ],
-              "type": "COGNITO_USER_POOLS",
-            },
-            "x-amazon-apigateway-authtype": "COGNITO_USER_POOLS",
-          },
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{"myCognitoAuthorizer":{"type":"apiKey","name":"Authorization","in":"header","x-amazon-apigateway-authtype":"COGNITO_USER_POOLS","x-amazon-apigateway-authorizer":{"type":"COGNITO_USER_POOLS","providerARNs":["",
+              {
+                "Fn::GetAtt": [
+                  "pool056F3F7E",
+                  "Arn",
+                ],
+              },
+              ""]}}},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+            ],
+          ],
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -15487,7 +15122,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -16943,94 +16578,51 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
             "Arn",
           ],
         },
-        "defaultAuthorizerReference": {
-          "authorizerId": "myCustomAuthorizer",
-        },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"defaultAuthorizerReference":{"authorizerId":"myCustomAuthorizer"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "LambdaD247545B",
+                  "Arn",
                 ],
               },
-            },
-          },
-        },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {
-          "myCustomAuthorizer": {
-            "in": "header",
-            "name": "Authorization",
-            "type": "apiKey",
-            "x-amazon-apigateway-authorizer": {
-              "authorizerResultTtlInSeconds": 300,
-              "authorizerUri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "AuthorizerBD825682",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{"myCustomAuthorizer":{"type":"apiKey","in":"header","name":"Authorization","x-amazon-apigateway-authtype":"CUSTOM","x-amazon-apigateway-authorizer":{"type":"token","authorizerUri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "AuthorizerBD825682",
+                  "Arn",
                 ],
               },
-              "identitySource": "method.request.header.Authorization",
-              "type": "token",
-            },
-            "x-amazon-apigateway-authtype": "CUSTOM",
-          },
+              "/invocations","authorizerResultTtlInSeconds":300,"identitySource":"method.request.header.Authorization"}}},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+            ],
+          ],
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -17077,7 +16669,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -18501,57 +18093,37 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
             "Arn",
           ],
         },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "LambdaD247545B",
+                  "Arn",
                 ],
               },
-            },
-          },
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+            ],
+          ],
         },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
       },
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
@@ -18597,7 +18169,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -19884,57 +19456,37 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules actio
             "Arn",
           ],
         },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "LambdaD247545B",
+                  "Arn",
                 ],
               },
-            },
-          },
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+            ],
+          ],
         },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
       },
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
@@ -19980,7 +19532,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules actio
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -21259,90 +20811,36 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
             "Arn",
           ],
         },
-        "corsOptions": {
-          "allowHeaders": [
-            "Content-Type",
-            "X-Amz-Date",
-            "Authorization",
-            "X-Api-Key",
-            "X-Amz-Security-Token",
-            "X-Amz-User-Agent",
-            "x-amz-content-sha256",
-          ],
-          "allowMethods": [
-            "OPTIONS",
-            "GET",
-            "PUT",
-            "POST",
-            "DELETE",
-            "PATCH",
-            "HEAD",
-          ],
-          "allowOrigins": [
-            "*",
-          ],
-          "statusCode": 200,
-        },
-        "defaultAuthorizerReference": {
-          "authorizerId": "aws.auth.sigv4",
-        },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"defaultAuthorizerReference":{"authorizerId":"aws.auth.sigv4"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "LambdaD247545B",
+                  "Arn",
                 ],
               },
-            },
-          },
-        },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {
-          "aws.auth.sigv4": {
-            "in": "header",
-            "name": "Authorization",
-            "type": "apiKey",
-            "x-amazon-apigateway-authtype": "awsSigv4",
-          },
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{"aws.auth.sigv4":{"type":"apiKey","name":"Authorization","in":"header","x-amazon-apigateway-authtype":"awsSigv4"}},"corsOptions":{"allowHeaders":["Content-Type","X-Amz-Date","Authorization","X-Api-Key","X-Amz-Security-Token","X-Amz-User-Agent","x-amz-content-sha256"],"allowMethods":["OPTIONS","GET","PUT","POST","DELETE","PATCH","HEAD"],"allowOrigins":["*"],"statusCode":200},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+            ],
+          ],
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -21389,7 +20887,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -23086,234 +22584,103 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
             "Arn",
           ],
         },
-        "defaultAuthorizerReference": {
-          "authorizerId": "aws.auth.sigv4",
-        },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "59c8d7b10656c48be66a3a7cb22540b5dc6f56cfa67229affa21977c6567f30e.json",
-        },
-        "integrations": {
-          "deleteOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaIntegrationdD45F0B2E",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"59c8d7b10656c48be66a3a7cb22540b5dc6f56cfa67229affa21977c6567f30e.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"59c8d7b10656c48be66a3a7cb22540b5dc6f56cfa67229affa21977c6567f30e.json-prepared"},"defaultAuthorizerReference":{"authorizerId":"aws.auth.sigv4"},"integrations":{"getOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "LambdaIntegrationaE925485E",
+                  "Arn",
                 ],
               },
-            },
-          },
-          "getOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaIntegrationaE925485E",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"},"methodAuthorizer":{"authorizerId":"myCognitoAuthorizer","authorizationScopes":["foo/bar"]}},"putOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "LambdaIntegrationb550BB0F2",
+                  "Arn",
                 ],
               },
-            },
-            "methodAuthorizer": {
-              "authorizationScopes": [
-                "foo/bar",
-              ],
-              "authorizerId": "myCognitoAuthorizer",
-            },
-          },
-          "postOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaIntegrationc8B199E47",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"},"methodAuthorizer":{"authorizerId":"myCognitoAuthorizer","authorizationScopes":["other/scope"]}},"postOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "LambdaIntegrationc8B199E47",
+                  "Arn",
                 ],
               },
-            },
-            "methodAuthorizer": {
-              "authorizerId": "myCustomAuthorizer",
-            },
-          },
-          "putOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaIntegrationb550BB0F2",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"},"methodAuthorizer":{"authorizerId":"myCustomAuthorizer"}},"deleteOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "LambdaIntegrationdD45F0B2E",
+                  "Arn",
                 ],
               },
-            },
-            "methodAuthorizer": {
-              "authorizationScopes": [
-                "other/scope",
-              ],
-              "authorizerId": "myCognitoAuthorizer",
-            },
-          },
-        },
-        "operationLookup": {
-          "deleteOperation": {
-            "method": "delete",
-            "path": "/test",
-          },
-          "getOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-          "postOperation": {
-            "method": "post",
-            "path": "/test",
-          },
-          "putOperation": {
-            "method": "put",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "59c8d7b10656c48be66a3a7cb22540b5dc6f56cfa67229affa21977c6567f30e.json-prepared",
-        },
-        "securitySchemes": {
-          "aws.auth.sigv4": {
-            "in": "header",
-            "name": "Authorization",
-            "type": "apiKey",
-            "x-amazon-apigateway-authtype": "awsSigv4",
-          },
-          "myCognitoAuthorizer": {
-            "in": "header",
-            "name": "Authorization",
-            "type": "apiKey",
-            "x-amazon-apigateway-authorizer": {
-              "providerARNs": [
-                {
-                  "Fn::GetAtt": [
-                    "pool056F3F7E",
-                    "Arn",
-                  ],
-                },
-              ],
-              "type": "COGNITO_USER_POOLS",
-            },
-            "x-amazon-apigateway-authtype": "COGNITO_USER_POOLS",
-          },
-          "myCustomAuthorizer": {
-            "in": "header",
-            "name": "Unused",
-            "type": "apiKey",
-            "x-amazon-apigateway-authorizer": {
-              "authorizerResultTtlInSeconds": 60,
-              "authorizerUri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaAuthorizerB5870E9B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{"myCognitoAuthorizer":{"type":"apiKey","name":"Authorization","in":"header","x-amazon-apigateway-authtype":"COGNITO_USER_POOLS","x-amazon-apigateway-authorizer":{"type":"COGNITO_USER_POOLS","providerARNs":["",
+              {
+                "Fn::GetAtt": [
+                  "pool056F3F7E",
+                  "Arn",
                 ],
               },
-              "identitySource": "method.request.querystring.QueryString1",
-              "type": "request",
-            },
-            "x-amazon-apigateway-authtype": "CUSTOM",
-          },
+              ""]}},"myCustomAuthorizer":{"type":"apiKey","in":"header","name":"Unused","x-amazon-apigateway-authtype":"CUSTOM","x-amazon-apigateway-authorizer":{"type":"request","authorizerUri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "LambdaAuthorizerB5870E9B",
+                  "Arn",
+                ],
+              },
+              "/invocations","authorizerResultTtlInSeconds":60,"identitySource":"method.request.querystring.QueryString1"}},"aws.auth.sigv4":{"type":"apiKey","name":"Authorization","in":"header","x-amazon-apigateway-authtype":"awsSigv4"}},"operationLookup":{"getOperation":{"method":"get","path":"/test"},"putOperation":{"method":"put","path":"/test"},"postOperation":{"method":"post","path":"/test"},"deleteOperation":{"method":"delete","path":"/test"}}}",
+            ],
+          ],
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -23360,7 +22727,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -24996,44 +24363,22 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
             "Arn",
           ],
         },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "requestTemplates": {
-                "application/json": "{"statusCode": 200}",
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
               },
-              "responses": {
-                "default": {
-                  "responseParameters": {},
-                  "responseTemplates": {
-                    "application/json": "{"message":"message"}",
-                  },
-                  "statusCode": "200",
-                },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
               },
-              "type": "MOCK",
-            },
-          },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"MOCK","requestTemplates":{"application/json":"{\\"statusCode\\": 200}"},"responses":{"default":{"statusCode":"200","responseParameters":{},"responseTemplates":{"application/json":"{\\"message\\":\\"message\\"}"}}}}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+            ],
+          ],
         },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
       },
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
@@ -25079,7 +24424,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -26307,72 +25652,22 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
             "Arn",
           ],
         },
-        "corsOptions": {
-          "allowHeaders": [
-            "Content-Type",
-            "X-Amz-Date",
-            "Authorization",
-            "X-Api-Key",
-            "X-Amz-Security-Token",
-            "X-Amz-User-Agent",
-            "x-amz-content-sha256",
-          ],
-          "allowMethods": [
-            "OPTIONS",
-            "GET",
-            "PUT",
-            "POST",
-            "DELETE",
-            "PATCH",
-            "HEAD",
-          ],
-          "allowOrigins": [
-            "*",
-          ],
-          "statusCode": 204,
-        },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "requestTemplates": {
-                "application/json": "{"statusCode": 200}",
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
               },
-              "responses": {
-                "default": {
-                  "responseParameters": {
-                    "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'",
-                    "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
-                    "method.response.header.Access-Control-Allow-Origin": "'*'",
-                  },
-                  "responseTemplates": {
-                    "application/json": "{"message":"message"}",
-                  },
-                  "statusCode": "200",
-                },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
               },
-              "type": "MOCK",
-            },
-          },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"MOCK","requestTemplates":{"application/json":"{\\"statusCode\\": 200}"},"responses":{"default":{"statusCode":"200","responseParameters":{"method.response.header.Access-Control-Allow-Headers":"'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'","method.response.header.Access-Control-Allow-Methods":"'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'","method.response.header.Access-Control-Allow-Origin":"'*'"},"responseTemplates":{"application/json":"{\\"message\\":\\"message\\"}"}}}}}},"securitySchemes":{},"corsOptions":{"allowHeaders":["Content-Type","X-Amz-Date","Authorization","X-Api-Key","X-Amz-Security-Token","X-Amz-User-Agent","x-amz-content-sha256"],"allowMethods":["OPTIONS","GET","PUT","POST","DELETE","PATCH","HEAD"],"allowOrigins":["*"],"statusCode":204},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+            ],
+          ],
         },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
       },
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
@@ -26418,7 +25713,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -27790,57 +27085,37 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
             "Arn",
           ],
         },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "6060611f34e7c9e9000a19922d48dfd8d47d66cbf3715fb30e173c4b51d9061b.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"6060611f34e7c9e9000a19922d48dfd8d47d66cbf3715fb30e173c4b51d9061b.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"6060611f34e7c9e9000a19922d48dfd8d47d66cbf3715fb30e173c4b51d9061b.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "LambdaD247545B",
+                  "Arn",
                 ],
               },
-            },
-          },
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"path":"/test/{param1}/fixed/{param2}/{param3}","method":"get"}}}",
+            ],
+          ],
         },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test/{param1}/fixed/{param2}/{param3}",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "6060611f34e7c9e9000a19922d48dfd8d47d66cbf3715fb30e173c4b51d9061b.json-prepared",
-        },
-        "securitySchemes": {},
       },
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
@@ -27886,7 +27161,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -29155,103 +28430,41 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration 1`] = `
             "Arn",
           ],
         },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "credentials": {
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS","httpMethod":"GET","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":s3:path/",
+              {
+                "Ref": "Bucket83908E77",
+              },
+              "//test","credentials":"",
+              {
                 "Fn::GetAtt": [
                   "ApiTestS3IntegrationsExecutionRole635C75E5",
                   "Arn",
                 ],
               },
-              "httpMethod": "GET",
-              "requestParameters": {},
-              "responses": {
-                "400": {
-                  "responseParameters": {},
-                  "responseTemplates": {
-                    "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
-{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
-",
-                  },
-                  "statusCode": "400",
-                },
-                "403": {
-                  "responseParameters": {},
-                  "responseTemplates": {
-                    "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
-{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
-",
-                  },
-                  "statusCode": "403",
-                },
-                "404": {
-                  "responseParameters": {},
-                  "responseTemplates": {
-                    "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
-{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
-",
-                  },
-                  "statusCode": "404",
-                },
-                "500": {
-                  "responseParameters": {},
-                  "responseTemplates": {
-                    "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
-{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
-",
-                  },
-                  "statusCode": "500",
-                },
-                "default": {
-                  "responseParameters": {},
-                  "responseTemplates": {},
-                  "statusCode": "200",
-                },
-              },
-              "type": "AWS",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":s3:path/",
-                    {
-                      "Ref": "Bucket83908E77",
-                    },
-                    "//test",
-                  ],
-                ],
-              },
-            },
-          },
+              "","requestParameters":{},"responses":{"400":{"statusCode":"400","responseParameters":{},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"403":{"statusCode":"403","responseParameters":{},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"404":{"statusCode":"404","responseParameters":{},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"500":{"statusCode":"500","responseParameters":{},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"default":{"statusCode":"200","responseParameters":{},"responseTemplates":{}}}}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+            ],
+          ],
         },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
       },
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
@@ -29297,7 +28510,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -30692,147 +29905,41 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and CORS 1`
             "Arn",
           ],
         },
-        "corsOptions": {
-          "allowHeaders": [
-            "Content-Type",
-            "X-Amz-Date",
-            "Authorization",
-            "X-Api-Key",
-            "X-Amz-Security-Token",
-            "X-Amz-User-Agent",
-            "x-amz-content-sha256",
-          ],
-          "allowMethods": [
-            "OPTIONS",
-            "GET",
-            "PUT",
-            "POST",
-            "DELETE",
-            "PATCH",
-            "HEAD",
-          ],
-          "allowOrigins": [
-            "*",
-          ],
-          "statusCode": 204,
-        },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "credentials": {
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS","httpMethod":"GET","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":s3:path/",
+              {
+                "Ref": "Bucket83908E77",
+              },
+              "//test","credentials":"",
+              {
                 "Fn::GetAtt": [
                   "ApiTestS3IntegrationsExecutionRole635C75E5",
                   "Arn",
                 ],
               },
-              "httpMethod": "GET",
-              "requestParameters": {},
-              "responses": {
-                "400": {
-                  "responseParameters": {
-                    "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'",
-                    "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
-                    "method.response.header.Access-Control-Allow-Origin": "'*'",
-                  },
-                  "responseTemplates": {
-                    "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
-{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
-",
-                  },
-                  "statusCode": "400",
-                },
-                "403": {
-                  "responseParameters": {
-                    "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'",
-                    "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
-                    "method.response.header.Access-Control-Allow-Origin": "'*'",
-                  },
-                  "responseTemplates": {
-                    "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
-{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
-",
-                  },
-                  "statusCode": "403",
-                },
-                "404": {
-                  "responseParameters": {
-                    "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'",
-                    "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
-                    "method.response.header.Access-Control-Allow-Origin": "'*'",
-                  },
-                  "responseTemplates": {
-                    "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
-{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
-",
-                  },
-                  "statusCode": "404",
-                },
-                "500": {
-                  "responseParameters": {
-                    "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'",
-                    "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
-                    "method.response.header.Access-Control-Allow-Origin": "'*'",
-                  },
-                  "responseTemplates": {
-                    "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
-{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
-",
-                  },
-                  "statusCode": "500",
-                },
-                "default": {
-                  "responseParameters": {
-                    "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'",
-                    "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
-                    "method.response.header.Access-Control-Allow-Origin": "'*'",
-                  },
-                  "responseTemplates": {},
-                  "statusCode": "200",
-                },
-              },
-              "type": "AWS",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":s3:path/",
-                    {
-                      "Ref": "Bucket83908E77",
-                    },
-                    "//test",
-                  ],
-                ],
-              },
-            },
-          },
+              "","requestParameters":{},"responses":{"400":{"statusCode":"400","responseParameters":{"method.response.header.Access-Control-Allow-Headers":"'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'","method.response.header.Access-Control-Allow-Methods":"'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'","method.response.header.Access-Control-Allow-Origin":"'*'"},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"403":{"statusCode":"403","responseParameters":{"method.response.header.Access-Control-Allow-Headers":"'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'","method.response.header.Access-Control-Allow-Methods":"'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'","method.response.header.Access-Control-Allow-Origin":"'*'"},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"404":{"statusCode":"404","responseParameters":{"method.response.header.Access-Control-Allow-Headers":"'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'","method.response.header.Access-Control-Allow-Methods":"'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'","method.response.header.Access-Control-Allow-Origin":"'*'"},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"500":{"statusCode":"500","responseParameters":{"method.response.header.Access-Control-Allow-Headers":"'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'","method.response.header.Access-Control-Allow-Methods":"'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'","method.response.header.Access-Control-Allow-Origin":"'*'"},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"default":{"statusCode":"200","responseParameters":{"method.response.header.Access-Control-Allow-Headers":"'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'","method.response.header.Access-Control-Allow-Methods":"'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'","method.response.header.Access-Control-Allow-Origin":"'*'"},"responseTemplates":{}}}}}},"securitySchemes":{},"corsOptions":{"allowHeaders":["Content-Type","X-Amz-Date","Authorization","X-Api-Key","X-Amz-Security-Token","X-Amz-User-Agent","x-amz-content-sha256"],"allowMethods":["OPTIONS","GET","PUT","POST","DELETE","PATCH","HEAD"],"allowOrigins":["*"],"statusCode":204},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+            ],
+          ],
         },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
       },
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
@@ -30878,7 +29985,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and CORS 1`
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -32364,72 +31471,41 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and catch a
             "Arn",
           ],
         },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "credentials": {
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS","httpMethod":"GET","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":s3:path/",
+              {
+                "Ref": "Bucket83908E77",
+              },
+              "//test","credentials":"",
+              {
                 "Fn::GetAtt": [
                   "ApiTestS3IntegrationsExecutionRole635C75E5",
                   "Arn",
                 ],
               },
-              "httpMethod": "GET",
-              "requestParameters": {},
-              "responses": {
-                "(4|5)\\d{2}": {
-                  "responseParameters": {},
-                  "responseTemplates": {},
-                  "statusCode": "500",
-                },
-                "default": {
-                  "responseParameters": {},
-                  "responseTemplates": {},
-                  "statusCode": "200",
-                },
-              },
-              "type": "AWS",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":s3:path/",
-                    {
-                      "Ref": "Bucket83908E77",
-                    },
-                    "//test",
-                  ],
-                ],
-              },
-            },
-          },
+              "","requestParameters":{},"responses":{"default":{"statusCode":"200","responseParameters":{},"responseTemplates":{}},"(4|5)\\\\d{2}":{"statusCode":"500","responseParameters":{},"responseTemplates":{}}}}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+            ],
+          ],
         },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
       },
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
@@ -32475,7 +31551,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and catch a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -33839,77 +32915,41 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and custom 
             "Arn",
           ],
         },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "credentials": {
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS","httpMethod":"GET","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":s3:path/",
+              {
+                "Ref": "Bucket83908E77",
+              },
+              "//test","credentials":"",
+              {
                 "Fn::GetAtt": [
                   "ApiTestS3IntegrationsExecutionRole635C75E5",
                   "Arn",
                 ],
               },
-              "httpMethod": "GET",
-              "requestParameters": {},
-              "responses": {
-                "4\\d{2}": {
-                  "responseParameters": {},
-                  "responseTemplates": {},
-                  "statusCode": "400",
-                },
-                "5\\d{2}": {
-                  "responseParameters": {},
-                  "responseTemplates": {},
-                  "statusCode": "500",
-                },
-                "default": {
-                  "responseParameters": {},
-                  "responseTemplates": {},
-                  "statusCode": "200",
-                },
-              },
-              "type": "AWS",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":s3:path/",
-                    {
-                      "Ref": "Bucket83908E77",
-                    },
-                    "//test",
-                  ],
-                ],
-              },
-            },
-          },
+              "","requestParameters":{},"responses":{"default":{"statusCode":"200","responseParameters":{},"responseTemplates":{}},"4\\\\d{2}":{"statusCode":"400","responseParameters":{},"responseTemplates":{}},"5\\\\d{2}":{"statusCode":"500","responseParameters":{},"responseTemplates":{}}}}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+            ],
+          ],
         },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
       },
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
@@ -33955,7 +32995,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and custom 
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -35324,103 +34364,41 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and props 1
             "Arn",
           ],
         },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "credentials": {
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS","httpMethod":"DELETE","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":s3:path/",
+              {
+                "Ref": "Bucket83908E77",
+              },
+              "//my-pets/{petId}/details.json","credentials":"",
+              {
                 "Fn::GetAtt": [
                   "ApiTestS3IntegrationsExecutionRole635C75E5",
                   "Arn",
                 ],
               },
-              "httpMethod": "DELETE",
-              "requestParameters": {},
-              "responses": {
-                "400": {
-                  "responseParameters": {},
-                  "responseTemplates": {
-                    "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
-{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
-",
-                  },
-                  "statusCode": "400",
-                },
-                "403": {
-                  "responseParameters": {},
-                  "responseTemplates": {
-                    "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
-{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
-",
-                  },
-                  "statusCode": "403",
-                },
-                "404": {
-                  "responseParameters": {},
-                  "responseTemplates": {
-                    "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
-{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
-",
-                  },
-                  "statusCode": "404",
-                },
-                "500": {
-                  "responseParameters": {},
-                  "responseTemplates": {
-                    "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
-{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
-",
-                  },
-                  "statusCode": "500",
-                },
-                "default": {
-                  "responseParameters": {},
-                  "responseTemplates": {},
-                  "statusCode": "204",
-                },
-              },
-              "type": "AWS",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":s3:path/",
-                    {
-                      "Ref": "Bucket83908E77",
-                    },
-                    "//my-pets/{petId}/details.json",
-                  ],
-                ],
-              },
-            },
-          },
+              "","requestParameters":{},"responses":{"400":{"statusCode":"400","responseParameters":{},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"403":{"statusCode":"403","responseParameters":{},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"404":{"statusCode":"404","responseParameters":{},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"500":{"statusCode":"500","responseParameters":{},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"default":{"statusCode":"204","responseParameters":{},"responseTemplates":{}}}}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+            ],
+          ],
         },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
       },
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
@@ -35466,7 +34444,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and props 1
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -37003,57 +35981,37 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
             "Arn",
           ],
         },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "LambdaD247545B",
+                  "Arn",
                 ],
               },
-            },
-          },
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+            ],
+          ],
         },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
       },
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
@@ -37099,7 +36057,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -38245,57 +37203,37 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
             "Arn",
           ],
         },
-        "inputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
-        },
-        "integrations": {
-          "testOperation": {
-            "integration": {
-              "httpMethod": "POST",
-              "passthroughBehavior": "WHEN_NO_MATCH",
-              "type": "AWS_PROXY",
-              "uri": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":apigateway:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":lambda:path/2015-03-31/functions/",
-                    {
-                      "Fn::GetAtt": [
-                        "LambdaD247545B",
-                        "Arn",
-                      ],
-                    },
-                    "/invocations",
-                  ],
+        "options": {
+          "Fn::Join": [
+            "",
+            [
+              "{"inputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
+              {
+                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+              },
+              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":lambda:path/2015-03-31/functions/",
+              {
+                "Fn::GetAtt": [
+                  "LambdaD247545B",
+                  "Arn",
                 ],
               },
-            },
-          },
+              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+            ],
+          ],
         },
-        "operationLookup": {
-          "testOperation": {
-            "method": "get",
-            "path": "/test",
-          },
-        },
-        "outputSpecLocation": {
-          "bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
-        },
-        "securitySchemes": {},
       },
       "Type": "AWS::CloudFormation::CustomResource",
       "UpdateReplacePolicy": "Delete",
@@ -38341,7 +37279,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",

--- a/packages/type-safe-api/test/construct/__snapshots__/type-safe-websocket-api.test.ts.snap
+++ b/packages/type-safe-api/test/construct/__snapshots__/type-safe-websocket-api.test.ts.snap
@@ -328,7 +328,7 @@ exports[`Type Safe WebSocket Api Construct Unit Tests Synthesizes 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "Handler": "websocket-schema-handler.handler",
         "Role": {
@@ -1501,7 +1501,7 @@ exports[`Type Safe WebSocket Api Construct Unit Tests Synthesizes With Connect a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "Handler": "websocket-schema-handler.handler",
         "Role": {
@@ -2594,7 +2594,7 @@ exports[`Type Safe WebSocket Api Construct Unit Tests Synthesizes With Mock Inte
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "8adf3c609b6d73fa935d9c361e37b816f2da1d59567bf9c753fc8319e6a58e7f.zip",
+          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
         },
         "Handler": "websocket-schema-handler.handler",
         "Role": {


### PR DESCRIPTION
A [bug in cloudformation custom resources](https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1037) meant that api key authentication could not be disabled for individual operations, as the boolean value `false` would be translated into the string `"false"` in the cloudformation custom resource properties. Since `"false"` is truthy, the security scheme for api key auth would be added to the operation where it should be disabled.

Fixes #910
