### PR TITLE
docs: Updated developer guide/monorepo example

### DIFF
--- a/packages/monorepo/docs/developer_guides/monorepo/index.md
+++ b/packages/monorepo/docs/developer_guides/monorepo/index.md
@@ -73,10 +73,10 @@ To get started, run the following command in an empty directory to create your M
     This will bootstrap your project given the above structure and contain the _.projenrc.ts_ file with your project definition which should contain the following:
 
     ```ts
-    import { MonorepoTsProject } from "@aws/pdk/monorepo";
-    const project = new MonorepoTsProject({
-      defaultReleaseBranch: "main",
-      name: "ts-bootstrap",
+    import { monorepo } from "@aws/pdk";
+    const project = new monorepo.MonorepoTsProject({
+      devDeps: ["@aws/pdk"],
+      name: "projen",
       projenrcTs: true,
     });
     project.synth();


### PR DESCRIPTION
Updated [developer_guide/monorepo](https://aws.github.io/aws-pdk/developer_guides/monorepo/index.html) example to the new syntax that is generated by running `npx projen new --from @aws/pdk monorepo-ts`

Fixes #