### PR TITLE
fix(type-safe-api): fix prepare-spec serialisation with tokens

### DIFF
--- a/packages/type-safe-api/src/construct/prepare-spec-event-handler/index.ts
+++ b/packages/type-safe-api/src/construct/prepare-spec-event-handler/index.ts
@@ -54,12 +54,7 @@ interface OnEventRequest {
    * Properties for preparing the api
    */
   readonly ResourceProperties: {
-    /**
-     * This is acually of type PrepareApiSpecCustomResourceProperties but JSON stringified to work around A
-     * bug in cloudformation!
-     * @see https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1037
-     */
-    options: string;
+    options: PrepareApiSpecCustomResourceProperties;
   };
 }
 
@@ -138,13 +133,80 @@ const prepare = async ({
   return outputLocation;
 };
 
+/**
+ * Due to a bug in cloudformation, primitive types are coerced into strings! Coerce them back here.
+ * @see https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1037
+ */
+export const ensurePrimitiveTypes = (
+  options: PrepareApiSpecCustomResourceProperties
+): PrepareApiSpecCustomResourceProperties => {
+  const result = JSON.parse(JSON.stringify(options));
+
+  // Handle apiKeyOptions.requiredByDefault (boolean)
+  if (result.apiKeyOptions?.requiredByDefault !== undefined) {
+    if (result.apiKeyOptions.requiredByDefault === "true") {
+      result.apiKeyOptions.requiredByDefault = true;
+    } else if (result.apiKeyOptions.requiredByDefault === "false") {
+      result.apiKeyOptions.requiredByDefault = false;
+    }
+  }
+
+  // Handle corsOptions.statusCode (number)
+  if (result.corsOptions?.statusCode !== undefined) {
+    const statusCode = Number(result.corsOptions.statusCode);
+    if (!isNaN(statusCode)) {
+      result.corsOptions.statusCode = statusCode;
+    }
+  }
+
+  if (result.integrations) {
+    for (const operationId in result.integrations) {
+      const integration = result.integrations[operationId];
+      // Handle integration options.apiKeyRequired (boolean)
+      if (integration.options?.apiKeyRequired !== undefined) {
+        if (integration.options.apiKeyRequired === "true") {
+          integration.options.apiKeyRequired = true;
+        } else if (integration.options.apiKeyRequired === "false") {
+          integration.options.apiKeyRequired = false;
+        }
+      }
+
+      // Handle timeoutInMillis (number)
+      if (integration.integration?.timeoutInMillis !== undefined) {
+        const timeoutInMillis = Number(integration.integration.timeoutInMillis);
+        if (!isNaN(timeoutInMillis)) {
+          integration.integration.timeoutInMillis = timeoutInMillis;
+        }
+      }
+
+      // Handle tlsConfig.insecureSkipVerification (boolean)
+      if (
+        integration.integration?.tlsConfig?.insecureSkipVerification !==
+        undefined
+      ) {
+        if (
+          integration.integration.tlsConfig.insecureSkipVerification === "true"
+        ) {
+          integration.integration.tlsConfig.insecureSkipVerification = true;
+        } else if (
+          integration.integration.tlsConfig.insecureSkipVerification === "false"
+        ) {
+          integration.integration.tlsConfig.insecureSkipVerification = false;
+        }
+      }
+    }
+  }
+
+  return result;
+};
+
 exports.handler = async (event: OnEventRequest): Promise<OnEventResponse> => {
   switch (event.RequestType) {
     case "Create":
     case "Update":
       // Prepare the spec on create
       const outputLocation = await prepare(
-        JSON.parse(event.ResourceProperties.options)
+        ensurePrimitiveTypes(event.ResourceProperties.options)
       );
       return {
         PhysicalResourceId: outputLocation.key,

--- a/packages/type-safe-api/src/construct/type-safe-rest-api.ts
+++ b/packages/type-safe-api/src/construct/type-safe-rest-api.ts
@@ -365,7 +365,7 @@ export class TypeSafeRestApi extends Construct {
       {
         serviceToken: provider.serviceToken,
         properties: {
-          options: JSON.stringify(prepareApiSpecCustomResourceProperties),
+          options: prepareApiSpecCustomResourceProperties,
         },
       }
     );

--- a/packages/type-safe-api/test/construct/__snapshots__/type-safe-rest-api.test.ts.snap
+++ b/packages/type-safe-api/test/construct/__snapshots__/type-safe-rest-api.test.ts.snap
@@ -751,35 +751,57 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+          },
+          "integrations": {
+            "testOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "LambdaD247545B",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
               },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "LambdaD247545B",
-                  "Arn",
-                ],
-              },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
-            ],
-          ],
+            },
+          },
+          "operationLookup": {
+            "testOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+          },
+          "securitySchemes": {},
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -826,7 +848,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-85532C36PrepSpec",
         "Handler": "index.handler",
@@ -1863,35 +1885,57 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+          },
+          "integrations": {
+            "testOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "LambdaD247545B",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
               },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "LambdaD247545B",
-                  "Arn",
-                ],
-              },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
-            ],
-          ],
+            },
+          },
+          "operationLookup": {
+            "testOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+          },
+          "securitySchemes": {},
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -1938,7 +1982,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-300D0E5FPrepSpec",
         "Handler": "index.handler",
@@ -3313,35 +3357,57 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+          },
+          "integrations": {
+            "testOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "LambdaD247545B",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
               },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "LambdaD247545B",
-                  "Arn",
-                ],
-              },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
-            ],
-          ],
+            },
+          },
+          "operationLookup": {
+            "testOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+          },
+          "securitySchemes": {},
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -3388,7 +3454,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -4668,35 +4734,60 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          "defaultAuthorizerReference": {
+            "authorizerId": "none",
+          },
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+          },
+          "integrations": {
+            "testOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "LambdaD247545B",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
               },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"defaultAuthorizerReference":{"authorizerId":"none"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "LambdaD247545B",
-                  "Arn",
-                ],
-              },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
-            ],
-          ],
+            },
+          },
+          "operationLookup": {
+            "testOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+          },
+          "securitySchemes": {},
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -4743,7 +4834,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -6318,80 +6409,193 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"1b379c070728ce6e390dc775a85f16303a2625450133ff14c948409d76eb41c8.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"1b379c070728ce6e390dc775a85f16303a2625450133ff14c948409d76eb41c8.json-prepared"},"defaultAuthorizerReference":{"authorizerId":"aws.auth.sigv4"},"integrations":{"getOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "Lambda1DB8E9965",
-                  "Arn",
-                ],
-              },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}},"putOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "Lambda217CFB423",
-                  "Arn",
-                ],
-              },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}},"deleteOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "Lambda35298F1AD",
-                  "Arn",
-                ],
-              },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}},"postOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "Lambda461E84558",
-                  "Arn",
-                ],
-              },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{"aws.auth.sigv4":{"type":"apiKey","name":"Authorization","in":"header","x-amazon-apigateway-authtype":"awsSigv4"}},"corsOptions":{"allowHeaders":["Content-Type","X-Amz-Date","Authorization","X-Api-Key","X-Amz-Security-Token","X-Amz-User-Agent","x-amz-content-sha256"],"allowMethods":["OPTIONS","GET","PUT","POST","DELETE","PATCH","HEAD"],"allowOrigins":["*"],"statusCode":200},"operationLookup":{"getOperation":{"method":"get","path":"/test"},"putOperation":{"method":"put","path":"/test"},"postOperation":{"method":"post","path":"/test"},"deleteOperation":{"method":"delete","path":"/test"}}}",
+          "corsOptions": {
+            "allowHeaders": [
+              "Content-Type",
+              "X-Amz-Date",
+              "Authorization",
+              "X-Api-Key",
+              "X-Amz-Security-Token",
+              "X-Amz-User-Agent",
+              "x-amz-content-sha256",
             ],
-          ],
+            "allowMethods": [
+              "OPTIONS",
+              "GET",
+              "PUT",
+              "POST",
+              "DELETE",
+              "PATCH",
+              "HEAD",
+            ],
+            "allowOrigins": [
+              "*",
+            ],
+            "statusCode": 200,
+          },
+          "defaultAuthorizerReference": {
+            "authorizerId": "aws.auth.sigv4",
+          },
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "1b379c070728ce6e390dc775a85f16303a2625450133ff14c948409d76eb41c8.json",
+          },
+          "integrations": {
+            "deleteOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "Lambda35298F1AD",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
+              },
+            },
+            "getOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "Lambda1DB8E9965",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
+              },
+            },
+            "postOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "Lambda461E84558",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
+              },
+            },
+            "putOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "Lambda217CFB423",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
+              },
+            },
+          },
+          "operationLookup": {
+            "deleteOperation": {
+              "method": "delete",
+              "path": "/test",
+            },
+            "getOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+            "postOperation": {
+              "method": "post",
+              "path": "/test",
+            },
+            "putOperation": {
+              "method": "put",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "1b379c070728ce6e390dc775a85f16303a2625450133ff14c948409d76eb41c8.json-prepared",
+          },
+          "securitySchemes": {
+            "aws.auth.sigv4": {
+              "in": "header",
+              "name": "Authorization",
+              "type": "apiKey",
+              "x-amazon-apigateway-authtype": "awsSigv4",
+            },
+          },
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -6438,7 +6642,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -8328,80 +8532,159 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "59c8d7b10656c48be66a3a7cb22540b5dc6f56cfa67229affa21977c6567f30e.json",
+          },
+          "integrations": {
+            "deleteOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "Lambda1DB8E9965",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
               },
-              "","key":"59c8d7b10656c48be66a3a7cb22540b5dc6f56cfa67229affa21977c6567f30e.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "getOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "Lambda1DB8E9965",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
               },
-              "","key":"59c8d7b10656c48be66a3a7cb22540b5dc6f56cfa67229affa21977c6567f30e.json-prepared"},"integrations":{"getOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
+            },
+            "postOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "Lambda217CFB423",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
               },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
+            },
+            "putOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "Lambda1DB8E9965",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
               },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "Lambda1DB8E9965",
-                  "Arn",
-                ],
-              },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}},"putOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "Lambda1DB8E9965",
-                  "Arn",
-                ],
-              },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}},"postOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "Lambda217CFB423",
-                  "Arn",
-                ],
-              },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}},"deleteOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "Lambda1DB8E9965",
-                  "Arn",
-                ],
-              },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"getOperation":{"method":"get","path":"/test"},"putOperation":{"method":"put","path":"/test"},"postOperation":{"method":"post","path":"/test"},"deleteOperation":{"method":"delete","path":"/test"}}}",
-            ],
-          ],
+            },
+          },
+          "operationLookup": {
+            "deleteOperation": {
+              "method": "delete",
+              "path": "/test",
+            },
+            "getOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+            "postOperation": {
+              "method": "post",
+              "path": "/test",
+            },
+            "putOperation": {
+              "method": "put",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "59c8d7b10656c48be66a3a7cb22540b5dc6f56cfa67229affa21977c6567f30e.json-prepared",
+          },
+          "securitySchemes": {},
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -8448,7 +8731,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -9779,35 +10062,57 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+          },
+          "integrations": {
+            "testOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "LambdaD247545B",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
               },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "LambdaD247545B",
-                  "Arn",
-                ],
-              },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
-            ],
-          ],
+            },
+          },
+          "operationLookup": {
+            "testOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+          },
+          "securitySchemes": {},
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -9854,7 +10159,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -11135,35 +11440,57 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+          },
+          "integrations": {
+            "testOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "LambdaD247545B",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
               },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "LambdaD247545B",
-                  "Arn",
-                ],
-              },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
-            ],
-          ],
+            },
+          },
+          "operationLookup": {
+            "testOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+          },
+          "securitySchemes": {},
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -11210,7 +11537,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -13590,35 +13917,57 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth with dedicated prepareSpe
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+          },
+          "integrations": {
+            "testOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "LambdaD247545B",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
               },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Ref": "PrepareSpecBucket95FB609F",
-              },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "LambdaD247545B",
-                  "Arn",
-                ],
-              },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
-            ],
-          ],
+            },
+          },
+          "operationLookup": {
+            "testOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Ref": "PrepareSpecBucket95FB609F",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+          },
+          "securitySchemes": {},
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -13665,7 +14014,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth with dedicated prepareSpe
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -15043,42 +15392,78 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          "defaultAuthorizerReference": {
+            "authorizerId": "myCognitoAuthorizer",
+          },
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+          },
+          "integrations": {
+            "testOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "LambdaD247545B",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
               },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"defaultAuthorizerReference":{"authorizerId":"myCognitoAuthorizer"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "LambdaD247545B",
-                  "Arn",
+            },
+          },
+          "operationLookup": {
+            "testOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+          },
+          "securitySchemes": {
+            "myCognitoAuthorizer": {
+              "in": "header",
+              "name": "Authorization",
+              "type": "apiKey",
+              "x-amazon-apigateway-authorizer": {
+                "providerARNs": [
+                  {
+                    "Fn::GetAtt": [
+                      "pool056F3F7E",
+                      "Arn",
+                    ],
+                  },
                 ],
+                "type": "COGNITO_USER_POOLS",
               },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{"myCognitoAuthorizer":{"type":"apiKey","name":"Authorization","in":"header","x-amazon-apigateway-authtype":"COGNITO_USER_POOLS","x-amazon-apigateway-authorizer":{"type":"COGNITO_USER_POOLS","providerARNs":["",
-              {
-                "Fn::GetAtt": [
-                  "pool056F3F7E",
-                  "Arn",
-                ],
-              },
-              ""]}}},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
-            ],
-          ],
+              "x-amazon-apigateway-authtype": "COGNITO_USER_POOLS",
+            },
+          },
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -15125,7 +15510,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -16582,50 +16967,95 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          "defaultAuthorizerReference": {
+            "authorizerId": "myCustomAuthorizer",
+          },
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+          },
+          "integrations": {
+            "testOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "LambdaD247545B",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
               },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+          },
+          "operationLookup": {
+            "testOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+          },
+          "securitySchemes": {
+            "myCustomAuthorizer": {
+              "in": "header",
+              "name": "Authorization",
+              "type": "apiKey",
+              "x-amazon-apigateway-authorizer": {
+                "authorizerResultTtlInSeconds": 300,
+                "authorizerUri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "AuthorizerBD825682",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
+                "identitySource": "method.request.header.Authorization",
+                "type": "token",
               },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"defaultAuthorizerReference":{"authorizerId":"myCustomAuthorizer"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "LambdaD247545B",
-                  "Arn",
-                ],
-              },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{"myCustomAuthorizer":{"type":"apiKey","in":"header","name":"Authorization","x-amazon-apigateway-authtype":"CUSTOM","x-amazon-apigateway-authorizer":{"type":"token","authorizerUri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "AuthorizerBD825682",
-                  "Arn",
-                ],
-              },
-              "/invocations","authorizerResultTtlInSeconds":300,"identitySource":"method.request.header.Authorization"}}},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
-            ],
-          ],
+              "x-amazon-apigateway-authtype": "CUSTOM",
+            },
+          },
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -16672,7 +17102,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -18097,35 +18527,57 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+          },
+          "integrations": {
+            "testOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "LambdaD247545B",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
               },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "LambdaD247545B",
-                  "Arn",
-                ],
-              },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
-            ],
-          ],
+            },
+          },
+          "operationLookup": {
+            "testOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+          },
+          "securitySchemes": {},
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -18172,7 +18624,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -19460,35 +19912,57 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules actio
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+          },
+          "integrations": {
+            "testOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "LambdaD247545B",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
               },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "LambdaD247545B",
-                  "Arn",
-                ],
-              },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
-            ],
-          ],
+            },
+          },
+          "operationLookup": {
+            "testOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+          },
+          "securitySchemes": {},
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -19535,7 +20009,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules actio
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -20815,35 +21289,91 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"defaultAuthorizerReference":{"authorizerId":"aws.auth.sigv4"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "LambdaD247545B",
-                  "Arn",
-                ],
-              },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{"aws.auth.sigv4":{"type":"apiKey","name":"Authorization","in":"header","x-amazon-apigateway-authtype":"awsSigv4"}},"corsOptions":{"allowHeaders":["Content-Type","X-Amz-Date","Authorization","X-Api-Key","X-Amz-Security-Token","X-Amz-User-Agent","x-amz-content-sha256"],"allowMethods":["OPTIONS","GET","PUT","POST","DELETE","PATCH","HEAD"],"allowOrigins":["*"],"statusCode":200},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+          "corsOptions": {
+            "allowHeaders": [
+              "Content-Type",
+              "X-Amz-Date",
+              "Authorization",
+              "X-Api-Key",
+              "X-Amz-Security-Token",
+              "X-Amz-User-Agent",
+              "x-amz-content-sha256",
             ],
-          ],
+            "allowMethods": [
+              "OPTIONS",
+              "GET",
+              "PUT",
+              "POST",
+              "DELETE",
+              "PATCH",
+              "HEAD",
+            ],
+            "allowOrigins": [
+              "*",
+            ],
+            "statusCode": 200,
+          },
+          "defaultAuthorizerReference": {
+            "authorizerId": "aws.auth.sigv4",
+          },
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+          },
+          "integrations": {
+            "testOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "LambdaD247545B",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
+              },
+            },
+          },
+          "operationLookup": {
+            "testOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+          },
+          "securitySchemes": {
+            "aws.auth.sigv4": {
+              "in": "header",
+              "name": "Authorization",
+              "type": "apiKey",
+              "x-amazon-apigateway-authtype": "awsSigv4",
+            },
+          },
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -20890,7 +21420,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -22588,102 +23118,235 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          "defaultAuthorizerReference": {
+            "authorizerId": "aws.auth.sigv4",
+          },
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "59c8d7b10656c48be66a3a7cb22540b5dc6f56cfa67229affa21977c6567f30e.json",
+          },
+          "integrations": {
+            "deleteOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "LambdaIntegrationdD45F0B2E",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
               },
-              "","key":"59c8d7b10656c48be66a3a7cb22540b5dc6f56cfa67229affa21977c6567f30e.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "getOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "LambdaIntegrationaE925485E",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
               },
-              "","key":"59c8d7b10656c48be66a3a7cb22540b5dc6f56cfa67229affa21977c6567f30e.json-prepared"},"defaultAuthorizerReference":{"authorizerId":"aws.auth.sigv4"},"integrations":{"getOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "LambdaIntegrationaE925485E",
-                  "Arn",
+              "methodAuthorizer": {
+                "authorizationScopes": [
+                  "foo/bar",
                 ],
+                "authorizerId": "myCognitoAuthorizer",
               },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"},"methodAuthorizer":{"authorizerId":"myCognitoAuthorizer","authorizationScopes":["foo/bar"]}},"putOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
+            },
+            "postOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "LambdaIntegrationc8B199E47",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
               },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
+              "methodAuthorizer": {
+                "authorizerId": "myCustomAuthorizer",
               },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "LambdaIntegrationb550BB0F2",
-                  "Arn",
+            },
+            "putOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "LambdaIntegrationb550BB0F2",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
+              },
+              "methodAuthorizer": {
+                "authorizationScopes": [
+                  "other/scope",
                 ],
+                "authorizerId": "myCognitoAuthorizer",
               },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"},"methodAuthorizer":{"authorizerId":"myCognitoAuthorizer","authorizationScopes":["other/scope"]}},"postOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "LambdaIntegrationc8B199E47",
-                  "Arn",
+            },
+          },
+          "operationLookup": {
+            "deleteOperation": {
+              "method": "delete",
+              "path": "/test",
+            },
+            "getOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+            "postOperation": {
+              "method": "post",
+              "path": "/test",
+            },
+            "putOperation": {
+              "method": "put",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "59c8d7b10656c48be66a3a7cb22540b5dc6f56cfa67229affa21977c6567f30e.json-prepared",
+          },
+          "securitySchemes": {
+            "aws.auth.sigv4": {
+              "in": "header",
+              "name": "Authorization",
+              "type": "apiKey",
+              "x-amazon-apigateway-authtype": "awsSigv4",
+            },
+            "myCognitoAuthorizer": {
+              "in": "header",
+              "name": "Authorization",
+              "type": "apiKey",
+              "x-amazon-apigateway-authorizer": {
+                "providerARNs": [
+                  {
+                    "Fn::GetAtt": [
+                      "pool056F3F7E",
+                      "Arn",
+                    ],
+                  },
                 ],
+                "type": "COGNITO_USER_POOLS",
               },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"},"methodAuthorizer":{"authorizerId":"myCustomAuthorizer"}},"deleteOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
+              "x-amazon-apigateway-authtype": "COGNITO_USER_POOLS",
+            },
+            "myCustomAuthorizer": {
+              "in": "header",
+              "name": "Unused",
+              "type": "apiKey",
+              "x-amazon-apigateway-authorizer": {
+                "authorizerResultTtlInSeconds": 60,
+                "authorizerUri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "LambdaAuthorizerB5870E9B",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
+                "identitySource": "method.request.querystring.QueryString1",
+                "type": "request",
               },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "LambdaIntegrationdD45F0B2E",
-                  "Arn",
-                ],
-              },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{"myCognitoAuthorizer":{"type":"apiKey","name":"Authorization","in":"header","x-amazon-apigateway-authtype":"COGNITO_USER_POOLS","x-amazon-apigateway-authorizer":{"type":"COGNITO_USER_POOLS","providerARNs":["",
-              {
-                "Fn::GetAtt": [
-                  "pool056F3F7E",
-                  "Arn",
-                ],
-              },
-              ""]}},"myCustomAuthorizer":{"type":"apiKey","in":"header","name":"Unused","x-amazon-apigateway-authtype":"CUSTOM","x-amazon-apigateway-authorizer":{"type":"request","authorizerUri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "LambdaAuthorizerB5870E9B",
-                  "Arn",
-                ],
-              },
-              "/invocations","authorizerResultTtlInSeconds":60,"identitySource":"method.request.querystring.QueryString1"}},"aws.auth.sigv4":{"type":"apiKey","name":"Authorization","in":"header","x-amazon-apigateway-authtype":"awsSigv4"}},"operationLookup":{"getOperation":{"method":"get","path":"/test"},"putOperation":{"method":"put","path":"/test"},"postOperation":{"method":"post","path":"/test"},"deleteOperation":{"method":"delete","path":"/test"}}}",
-            ],
-          ],
+              "x-amazon-apigateway-authtype": "CUSTOM",
+            },
+          },
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -22730,7 +23393,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -24367,20 +25030,44 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+          },
+          "integrations": {
+            "testOperation": {
+              "integration": {
+                "requestTemplates": {
+                  "application/json": "{"statusCode": 200}",
+                },
+                "responses": {
+                  "default": {
+                    "responseParameters": {},
+                    "responseTemplates": {
+                      "application/json": "{"message":"message"}",
+                    },
+                    "statusCode": "200",
+                  },
+                },
+                "type": "MOCK",
               },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"MOCK","requestTemplates":{"application/json":"{\\"statusCode\\": 200}"},"responses":{"default":{"statusCode":"200","responseParameters":{},"responseTemplates":{"application/json":"{\\"message\\":\\"message\\"}"}}}}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
-            ],
-          ],
+            },
+          },
+          "operationLookup": {
+            "testOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+          },
+          "securitySchemes": {},
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -24427,7 +25114,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -25656,20 +26343,72 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"MOCK","requestTemplates":{"application/json":"{\\"statusCode\\": 200}"},"responses":{"default":{"statusCode":"200","responseParameters":{"method.response.header.Access-Control-Allow-Headers":"'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'","method.response.header.Access-Control-Allow-Methods":"'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'","method.response.header.Access-Control-Allow-Origin":"'*'"},"responseTemplates":{"application/json":"{\\"message\\":\\"message\\"}"}}}}}},"securitySchemes":{},"corsOptions":{"allowHeaders":["Content-Type","X-Amz-Date","Authorization","X-Api-Key","X-Amz-Security-Token","X-Amz-User-Agent","x-amz-content-sha256"],"allowMethods":["OPTIONS","GET","PUT","POST","DELETE","PATCH","HEAD"],"allowOrigins":["*"],"statusCode":204},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+          "corsOptions": {
+            "allowHeaders": [
+              "Content-Type",
+              "X-Amz-Date",
+              "Authorization",
+              "X-Api-Key",
+              "X-Amz-Security-Token",
+              "X-Amz-User-Agent",
+              "x-amz-content-sha256",
             ],
-          ],
+            "allowMethods": [
+              "OPTIONS",
+              "GET",
+              "PUT",
+              "POST",
+              "DELETE",
+              "PATCH",
+              "HEAD",
+            ],
+            "allowOrigins": [
+              "*",
+            ],
+            "statusCode": 204,
+          },
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+          },
+          "integrations": {
+            "testOperation": {
+              "integration": {
+                "requestTemplates": {
+                  "application/json": "{"statusCode": 200}",
+                },
+                "responses": {
+                  "default": {
+                    "responseParameters": {
+                      "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'",
+                      "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+                      "method.response.header.Access-Control-Allow-Origin": "'*'",
+                    },
+                    "responseTemplates": {
+                      "application/json": "{"message":"message"}",
+                    },
+                    "statusCode": "200",
+                  },
+                },
+                "type": "MOCK",
+              },
+            },
+          },
+          "operationLookup": {
+            "testOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+          },
+          "securitySchemes": {},
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -25716,7 +26455,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -27089,35 +27828,57 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "6060611f34e7c9e9000a19922d48dfd8d47d66cbf3715fb30e173c4b51d9061b.json",
+          },
+          "integrations": {
+            "testOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "LambdaD247545B",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
               },
-              "","key":"6060611f34e7c9e9000a19922d48dfd8d47d66cbf3715fb30e173c4b51d9061b.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"6060611f34e7c9e9000a19922d48dfd8d47d66cbf3715fb30e173c4b51d9061b.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "LambdaD247545B",
-                  "Arn",
-                ],
-              },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"path":"/test/{param1}/fixed/{param2}/{param3}","method":"get"}}}",
-            ],
-          ],
+            },
+          },
+          "operationLookup": {
+            "testOperation": {
+              "method": "get",
+              "path": "/test/{param1}/fixed/{param2}/{param3}",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "6060611f34e7c9e9000a19922d48dfd8d47d66cbf3715fb30e173c4b51d9061b.json-prepared",
+          },
+          "securitySchemes": {},
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -27164,7 +27925,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -28434,39 +29195,103 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration 1`] = `
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+          },
+          "integrations": {
+            "testOperation": {
+              "integration": {
+                "credentials": {
+                  "Fn::GetAtt": [
+                    "ApiTestS3IntegrationsExecutionRole635C75E5",
+                    "Arn",
+                  ],
+                },
+                "httpMethod": "GET",
+                "requestParameters": {},
+                "responses": {
+                  "400": {
+                    "responseParameters": {},
+                    "responseTemplates": {
+                      "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
+{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
+",
+                    },
+                    "statusCode": "400",
+                  },
+                  "403": {
+                    "responseParameters": {},
+                    "responseTemplates": {
+                      "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
+{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
+",
+                    },
+                    "statusCode": "403",
+                  },
+                  "404": {
+                    "responseParameters": {},
+                    "responseTemplates": {
+                      "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
+{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
+",
+                    },
+                    "statusCode": "404",
+                  },
+                  "500": {
+                    "responseParameters": {},
+                    "responseTemplates": {
+                      "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
+{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
+",
+                    },
+                    "statusCode": "500",
+                  },
+                  "default": {
+                    "responseParameters": {},
+                    "responseTemplates": {},
+                    "statusCode": "200",
+                  },
+                },
+                "type": "AWS",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":s3:path/",
+                      {
+                        "Ref": "Bucket83908E77",
+                      },
+                      "//test",
+                    ],
+                  ],
+                },
               },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS","httpMethod":"GET","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":s3:path/",
-              {
-                "Ref": "Bucket83908E77",
-              },
-              "//test","credentials":"",
-              {
-                "Fn::GetAtt": [
-                  "ApiTestS3IntegrationsExecutionRole635C75E5",
-                  "Arn",
-                ],
-              },
-              "","requestParameters":{},"responses":{"400":{"statusCode":"400","responseParameters":{},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"403":{"statusCode":"403","responseParameters":{},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"404":{"statusCode":"404","responseParameters":{},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"500":{"statusCode":"500","responseParameters":{},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"default":{"statusCode":"200","responseParameters":{},"responseTemplates":{}}}}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
-            ],
-          ],
+            },
+          },
+          "operationLookup": {
+            "testOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+          },
+          "securitySchemes": {},
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -28513,7 +29338,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -29909,39 +30734,147 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and CORS 1`
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS","httpMethod":"GET","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":s3:path/",
-              {
-                "Ref": "Bucket83908E77",
-              },
-              "//test","credentials":"",
-              {
-                "Fn::GetAtt": [
-                  "ApiTestS3IntegrationsExecutionRole635C75E5",
-                  "Arn",
-                ],
-              },
-              "","requestParameters":{},"responses":{"400":{"statusCode":"400","responseParameters":{"method.response.header.Access-Control-Allow-Headers":"'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'","method.response.header.Access-Control-Allow-Methods":"'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'","method.response.header.Access-Control-Allow-Origin":"'*'"},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"403":{"statusCode":"403","responseParameters":{"method.response.header.Access-Control-Allow-Headers":"'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'","method.response.header.Access-Control-Allow-Methods":"'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'","method.response.header.Access-Control-Allow-Origin":"'*'"},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"404":{"statusCode":"404","responseParameters":{"method.response.header.Access-Control-Allow-Headers":"'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'","method.response.header.Access-Control-Allow-Methods":"'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'","method.response.header.Access-Control-Allow-Origin":"'*'"},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"500":{"statusCode":"500","responseParameters":{"method.response.header.Access-Control-Allow-Headers":"'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'","method.response.header.Access-Control-Allow-Methods":"'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'","method.response.header.Access-Control-Allow-Origin":"'*'"},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"default":{"statusCode":"200","responseParameters":{"method.response.header.Access-Control-Allow-Headers":"'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'","method.response.header.Access-Control-Allow-Methods":"'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'","method.response.header.Access-Control-Allow-Origin":"'*'"},"responseTemplates":{}}}}}},"securitySchemes":{},"corsOptions":{"allowHeaders":["Content-Type","X-Amz-Date","Authorization","X-Api-Key","X-Amz-Security-Token","X-Amz-User-Agent","x-amz-content-sha256"],"allowMethods":["OPTIONS","GET","PUT","POST","DELETE","PATCH","HEAD"],"allowOrigins":["*"],"statusCode":204},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
+          "corsOptions": {
+            "allowHeaders": [
+              "Content-Type",
+              "X-Amz-Date",
+              "Authorization",
+              "X-Api-Key",
+              "X-Amz-Security-Token",
+              "X-Amz-User-Agent",
+              "x-amz-content-sha256",
             ],
-          ],
+            "allowMethods": [
+              "OPTIONS",
+              "GET",
+              "PUT",
+              "POST",
+              "DELETE",
+              "PATCH",
+              "HEAD",
+            ],
+            "allowOrigins": [
+              "*",
+            ],
+            "statusCode": 204,
+          },
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+          },
+          "integrations": {
+            "testOperation": {
+              "integration": {
+                "credentials": {
+                  "Fn::GetAtt": [
+                    "ApiTestS3IntegrationsExecutionRole635C75E5",
+                    "Arn",
+                  ],
+                },
+                "httpMethod": "GET",
+                "requestParameters": {},
+                "responses": {
+                  "400": {
+                    "responseParameters": {
+                      "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'",
+                      "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+                      "method.response.header.Access-Control-Allow-Origin": "'*'",
+                    },
+                    "responseTemplates": {
+                      "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
+{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
+",
+                    },
+                    "statusCode": "400",
+                  },
+                  "403": {
+                    "responseParameters": {
+                      "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'",
+                      "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+                      "method.response.header.Access-Control-Allow-Origin": "'*'",
+                    },
+                    "responseTemplates": {
+                      "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
+{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
+",
+                    },
+                    "statusCode": "403",
+                  },
+                  "404": {
+                    "responseParameters": {
+                      "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'",
+                      "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+                      "method.response.header.Access-Control-Allow-Origin": "'*'",
+                    },
+                    "responseTemplates": {
+                      "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
+{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
+",
+                    },
+                    "statusCode": "404",
+                  },
+                  "500": {
+                    "responseParameters": {
+                      "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'",
+                      "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+                      "method.response.header.Access-Control-Allow-Origin": "'*'",
+                    },
+                    "responseTemplates": {
+                      "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
+{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
+",
+                    },
+                    "statusCode": "500",
+                  },
+                  "default": {
+                    "responseParameters": {
+                      "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent,x-amz-content-sha256'",
+                      "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'",
+                      "method.response.header.Access-Control-Allow-Origin": "'*'",
+                    },
+                    "responseTemplates": {},
+                    "statusCode": "200",
+                  },
+                },
+                "type": "AWS",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":s3:path/",
+                      {
+                        "Ref": "Bucket83908E77",
+                      },
+                      "//test",
+                    ],
+                  ],
+                },
+              },
+            },
+          },
+          "operationLookup": {
+            "testOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+          },
+          "securitySchemes": {},
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -29988,7 +30921,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and CORS 1`
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -31475,39 +32408,72 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and catch a
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+          },
+          "integrations": {
+            "testOperation": {
+              "integration": {
+                "credentials": {
+                  "Fn::GetAtt": [
+                    "ApiTestS3IntegrationsExecutionRole635C75E5",
+                    "Arn",
+                  ],
+                },
+                "httpMethod": "GET",
+                "requestParameters": {},
+                "responses": {
+                  "(4|5)\\d{2}": {
+                    "responseParameters": {},
+                    "responseTemplates": {},
+                    "statusCode": "500",
+                  },
+                  "default": {
+                    "responseParameters": {},
+                    "responseTemplates": {},
+                    "statusCode": "200",
+                  },
+                },
+                "type": "AWS",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":s3:path/",
+                      {
+                        "Ref": "Bucket83908E77",
+                      },
+                      "//test",
+                    ],
+                  ],
+                },
               },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS","httpMethod":"GET","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":s3:path/",
-              {
-                "Ref": "Bucket83908E77",
-              },
-              "//test","credentials":"",
-              {
-                "Fn::GetAtt": [
-                  "ApiTestS3IntegrationsExecutionRole635C75E5",
-                  "Arn",
-                ],
-              },
-              "","requestParameters":{},"responses":{"default":{"statusCode":"200","responseParameters":{},"responseTemplates":{}},"(4|5)\\\\d{2}":{"statusCode":"500","responseParameters":{},"responseTemplates":{}}}}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
-            ],
-          ],
+            },
+          },
+          "operationLookup": {
+            "testOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+          },
+          "securitySchemes": {},
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -31554,7 +32520,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and catch a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -32919,39 +33885,77 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and custom 
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+          },
+          "integrations": {
+            "testOperation": {
+              "integration": {
+                "credentials": {
+                  "Fn::GetAtt": [
+                    "ApiTestS3IntegrationsExecutionRole635C75E5",
+                    "Arn",
+                  ],
+                },
+                "httpMethod": "GET",
+                "requestParameters": {},
+                "responses": {
+                  "4\\d{2}": {
+                    "responseParameters": {},
+                    "responseTemplates": {},
+                    "statusCode": "400",
+                  },
+                  "5\\d{2}": {
+                    "responseParameters": {},
+                    "responseTemplates": {},
+                    "statusCode": "500",
+                  },
+                  "default": {
+                    "responseParameters": {},
+                    "responseTemplates": {},
+                    "statusCode": "200",
+                  },
+                },
+                "type": "AWS",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":s3:path/",
+                      {
+                        "Ref": "Bucket83908E77",
+                      },
+                      "//test",
+                    ],
+                  ],
+                },
               },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS","httpMethod":"GET","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":s3:path/",
-              {
-                "Ref": "Bucket83908E77",
-              },
-              "//test","credentials":"",
-              {
-                "Fn::GetAtt": [
-                  "ApiTestS3IntegrationsExecutionRole635C75E5",
-                  "Arn",
-                ],
-              },
-              "","requestParameters":{},"responses":{"default":{"statusCode":"200","responseParameters":{},"responseTemplates":{}},"4\\\\d{2}":{"statusCode":"400","responseParameters":{},"responseTemplates":{}},"5\\\\d{2}":{"statusCode":"500","responseParameters":{},"responseTemplates":{}}}}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
-            ],
-          ],
+            },
+          },
+          "operationLookup": {
+            "testOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+          },
+          "securitySchemes": {},
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -32998,7 +34002,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and custom 
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -34368,39 +35372,103 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and props 1
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+          },
+          "integrations": {
+            "testOperation": {
+              "integration": {
+                "credentials": {
+                  "Fn::GetAtt": [
+                    "ApiTestS3IntegrationsExecutionRole635C75E5",
+                    "Arn",
+                  ],
+                },
+                "httpMethod": "DELETE",
+                "requestParameters": {},
+                "responses": {
+                  "400": {
+                    "responseParameters": {},
+                    "responseTemplates": {
+                      "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
+{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
+",
+                    },
+                    "statusCode": "400",
+                  },
+                  "403": {
+                    "responseParameters": {},
+                    "responseTemplates": {
+                      "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
+{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
+",
+                    },
+                    "statusCode": "403",
+                  },
+                  "404": {
+                    "responseParameters": {},
+                    "responseTemplates": {
+                      "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
+{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
+",
+                    },
+                    "statusCode": "404",
+                  },
+                  "500": {
+                    "responseParameters": {},
+                    "responseTemplates": {
+                      "application/json": "#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])
+{"message": "$util.escapeJavaScript($message).replaceAll("\\'","'")"}
+",
+                    },
+                    "statusCode": "500",
+                  },
+                  "default": {
+                    "responseParameters": {},
+                    "responseTemplates": {},
+                    "statusCode": "204",
+                  },
+                },
+                "type": "AWS",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":s3:path/",
+                      {
+                        "Ref": "Bucket83908E77",
+                      },
+                      "//my-pets/{petId}/details.json",
+                    ],
+                  ],
+                },
               },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS","httpMethod":"DELETE","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":s3:path/",
-              {
-                "Ref": "Bucket83908E77",
-              },
-              "//my-pets/{petId}/details.json","credentials":"",
-              {
-                "Fn::GetAtt": [
-                  "ApiTestS3IntegrationsExecutionRole635C75E5",
-                  "Arn",
-                ],
-              },
-              "","requestParameters":{},"responses":{"400":{"statusCode":"400","responseParameters":{},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"403":{"statusCode":"403","responseParameters":{},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"404":{"statusCode":"404","responseParameters":{},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"500":{"statusCode":"500","responseParameters":{},"responseTemplates":{"application/json":"#set($message = $input.body.split('<Message>')[1].split('</Message>')[0])\\n{\\"message\\": \\"$util.escapeJavaScript($message).replaceAll(\\"\\\\'\\",\\"'\\")\\"}\\n"}},"default":{"statusCode":"204","responseParameters":{},"responseTemplates":{}}}}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
-            ],
-          ],
+            },
+          },
+          "operationLookup": {
+            "testOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+          },
+          "securitySchemes": {},
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -34447,7 +35515,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and props 1
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -35985,35 +37053,57 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+          },
+          "integrations": {
+            "testOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "LambdaD247545B",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
               },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "LambdaD247545B",
-                  "Arn",
-                ],
-              },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
-            ],
-          ],
+            },
+          },
+          "operationLookup": {
+            "testOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+          },
+          "securitySchemes": {},
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -36060,7 +37150,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -37207,35 +38297,57 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
           ],
         },
         "options": {
-          "Fn::Join": [
-            "",
-            [
-              "{"inputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+          },
+          "integrations": {
+            "testOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "LambdaD247545B",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
               },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json"},"outputSpecLocation":{"bucket":"",
-              {
-                "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-              },
-              "","key":"ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared"},"integrations":{"testOperation":{"integration":{"type":"AWS_PROXY","httpMethod":"POST","uri":"arn:",
-              {
-                "Ref": "AWS::Partition",
-              },
-              ":apigateway:",
-              {
-                "Ref": "AWS::Region",
-              },
-              ":lambda:path/2015-03-31/functions/",
-              {
-                "Fn::GetAtt": [
-                  "LambdaD247545B",
-                  "Arn",
-                ],
-              },
-              "/invocations","passthroughBehavior":"WHEN_NO_MATCH"}}},"securitySchemes":{},"operationLookup":{"testOperation":{"method":"get","path":"/test"}}}",
-            ],
-          ],
+            },
+          },
+          "operationLookup": {
+            "testOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+          },
+          "securitySchemes": {},
         },
       },
       "Type": "AWS::CloudFormation::CustomResource",
@@ -37282,7 +38394,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",

--- a/packages/type-safe-api/test/construct/__snapshots__/type-safe-websocket-api.test.ts.snap
+++ b/packages/type-safe-api/test/construct/__snapshots__/type-safe-websocket-api.test.ts.snap
@@ -329,7 +329,7 @@ exports[`Type Safe WebSocket Api Construct Unit Tests Synthesizes 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "Handler": "websocket-schema-handler.handler",
         "Role": {
@@ -1503,7 +1503,7 @@ exports[`Type Safe WebSocket Api Construct Unit Tests Synthesizes With Connect a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "Handler": "websocket-schema-handler.handler",
         "Role": {
@@ -2597,7 +2597,7 @@ exports[`Type Safe WebSocket Api Construct Unit Tests Synthesizes With Mock Inte
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "89c1eb07b2d0e0a45acf88406edc63dc5d4b76516b9d3be5a41567efd5691920.zip",
+          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
         },
         "Handler": "websocket-schema-handler.handler",
         "Role": {

--- a/packages/type-safe-api/test/construct/prepare-spec-event-handler/index.test.ts
+++ b/packages/type-safe-api/test/construct/prepare-spec-event-handler/index.test.ts
@@ -1,0 +1,207 @@
+/*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0 */
+import _ from "lodash";
+import { ApiGatewayIntegration } from "../../../src/construct/integrations";
+import {
+  PrepareApiSpecCustomResourceProperties,
+  ensurePrimitiveTypes,
+} from "../../../src/construct/prepare-spec-event-handler";
+import { DefaultAuthorizerIds } from "../../../src/construct/prepare-spec-event-handler/constants";
+import { SerialisedAuthorizerReference } from "../../../src/construct/spec/api-gateway-auth";
+
+type DeepRequired<T> = T extends Array<infer U>
+  ? [DeepRequired<U>, ...DeepRequired<U>[]]
+  : T extends object
+  ? {
+      [P in keyof T]-?: DeepRequired<T[P]>;
+    }
+  : T;
+
+describe("prepare-spec-event-handler index.ts", () => {
+  /**
+   * Since CloudFormation has a bug where it coerces primitive types to strings, we include this test to ensure that our custom
+   * event handler coerces them back.
+   * To attempt to ensure that we don't introduce new properties that aren't covered, we define an example payload for the
+   * custom resource where all properties are recursively required, so that the build will fail if this test isn't updated with
+   * an example value of that property.
+   */
+  describe("ensurePrimitiveTypes", () => {
+    const mockIntegration: DeepRequired<ApiGatewayIntegration> = {
+      type: "AWS_PROXY",
+      uri: "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:123456789012:function:my-function/invocations",
+      cacheKeyParameters: ["method.request.path.id"],
+      cacheNamespace: "test-namespace",
+      connectionId: "test-connection-id",
+      connectionType: "INTERNET",
+      credentials: "arn:aws:iam::123456789012:role/test-role",
+      contentHandling: "CONVERT_TO_TEXT",
+      httpMethod: "POST",
+      passthroughBehavior: "WHEN_NO_MATCH",
+      requestParameters: {
+        "integration.request.path.id": "method.request.path.id",
+      },
+      requestTemplates: {
+        "application/json": '{"statusCode": 200}',
+      },
+      responses: {
+        default: {
+          statusCode: "200",
+          responseParameters: {
+            "method.response.header.Content-Type": "'application/json'",
+          },
+          responseTemplates: {
+            "application/json": '{"message": "Success"}',
+          },
+          contentHandling: "CONVERT_TO_TEXT",
+        },
+      },
+      timeoutInMillis: 29000,
+      tlsConfig: {
+        insecureSkipVerification: false,
+      },
+    };
+
+    const mockAuthorizerRef: DeepRequired<SerialisedAuthorizerReference> = {
+      authorizerId: DefaultAuthorizerIds.IAM,
+      authorizationScopes: ["read", "write"],
+    };
+
+    const exampleOptions: DeepRequired<PrepareApiSpecCustomResourceProperties> =
+      {
+        inputSpecLocation: {
+          bucket: "input-bucket",
+          key: "input-key",
+        },
+        outputSpecLocation: {
+          bucket: "output-bucket",
+          key: "output-key",
+        },
+        integrations: {
+          getItem: {
+            integration: mockIntegration,
+            methodAuthorizer: mockAuthorizerRef,
+            options: {
+              apiKeyRequired: true, // Boolean property that might be converted to string
+            },
+          },
+          deleteItem: {
+            integration: mockIntegration,
+            methodAuthorizer: mockAuthorizerRef,
+            options: {
+              apiKeyRequired: false, // Boolean property that might be converted to string
+            },
+          },
+        },
+        corsOptions: {
+          allowMethods: ["GET", "POST"],
+          allowHeaders: ["Content-Type", "Authorization"],
+          allowOrigins: ["*"],
+          statusCode: 200, // Number property that might be converted to string
+        },
+        operationLookup: {
+          getItem: {
+            path: "/items/{id}",
+            method: "get",
+            contentTypes: ["application/json"],
+          },
+          deleteItem: {
+            path: "/items/{id}",
+            method: "delete",
+            contentTypes: ["application/json"],
+          },
+        },
+        securitySchemes: {
+          "aws.auth.sigv4": {
+            type: "apiKey",
+            name: "Authorization",
+            in: "header",
+            description: "description",
+          },
+        },
+        defaultAuthorizerReference: mockAuthorizerRef,
+        apiKeyOptions: {
+          source: "HEADER",
+          requiredByDefault: true, // Boolean property that might be converted to string
+        },
+      };
+
+    it("should coerce string values back to their appropriate types", () => {
+      // Create a deep copy of the example options
+      const options = JSON.parse(JSON.stringify(exampleOptions));
+
+      // Keep track of all primitive values and their paths
+      const primitiveValues: { path: string; originalValue: any }[] = [];
+
+      // Function to convert all primitive values to strings and track them
+      const convertPrimitivesToStrings = (obj: any, path: string = ""): any => {
+        if (typeof obj === "number" || typeof obj === "boolean") {
+          primitiveValues.push({ path, originalValue: obj });
+          return String(obj);
+        }
+
+        if (obj === null || obj === undefined || typeof obj !== "object") {
+          return obj;
+        }
+
+        if (Array.isArray(obj)) {
+          return obj.map((item, index) =>
+            convertPrimitivesToStrings(item, `${path}[${index}]`)
+          );
+        }
+
+        return Object.fromEntries(
+          Object.entries(obj).map(([key, value]) => {
+            return [
+              key,
+              convertPrimitivesToStrings(value, path ? `${path}.${key}` : key),
+            ];
+          })
+        );
+      };
+
+      // Convert all primitive values to strings
+      const stringifiedOptions = convertPrimitivesToStrings(options);
+
+      // Apply the ensurePrimitiveTypes function
+      const coercedOptions = ensurePrimitiveTypes(stringifiedOptions);
+
+      // Verify that all tracked primitive values were coerced back to their original types
+      for (const key in primitiveValues) {
+        const { path, originalValue } = primitiveValues[key];
+        const coercedValue = _.get(coercedOptions, path);
+
+        try {
+          expect(typeof coercedValue).toBe(typeof originalValue);
+          expect(coercedValue).toEqual(originalValue);
+        } catch (e) {
+          throw new Error(
+            `Expected value at ${path} to be coerced to ${typeof originalValue}: ${e}`
+          );
+        }
+      }
+
+      // Specifically check some known boolean and number properties
+      expect(typeof coercedOptions.apiKeyOptions!.requiredByDefault).toBe(
+        "boolean"
+      );
+      expect(coercedOptions.apiKeyOptions!.requiredByDefault).toBe(true);
+
+      expect(typeof coercedOptions.corsOptions!.statusCode).toBe("number");
+      expect(coercedOptions.corsOptions!.statusCode).toBe(200);
+
+      expect(
+        typeof coercedOptions.integrations.getItem.options!.apiKeyRequired
+      ).toBe("boolean");
+      expect(coercedOptions.integrations.getItem.options!.apiKeyRequired).toBe(
+        true
+      );
+
+      expect(
+        typeof coercedOptions.integrations.deleteItem.options!.apiKeyRequired
+      ).toBe("boolean");
+      expect(
+        coercedOptions.integrations.deleteItem.options!.apiKeyRequired
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
CloudFormation has a bug where all primitive custom resource properties are converted to strings: https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1037 which caused an issue with disabling api key access here: #910

We previously worked around the CloudFormation bug by serialising and deserialising using `JSON.stringify`/`JSON.parse` to ensure these primitives were resolved (#911).

Unfortunately however, the use of tokens (for example an SSM parameter value for a response template) breaks deserialisation, since the `JSON.stringify` is done at synth time before tokens have been resolved. This means that at deploy time the substituted values from CloudFormation aren't properly escaped in the JSON payload, which causes `JSON.parse` to fail in the custom resource.

We revert the serialisation change to instead coerce the specific primitive properties back to their original types in the custom resource.

I considered trying to make this a bit more generic to "just work" if new properties are added to the payload, however at runtime the TypeScript types aren't available so we'd need some kind of schema to check against, but inferring the type from a schema with eg Zod or JSON Schema won't work with JSII. Instead we coerce the specific primitive properties, but write a test that should catch any properties missed in the conversion.

Fixes #918
