### PR TITLE
fix(static-website): fix deep linking access denied issue and bucket deployment oom kill issue

### DIFF
--- a/packages/static-website/src/static-website.ts
+++ b/packages/static-website/src/static-website.ts
@@ -214,18 +214,20 @@ export class StaticWebsite extends Construct {
           viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         },
         defaultRootObject,
-        errorResponses: distributionProps?.errorResponses ?? [
-          {
-            httpStatus: 404, // We need to redirect "key not found errors" to index.html for single page apps
+        // We need to redirect "key not found errors" to index.html for single page apps
+        errorResponses:
+          distributionProps?.errorResponses ??
+          [403, 404].map((httpStatus) => ({
+            httpStatus,
             responseHttpStatus: 200,
             responsePagePath: `/${defaultRootObject}`,
-          },
-        ],
+          })),
       }
     );
 
     // Deploy Website
     this.bucketDeployment = new BucketDeployment(this, "WebsiteDeployment", {
+      memoryLimit: 2048,
       ...props.bucketDeploymentProps,
       sources: [
         Source.asset(props.websiteContentPath),

--- a/packages/static-website/test/__snapshots__/static-website.test.ts.snap
+++ b/packages/static-website/test/__snapshots__/static-website.test.ts.snap
@@ -138,10 +138,10 @@ exports[`Static Website Unit Tests Defaults - Nested 1`] = `
     },
   },
   "Resources": {
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiB8AA4A604": {
       "DependsOn": [
-        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
-        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796",
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
       ],
       "Properties": {
         "Code": {
@@ -161,9 +161,10 @@ exports[`Static Website Unit Tests Defaults - Nested 1`] = `
             "Ref": "DefaultsWebsiteDeploymentAwsCliLayerD5AA12CC",
           },
         ],
+        "MemorySize": 2048,
         "Role": {
           "Fn::GetAtt": [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
             "Arn",
           ],
         },
@@ -172,7 +173,7 @@ exports[`Static Website Unit Tests Defaults - Nested 1`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -203,7 +204,7 @@ exports[`Static Website Unit Tests Defaults - Nested 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -296,10 +297,10 @@ exports[`Static Website Unit Tests Defaults - Nested 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
+        "PolicyName": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796",
         "Roles": [
           {
-            "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+            "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
           },
         ],
       },
@@ -851,6 +852,11 @@ exports[`Static Website Unit Tests Defaults - Nested 1`] = `
       "Properties": {
         "DistributionConfig": {
           "CustomErrorResponses": [
+            {
+              "ErrorCode": 403,
+              "ResponseCode": 200,
+              "ResponsePagePath": "/index.html",
+            },
             {
               "ErrorCode": 404,
               "ResponseCode": 200,
@@ -2247,7 +2253,7 @@ exports[`Static Website Unit Tests Defaults - Nested 1`] = `
             "Value": "true",
           },
           {
-            "Key": "aws-cdk:cr-owned:df4f5c8e",
+            "Key": "aws-cdk:cr-owned:ebe29d05",
             "Value": "true",
           },
         ],
@@ -2611,7 +2617,7 @@ exports[`Static Website Unit Tests Defaults - Nested 1`] = `
       },
       "Type": "AWS::Lambda::LayerVersion",
     },
-    "DefaultsWebsiteDeploymentCustomResource326CD6C1": {
+    "DefaultsWebsiteDeploymentCustomResource2048MiBC2803829": {
       "DeletionPolicy": "Delete",
       "Metadata": {
         "cdk_nag": {
@@ -2688,7 +2694,7 @@ exports[`Static Website Unit Tests Defaults - Nested 1`] = `
         "Prune": true,
         "ServiceToken": {
           "Fn::GetAtt": [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiB8AA4A604",
             "Arn",
           ],
         },
@@ -2853,10 +2859,10 @@ exports[`Static Website Unit Tests Defaults - using AwsPrototyping NagPack 1`] =
     },
   },
   "Resources": {
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiB8AA4A604": {
       "DependsOn": [
-        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
-        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796",
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
       ],
       "Properties": {
         "Code": {
@@ -2876,9 +2882,10 @@ exports[`Static Website Unit Tests Defaults - using AwsPrototyping NagPack 1`] =
             "Ref": "DefaultsWebsiteDeploymentAwsCliLayerD5AA12CC",
           },
         ],
+        "MemorySize": 2048,
         "Role": {
           "Fn::GetAtt": [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
             "Arn",
           ],
         },
@@ -2887,7 +2894,7 @@ exports[`Static Website Unit Tests Defaults - using AwsPrototyping NagPack 1`] =
       },
       "Type": "AWS::Lambda::Function",
     },
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -2918,7 +2925,7 @@ exports[`Static Website Unit Tests Defaults - using AwsPrototyping NagPack 1`] =
       },
       "Type": "AWS::IAM::Role",
     },
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -3011,10 +3018,10 @@ exports[`Static Website Unit Tests Defaults - using AwsPrototyping NagPack 1`] =
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
+        "PolicyName": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796",
         "Roles": [
           {
-            "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+            "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
           },
         ],
       },
@@ -3566,6 +3573,11 @@ exports[`Static Website Unit Tests Defaults - using AwsPrototyping NagPack 1`] =
       "Properties": {
         "DistributionConfig": {
           "CustomErrorResponses": [
+            {
+              "ErrorCode": 403,
+              "ResponseCode": 200,
+              "ResponsePagePath": "/index.html",
+            },
             {
               "ErrorCode": 404,
               "ResponseCode": 200,
@@ -4940,7 +4952,7 @@ exports[`Static Website Unit Tests Defaults - using AwsPrototyping NagPack 1`] =
             "Value": "true",
           },
           {
-            "Key": "aws-cdk:cr-owned:fb67e0d5",
+            "Key": "aws-cdk:cr-owned:0b2e0e9f",
             "Value": "true",
           },
         ],
@@ -5304,7 +5316,7 @@ exports[`Static Website Unit Tests Defaults - using AwsPrototyping NagPack 1`] =
       },
       "Type": "AWS::Lambda::LayerVersion",
     },
-    "DefaultsWebsiteDeploymentCustomResource326CD6C1": {
+    "DefaultsWebsiteDeploymentCustomResource2048MiBC2803829": {
       "DeletionPolicy": "Delete",
       "Metadata": {
         "cdk_nag": {
@@ -5381,7 +5393,7 @@ exports[`Static Website Unit Tests Defaults - using AwsPrototyping NagPack 1`] =
         "Prune": true,
         "ServiceToken": {
           "Fn::GetAtt": [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiB8AA4A604",
             "Arn",
           ],
         },
@@ -5573,10 +5585,10 @@ exports[`Static Website Unit Tests Defaults 1`] = `
     },
   },
   "Resources": {
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiB8AA4A604": {
       "DependsOn": [
-        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
-        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796",
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
       ],
       "Properties": {
         "Code": {
@@ -5596,9 +5608,10 @@ exports[`Static Website Unit Tests Defaults 1`] = `
             "Ref": "DefaultsWebsiteDeploymentAwsCliLayerD5AA12CC",
           },
         ],
+        "MemorySize": 2048,
         "Role": {
           "Fn::GetAtt": [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
             "Arn",
           ],
         },
@@ -5607,7 +5620,7 @@ exports[`Static Website Unit Tests Defaults 1`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -5638,7 +5651,7 @@ exports[`Static Website Unit Tests Defaults 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -5731,10 +5744,10 @@ exports[`Static Website Unit Tests Defaults 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
+        "PolicyName": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796",
         "Roles": [
           {
-            "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+            "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
           },
         ],
       },
@@ -6286,6 +6299,11 @@ exports[`Static Website Unit Tests Defaults 1`] = `
       "Properties": {
         "DistributionConfig": {
           "CustomErrorResponses": [
+            {
+              "ErrorCode": 403,
+              "ResponseCode": 200,
+              "ResponsePagePath": "/index.html",
+            },
             {
               "ErrorCode": 404,
               "ResponseCode": 200,
@@ -7660,7 +7678,7 @@ exports[`Static Website Unit Tests Defaults 1`] = `
             "Value": "true",
           },
           {
-            "Key": "aws-cdk:cr-owned:fb67e0d5",
+            "Key": "aws-cdk:cr-owned:0b2e0e9f",
             "Value": "true",
           },
         ],
@@ -8024,7 +8042,7 @@ exports[`Static Website Unit Tests Defaults 1`] = `
       },
       "Type": "AWS::Lambda::LayerVersion",
     },
-    "DefaultsWebsiteDeploymentCustomResource326CD6C1": {
+    "DefaultsWebsiteDeploymentCustomResource2048MiBC2803829": {
       "DeletionPolicy": "Delete",
       "Metadata": {
         "cdk_nag": {
@@ -8101,7 +8119,7 @@ exports[`Static Website Unit Tests Defaults 1`] = `
         "Prune": true,
         "ServiceToken": {
           "Fn::GetAtt": [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiB8AA4A604",
             "Arn",
           ],
         },
@@ -8293,10 +8311,10 @@ exports[`Static Website Unit Tests Defaults and Geoblocking - using AwsPrototypi
     },
   },
   "Resources": {
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiB8AA4A604": {
       "DependsOn": [
-        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
-        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796",
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
       ],
       "Properties": {
         "Code": {
@@ -8316,9 +8334,10 @@ exports[`Static Website Unit Tests Defaults and Geoblocking - using AwsPrototypi
             "Ref": "DefaultsWebsiteDeploymentAwsCliLayerD5AA12CC",
           },
         ],
+        "MemorySize": 2048,
         "Role": {
           "Fn::GetAtt": [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
             "Arn",
           ],
         },
@@ -8327,7 +8346,7 @@ exports[`Static Website Unit Tests Defaults and Geoblocking - using AwsPrototypi
       },
       "Type": "AWS::Lambda::Function",
     },
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -8358,7 +8377,7 @@ exports[`Static Website Unit Tests Defaults and Geoblocking - using AwsPrototypi
       },
       "Type": "AWS::IAM::Role",
     },
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -8451,10 +8470,10 @@ exports[`Static Website Unit Tests Defaults and Geoblocking - using AwsPrototypi
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
+        "PolicyName": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796",
         "Roles": [
           {
-            "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+            "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
           },
         ],
       },
@@ -9006,6 +9025,11 @@ exports[`Static Website Unit Tests Defaults and Geoblocking - using AwsPrototypi
       "Properties": {
         "DistributionConfig": {
           "CustomErrorResponses": [
+            {
+              "ErrorCode": 403,
+              "ResponseCode": 200,
+              "ResponsePagePath": "/index.html",
+            },
             {
               "ErrorCode": 404,
               "ResponseCode": 200,
@@ -10389,7 +10413,7 @@ exports[`Static Website Unit Tests Defaults and Geoblocking - using AwsPrototypi
             "Value": "true",
           },
           {
-            "Key": "aws-cdk:cr-owned:fb67e0d5",
+            "Key": "aws-cdk:cr-owned:0b2e0e9f",
             "Value": "true",
           },
         ],
@@ -10753,7 +10777,7 @@ exports[`Static Website Unit Tests Defaults and Geoblocking - using AwsPrototypi
       },
       "Type": "AWS::Lambda::LayerVersion",
     },
-    "DefaultsWebsiteDeploymentCustomResource326CD6C1": {
+    "DefaultsWebsiteDeploymentCustomResource2048MiBC2803829": {
       "DeletionPolicy": "Delete",
       "Metadata": {
         "cdk_nag": {
@@ -10830,7 +10854,7 @@ exports[`Static Website Unit Tests Defaults and Geoblocking - using AwsPrototypi
         "Prune": true,
         "ServiceToken": {
           "Fn::GetAtt": [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiB8AA4A604",
             "Arn",
           ],
         },
@@ -11022,10 +11046,10 @@ exports[`Static Website Unit Tests Defaults with suppression rule - using AwsPro
     },
   },
   "Resources": {
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiB8AA4A604": {
       "DependsOn": [
-        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
-        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796",
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
       ],
       "Metadata": {
         "cdk_nag": {
@@ -11055,9 +11079,10 @@ exports[`Static Website Unit Tests Defaults with suppression rule - using AwsPro
             "Ref": "DefaultsWebsiteDeploymentAwsCliLayerD5AA12CC",
           },
         ],
+        "MemorySize": 2048,
         "Role": {
           "Fn::GetAtt": [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
             "Arn",
           ],
         },
@@ -11066,7 +11091,7 @@ exports[`Static Website Unit Tests Defaults with suppression rule - using AwsPro
       },
       "Type": "AWS::Lambda::Function",
     },
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -11107,7 +11132,7 @@ exports[`Static Website Unit Tests Defaults with suppression rule - using AwsPro
       },
       "Type": "AWS::IAM::Role",
     },
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796": {
       "Metadata": {
         "cdk_nag": {
           "rules_to_suppress": [
@@ -11210,10 +11235,10 @@ exports[`Static Website Unit Tests Defaults with suppression rule - using AwsPro
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
+        "PolicyName": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796",
         "Roles": [
           {
-            "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+            "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
           },
         ],
       },
@@ -11801,6 +11826,11 @@ exports[`Static Website Unit Tests Defaults with suppression rule - using AwsPro
       "Properties": {
         "DistributionConfig": {
           "CustomErrorResponses": [
+            {
+              "ErrorCode": 403,
+              "ResponseCode": 200,
+              "ResponsePagePath": "/index.html",
+            },
             {
               "ErrorCode": 404,
               "ResponseCode": 200,
@@ -13219,7 +13249,7 @@ exports[`Static Website Unit Tests Defaults with suppression rule - using AwsPro
             "Value": "true",
           },
           {
-            "Key": "aws-cdk:cr-owned:fb67e0d5",
+            "Key": "aws-cdk:cr-owned:0b2e0e9f",
             "Value": "true",
           },
         ],
@@ -13595,7 +13625,7 @@ exports[`Static Website Unit Tests Defaults with suppression rule - using AwsPro
       },
       "Type": "AWS::Lambda::LayerVersion",
     },
-    "DefaultsWebsiteDeploymentCustomResource326CD6C1": {
+    "DefaultsWebsiteDeploymentCustomResource2048MiBC2803829": {
       "DeletionPolicy": "Delete",
       "Metadata": {
         "cdk_nag": {
@@ -13676,7 +13706,7 @@ exports[`Static Website Unit Tests Defaults with suppression rule - using AwsPro
         "Prune": true,
         "ServiceToken": {
           "Fn::GetAtt": [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiB8AA4A604",
             "Arn",
           ],
         },
@@ -13868,10 +13898,10 @@ exports[`Static Website Unit Tests Disable Web ACL 1`] = `
     },
   },
   "Resources": {
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiB8AA4A604": {
       "DependsOn": [
-        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
-        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796",
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
       ],
       "Properties": {
         "Code": {
@@ -13891,9 +13921,10 @@ exports[`Static Website Unit Tests Disable Web ACL 1`] = `
             "Ref": "WithoutWebAclWebsiteDeploymentAwsCliLayerD4021A44",
           },
         ],
+        "MemorySize": 2048,
         "Role": {
           "Fn::GetAtt": [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
             "Arn",
           ],
         },
@@ -13902,7 +13933,7 @@ exports[`Static Website Unit Tests Disable Web ACL 1`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -13933,7 +13964,7 @@ exports[`Static Website Unit Tests Disable Web ACL 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -14026,10 +14057,10 @@ exports[`Static Website Unit Tests Disable Web ACL 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
+        "PolicyName": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796",
         "Roles": [
           {
-            "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+            "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
           },
         ],
       },
@@ -14581,6 +14612,11 @@ exports[`Static Website Unit Tests Disable Web ACL 1`] = `
       "Properties": {
         "DistributionConfig": {
           "CustomErrorResponses": [
+            {
+              "ErrorCode": 403,
+              "ResponseCode": 200,
+              "ResponsePagePath": "/index.html",
+            },
             {
               "ErrorCode": 404,
               "ResponseCode": 200,
@@ -15143,7 +15179,7 @@ exports[`Static Website Unit Tests Disable Web ACL 1`] = `
             "Value": "true",
           },
           {
-            "Key": "aws-cdk:cr-owned:935a6988",
+            "Key": "aws-cdk:cr-owned:47aa640f",
             "Value": "true",
           },
         ],
@@ -15507,7 +15543,7 @@ exports[`Static Website Unit Tests Disable Web ACL 1`] = `
       },
       "Type": "AWS::Lambda::LayerVersion",
     },
-    "WithoutWebAclWebsiteDeploymentCustomResource517CC44A": {
+    "WithoutWebAclWebsiteDeploymentCustomResource2048MiB771412A6": {
       "DeletionPolicy": "Delete",
       "Metadata": {
         "cdk_nag": {
@@ -15584,7 +15620,7 @@ exports[`Static Website Unit Tests Disable Web ACL 1`] = `
         "Prune": true,
         "ServiceToken": {
           "Fn::GetAtt": [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiB8AA4A604",
             "Arn",
           ],
         },
@@ -15776,10 +15812,10 @@ exports[`Static Website Unit Tests With Provided WebAclId, should configure the 
     },
   },
   "Resources": {
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiB8AA4A604": {
       "DependsOn": [
-        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
-        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796",
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
       ],
       "Properties": {
         "Code": {
@@ -15799,9 +15835,10 @@ exports[`Static Website Unit Tests With Provided WebAclId, should configure the 
             "Ref": "WebAclIdProvidedWebsiteDeploymentAwsCliLayer74D026BE",
           },
         ],
+        "MemorySize": 2048,
         "Role": {
           "Fn::GetAtt": [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
             "Arn",
           ],
         },
@@ -15810,7 +15847,7 @@ exports[`Static Website Unit Tests With Provided WebAclId, should configure the 
       },
       "Type": "AWS::Lambda::Function",
     },
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -15841,7 +15878,7 @@ exports[`Static Website Unit Tests With Provided WebAclId, should configure the 
       },
       "Type": "AWS::IAM::Role",
     },
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -15934,10 +15971,10 @@ exports[`Static Website Unit Tests With Provided WebAclId, should configure the 
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
+        "PolicyName": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796",
         "Roles": [
           {
-            "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+            "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
           },
         ],
       },
@@ -16489,6 +16526,11 @@ exports[`Static Website Unit Tests With Provided WebAclId, should configure the 
       "Properties": {
         "DistributionConfig": {
           "CustomErrorResponses": [
+            {
+              "ErrorCode": 403,
+              "ResponseCode": 200,
+              "ResponsePagePath": "/index.html",
+            },
             {
               "ErrorCode": 404,
               "ResponseCode": 200,
@@ -17052,7 +17094,7 @@ exports[`Static Website Unit Tests With Provided WebAclId, should configure the 
             "Value": "true",
           },
           {
-            "Key": "aws-cdk:cr-owned:ac05f6ea",
+            "Key": "aws-cdk:cr-owned:a64cafb5",
             "Value": "true",
           },
         ],
@@ -17416,7 +17458,7 @@ exports[`Static Website Unit Tests With Provided WebAclId, should configure the 
       },
       "Type": "AWS::Lambda::LayerVersion",
     },
-    "WebAclIdProvidedWebsiteDeploymentCustomResource9FA35F92": {
+    "WebAclIdProvidedWebsiteDeploymentCustomResource2048MiB48866F2B": {
       "DeletionPolicy": "Delete",
       "Metadata": {
         "cdk_nag": {
@@ -17493,7 +17535,7 @@ exports[`Static Website Unit Tests With Provided WebAclId, should configure the 
         "Prune": true,
         "ServiceToken": {
           "Fn::GetAtt": [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiB8AA4A604",
             "Arn",
           ],
         },
@@ -18165,6 +18207,11 @@ exports[`Static Website Unit Tests With custom bucket deployment props 1`] = `
       "Properties": {
         "DistributionConfig": {
           "CustomErrorResponses": [
+            {
+              "ErrorCode": 403,
+              "ResponseCode": 200,
+              "ResponsePagePath": "/index.html",
+            },
             {
               "ErrorCode": 404,
               "ResponseCode": 200,
@@ -19539,7 +19586,7 @@ exports[`Static Website Unit Tests With custom bucket deployment props 1`] = `
             "Value": "true",
           },
           {
-            "Key": "aws-cdk:cr-owned:907c0d02",
+            "Key": "aws-cdk:cr-owned:156c6683",
             "Value": "true",
           },
         ],
@@ -19903,7 +19950,7 @@ exports[`Static Website Unit Tests With custom bucket deployment props 1`] = `
       },
       "Type": "AWS::Lambda::LayerVersion",
     },
-    "CustomBucketDeploymentPropsWebsiteDeploymentCustomResource47254BC8": {
+    "CustomBucketDeploymentPropsWebsiteDeploymentCustomResource2048MiB77C37836": {
       "DeletionPolicy": "Delete",
       "Metadata": {
         "cdk_nag": {
@@ -19980,7 +20027,7 @@ exports[`Static Website Unit Tests With custom bucket deployment props 1`] = `
         "Prune": true,
         "ServiceToken": {
           "Fn::GetAtt": [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiB8AA4A604",
             "Arn",
           ],
         },
@@ -19996,10 +20043,10 @@ exports[`Static Website Unit Tests With custom bucket deployment props 1`] = `
       "Type": "Custom::CDKBucketDeployment",
       "UpdateReplacePolicy": "Delete",
     },
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiB8AA4A604": {
       "DependsOn": [
-        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
-        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796",
+        "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
       ],
       "Properties": {
         "Code": {
@@ -20019,9 +20066,10 @@ exports[`Static Website Unit Tests With custom bucket deployment props 1`] = `
             "Ref": "CustomBucketDeploymentPropsWebsiteDeploymentAwsCliLayer06EBA27F",
           },
         ],
+        "MemorySize": 2048,
         "Role": {
           "Fn::GetAtt": [
-            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+            "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
             "Arn",
           ],
         },
@@ -20030,7 +20078,7 @@ exports[`Static Website Unit Tests With custom bucket deployment props 1`] = `
       },
       "Type": "AWS::Lambda::Function",
     },
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CLogRetention1948627D": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBLogRetentionA802466B": {
       "Properties": {
         "LogGroupName": {
           "Fn::Join": [
@@ -20038,7 +20086,7 @@ exports[`Static Website Unit Tests With custom bucket deployment props 1`] = `
             [
               "/aws/lambda/",
               {
-                "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C81C01536",
+                "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiB8AA4A604",
               },
             ],
           ],
@@ -20053,7 +20101,7 @@ exports[`Static Website Unit Tests With custom bucket deployment props 1`] = `
       },
       "Type": "Custom::LogRetention",
     },
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -20084,7 +20132,7 @@ exports[`Static Website Unit Tests With custom bucket deployment props 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF": {
+    "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -20177,10 +20225,10 @@ exports[`Static Website Unit Tests With custom bucket deployment props 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRoleDefaultPolicy88902FDF",
+        "PolicyName": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleDefaultPolicy5D765796",
         "Roles": [
           {
-            "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756CServiceRole89A01265",
+            "Ref": "CustomCDKBucketDeployment8693BB64968944B69AAFB0CC9EB8756C2048MiBServiceRoleB37F9ACF",
           },
         ],
       },


### PR DESCRIPTION
CloudFront with S3 OAC returns a 403 instead of a 404 when an object is missing from an S3 bucket, and so the redirect for single-page apps was broken. Updated to handle both 403 and 404 to be safe.

Additionally bumped the default memory size for the bucket deployment lambda which was being killed due to exceeding the memory limit for just the default website.

Fixes #915
Fixes #909
