### PR TITLE
feat(type-safe-api): add support for Node.js 24 and Python 3.14 runtimes

### DIFF
--- a/packages/type-safe-api/src/project/codegen/runtime-version-utils.ts
+++ b/packages/type-safe-api/src/project/codegen/runtime-version-utils.ts
@@ -64,6 +64,8 @@ class NodeRuntimeVersionUtils {
         return "NODEJS_20_X";
       case NodeVersion.NODE_22:
         return "NODEJS_22_X";
+      case NodeVersion.NODE_24:
+        return "NODEJS_24_X";
       default:
         throw new Error(`Unsupported node runtime ${runtimeVersion}`);
     }
@@ -77,6 +79,8 @@ class NodeRuntimeVersionUtils {
     runtimeVersion: NodeVersion
   ): string => {
     switch (runtimeVersion) {
+      case NodeVersion.NODE_24:
+        return "node24";
       case NodeVersion.NODE_22:
         return "node22";
       case NodeVersion.NODE_20:
@@ -105,6 +109,8 @@ class PythonRuntimeVersionUtils {
         return "PYTHON_3_12";
       case PythonVersion.PYTHON_3_13:
         return "PYTHON_3_13";
+      case PythonVersion.PYTHON_3_14:
+        return "PYTHON_3_14";
       default:
         throw new Error(`Unsupported python runtime ${runtimeVersion}`);
     }
@@ -137,6 +143,8 @@ class PythonRuntimeVersionUtils {
     runtimeVersion: PythonVersion
   ): string => {
     switch (runtimeVersion) {
+      case PythonVersion.PYTHON_3_14:
+        return "3.14";
       case PythonVersion.PYTHON_3_13:
         return "3.13";
       case PythonVersion.PYTHON_3_12:

--- a/packages/type-safe-api/src/project/languages.ts
+++ b/packages/type-safe-api/src/project/languages.ts
@@ -16,6 +16,7 @@ export enum NodeVersion {
   NODE_18 = "NODE_18",
   NODE_20 = "NODE_20",
   NODE_22 = "NODE_22",
+  NODE_24 = "NODE_24",
 }
 
 /**
@@ -35,6 +36,7 @@ export enum PythonVersion {
   PYTHON_3_11 = "PYTHON_3_11",
   PYTHON_3_12 = "PYTHON_3_12",
   PYTHON_3_13 = "PYTHON_3_13",
+  PYTHON_3_14 = "PYTHON_3_14",
 }
 
 /**

--- a/packages/type-safe-api/test/project/codegen/__snapshots__/runtime-version-utils.test.ts.snap
+++ b/packages/type-safe-api/test/project/codegen/__snapshots__/runtime-version-utils.test.ts.snap
@@ -42,11 +42,15 @@ exports[`RuntimeVersionUtils Node maps the esbuild target for NODE_20 1`] = `"no
 
 exports[`RuntimeVersionUtils Node maps the esbuild target for NODE_22 1`] = `"node22"`;
 
+exports[`RuntimeVersionUtils Node maps the esbuild target for NODE_24 1`] = `"node24"`;
+
 exports[`RuntimeVersionUtils Node maps the lambda runtime version for NODE_18 1`] = `"NODEJS_18_X"`;
 
 exports[`RuntimeVersionUtils Node maps the lambda runtime version for NODE_20 1`] = `"NODEJS_20_X"`;
 
 exports[`RuntimeVersionUtils Node maps the lambda runtime version for NODE_22 1`] = `"NODEJS_22_X"`;
+
+exports[`RuntimeVersionUtils Node maps the lambda runtime version for NODE_24 1`] = `"NODEJS_24_X"`;
 
 exports[`RuntimeVersionUtils Python maps the lambda runtime version for PYTHON_3_11 1`] = `"PYTHON_3_11"`;
 
@@ -54,14 +58,20 @@ exports[`RuntimeVersionUtils Python maps the lambda runtime version for PYTHON_3
 
 exports[`RuntimeVersionUtils Python maps the lambda runtime version for PYTHON_3_13 1`] = `"PYTHON_3_13"`;
 
+exports[`RuntimeVersionUtils Python maps the lambda runtime version for PYTHON_3_14 1`] = `"PYTHON_3_14"`;
+
 exports[`RuntimeVersionUtils Python maps the pip packaging python version for PYTHON_3_11 1`] = `"3.11"`;
 
 exports[`RuntimeVersionUtils Python maps the pip packaging python version for PYTHON_3_12 1`] = `"3.12"`;
 
 exports[`RuntimeVersionUtils Python maps the pip packaging python version for PYTHON_3_13 1`] = `"3.13"`;
 
+exports[`RuntimeVersionUtils Python maps the pip packaging python version for PYTHON_3_14 1`] = `"3.14"`;
+
 exports[`RuntimeVersionUtils Python maps the python dependency version for PYTHON_3_11 1`] = `"python@^3.11"`;
 
 exports[`RuntimeVersionUtils Python maps the python dependency version for PYTHON_3_12 1`] = `"python@^3.12"`;
 
 exports[`RuntimeVersionUtils Python maps the python dependency version for PYTHON_3_13 1`] = `"python@^3.13"`;
+
+exports[`RuntimeVersionUtils Python maps the python dependency version for PYTHON_3_14 1`] = `"python@^3.14"`;

--- a/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript-esm.test.ts.snap
+++ b/packages/type-safe-api/test/scripts/generators/__snapshots__/typescript-esm.test.ts.snap
@@ -2572,7 +2572,7 @@ export interface $ConnectFunctionProps extends Omit<FunctionProps, 'code' | 'han
 export class $ConnectFunction extends Function {
   constructor(scope: Construct, id: string, props?: $ConnectFunctionProps) {
     super(scope, id, {
-      runtime: Runtime.NODEJS_22_X,
+      runtime: Runtime.NODEJS_24_X,
       handler: "index.handler",
       code: Code.fromAsset(url.fileURLToPath(new URL(path.join("..",
         "test/ts/dist",
@@ -2667,7 +2667,7 @@ export interface PythonOneFunctionProps extends Omit<FunctionProps, 'code' | 'ha
 export class PythonOneFunction extends Function {
   constructor(scope: Construct, id: string, props?: PythonOneFunctionProps) {
     super(scope, id, {
-      runtime: Runtime.PYTHON_3_13,
+      runtime: Runtime.PYTHON_3_14,
       handler: "test_py.python_one.handler",
       code: Code.fromAsset(url.fileURLToPath(new URL(path.join("..",
         "test/py/dist",
@@ -2691,7 +2691,7 @@ export interface PythonTwoFunctionProps extends Omit<FunctionProps, 'code' | 'ha
 export class PythonTwoFunction extends Function {
   constructor(scope: Construct, id: string, props?: PythonTwoFunctionProps) {
     super(scope, id, {
-      runtime: Runtime.PYTHON_3_13,
+      runtime: Runtime.PYTHON_3_14,
       handler: "test_py.python_two.handler",
       code: Code.fromAsset(url.fileURLToPath(new URL(path.join("..",
         "test/py/dist",
@@ -2715,7 +2715,7 @@ export interface TypescriptOneFunctionProps extends Omit<FunctionProps, 'code' |
 export class TypescriptOneFunction extends Function {
   constructor(scope: Construct, id: string, props?: TypescriptOneFunctionProps) {
     super(scope, id, {
-      runtime: Runtime.NODEJS_22_X,
+      runtime: Runtime.NODEJS_24_X,
       handler: "index.handler",
       code: Code.fromAsset(url.fileURLToPath(new URL(path.join("..",
         "test/ts/dist",
@@ -2740,7 +2740,7 @@ export interface TypescriptTwoFunctionProps extends Omit<FunctionProps, 'code' |
 export class TypescriptTwoFunction extends Function {
   constructor(scope: Construct, id: string, props?: TypescriptTwoFunctionProps) {
     super(scope, id, {
-      runtime: Runtime.NODEJS_22_X,
+      runtime: Runtime.NODEJS_24_X,
       handler: "index.handler",
       code: Code.fromAsset(url.fileURLToPath(new URL(path.join("..",
         "test/ts/dist",
@@ -3876,7 +3876,7 @@ export interface PythonOneFunctionProps extends Omit<FunctionProps, 'code' | 'ha
 export class PythonOneFunction extends Function {
   constructor(scope: Construct, id: string, props?: PythonOneFunctionProps) {
     super(scope, id, {
-      runtime: Runtime.PYTHON_3_13,
+      runtime: Runtime.PYTHON_3_14,
       handler: "test_py.python_one.handler",
       code: Code.fromAsset(url.fileURLToPath(new URL(path.join("..",
         "test/py/dist",
@@ -3899,7 +3899,7 @@ export interface PythonTwoFunctionProps extends Omit<FunctionProps, 'code' | 'ha
 export class PythonTwoFunction extends Function {
   constructor(scope: Construct, id: string, props?: PythonTwoFunctionProps) {
     super(scope, id, {
-      runtime: Runtime.PYTHON_3_13,
+      runtime: Runtime.PYTHON_3_14,
       handler: "test_py.python_two.handler",
       code: Code.fromAsset(url.fileURLToPath(new URL(path.join("..",
         "test/py/dist",
@@ -3922,7 +3922,7 @@ export interface TypescriptOneFunctionProps extends Omit<FunctionProps, 'code' |
 export class TypescriptOneFunction extends Function {
   constructor(scope: Construct, id: string, props?: TypescriptOneFunctionProps) {
     super(scope, id, {
-      runtime: Runtime.NODEJS_22_X,
+      runtime: Runtime.NODEJS_24_X,
       handler: "index.handler",
       code: Code.fromAsset(url.fileURLToPath(new URL(path.join("..",
         "test/ts/dist",
@@ -3946,7 +3946,7 @@ export interface TypescriptTwoFunctionProps extends Omit<FunctionProps, 'code' |
 export class TypescriptTwoFunction extends Function {
   constructor(scope: Construct, id: string, props?: TypescriptTwoFunctionProps) {
     super(scope, id, {
-      runtime: Runtime.NODEJS_22_X,
+      runtime: Runtime.NODEJS_24_X,
       handler: "index.handler",
       code: Code.fromAsset(url.fileURLToPath(new URL(path.join("..",
         "test/ts/dist",

--- a/packages/type-safe-api/test/scripts/generators/typescript-esm.test.ts
+++ b/packages/type-safe-api/test/scripts/generators/typescript-esm.test.ts
@@ -41,8 +41,8 @@ describe("TypeScript ESM Generator Tests", () => {
                 "x-handlers-typescript-asset-path": "test/ts/dist",
                 "x-handlers-python-asset-path": "test/py/dist",
                 "x-handlers-java-asset-path": "test/java/dist",
-                "x-handlers-node-lambda-runtime-version": "NODEJS_22_X",
-                "x-handlers-python-lambda-runtime-version": "PYTHON_3_13",
+                "x-handlers-node-lambda-runtime-version": "NODEJS_24_X",
+                "x-handlers-python-lambda-runtime-version": "PYTHON_3_14",
                 "x-handlers-java-lambda-runtime-version": "JAVA_21",
               }
             )}'`,


### PR DESCRIPTION
AWS Lambda now supports Python 3.14 and NodeJS 24.  Change based on #899

Fixes #939