### PR TITLE
feat(type-safe-api): support configuring custom gateway responses

### DIFF
--- a/packages/type-safe-api/src/construct/prepare-spec-event-handler/prepare-spec.ts
+++ b/packages/type-safe-api/src/construct/prepare-spec-event-handler/prepare-spec.ts
@@ -1,5 +1,6 @@
 /*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0 */
+import { GatewayResponseOptions } from "aws-cdk-lib/aws-apigateway";
 import type { OpenAPIV3 } from "openapi-types";
 import { DefaultAuthorizerIds, HttpMethods } from "./constants";
 import { ApiGatewayIntegration } from "../integrations";
@@ -80,6 +81,11 @@ export interface PrepareApiSpecOptions {
    * Default options for API keys
    */
   readonly apiKeyOptions?: SerializedApiKeyOptions;
+  /**
+   * Optional gateway responses for the API
+   * @see https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-gatewayResponse-definition.html
+   */
+  readonly gatewayResponses?: GatewayResponseOptions[];
 }
 
 /**
@@ -505,6 +511,31 @@ const findHeaderParameters = (spec: OpenAPIV3.Document): string[] => {
 };
 
 /**
+ * Generate a gateway response snippet
+ * @see https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-swagger-extensions-gateway-responses.gatewayResponse.html
+ */
+export const generateGatewayResponse = ({
+  statusCode,
+  templates,
+  responseHeaders,
+}: GatewayResponseOptions) => {
+  return {
+    statusCode,
+    ...(responseHeaders
+      ? {
+          responseParameters: Object.fromEntries(
+            Object.entries(responseHeaders).map(([header, value]) => [
+              `gatewayresponse.header.${header}`,
+              value,
+            ])
+          ),
+        }
+      : {}),
+    responseTemplates: templates,
+  };
+};
+
+/**
  * Prepares the api spec for deployment by adding integrations, configuring auth, etc
  */
 export const prepareApiSpec = (
@@ -576,6 +607,12 @@ export const prepareApiSpec = (
             }
           : {}),
       },
+      ...Object.fromEntries(
+        (options.gatewayResponses ?? []).map((gatewayResponse) => [
+          gatewayResponse.type.responseType,
+          generateGatewayResponse(gatewayResponse),
+        ])
+      ),
     },
     paths: {
       ...Object.fromEntries(

--- a/packages/type-safe-api/src/construct/type-safe-rest-api.ts
+++ b/packages/type-safe-api/src/construct/type-safe-rest-api.ts
@@ -9,6 +9,7 @@ import {
   AccessLogFormat,
   ApiDefinition,
   Cors,
+  GatewayResponseOptions,
   LogGroupLogDestination,
   MethodLoggingLevel,
   RestApiBaseProps,
@@ -85,6 +86,17 @@ export interface TypeSafeRestApiProps
    * use this option to specify the output bucket.
    */
   readonly outputSpecBucket?: IBucket;
+
+  /**
+   * Optional gateway responses for the API.
+   *
+   * Note that Type Safe API automatically configures request validation for you, and defines a
+   * default BAD_REQUEST_BODY gateway response which returns the validation error message. You can
+   * use this property to override this gateway response if desired.
+   *
+   * @see https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-gatewayResponse-definition.html
+   */
+  readonly gatewayResponses?: GatewayResponseOptions[];
 }
 
 /**
@@ -339,6 +351,7 @@ export class TypeSafeRestApi extends Construct {
       corsOptions: serializedCorsOptions,
       operationLookup,
       apiKeyOptions: options.apiKeyOptions,
+      gatewayResponses: options.gatewayResponses,
     };
 
     // Spec preparation will happen in a custom resource lambda so that references to lambda integrations etc can be

--- a/packages/type-safe-api/test/construct/__snapshots__/type-safe-rest-api.test.ts.snap
+++ b/packages/type-safe-api/test/construct/__snapshots__/type-safe-rest-api.test.ts.snap
@@ -848,7 +848,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-85532C36PrepSpec",
         "Handler": "index.handler",
@@ -1982,7 +1982,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Create 2 APIs on same stack 1`]
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-300D0E5FPrepSpec",
         "Handler": "index.handler",
@@ -3454,7 +3454,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Local Mode 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -4834,7 +4834,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Permits Matching No Authorizers
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -6642,7 +6642,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should add header parameters to
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -8731,7 +8731,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should consolidate permissions 
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -10159,7 +10159,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Should enable compression 1`] =
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -11537,7 +11537,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -14014,7 +14014,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Synth with dedicated prepareSpe
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -15510,7 +15510,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Cognito Auth 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -17102,7 +17102,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Auth 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -18624,7 +18624,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules 1`] =
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -20009,7 +20009,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules actio
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -20560,6 +20560,1487 @@ exports[`Type Safe Rest Api Construct Unit Tests With Custom Managed Rules actio
           "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
         },
       ],
+    },
+  },
+}
+`;
+
+exports[`Type Safe Rest Api Construct Unit Tests With Gateway Responses 1`] = `
+{
+  "Mappings": {
+    "LatestNodeRuntimeMap": {
+      "af-south-1": {
+        "value": "nodejs20.x",
+      },
+      "ap-east-1": {
+        "value": "nodejs20.x",
+      },
+      "ap-northeast-1": {
+        "value": "nodejs20.x",
+      },
+      "ap-northeast-2": {
+        "value": "nodejs20.x",
+      },
+      "ap-northeast-3": {
+        "value": "nodejs20.x",
+      },
+      "ap-south-1": {
+        "value": "nodejs20.x",
+      },
+      "ap-south-2": {
+        "value": "nodejs20.x",
+      },
+      "ap-southeast-1": {
+        "value": "nodejs20.x",
+      },
+      "ap-southeast-2": {
+        "value": "nodejs20.x",
+      },
+      "ap-southeast-3": {
+        "value": "nodejs20.x",
+      },
+      "ap-southeast-4": {
+        "value": "nodejs20.x",
+      },
+      "ap-southeast-5": {
+        "value": "nodejs20.x",
+      },
+      "ap-southeast-7": {
+        "value": "nodejs20.x",
+      },
+      "ca-central-1": {
+        "value": "nodejs20.x",
+      },
+      "ca-west-1": {
+        "value": "nodejs20.x",
+      },
+      "cn-north-1": {
+        "value": "nodejs18.x",
+      },
+      "cn-northwest-1": {
+        "value": "nodejs18.x",
+      },
+      "eu-central-1": {
+        "value": "nodejs20.x",
+      },
+      "eu-central-2": {
+        "value": "nodejs20.x",
+      },
+      "eu-isoe-west-1": {
+        "value": "nodejs18.x",
+      },
+      "eu-north-1": {
+        "value": "nodejs20.x",
+      },
+      "eu-south-1": {
+        "value": "nodejs20.x",
+      },
+      "eu-south-2": {
+        "value": "nodejs20.x",
+      },
+      "eu-west-1": {
+        "value": "nodejs20.x",
+      },
+      "eu-west-2": {
+        "value": "nodejs20.x",
+      },
+      "eu-west-3": {
+        "value": "nodejs20.x",
+      },
+      "il-central-1": {
+        "value": "nodejs20.x",
+      },
+      "me-central-1": {
+        "value": "nodejs20.x",
+      },
+      "me-south-1": {
+        "value": "nodejs20.x",
+      },
+      "mx-central-1": {
+        "value": "nodejs20.x",
+      },
+      "sa-east-1": {
+        "value": "nodejs20.x",
+      },
+      "us-east-1": {
+        "value": "nodejs20.x",
+      },
+      "us-east-2": {
+        "value": "nodejs20.x",
+      },
+      "us-gov-east-1": {
+        "value": "nodejs18.x",
+      },
+      "us-gov-west-1": {
+        "value": "nodejs18.x",
+      },
+      "us-iso-east-1": {
+        "value": "nodejs18.x",
+      },
+      "us-iso-west-1": {
+        "value": "nodejs18.x",
+      },
+      "us-isob-east-1": {
+        "value": "nodejs18.x",
+      },
+      "us-west-1": {
+        "value": "nodejs20.x",
+      },
+      "us-west-2": {
+        "value": "nodejs20.x",
+      },
+    },
+  },
+  "Outputs": {
+    "ApiTestEndpoint34A72375": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "ApiTestEE73F324",
+            },
+            ".execute-api.",
+            {
+              "Ref": "AWS::Region",
+            },
+            ".",
+            {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            {
+              "Ref": "ApiTestDeploymentStageprod660267A6",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "ApiTestAccessLogs92CFE051": {
+      "DeletionPolicy": "Retain",
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "RetentionInDays": 731,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "ApiTestAccount272B5CDD": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": [
+        "ApiTestEE73F324",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
+      ],
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "CloudWatchRoleArn": {
+          "Fn::GetAtt": [
+            "ApiTestCloudWatchRole56ED0814",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "ApiTestApiTestAclApiWebACLA53F05F1": {
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "DefaultAction": {
+          "Allow": {},
+        },
+        "Name": "Default-ApiTest-Acl-b8f2cb4d",
+        "Rules": [
+          {
+            "Name": "AWS-AWSManagedRulesCommonRuleSet",
+            "OverrideAction": {
+              "None": {},
+            },
+            "Priority": 2,
+            "Statement": {
+              "ManagedRuleGroupStatement": {
+                "Name": "AWSManagedRulesCommonRuleSet",
+                "VendorName": "AWS",
+              },
+            },
+            "VisibilityConfig": {
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "Default-ApiTest-Acl-b8f2cb4d-AWS-AWSManagedRulesCommonRuleSet",
+              "SampledRequestsEnabled": true,
+            },
+          },
+        ],
+        "Scope": "REGIONAL",
+        "VisibilityConfig": {
+          "CloudWatchMetricsEnabled": true,
+          "MetricName": "Default-ApiTest-Acl-b8f2cb4d",
+          "SampledRequestsEnabled": true,
+        },
+      },
+      "Type": "AWS::WAFv2::WebACL",
+    },
+    "ApiTestApiTestAclWebACLAssociation54801610": {
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "ResourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":apigateway:",
+              {
+                "Ref": "AWS::Region",
+              },
+              "::/restapis/",
+              {
+                "Ref": "ApiTestEE73F324",
+              },
+              "/stages/",
+              {
+                "Ref": "ApiTestDeploymentStageprod660267A6",
+              },
+            ],
+          ],
+        },
+        "WebACLArn": {
+          "Fn::GetAtt": [
+            "ApiTestApiTestAclApiWebACLA53F05F1",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::WAFv2::WebACLAssociation",
+    },
+    "ApiTestCloudWatchRole56ED0814": {
+      "DeletionPolicy": "Retain",
+      "DependsOn": [
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
+      ],
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "ApiTestDeployment153EC47890f4f4f8f78df5223931c2750e6b0e81": {
+      "DependsOn": [
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
+      ],
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": {
+          "Ref": "ApiTestEE73F324",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "ApiTestDeploymentStageprod660267A6": {
+      "DependsOn": [
+        "ApiTestAccount272B5CDD",
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
+      ],
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "AccessLogSetting": {
+          "DestinationArn": {
+            "Fn::GetAtt": [
+              "ApiTestAccessLogs92CFE051",
+              "Arn",
+            ],
+          },
+          "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId",
+        },
+        "DeploymentId": {
+          "Ref": "ApiTestDeployment153EC47890f4f4f8f78df5223931c2750e6b0e81",
+        },
+        "MethodSettings": [
+          {
+            "DataTraceEnabled": false,
+            "HttpMethod": "*",
+            "LoggingLevel": "INFO",
+            "ResourcePath": "/*",
+          },
+        ],
+        "RestApiId": {
+          "Ref": "ApiTestEE73F324",
+        },
+        "StageName": "prod",
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "ApiTestEE73F324": {
+      "DependsOn": [
+        "ApiTestPrepareSpecCustomResourceC9800EE6",
+      ],
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "BodyS3Location": {
+          "Bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "Key": {
+            "Fn::GetAtt": [
+              "ApiTestPrepareSpecCustomResourceC9800EE6",
+              "outputSpecKey",
+            ],
+          },
+        },
+        "Name": "ApiTest",
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "ApiTestLambdaPermissiontestOperationECAC1A2D": {
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "LambdaD247545B",
+            "Arn",
+          ],
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":execute-api:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":",
+              {
+                "Ref": "ApiTestEE73F324",
+              },
+              "/*/GET/test",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "ApiTestPrepareSpecCustomResourceC9800EE6": {
+      "DeletionPolicy": "Delete",
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188",
+            "Arn",
+          ],
+        },
+        "options": {
+          "gatewayResponses": [
+            {
+              "responseHeaders": {
+                "Access-Control-Allow-Origin": "'*'",
+                "x-request-id": "method.request.header.x-request-id",
+              },
+              "templates": {
+                "application/json": "{"message": "$context.error.message", "requestId": "$context.requestId"}",
+              },
+              "type": {
+                "responseType": "DEFAULT_4XX",
+              },
+            },
+            {
+              "responseHeaders": {
+                "Access-Control-Allow-Origin": "'*'",
+              },
+              "statusCode": "401",
+              "templates": {
+                "application/json": "{"message": "Authentication required", "requestId": "$context.requestId"}",
+              },
+              "type": {
+                "responseType": "UNAUTHORIZED",
+              },
+            },
+          ],
+          "inputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+          },
+          "integrations": {
+            "testOperation": {
+              "integration": {
+                "httpMethod": "POST",
+                "passthroughBehavior": "WHEN_NO_MATCH",
+                "type": "AWS_PROXY",
+                "uri": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":apigateway:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":lambda:path/2015-03-31/functions/",
+                      {
+                        "Fn::GetAtt": [
+                          "LambdaD247545B",
+                          "Arn",
+                        ],
+                      },
+                      "/invocations",
+                    ],
+                  ],
+                },
+              },
+            },
+          },
+          "operationLookup": {
+            "testOperation": {
+              "method": "get",
+              "path": "/test",
+            },
+          },
+          "outputSpecLocation": {
+            "bucket": {
+              "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+            },
+            "key": "ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared",
+          },
+          "securitySchemes": {},
+        },
+      },
+      "Type": "AWS::CloudFormation::CustomResource",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ApiTestPrepareSpecHandler46C6FEB5": {
+      "DependsOn": [
+        "ApiTestPrepareSpecRole44D562E5",
+      ],
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
+        },
+        "FunctionName": "Default-3E755E54PrepSpec",
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiTestPrepareSpecRole44D562E5",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78": {
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "ApiTestPrepareSpecHandler46C6FEB5",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "ApiTestPrepareSpecHandler46C6FEB5",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
+        "Roles": [
+          {
+            "Ref": "ApiTestPrepareSpecProviderRoleF47822B8",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ApiTestPrepareSpecProviderRoleF47822B8": {
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "AwsSolutions-IAM5",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            {
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:logs:",
+                          {
+                            "Ref": "AWS::Region",
+                          },
+                          ":",
+                          {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider",
+                        ],
+                      ],
+                    },
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:logs:",
+                          {
+                            "Ref": "AWS::Region",
+                          },
+                          ":",
+                          {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpecProvider:*",
+                        ],
+                      ],
+                    },
+                  ],
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "logs",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ApiTestPrepareSpecProviderframeworkonEvent2FA9E188": {
+      "DependsOn": [
+        "ApiTestPrepareSpecProviderRoleDefaultPolicy99662E78",
+        "ApiTestPrepareSpecProviderRoleF47822B8",
+      ],
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "AwsSolutions-L1",
+              "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
+            },
+            {
+              "id": "AwsPrototyping-LambdaLatestVersion",
+              "reason": "Latest runtime cannot be configured. CDK will need to upgrade the Provider construct accordingly.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "4dc48ffba382f93077a1e6824599bbd4ceb6f91eb3d9442eca3b85bdb1a20b1e.zip",
+        },
+        "Description": "AWS CDK resource provider framework - onEvent (Default/ApiTest/PrepareSpecProvider)",
+        "Environment": {
+          "Variables": {
+            "USER_ON_EVENT_FUNCTION_ARN": {
+              "Fn::GetAtt": [
+                "ApiTestPrepareSpecHandler46C6FEB5",
+                "Arn",
+              ],
+            },
+          },
+        },
+        "FunctionName": "Default-3E755E54PrepSpecProvider",
+        "Handler": "framework.onEvent",
+        "Role": {
+          "Fn::GetAtt": [
+            "ApiTestPrepareSpecProviderRoleF47822B8",
+            "Arn",
+          ],
+        },
+        "Runtime": {
+          "Fn::FindInMap": [
+            "LatestNodeRuntimeMap",
+            {
+              "Ref": "AWS::Region",
+            },
+            "value",
+          ],
+        },
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ApiTestPrepareSpecRole44D562E5": {
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Resource::arn:<AWS::Partition>:s3:.*/ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared/*/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM5",
+              "reason": "S3 resources have been scoped down to the appropriate prefix in the CDK asset bucket, however * is still needed as since the prepared spec hash is not known until deploy time.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:/aws/lambda/Default-3E755E54PrepSpec:*/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "Cloudwatch resources have been scoped down to the LogGroup level, however * is still needed as stream names are created just in time.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Resource::arn:<AWS::Partition>:s3:.*/ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared/*/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoWildcardPermissions",
+              "reason": "S3 resources have been scoped down to the appropriate prefix in the CDK asset bucket, however * is still needed as since the prepared spec hash is not known until deploy time.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsSolutions-IAM4",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "applies_to": [
+                {
+                  "regex": "/^Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs$/g",
+                },
+              ],
+              "id": "AwsPrototyping-IAMNoManagedPolicies",
+              "reason": "Cloudwatch Role requires access to create/read groups at the root level.",
+            },
+            {
+              "id": "AwsSolutions-APIG2",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+            {
+              "id": "AwsPrototyping-APIGWRequestValidation",
+              "reason": "This construct implements fine grained validation via OpenApi.",
+            },
+          ],
+        },
+      },
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": [
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:logs:",
+                          {
+                            "Ref": "AWS::Region",
+                          },
+                          ":",
+                          {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec",
+                        ],
+                      ],
+                    },
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "arn:aws:logs:",
+                          {
+                            "Ref": "AWS::Region",
+                          },
+                          ":",
+                          {
+                            "Ref": "AWS::AccountId",
+                          },
+                          ":log-group:/aws/lambda/Default-3E755E54PrepSpec:*",
+                        ],
+                      ],
+                    },
+                  ],
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "logs",
+          },
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "s3:getObject",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":s3:::",
+                        {
+                          "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+                        },
+                        "/ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json",
+                      ],
+                    ],
+                  },
+                },
+                {
+                  "Action": "s3:putObject",
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":s3:::",
+                        {
+                          "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+                        },
+                        "/ec22714a0fde30e0834df19bc639f3cb3519abd3ccd6dcf6b761d105827ca227.json-prepared/*",
+                      ],
+                    ],
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "s3",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "LambdaD247545B": {
+      "DependsOn": [
+        "LambdaServiceRoleA8ED4D3B",
+      ],
+      "Properties": {
+        "Code": {
+          "ZipFile": "code",
+        },
+        "Handler": "handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "LambdaServiceRoleA8ED4D3B",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs16.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "LambdaServiceRoleA8ED4D3B": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`Type Safe Rest Api Construct Unit Tests With Gateway Responses 2`] = `
+{
+  "components": {
+    "securitySchemes": {},
+  },
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/test": {
+      "get": {
+        "operationId": "testOperation",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Successful response",
+            "headers": {},
+          },
+        },
+        "x-amazon-apigateway-integration": {
+          "httpMethod": "POST",
+          "passthroughBehavior": "WHEN_NO_MATCH",
+          "type": "AWS_PROXY",
+          "uri": "arn:\${<TOKEN>}:apigateway:\${<TOKEN>}:lambda:path/2015-03-31/functions/\${<TOKEN>}/invocations",
+        },
+      },
+    },
+  },
+  "x-amazon-apigateway-gateway-responses": {
+    "BAD_REQUEST_BODY": {
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.validationErrorString"}",
+      },
+      "statusCode": 400,
+    },
+    "DEFAULT_4XX": {
+      "responseParameters": {
+        "gatewayresponse.header.Access-Control-Allow-Origin": "'*'",
+        "gatewayresponse.header.x-request-id": "method.request.header.x-request-id",
+      },
+      "responseTemplates": {
+        "application/json": "{"message": "$context.error.message", "requestId": "$context.requestId"}",
+      },
+      "statusCode": undefined,
+    },
+    "UNAUTHORIZED": {
+      "responseParameters": {
+        "gatewayresponse.header.Access-Control-Allow-Origin": "'*'",
+      },
+      "responseTemplates": {
+        "application/json": "{"message": "Authentication required", "requestId": "$context.requestId"}",
+      },
+      "statusCode": "401",
+    },
+  },
+  "x-amazon-apigateway-request-validator": "all",
+  "x-amazon-apigateway-request-validators": {
+    "all": {
+      "validateRequestBody": true,
+      "validateRequestParameters": true,
     },
   },
 }
@@ -21420,7 +22901,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With IAM Auth and CORS 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -23393,7 +24874,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mixed Auth 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -25114,7 +26595,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -26455,7 +27936,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Mock Integration and CORS 
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -27925,7 +29406,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Path Parameters 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -29338,7 +30819,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -30921,7 +32402,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and CORS 1`
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -32520,7 +34001,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and catch a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -34002,7 +35483,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and custom 
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -35515,7 +36996,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With S3 Integration and props 1
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -37150,7 +38631,7 @@ exports[`Type Safe Rest Api Construct Unit Tests With Waf IP Set 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",
@@ -38394,7 +39875,7 @@ exports[`Type Safe Rest Api Construct Unit Tests Without Waf 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "FunctionName": "Default-3E755E54PrepSpec",
         "Handler": "index.handler",

--- a/packages/type-safe-api/test/construct/__snapshots__/type-safe-websocket-api.test.ts.snap
+++ b/packages/type-safe-api/test/construct/__snapshots__/type-safe-websocket-api.test.ts.snap
@@ -329,7 +329,7 @@ exports[`Type Safe WebSocket Api Construct Unit Tests Synthesizes 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "Handler": "websocket-schema-handler.handler",
         "Role": {
@@ -1503,7 +1503,7 @@ exports[`Type Safe WebSocket Api Construct Unit Tests Synthesizes With Connect a
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "Handler": "websocket-schema-handler.handler",
         "Role": {
@@ -2597,7 +2597,7 @@ exports[`Type Safe WebSocket Api Construct Unit Tests Synthesizes With Mock Inte
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5c5f485bd3655f3762f39dceb6ca3bdb6a340a4e5687c119917db517b929ae6f.zip",
+          "S3Key": "62e435e908eb6cd4d2c1b7422ef1ad037732056e198b2e85d18aa5c88c4bd09a.zip",
         },
         "Handler": "websocket-schema-handler.handler",
         "Role": {

--- a/packages/type-safe-api/test/construct/prepare-spec-event-handler/index.test.ts
+++ b/packages/type-safe-api/test/construct/prepare-spec-event-handler/index.test.ts
@@ -1,5 +1,6 @@
 /*! Copyright [Amazon.com](http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0 */
+import { ResponseType } from "aws-cdk-lib/aws-apigateway";
 import _ from "lodash";
 import { ApiGatewayIntegration } from "../../../src/construct/integrations";
 import {
@@ -123,6 +124,18 @@ describe("prepare-spec-event-handler index.ts", () => {
           source: "HEADER",
           requiredByDefault: true, // Boolean property that might be converted to string
         },
+        gatewayResponses: [
+          {
+            type: ResponseType.DEFAULT_5XX,
+            statusCode: "500",
+            responseHeaders: {
+              "x-foo": "'bar'",
+            },
+            templates: {
+              "application/json": '{ "message": "internal error" }',
+            },
+          },
+        ],
       };
 
     it("should coerce string values back to their appropriate types", () => {

--- a/packages/type-safe-api/test/construct/type-safe-rest-api.test.ts
+++ b/packages/type-safe-api/test/construct/type-safe-rest-api.test.ts
@@ -3,7 +3,11 @@ SPDX-License-Identifier: Apache-2.0 */
 import { PDKNag } from "@aws/pdk-nag";
 import { App, CfnOutput, Size, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { ApiKeySourceType, Cors } from "aws-cdk-lib/aws-apigateway";
+import {
+  ApiKeySourceType,
+  Cors,
+  ResponseType,
+} from "aws-cdk-lib/aws-apigateway";
 import { UserPool } from "aws-cdk-lib/aws-cognito";
 import { Code, Function, Runtime } from "aws-cdk-lib/aws-lambda";
 import { BlockPublicAccess, Bucket } from "aws-cdk-lib/aws-s3";
@@ -1572,6 +1576,52 @@ describe("Type Safe Rest Api Construct Unit Tests", () => {
         },
       });
 
+      snapshotExtendedSpec(api);
+    });
+  });
+
+  it("With Gateway Responses", () => {
+    const stack = new Stack();
+    const func = new Function(stack, "Lambda", {
+      code: Code.fromInline("code"),
+      handler: "handler",
+      runtime: Runtime.NODEJS_16_X,
+    });
+    withTempSpec(sampleSpec, (specPath) => {
+      const api = new TypeSafeRestApi(stack, "ApiTest", {
+        specPath,
+        operationLookup,
+        integrations: {
+          testOperation: {
+            integration: Integrations.lambda(func),
+          },
+        },
+        gatewayResponses: [
+          {
+            type: ResponseType.DEFAULT_4XX,
+            responseHeaders: {
+              "Access-Control-Allow-Origin": "'*'",
+              "x-request-id": "method.request.header.x-request-id",
+            },
+            templates: {
+              "application/json":
+                '{"message": "$context.error.message", "requestId": "$context.requestId"}',
+            },
+          },
+          {
+            type: ResponseType.UNAUTHORIZED,
+            statusCode: "401",
+            responseHeaders: {
+              "Access-Control-Allow-Origin": "'*'",
+            },
+            templates: {
+              "application/json":
+                '{"message": "Authentication required", "requestId": "$context.requestId"}',
+            },
+          },
+        ],
+      });
+      expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
       snapshotExtendedSpec(api);
     });
   });


### PR DESCRIPTION
Add support for configuring [Gateway Responses](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-gatewayResponse-definition.html) in Type Safe API.

Fixes #922
