### PR TITLE
feat: remove upper bound on pnpm version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -181,7 +181,7 @@ RUN set -ex \
 # ===== PDK dependencies =====
 
 # Package managers
-RUN npm install -g @aws/pdk aws-cdk bun pnpm@8 projen yarn
+RUN npm install -g @aws/pdk aws-cdk bun pnpm@10 projen yarn
 
 # Poetry setup
 RUN curl -sSL https://install.python-poetry.org | python

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "engines": {
     "node": ">=16",
-    "pnpm": ">=8 <9"
+    "pnpm": ">=8"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/monorepo/src/components/nx-configurator.ts
+++ b/packages/monorepo/src/components/nx-configurator.ts
@@ -464,7 +464,7 @@ export class NxConfigurator extends Component implements INxProjectCore {
           private: true,
           engines: {
             node: ">=16",
-            pnpm: ">=8 <9",
+            pnpm: ">=8",
           },
           scripts: Object.fromEntries(
             this.project.tasks.all

--- a/packages/monorepo/src/projects/typescript/monorepo-ts.ts
+++ b/packages/monorepo/src/projects/typescript/monorepo-ts.ts
@@ -226,8 +226,7 @@ export class MonorepoTsProject
       }
       case NodePackageManager.PNPM: {
         // https://pnpm.io/package_json
-        // https://github.com/pnpm/pnpm/releases/tag/v8.0.0
-        this.package.addEngine("pnpm", ">=8 <9");
+        this.package.addEngine("pnpm", ">=8");
         break;
       }
       case NodePackageManager.YARN_CLASSIC:

--- a/packages/monorepo/test/__snapshots__/monorepo.test.ts.snap
+++ b/packages/monorepo/test/__snapshots__/monorepo.test.ts.snap
@@ -933,7 +933,7 @@ yes=true
     },
     "engines": {
       "node": ">=16",
-      "pnpm": ">=8 <9",
+      "pnpm": ">=8",
     },
     "license": "Apache-2.0",
     "main": "lib/index.js",
@@ -19938,7 +19938,7 @@ link-workspace-packages=true
     },
     "engines": {
       "node": ">=16",
-      "pnpm": ">=8 <9",
+      "pnpm": ">=8",
     },
     "private": true,
     "scripts": {
@@ -22376,7 +22376,7 @@ yes=true
     },
     "engines": {
       "node": ">=16",
-      "pnpm": ">=8 <9",
+      "pnpm": ">=8",
     },
     "license": "Apache-2.0",
     "main": "lib/index.js",

--- a/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/__snapshots__/type-safe-api-project.test.ts.snap
@@ -50678,7 +50678,7 @@ yes=true
     },
     "engines": {
       "node": ">=16",
-      "pnpm": ">=8 <9",
+      "pnpm": ">=8",
     },
     "license": "Apache-2.0",
     "main": "lib/index.js",

--- a/packages/type-safe-api/test/project/__snapshots__/type-safe-websocket-api-project.test.ts.snap
+++ b/packages/type-safe-api/test/project/__snapshots__/type-safe-websocket-api-project.test.ts.snap
@@ -21368,7 +21368,7 @@ yes=true
     },
     "engines": {
       "node": ">=16",
-      "pnpm": ">=8 <9",
+      "pnpm": ">=8",
     },
     "license": "Apache-2.0",
     "main": "lib/index.js",


### PR DESCRIPTION
Allows users to use pnpm 9 or 10.

Note jsii packaging didn't work with pnpm 10 so I'm leaving this repo at pnpm 8 for now.

Fixes #901
